### PR TITLE
docs: refresh READMEs, add namespace/rooted-truth/ccc-audit docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,360 +1,302 @@
-# 🚀 NoKV — Not Only KV Store
-
 <div align="center">
-  <img src="./img/logo.svg" width="220" alt="NoKV Logo" />
+  <img src="./img/logo.svg" width="200" alt="NoKV" />
+
+  <h1>NoKV</h1>
 
   <p>
-    <!-- Build / Quality -->
-    <a href="https://github.com/feichai0017/NoKV/actions">
-      <img alt="CI" src="https://img.shields.io/github/actions/workflow/status/feichai0017/NoKV/go.yml?branch=main" />
-    </a>
-    <a href="https://codecov.io/gh/feichai0017/NoKV">
-      <img alt="Coverage" src="https://img.shields.io/codecov/c/gh/feichai0017/NoKV" />
-    </a>
-    <a href="https://goreportcard.com/report/github.com/feichai0017/NoKV">
-      <img alt="Go Report Card" src="https://img.shields.io/badge/go%20report-A+-brightgreen" />
-    </a>
-    <a href="https://pkg.go.dev/github.com/feichai0017/NoKV">
-      <img alt="Go Reference" src="https://img.shields.io/badge/go.dev-reference-007d9c?logo=go&logoColor=white" />
-    </a>
-    <a href="https://github.com/avelino/awesome-go#databases-implemented-in-go">
-      <img alt="Mentioned in Awesome" src="https://awesome.re/mentioned-badge.svg" />
-    </a>
-    <a href="https://dbdb.io/db/nokv">
-      <img alt="DBDB.io" src="https://img.shields.io/badge/dbdb.io-listed-2f80ed" />
-    </a>
+    <strong>A full-stack, formally-specified, distributed storage platform — built as one coherent system.</strong>
   </p>
 
   <p>
-    <!-- Meta -->
-    <img alt="Go Version" src="https://img.shields.io/badge/go-1.26%2B-00ADD8?logo=go&logoColor=white" />
-    <img alt="License" src="https://img.shields.io/badge/license-Apache--2.0-yellow" />
-    <a href="https://deepwiki.com/feichai0017/NoKV">
-      <img alt="DeepWiki" src="https://img.shields.io/badge/DeepWiki-Ask-6f42c1" />
-    </a>
+    <em>Own LSM engine · Own Raft · Own control plane · Own MVCC · Own Redis frontend</em>
   </p>
 
-  <p><strong>Not Only KV Store • Distributed Storage Research Platform • LSM Tree • ValueLog • MVCC • Multi-Raft Regions</strong></p>
+  <p>
+    <a href="https://github.com/feichai0017/NoKV/actions"><img alt="CI" src="https://img.shields.io/github/actions/workflow/status/feichai0017/NoKV/go.yml?branch=main&style=flat-square&label=CI&logo=github" /></a>
+    <a href="https://codecov.io/gh/feichai0017/NoKV"><img alt="Coverage" src="https://img.shields.io/codecov/c/gh/feichai0017/NoKV?style=flat-square&logo=codecov" /></a>
+    <a href="https://pkg.go.dev/github.com/feichai0017/NoKV"><img alt="Go Reference" src="https://img.shields.io/badge/go.dev-reference-007d9c?style=flat-square&logo=go&logoColor=white" /></a>
+    <img alt="Go" src="https://img.shields.io/badge/go-1.26+-00ADD8?style=flat-square&logo=go&logoColor=white" />
+    <img alt="License" src="https://img.shields.io/badge/license-Apache--2.0-green?style=flat-square" />
+    <a href="https://deepwiki.com/feichai0017/NoKV"><img alt="DeepWiki" src="https://img.shields.io/badge/DeepWiki-Ask-6f42c1?style=flat-square" /></a>
+  </p>
+
+  <p>
+    <img alt="LOC" src="https://img.shields.io/badge/core_LOC-50k+-informational?style=flat-square" />
+    <img alt="TLA+" src="https://img.shields.io/badge/formally_specified-TLA%2B-blueviolet?style=flat-square" />
+    <img alt="Fault Injection" src="https://img.shields.io/badge/fault_injection-18_ops_%2B_8_phases-orange?style=flat-square" />
+    <img alt="Self-contained" src="https://img.shields.io/badge/external_deps-none-brightgreen?style=flat-square" />
+  </p>
 </div>
 
+<br/>
 
-NoKV stands for <strong>Not Only KV Store</strong>. It is a Go-native storage system that starts as a serious standalone engine and grows into a multi-Raft distributed KV cluster without changing its underlying data plane.
+## What is NoKV?
 
-The interesting part is not just that it has WAL, LSM, MVCC, Redis compatibility, or Raft. The interesting part is that these pieces are built as one system: a single storage substrate that can be embedded locally, migrated into a seeded distributed node, and then expanded into a replicated cluster with an explicit protocol.
+NoKV is a distributed key-value storage platform written from the ground up in Go. **Nothing is borrowed from another database** — the LSM engine, the Raft implementation, the control plane, the MVCC layer, and the Redis-compatible frontend are all native to this repository and share a single storage substrate.
 
-> NoKV is not trying to be "yet another KV". It is trying to make the path from standalone storage to distributed replication coherent, inspectable, and testable.
+The interesting part isn't that NoKV has "WAL, LSM, MVCC, Raft". The interesting part is that **these pieces are built as one system**:
 
-## 🎯 Project Positioning
+- **One storage core, three deployment shapes.** The same `DB` substrate runs embedded in a Go program, seeded as the first node of a cluster, or replicated across a multi-Raft mesh. You don't migrate data — you migrate shape.
+- **Execution plane and control plane are separate on purpose.** `raftstore/` executes writes. `coordinator/` answers "who holds authority, and for how long". `meta/root/` is the rooted truth they both consume.
+- **Correctness is formally specified.** Six TLA+ specifications under [`spec/`](./spec/) model control-plane authority handoff, with machine-checked contrast models showing why weaker designs break.
+- **Fault injection is a first-class primitive.** 18 operation-level VFS hooks, 8 Raft protocol-phase failpoints, and a shared `FaultFS` interface let any write path be stress-tested under crash-consistent failure schedules.
 
-NoKV is intended to be a **maintainable and extensible distributed storage research platform**, not just a feature demo.
+> NoKV is structured so new storage, replication, and control-plane ideas can land without rewriting the system each time. Treat it as a **serious engineering base** for exploring distributed storage internals, not as a production database.
 
-That means the repository is organized so new storage and distributed-systems ideas can land without rewriting the whole system each time:
+<br/>
 
-- **One storage core, multiple system shapes**  
-  Embedded mode, seeded migration, and distributed raft mode all reuse the same underlying engine instead of forking into separate prototypes.
+## 📊 Benchmarks
 
-- **Explicit boundaries for long-term maintenance**  
-  `engine/*` contains single-node storage substrate, `raftstore/*` and `coordinator/*` contain distributed runtime/control-plane logic, and `internal/runtime` is reserved for DB runtime support instead of subsystem-specific glue.
+Performance-first YCSB on a single node, **NoKV vs industrial-grade embedded KVs** (Badger, Pebble). Apple M3 Pro, `records=1M`, `ops=1M`, `value_size=1000`, `conc=16`. Snapshot from CI [run #23701742757](https://github.com/feichai0017/NoKV/actions/runs/23701742757).
 
-- **Research workflows live in the repo, not outside it**  
-  `benchmark/*`, plotting tools, scripts, and design docs are part of the system so papers, experiments, and implementation evolve together.
+| Workload | Description | **NoKV** | Badger | Pebble |
+|---|---|---:|---:|---:|
+| **YCSB-A** | 50/50 read/update | **175,905** | 108,232 | 169,792 |
+| **YCSB-B** | 95/5 read/update | **525,631** | 188,893 | 137,483 |
+| **YCSB-C** | 100% read | **409,136** | 242,463 | 90,474 |
+| **YCSB-D** | 95% read, 5% insert (latest) | **632,031** | 284,205 | 198,139 |
+| **YCSB-E** | 95% scan, 5% insert | **45,620** | 15,027 | 40,793 |
+| **YCSB-F** | read-modify-write | **157,732** | 84,601 | 122,192 |
 
-- **Extensibility matters as much as features**  
-  The goal is to make it practical to explore new metadata models, control-plane designs, benchmarking setups, and eventually different replication designs on top of a stable codebase.
+> Units: **operations per second** (higher is better). Full latency distribution and methodology in [`benchmark/README.md`](./benchmark/README.md).
+
+Representative latency snapshot (NoKV):
+
+| Workload | Avg | P95 | P99 |
+|---|---:|---:|---:|
+| YCSB-A | 5.68 µs | 204 µs | 308 µs |
+| YCSB-B | 1.90 µs | 24 µs | 750 µs |
+| YCSB-C | 2.44 µs | 15 µs | 26 µs |
+| YCSB-D | 1.58 µs | 22 µs | 638 µs |
+| YCSB-F | 6.34 µs | 233 µs | 371 µs |
+
+**Caveat**: single-node, localhost, read-heavy profile favors NoKV's flush/compaction design. These numbers are honest but not representative of multi-tenant production stress.
+
+<br/>
+
+## 🧭 Why NoKV vs X?
+
+| If you need… | You should probably use… | Why NoKV exists |
+|---|---|---|
+| Production distributed SQL | **CockroachDB**, TiDB | Different scope — NoKV is a research-grade KV layer |
+| Production distributed KV | **TiKV** | NoKV is not yet battle-tested at scale |
+| Just an embedded LSM library | **Pebble**, **Badger** | NoKV ships its own engine, but is not trying to be a drop-in library |
+| A Raft library | **etcd/raft**, dragonboat | NoKV has its own Raft integrated with the storage substrate |
+| **A self-contained platform to study how LSM, Raft, MVCC, and control-plane design interact** | — | **This is what NoKV is for.** |
+
+The project's value comes from **owning the entire vertical**. If you want to change how compaction interacts with Raft log GC, or how control-plane lease renewal affects write latency, no external dependency gets in the way.
+
+<br/>
+
+## 🏗️ Architecture
+
+<p align="center">
+  <img src="./img/architecture.svg" alt="NoKV Architecture" width="100%" />
+</p>
+
+Four boundaries that set NoKV apart from typical single-purpose KV prototypes:
+
+- **One storage core, two deployment shapes.** Embedded and distributed modes sit on the same `DB` substrate. No data dump/reimport when you grow from local to clustered.
+- **Migration is a protocol, not a hack.** `plan → init → seeded → expand` has explicit lifecycle state, failpoint coverage, and restart semantics at every stage.
+- **Execution plane / control plane split.** `RaftAdmin` runs membership changes leader-side; `Coordinator` owns routing, TSO, heartbeats, and cluster view. They never share mutable state.
+- **Recovery metadata is partitioned.** Manifest (storage engine), local recovery catalog (Raft), raft durable log, and logical region snapshots each have distinct ownership — no single corrupt file blocks all recovery paths.
+
+Deep-dive: [`docs/architecture.md`](docs/architecture.md) · [`docs/runtime.md`](docs/runtime.md) · [`docs/control_and_execution_protocols.md`](docs/control_and_execution_protocols.md)
+
+<br/>
+
+## ✨ Notable Design Points
+
+Selected features that are genuinely non-obvious — and have design notes explaining *why* they're the way they are:
+
+| | Feature | Reference |
+|---|---|---|
+| 🌡️ | **Ingest Buffer for anti-stall LSM** — "catch first, sort later" absorbs L0 pressure without blocking writes | [`engine/lsm/`](./engine/lsm) · [design note](docs/notes/2026-02-01-compaction-and-ingest.md) |
+| 🪣 | **Value Log with KV separation + hash buckets + parallel GC** — WiscKey + HashKV merged into a single pragmatic design | [`engine/vlog/`](./engine/vlog) · [design note](docs/notes/2026-02-05-vlog-design-and-gc.md) |
+| 🧠 | **Adaptive memtable index (SkipList ↔ ART)** over arena-managed memory — no Go GC pressure on hot writes | [`engine/lsm/memtable.go`](./engine/lsm/memtable.go) · [design note](docs/notes/2026-02-09-memory-kernel-arena-and-adaptive-index.md) |
+| 🚦 | **MPSC write pipeline with adaptive coalescing** — thousands of concurrent producers, one long-lived consumer, backlog-aware batching | [`db_write.go`](./db_write.go) · [design note](docs/notes/2026-02-09-write-pipeline-mpsc-and-adaptive-batching.md) |
+| 🔍 | **GRF-inspired range filter** for cheap bounded-scan pruning at block granularity | [`engine/lsm/range_filter.go`](./engine/lsm/range_filter.go) · [design note](docs/notes/2026-04-05-range-filter-from-grf.md) |
+| 🎯 | **HotRing as a side-channel observer** — hot-key detection without putting it on the main read path | [`hotring/`](./hotring) · [design note](docs/notes/2026-01-16-hotring-design.md) |
+| 🧰 | **VFS abstraction with 18-op fault injection** — cross-platform atomic rename semantics, FaultFS for testing any syscall failure | [`engine/vfs/`](./engine/vfs) · [design note](docs/notes/2026-02-15-vfs-abstraction-and-deterministic-reliability.md) |
+| 📦 | **SST-based Raft snapshot install** — snapshots ship materialized SST files, target node ingests directly | [`raftstore/snapshot/`](./raftstore/snapshot) · [design note](docs/notes/2026-03-31-sst-snapshot-install.md) |
+| 🏛️ | **Delos-lite rooted truth kernel** — minimal typed event log is the single source of truth; Coordinator and raftstore are consumers | [`meta/root/`](./meta/root) · [design note](docs/notes/2026-04-03-delos-lite-metadata-root-roadmap.md) |
+
+All design notes under [`docs/notes/`](./docs/notes/) are dated decision records — read them to understand *why* something is the way it is, not just what it does.
+
+<br/>
+
+## 🔬 Formally Specified
+
+Control-plane correctness is modeled in TLA+ under [`spec/`](./spec/), with a **contrast family** that machine-checks why weaker designs fail:
+
+| Spec | Role | TLC outcome |
+|---|---|---|
+| [`CCC.tla`](./spec/CCC.tla) | Positive model — repeated authority handoff with closure lifecycle | ✅ 3924 distinct states, depth 20, invariants hold |
+| [`CCCMultiDim.tla`](./spec/CCCMultiDim.tla) | Multi-dimensional frontier coverage | ✅ 326 distinct states, invariants hold |
+| [`LeaseOnly.tla`](./spec/LeaseOnly.tla) | Contrast — no reply-side guard, no rooted closure | ❌ counterexample: old-generation reply delivered after successor |
+| [`TokenOnly.tla`](./spec/TokenOnly.tla) | Contrast — bounded-freshness token only | ❌ counterexample: freshness ≠ authority lineage |
+| [`ChubbyFencedLease.tla`](./spec/ChubbyFencedLease.tla) | Contrast — per-reply sequencer fencing | ❌ counterexample: stale-reject holds, but successor coverage fails |
+| [`LeaseStartOnly.tla`](./spec/LeaseStartOnly.tla) | Contrast — no lease-start coverage | ❌ counterexample: write accepted behind predecessor's served read |
+
+Run `make tlc-ccc` / `make tlc-leaseonly-counterexample` / etc. to reproduce. Artifact outputs are checked in under [`spec/artifacts/`](./spec/artifacts/).
+
+<br/>
 
 ## 🚦 Quick Start
 
-Start an end-to-end playground with either the local script or Docker Compose. Both spin up a three-node Raft cluster with a Coordinator service and expose the Redis-compatible gateway.
+Spin up a full three-node Raft cluster with Coordinator and Redis gateway in one command:
 
 ![NoKV demo](./img/nokv-demo.gif)
 
 ```bash
-# Option A: local processes
+# Local processes
 ./scripts/dev/cluster.sh --config ./raft_config.example.json
-# In another shell: launch the Redis gateway on top of the running cluster
+
+# In another terminal: Redis gateway on top of the running cluster
 go run ./cmd/nokv-redis \
   --addr 127.0.0.1:6380 \
   --raft-config ./raft_config.example.json \
   --metrics-addr 127.0.0.1:9100
 
-# Option B: Docker Compose (cluster + gateway + Coordinator)
+# Or: Docker Compose (cluster + gateway + Coordinator in one stack)
 docker compose up --build
-# Tear down
-docker compose down -v
 ```
 
-Once the cluster is running you can point any Redis client at `127.0.0.1:6380` (or the address exposed by Compose).
-
-For quick CLI checks:
+Point any Redis client at `127.0.0.1:6380`. Inspect runtime state:
 
 ```bash
-# Online stats from a running node
+# Online — via expvar
 go run ./cmd/nokv stats --expvar http://127.0.0.1:9100
 
-# Offline forensics from a stopped node workdir
+# Offline forensics — from a stopped node's workdir
 go run ./cmd/nokv stats --workdir ./artifacts/cluster/store-1
+go run ./cmd/nokv manifest --workdir ./artifacts/cluster/store-1
+go run ./cmd/nokv regions --workdir ./artifacts/cluster/store-1 --json
 ```
 
-Minimal embedded snippet:
+### Embedded mode
 
 ```go
 package main
 
 import (
-	"fmt"
-	"log"
+    "fmt"
+    "log"
 
-	NoKV "github.com/feichai0017/NoKV"
+    NoKV "github.com/feichai0017/NoKV"
 )
 
 func main() {
-	opt := NoKV.NewDefaultOptions()
-	opt.WorkDir = "./workdir-demo"
+    opt := NoKV.NewDefaultOptions()
+    opt.WorkDir = "./workdir-demo"
 
-	db, err := NoKV.Open(opt)
-	if err != nil {
-		log.Fatalf("open failed: %v", err)
-	}
-	defer db.Close()
+    db, err := NoKV.Open(opt)
+    if err != nil {
+        log.Fatal(err)
+    }
+    defer db.Close()
 
-	key := []byte("hello")
-	if err := db.Set(key, []byte("world")); err != nil {
-		log.Fatalf("set failed: %v", err)
-	}
+    _ = db.Set([]byte("hello"), []byte("world"))
 
-	entry, err := db.Get(key)
-	if err != nil {
-		log.Fatalf("get failed: %v", err)
-	}
-	fmt.Printf("value=%s\n", entry.Value)
+    entry, _ := db.Get([]byte("hello"))
+    fmt.Printf("value=%s\n", entry.Value)
 }
 ```
 
-> Note:
-> - `DB.Get` returns detached entries (do not call `DecrRef`).
-> - `DB.GetInternalEntry` returns borrowed entries and callers must call `DecrRef` exactly once.
-> - `DB.SetWithTTL` accepts `time.Duration` (relative TTL). `DB.Set`/`DB.SetBatch`/`DB.SetWithTTL` reject `nil` values; use `DB.Del` or `DB.DeleteRange(start,end)` for deletes.
-> - `DB.NewIterator` exposes user-facing entries, while `DB.NewInternalIterator` scans raw internal keys (`cf+user_key+ts`).
+> API notes:
+> - `DB.Get` returns **detached** entries — caller owns the bytes, do not `DecrRef`.
+> - `DB.GetInternalEntry` returns **borrowed** entries — caller must `DecrRef` exactly once.
+> - `DB.Set`/`DB.SetBatch`/`DB.SetWithTTL` reject `nil` values; use `DB.Del` or `DB.DeleteRange(start, end)` for deletes.
+> - `DB.NewIterator` exposes user-facing entries; `DB.NewInternalIterator` scans raw internal keys.
 
-> ℹ️ `scripts/dev/cluster.sh` rebuilds `nokv` and `nokv-config`, seeds local peer catalogs via `nokv-config catalog`, starts Coordinator (`nokv coordinator`), streams Coordinator/store logs to the current terminal, and also writes them under `artifacts/cluster/store-<id>/server.log` and `artifacts/cluster/coordinator.log`. Use `Ctrl+C` to exit cleanly; if the process crashes, wipe the workdir (`rm -rf ./artifacts/cluster`) before restarting to avoid WAL replay errors.
+Full guide: [`docs/getting_started.md`](docs/getting_started.md)
 
----
+<br/>
 
 ## 🧭 Topology & Configuration
 
-Everything hangs off a single file: [`raft_config.example.json`](./raft_config.example.json).
+All deployment shapes share one configuration file: [`raft_config.example.json`](./raft_config.example.json).
 
 ```jsonc
-"coordinator": { "addr": "127.0.0.1:2379", "docker_addr": "nokv-coordinator:2379" },
-"stores": [
-  { "store_id": 1, "listen_addr": "127.0.0.1:20170", ... },
-  { "store_id": 2, "listen_addr": "127.0.0.1:20171", ... },
-  { "store_id": 3, "listen_addr": "127.0.0.1:20172", ... }
-],
-"regions": [
-  { "id": 1, "range": [-inf,"m"), peers: 101/201/301, leader: store 1 },
-  { "id": 2, "range": ["m",+inf), peers: 102/202/302, leader: store 2 }
-]
+{
+  "coordinator": { "addr": "127.0.0.1:2379", ... },
+  "stores": [
+    { "store_id": 1, "listen_addr": "127.0.0.1:20170", ... },
+    { "store_id": 2, "listen_addr": "127.0.0.1:20171", ... },
+    { "store_id": 3, "listen_addr": "127.0.0.1:20172", ... }
+  ],
+  "regions": [
+    { "id": 1, "range": [-inf, "m"), "leader": 1, ... },
+    { "id": 2, "range": ["m", +inf), "leader": 2, ... }
+  ]
+}
 ```
 
-- **Local scripts** (`scripts/dev/cluster.sh`, `scripts/ops/serve-store.sh`, `scripts/ops/bootstrap.sh`) ingest the same JSON, so local runs match production layouts.
-- **Docker Compose** mounts the file into each container; manifests, transports, and Redis gateway all stay in sync.
-- Need more stores or regions? Update the JSON and re-run the script/Compose—no code changes required.
-- Programmatic access: import `github.com/feichai0017/NoKV/config` and call `config.LoadFile` / `Validate` for a single source of truth across tools.
+Local scripts, Docker Compose, and all CLI tools consume the same file. Need more stores or regions? Edit the JSON and re-run — no code changes.
 
-### 🧬 Tech Stack Snapshot
+Programmatic access: `import "github.com/feichai0017/NoKV/config"` and call `config.LoadFile` / `Validate`.
 
-| Layer | Tech/Package | Why it matters |
-| --- | --- | --- |
-| Storage Core | `engine/lsm/`, `engine/wal/`, `engine/vlog/` | Hybrid log-structured design with manifest-backed durability and value separation. |
-| Concurrency | `percolator/`, `raftstore/client` | Distributed 2PC, lock management, and MVCC version semantics in raft mode. |
-| Replication | `raftstore/*` + `coordinator/*` | Multi-Raft data plane plus Coordinator-backed control plane (routing, TSO, heartbeats). |
-| Tooling | `cmd/nokv`, `cmd/nokv-config`, `cmd/nokv-redis` | CLI, config helper, Redis-compatible gateway share the same topology file. |
-| Observability | `stats`, `hotring`, expvar | Built-in metrics, hot-key analytics, and crash recovery traces. |
+<br/>
 
----
+## 🧩 Modules
 
-## 🧱 Architecture Overview
+| Module | Responsibility | Docs |
+|---|---|---|
+| [`engine/lsm/`](./engine/lsm) | MemTable, flush pipeline, leveled compaction, SST | [LSM](docs/memtable.md) · [flush](docs/flush.md) · [compaction](docs/compaction.md) |
+| [`engine/wal/`](./engine/wal) | WAL segments, CRC, rotation, replay, watchdog | [WAL](docs/wal.md) |
+| [`engine/vlog/`](./engine/vlog) | KV-separated value log, hash buckets, parallel GC | [ValueLog](docs/vlog.md) |
+| [`engine/manifest/`](./engine/manifest) | VersionEdit log, atomic `CURRENT` handling | [Manifest](docs/manifest.md) |
+| [`engine/vfs/`](./engine/vfs) | VFS abstraction, FaultFS, cross-platform atomic rename | [VFS](docs/vfs.md) |
+| [`percolator/`](./percolator) | Distributed MVCC 2PC (prewrite/commit/rollback/resolve) | [Percolator](docs/percolator.md) |
+| [`raftstore/`](./raftstore) | Multi-Raft region management, transport, membership, snapshot install | [RaftStore](docs/raftstore.md) |
+| [`coordinator/`](./coordinator) | Control plane: routing, TSO, heartbeats, lease management | [Coordinator](docs/coordinator.md) |
+| [`meta/root/`](./meta/root) | Typed rooted truth kernel (Delos-lite), replicated/local backends | [Rooted Truth](docs/rooted_truth.md) |
+| [`namespace/`](./namespace) | Hierarchical listing infrastructure on top of LSM | [Namespace](docs/namespace.md) |
+| [`hotring/`](./hotring) | Hot-key detection and throttling | [HotRing](docs/hotring.md) |
+| [`spec/`](./spec) | TLA+ specifications and contrast models | [spec/README.md](./spec/README.md) |
+| [`cmd/nokv/`](./cmd/nokv) | CLI: stats, manifest, regions, vlog, migrate, coordinator | [CLI](docs/cli.md) |
+| [`cmd/nokv-redis/`](./cmd/nokv-redis) | Redis-compatible gateway | [Redis](docs/nokv-redis.md) |
 
-```mermaid
-%%{init: {
-  "themeVariables": { "fontSize": "17px" },
-  "flowchart": { "nodeSpacing": 42, "rankSpacing": 58, "curve": "basis" }
-}}%%
-flowchart TD
-    App["App / CLI / Redis Client"]
+<br/>
 
-    subgraph Standalone["Standalone Shape"]
-        Embedded["Embedded NoKV DB API"]
-    end
+## 📡 Observability
 
-    subgraph Distributed["Distributed Shape"]
-        Gateway["NoKV RPC / Redis Gateway"]
-        Client["raftstore/client"]
-        Coordinator["Coordinator<br/>route / tso / heartbeats"]
-        Server["Node Server"]
-        Store["Store runtime root"]
-        Peer["Peer runtime"]
-        Admin["RaftAdmin<br/>execution plane"]
-        Meta["raftstore/localmeta<br/>local recovery metadata"]
-        RaftEngine["raftstore/engine<br/>raft durable state"]
-        Snap["logical region snapshot"]
-    end
+- **expvar metrics** via `Stats.StartStats` — flush backlog, WAL segments, value-log GC stats, region/cache/hot metrics
+- **CLI inspection** from either live endpoint (`--expvar`) or stopped workdir (`--workdir`)
+- **Structured logs** streamed from Coordinator and each store, also written under `artifacts/cluster/<name>/server.log`
 
-    subgraph DataPlane["Shared Storage Core"]
-        DB["NoKV DB"]
-        WAL["WAL"]
-        LSM["LSM + SST"]
-        VLog["ValueLog"]
-        MVCC["Percolator / MVCC"]
-        Manifest["Manifest"]
-    end
+More in [`docs/stats.md`](docs/stats.md) · [`docs/cli.md`](docs/cli.md) · [`docs/testing.md`](docs/testing.md).
 
-    subgraph Migration["Standalone → Cluster Bridge"]
-        Plan["migrate plan"]
-        Init["migrate init"]
-        Seed["seeded workdir"]
-        Expand["expand / remove-peer / transfer-leader"]
-    end
-
-    App --> Embedded
-    App --> Gateway
-    Gateway --> Client
-    Client --> Coordinator
-    Client --> Server
-    Server --> Store
-    Store --> Peer
-    Store --> Admin
-    Store --> Meta
-    Peer --> RaftEngine
-    Peer --> Snap
-    Embedded --> DB
-    Peer --> DB
-    Snap --> DB
-    DB --> WAL
-    DB --> LSM
-    DB --> VLog
-    DB --> MVCC
-    DB --> Manifest
-    Embedded -.same data plane.- DB
-    Plan --> Init
-    Init --> Seed
-    Seed --> Server
-    Seed --> Expand
-```
-
-What makes this layout distinctive:
-- **One storage core, two deployment shapes** – embedded mode and raft mode both sit on the same `DB` substrate instead of splitting into separate engines.
-- **Migration is a protocol, not a dump/import hack** – `plan → init → seeded → expand` turns an existing standalone workdir into a replicated cluster path with explicit lifecycle state.
-- **Execution plane and control plane are split on purpose** – `RaftAdmin` executes leader-side membership changes, while `Coordinator` stays responsible for routing, allocation, timestamps, and cluster view.
-- **Recovery metadata is not mixed with engine metadata** – manifest, local recovery catalog, raft durable state, and logical region snapshots each have distinct ownership.
-
-## 🧪 Why This Works As A Research Platform
-
-The repository is meant to support multiple storage and distributed-systems research lines without turning into a one-off paper artifact.
-
-- **Maintainable layering**  
-  Root `DB` APIs stay thin, engine internals live under `engine/*`, distributed runtime lives under `raftstore/*`, and experiments live under `benchmark/*`.
-
-- **Extensible control/data-plane split**  
-  The architecture already separates storage substrate, distributed execution, metadata root, and coordinator services, which makes it much easier to evolve one area without destabilizing the whole system.
-
-- **Evidence-oriented development**  
-  Benchmarks, failure injection, restart recovery tests, and design docs are treated as first-class project assets rather than after-the-fact appendices.
-
-- **Good fit for exploratory systems work**  
-  NoKV is structured to support questions about storage-engine internals, metadata/control-plane design, migration protocols, namespace services, and evaluation methodology in the same repository.
-
-Key ideas:
-- **Durability path** – WAL first, memtable second. ValueLog writes occur before WAL append so crash replay can fully rebuild state.
-- **Metadata** – manifest stores SST topology, WAL checkpoints, and vlog head/deletion metadata.
-- **Background workers** – flush manager handles `Prepare → Build → Install → Release`, compaction reduces level overlap, and value log GC rewrites segments based on discard stats.
-- **Distributed transactions** – Percolator 2PC runs in raft mode; embedded mode exposes non-transactional DB APIs.
-
-Dive deeper in [docs/architecture.md](docs/architecture.md).
-
----
-
-## 📊 CI Benchmark Snapshot
-
-Benchmarks matter here, but they are not the whole story. NoKV is trying to be fast **and** structurally coherent: durability, migration, control-plane separation, and recovery semantics come first.
-
-Latest public benchmark snapshot currently checked into the repository, taken
-from the latest successful `main` CI YCSB run available at the time of update
-([run #23701742757](https://github.com/feichai0017/NoKV/actions/runs/23701742757)).
-This snapshot used the then-current benchmark profile:
-`A-F`, `records=1,000,000`, `ops=1,000,000`, `value_size=1000`,
-`value_threshold=2048`, `conc=16`.
-
-Methodology and harness details live in [`benchmark/README.md`](./benchmark/README.md).
-
-| Engine | Workload | Mode | Ops/s | Avg Latency | P95 | P99 |
-| --- | --- | --- | ---: | ---: | ---: | ---: |
-| NoKV | YCSB-A | 50/50 read/update | 175,905 | 5.684µs | 204.039µs | 307.851µs |
-| NoKV | YCSB-B | 95/5 read/update | 525,631 | 1.902µs | 24.115µs | 750.413µs |
-| NoKV | YCSB-C | 100% read | 409,136 | 2.444µs | 15.077µs | 25.658µs |
-| NoKV | YCSB-D | 95% read, 5% insert (latest) | 632,031 | 1.582µs | 21.811µs | 638.457µs |
-| NoKV | YCSB-E | 95% scan, 5% insert | 45,620 | 21.92µs | 139.449µs | 9.203945ms |
-| NoKV | YCSB-F | read-modify-write | 157,732 | 6.339µs | 232.743µs | 371.209µs |
-| Badger | YCSB-A | 50/50 read/update | 108,232 | 9.239µs | 285.74µs | 483.139µs |
-| Badger | YCSB-B | 95/5 read/update | 188,893 | 5.294µs | 274.549µs | 566.042µs |
-| Badger | YCSB-C | 100% read | 242,463 | 4.124µs | 36.549µs | 1.862803ms |
-| Badger | YCSB-D | 95% read, 5% insert (latest) | 284,205 | 3.518µs | 233.414µs | 479.801µs |
-| Badger | YCSB-E | 95% scan, 5% insert | 15,027 | 66.547µs | 4.064653ms | 7.534558ms |
-| Badger | YCSB-F | read-modify-write | 84,601 | 11.82µs | 407.624µs | 645.491µs |
-| Pebble | YCSB-A | 50/50 read/update | 169,792 | 5.889µs | 491.322µs | 1.65907ms |
-| Pebble | YCSB-B | 95/5 read/update | 137,483 | 7.273µs | 658.763µs | 1.415039ms |
-| Pebble | YCSB-C | 100% read | 90,474 | 11.052µs | 878.733µs | 1.817526ms |
-| Pebble | YCSB-D | 95% read, 5% insert (latest) | 198,139 | 5.046µs | 491.515µs | 1.282231ms |
-| Pebble | YCSB-E | 95% scan, 5% insert | 40,793 | 24.513µs | 1.332974ms | 2.301008ms |
-| Pebble | YCSB-F | read-modify-write | 122,192 | 8.183µs | 760.934µs | 1.71655ms |
-
----
-
-## 🧩 Module Breakdown
-
-| Module | Responsibilities | Source | Docs |
-| --- | --- | --- | --- |
-| WAL | Append-only segments with CRC, rotation, replay (`wal.Manager`). | [`engine/wal/`](./engine/wal) | [WAL internals](docs/wal.md) |
-| LSM | MemTable, flush pipeline, leveled compactions, iterator merging. | [`engine/lsm/`](./engine/lsm) | [Memtable](docs/memtable.md)<br>[Flush pipeline](docs/flush.md)<br>[Cache](docs/cache.md)<br>[Range filter](docs/range_filter.md) |
-| Manifest | VersionEdit log + CURRENT handling, WAL/vlog checkpoints, value-log metadata. | [`engine/manifest/`](./engine/manifest) | [Manifest semantics](docs/manifest.md) |
-| ValueLog | Large value storage, GC, discard stats integration. | [`vlog.go`](./vlog.go), [`engine/vlog/`](./engine/vlog) | [Value log design](docs/vlog.md) |
-| Percolator | Distributed MVCC 2PC primitives (prewrite/commit/rollback/resolve/status). | [`percolator/`](./percolator) | [Percolator transactions](docs/percolator.md) |
-| RaftStore | Multi-Raft Region management, hooks, metrics, transport. | [`raftstore/`](./raftstore) | [RaftStore overview](docs/raftstore.md) |
-| HotRing | Hot key tracking, throttling helpers. | [`hotring/`](./hotring) | [HotRing overview](docs/hotring.md) |
-| Observability | Periodic stats, hot key tracking, CLI integration. | [`stats.go`](./stats.go), [`cmd/nokv`](./cmd/nokv) | [Stats & observability](docs/stats.md)<br>[CLI reference](docs/cli.md) |
-| Filesystem | Pebble-inspired `vfs` abstraction + mmap-backed file helpers shared by SST/vlog, WAL, and manifest. | [`engine/vfs/`](./engine/vfs), [`engine/file/`](./engine/file) | [VFS](docs/vfs.md)<br>[File abstractions](docs/file.md) |
-
-Each module has a dedicated document under `docs/` describing APIs, diagrams, and recovery notes.
-
----
-
-
-## 📡 Observability & CLI
-
-- `Stats.StartStats` publishes metrics via `expvar` (flush backlog, WAL segments, value log GC stats, raft/region/cache/hot metrics).
-- `cmd/nokv` gives you:
-  - `nokv stats --workdir <dir> [--json] [--no-region-metrics]`
-  - `nokv manifest --workdir <dir>`
-  - `nokv regions --workdir <dir> [--json]`
-  - `nokv vlog --workdir <dir>`
-- `hotring` continuously surfaces hot keys in stats + CLI so you can pre-warm caches or debug skewed workloads.
-
-More in [docs/cli.md](docs/cli.md) and [docs/testing.md](docs/testing.md#4-observability-in-tests).
-
----
+<br/>
 
 ## 🔌 Redis Gateway
 
-- `cmd/nokv-redis` exposes a RESP-compatible endpoint. In embedded mode (`--workdir`) commands execute through regular DB APIs; in distributed mode (`--raft-config`) calls are routed through `raftstore/client` and committed with TwoPhaseCommit.
-- In raft mode, TTL is persisted directly in each value entry (`expires_at`) through the same 2PC write path as the value payload.
-- `--metrics-addr` exposes Redis gateway metrics under `NoKV.Stats.redis` via expvar. In raft mode, `--coordinator-addr` can override `config.coordinator` when you need a non-default Coordinator endpoint.
-- A ready-to-use cluster configuration is available at `raft_config.example.json`, matching both `scripts/dev/cluster.sh` and the Docker Compose setup.
+`cmd/nokv-redis` exposes a RESP-compatible endpoint. In embedded mode (`--workdir`) commands execute through `DB` APIs; in distributed mode (`--raft-config`) calls are routed through `raftstore/client` and committed via Percolator 2PC.
 
-> For the complete command matrix, configuration and deployment guides, see [docs/nokv-redis.md](docs/nokv-redis.md).
+- TTL is persisted in the value entry (`expires_at`) through the same 2PC write path
+- `--metrics-addr` exposes Redis-gateway metrics under `NoKV.Stats.redis` via expvar
+- `--coordinator-addr` overrides the coordinator endpoint when you don't want the default
 
----
+Full command matrix: [`docs/nokv-redis.md`](docs/nokv-redis.md).
+
+<br/>
+
+## 📖 Further Reading
+
+- [`docs/architecture.md`](docs/architecture.md) — shortest path from "what is NoKV" to "which package owns what"
+- [`docs/runtime.md`](docs/runtime.md) — function-level call chains for embedded and distributed read/write paths
+- [`docs/control_and_execution_protocols.md`](docs/control_and_execution_protocols.md) — control-plane / execution-plane contract
+- [`docs/notes/`](docs/notes/) — dated design decision records
+- [`docs/SUMMARY.md`](docs/SUMMARY.md) — full table of contents (mdbook index)
+
+<br/>
 
 ## 📄 License
 
-Apache-2.0. See [LICENSE](LICENSE).
+[Apache-2.0](./LICENSE)
+
+---
+
+<div align="center">
+<sub>Built from scratch — no external storage engine, no external Raft library, no external coordinator.</sub>
+</div>

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,358 +1,187 @@
-# Overview
+# NoKV — Documentation
 
-<div class="hero">
-  <div class="hero-top">
-    <div class="hero-brand">
-      <div class="hero-logo">
-        <img src="assets/logo.svg" alt="NoKV logo">
-      </div>
-      <div>
-        <p class="hero-kicker">Distributed Storage Research Platform, Built As One System</p>
-        <h1>NoKV</h1>
-      </div>
-    </div>
-    <div class="hero-signal-panel">
-      <span class="hero-panel-kicker">Launch View</span>
-      <div class="hero-panel-grid">
-        <div class="hero-panel-metric">
-          <strong>Embedded</strong>
-          <span>Use <code>NoKV.Open</code> as a serious local engine.</span>
-        </div>
-        <div class="hero-panel-metric">
-          <strong>Seeded</strong>
-          <span>Promote an existing workdir into a distributed seed.</span>
-        </div>
-        <div class="hero-panel-metric">
-          <strong>Replicated</strong>
-          <span>Roll out peers, move leaders, and verify recovery.</span>
-        </div>
-      </div>
-    </div>
-  </div>
+<div align="center">
+  <img src="assets/logo.svg" width="160" alt="NoKV" />
 
-  <p class="hero-lead">
-    NoKV starts as a serious standalone engine and grows into a multi-Raft distributed
-    KV database without swapping out its storage core. That is the hook: WAL, LSM,
-    MVCC, migration, replication, and control-plane behavior are treated as one system,
-    not a pile of loosely connected features.
+  <p><strong>A full-stack, formally-specified, distributed storage platform — built as one coherent system.</strong></p>
+
+  <p>
+    <em>Own LSM engine · Own Raft · Own control plane · Own MVCC · Own Redis frontend</em>
   </p>
 
-  <p class="hero-lead">
-    The project is also intended to be a maintainable and extensible research platform:
-    one repository where engine internals, distributed runtime, control-plane logic,
-    experiments, and system papers can evolve together without collapsing into ad-hoc
-    prototypes.
-  </p>
-
-  <div class="hero-summary">
-    <div class="hero-stat">
-      <strong>Standalone to Cluster</strong>
-      <span>Seed a distributed region from an existing workdir and keep the same storage layer.</span>
-    </div>
-    <div class="hero-stat">
-      <strong>Correctness First</strong>
-      <span>Mode gates, logical region snapshots, recovery metadata, and execution/control-plane split.</span>
-    </div>
-    <div class="hero-stat">
-      <strong>Tested as a System</strong>
-      <span>Migration flow, restart recovery, Coordinator degradation, transport chaos, and publish-boundary failpoints.</span>
-    </div>
-    <div class="hero-stat">
-      <strong>Built To Evolve</strong>
-      <span>Clear package layering, experiment tooling, and architecture docs make the repo usable as a long-lived systems research base.</span>
-    </div>
-  </div>
-
-  <div class="badge-row">
-    <a href="https://github.com/feichai0017/NoKV/actions">
-      <img alt="CI" src="https://img.shields.io/github/actions/workflow/status/feichai0017/NoKV/go.yml?branch=main" />
-    </a>
-    <a href="https://codecov.io/gh/feichai0017/NoKV">
-      <img alt="Coverage" src="https://img.shields.io/codecov/c/gh/feichai0017/NoKV" />
-    </a>
-    <a href="https://goreportcard.com/report/github.com/feichai0017/NoKV">
-      <img alt="Go Report Card" src="https://img.shields.io/badge/go%20report-A+-brightgreen" />
-    </a>
-    <a href="https://pkg.go.dev/github.com/feichai0017/NoKV">
-      <img alt="Go Reference" src="https://img.shields.io/badge/go.dev-reference-007d9c?logo=go&logoColor=white" />
-    </a>
-    <a href="https://dbdb.io/db/nokv">
-      <img alt="DBDB.io" src="https://img.shields.io/badge/dbdb.io-listed-2f80ed" />
-    </a>
-    <a href="https://deepwiki.com/feichai0017/NoKV">
-      <img alt="DeepWiki" src="https://img.shields.io/badge/DeepWiki-Ask-6f42c1" />
-    </a>
-  </div>
-
-  <div class="cta-zone">
-    <div class="cta-copy">
-      <span class="cta-kicker">Start Here</span>
-      <p>Run a local cluster first, then follow the standalone → seeded → cluster path.</p>
-    </div>
-    <div class="cta-row">
-      <a class="cta-button primary" href="getting_started.html">Quick Start</a>
-      <a class="cta-button secondary" href="architecture.html">Architecture</a>
-      <a class="cta-button secondary" href="migration.html">Migration</a>
-    </div>
-  </div>
-
-  <p class="hero-footer">
-    Built around Go, WAL + LSM storage, Percolator-style MVCC, multi-Raft replication,
-    Coordinator control plane, and a formal standalone-to-cluster migration path.
+  <p>
+    <a href="https://github.com/feichai0017/NoKV/actions"><img alt="CI" src="https://img.shields.io/github/actions/workflow/status/feichai0017/NoKV/go.yml?branch=main&style=flat-square&logo=github" /></a>
+    <a href="https://codecov.io/gh/feichai0017/NoKV"><img alt="Coverage" src="https://img.shields.io/codecov/c/gh/feichai0017/NoKV?style=flat-square&logo=codecov" /></a>
+    <a href="https://pkg.go.dev/github.com/feichai0017/NoKV"><img alt="Go Reference" src="https://img.shields.io/badge/go.dev-reference-007d9c?style=flat-square&logo=go&logoColor=white" /></a>
+    <img alt="Go" src="https://img.shields.io/badge/go-1.26+-00ADD8?style=flat-square&logo=go&logoColor=white" />
+    <img alt="License" src="https://img.shields.io/badge/license-Apache--2.0-green?style=flat-square" />
+    <a href="https://deepwiki.com/feichai0017/NoKV"><img alt="DeepWiki" src="https://img.shields.io/badge/DeepWiki-Ask-6f42c1?style=flat-square" /></a>
   </p>
 </div>
 
-<div class="project-masthead">
-  <div class="masthead-panel">
-    <span class="masthead-kicker">What You Can Actually Do</span>
-    <h3>Use NoKV in three different ways</h3>
-    <ul>
-      <li>Embed it locally through <code>NoKV.Open</code>.</li>
-      <li>Start a multi-node cluster with <code>scripts/dev/cluster.sh</code>.</li>
-      <li>Take an existing standalone workdir and migrate it into a replicated region.</li>
-    </ul>
-  </div>
-  <div class="masthead-panel">
-    <span class="masthead-kicker">What To Look For</span>
-    <h3>What makes this project worth reading</h3>
-    <ul>
-      <li>One storage layer instead of separate standalone and distributed engines.</li>
-      <li>Formal lifecycle and migration protocol instead of dump/import glue.</li>
-      <li>System-level verification under restart, degraded Coordinator, chaos, and failpoints.</li>
-      <li>A package structure designed to keep the codebase maintainable as a research platform, not just a one-off prototype.</li>
-    </ul>
-  </div>
-</div>
+NoKV is a distributed key-value storage platform written from scratch in Go. Nothing is borrowed from another database — the LSM engine, the Raft implementation, the control plane, the MVCC layer, and the Redis-compatible frontend all live in this repository and share a single storage substrate.
 
-<span class="section-kicker">What Matters</span>
+The interesting part isn't the feature list. The interesting part is that **these pieces are built as one system** — embedded mode, seeded migration, and replicated Raft mode all sit on the same `DB` core, and the distinction between execution plane, control plane, and rooted truth is enforced in code, not just in documentation.
 
-## Why NoKV
+> This site is the **technical docs hub**. For a project overview, landing page, and benchmark headline, see the [root README](../README.md).
 
-<div class="why-layout">
-  <div class="why-intro">
-    <span class="why-kicker">Three reasons this project is interesting</span>
-    <h3>NoKV is not trying to be a feature checklist.</h3>
-    <p>It is trying to answer a narrower and harder question well: can one storage core grow from an embedded engine into a distributed multi-Raft KV without turning migration, metadata, and recovery into glue code?</p>
-    <ul class="why-points">
-      <li>One storage layer across standalone and distributed modes.</li>
-      <li>Explicit lifecycle and migration semantics instead of hidden bootstrap magic.</li>
-      <li>Verification aimed at restart, degraded control plane, and publish-boundary correctness.</li>
-      <li>Code, benchmarks, and documentation are organized so new research directions can be added without re-deriving the whole system.</li>
-    </ul>
-  </div>
+---
 
-  <div class="feature-grid">
-    <div class="feature-card">
-      <span class="feature-eyebrow">Storage Story</span>
-      <h3>One data plane, two deployment shapes</h3>
-      <p>NoKV does not fork into separate standalone and distributed engines. The distributed layer grows on top of the same underlying DB workdir.</p>
-      <small>That is why migration can be a protocol instead of a dump/import afterthought.</small>
-    </div>
-    <div class="feature-card">
-      <span class="feature-eyebrow">Runtime Ownership</span>
-      <h3>Replication with clear ownership</h3>
-      <p><code>Store</code> owns the node runtime, <code>Peer</code> owns a region replica runtime, <code>RaftAdmin</code> is the execution plane, and Coordinator stays in the control plane.</p>
-      <small>The system avoids mixing local truth, local recovery metadata, and cluster control metadata.</small>
-    </div>
-    <div class="feature-card">
-      <span class="feature-eyebrow">Migration Primitive</span>
-      <h3>Logical region snapshots</h3>
-      <p>Raft durable snapshot metadata is split from logical region state snapshots, which keeps migration, add-peer install, and recovery semantics clean.</p>
-      <small>This is a correctness-first design, not a one-shot performance shortcut.</small>
-    </div>
-    <div class="feature-card">
-      <span class="feature-eyebrow">Validation Surface</span>
-      <h3>System-level validation</h3>
-      <p>The project is tested beyond unit semantics: migration flow, restart safety, degraded Coordinator behavior, transport chaos, and context propagation are all exercised.</p>
-      <small>The goal is to verify lifecycle and recovery behavior, not just happy-path RPCs.</small>
-    </div>
-    <div class="feature-card">
-      <span class="feature-eyebrow">Research Substrate</span>
-      <h3>A codebase meant to keep growing</h3>
-      <p>The repository separates engine substrate, distributed runtime, control-plane components, benchmark tooling, and design documentation so new systems ideas can be implemented without turning the tree into a disposable artifact.</p>
-      <small>This is a platform for iterative storage research, not only a fixed implementation snapshot.</small>
-    </div>
-  </div>
-</div>
+## 🧭 Three Modes, One Core
 
-<span class="section-kicker">Platform Goal</span>
+|  | Embedded | Seeded | Distributed |
+|---|---|---|---|
+| **Use case** | Library in a Go program | First node of a future cluster | Multi-Raft replicated cluster |
+| **Entry point** | `NoKV.Open(opt)` | `migrate init` → `migrate plan` | `scripts/dev/cluster.sh` / `docker compose up` |
+| **Data plane** | `DB` substrate | Same `DB`, plus seeded lifecycle state | Same `DB`, plus Raft apply, plus snapshots |
+| **Metadata shape** | Manifest only | Manifest + local catalog + seeded mode | Manifest + local catalog + rooted truth (`meta/root`) |
+| **Deep dive** | [getting_started.md](getting_started.md) | [migration.md](migration.md) | [raftstore.md](raftstore.md) |
 
-## NoKV As A Research Platform
+The promotion path `Embedded → Seeded → Distributed` has explicit lifecycle state and failpoint coverage at every stage. You don't dump/reimport data when you grow the cluster — you migrate shape.
 
-NoKV is intended to serve as a long-lived platform for storage and distributed-systems research.
+---
 
-- `engine/*` holds the single-node storage substrate: WAL, LSM, manifest, value log, file/VFS primitives.
-- `raftstore/*`, `meta/*`, and `coordinator/*` hold distributed execution and control-plane components.
-- `benchmark/*` holds experiment code and result-generation paths so evaluations stay close to implementation changes.
-- The docs tree is part of the platform contract: architecture, migration, recovery, testing, and benchmarking expectations are documented alongside code.
+## 📑 If You Read Only Three Pages
 
-The point is not only to run NoKV as a system today, but to make it practical to:
+Start here:
 
-- test new storage-engine mechanisms,
-- evolve metadata and control-plane designs,
-- compare distributed execution protocols,
-- and publish repeatable systems experiments from the same repository.
+1. **[architecture.md](architecture.md)** — shortest path from "what is NoKV" to "which package owns what"
+2. **[runtime.md](runtime.md)** — function-level call chains for embedded and distributed read/write paths, with sequence diagrams
+3. **[control_and_execution_protocols.md](control_and_execution_protocols.md)** — the contract between the control plane (`coordinator/`), the execution plane (`raftstore/`), and rooted truth (`meta/root/`)
 
-<div class="benchmark-note">
-  Benchmark methodology and result snapshots live in <a href="../benchmark/README.md"><code>../benchmark/README.md</code></a>. The docs site keeps architecture and operating guidance separate from benchmark storytelling.
-</div>
+These three together give you the whole system's mental model.
 
-<span class="section-kicker">Fastest Path</span>
+---
 
-## Try NoKV In Five Minutes
+## 🗺️ Read By Interest
 
-<div class="launchpad">
-  <div class="launchpad-copy">
-    <span class="launchpad-kicker">Fastest Demo Loop</span>
-    <h3>Boot a cluster, front it with Redis, inspect the runtime.</h3>
-    <p>If you only want one practical path, this is the shortest route from clone to “I can see the system running”. It uses the local cluster helper, the Redis-compatible gateway, and the built-in runtime inspection commands.</p>
-    <div class="launchpad-tags">
-      <span class="tag-pill">local cluster</span>
-      <span class="tag-pill">redis gateway</span>
-      <span class="tag-pill">runtime inspect</span>
-    </div>
-  </div>
-  <div class="launchpad-steps">
-    <div class="launch-step">
-      <strong>01</strong>
-      <div>
-        <h4>Start the cluster</h4>
-        <p>Use the shared topology file and bring up the local Coordinator + store layout.</p>
-      </div>
-    </div>
-    <div class="launch-step">
-      <strong>02</strong>
-      <div>
-        <h4>Expose a familiar interface</h4>
-        <p>Run the Redis-compatible gateway so you can talk to NoKV with an off-the-shelf client.</p>
-      </div>
-    </div>
-    <div class="launch-step">
-      <strong>03</strong>
-      <div>
-        <h4>Inspect the system</h4>
-        <p>Query stats and region ownership so the demo ends with visibility instead of blind writes.</p>
-      </div>
-    </div>
-  </div>
-</div>
+### Storage engine internals
+
+The single-node substrate — WAL, MemTable, flush, compaction, value log, manifest, VFS.
+
+| Topic | Doc |
+|---|---|
+| High-level architecture | [architecture.md](architecture.md) |
+| WAL discipline and replay | [wal.md](wal.md) |
+| MemTable + ART/SkipList | [memtable.md](memtable.md) |
+| Flush pipeline | [flush.md](flush.md) |
+| Leveled compaction + ingest buffer | [compaction.md](compaction.md) · [ingest_buffer.md](ingest_buffer.md) |
+| Value log (KV separation + GC) | [vlog.md](vlog.md) |
+| Manifest semantics | [manifest.md](manifest.md) |
+| Range filter | [range_filter.md](range_filter.md) |
+| Block / row cache | [cache.md](cache.md) |
+| VFS abstraction + FaultFS | [vfs.md](vfs.md) · [file.md](file.md) |
+| Hot-key observer (HotRing) | [hotring.md](hotring.md) |
+| Entry / error model | [entry.md](entry.md) · [errors.md](errors.md) |
+
+### Distributed runtime
+
+Raftstore, coordinator, rooted truth, migration — the distributed layer.
+
+| Topic | Doc |
+|---|---|
+| Raftstore overview (store/peer/admin) | [raftstore.md](raftstore.md) |
+| Coordinator (route / TSO / heartbeats) | [coordinator.md](coordinator.md) |
+| **Rooted truth kernel** (`meta/root`) | [rooted_truth.md](rooted_truth.md) |
+| **Namespace** (hierarchical listing) | [namespace.md](namespace.md) |
+| Control-plane ↔ execution-plane contract | [control_and_execution_protocols.md](control_and_execution_protocols.md) |
+| Standalone → distributed migration | [migration.md](migration.md) |
+| Recovery model | [recovery.md](recovery.md) |
+| Percolator MVCC 2PC | [percolator.md](percolator.md) |
+| Runtime call chains | [runtime.md](runtime.md) |
+
+### Operations and tooling
+
+Binaries, scripts, configuration, observability.
+
+| Topic | Doc |
+|---|---|
+| CLI reference (`nokv`) | [cli.md](cli.md) |
+| **ccc-audit** (rooted state + reply-trace audit) | [ccc-audit.md](ccc-audit.md) |
+| Redis gateway (`nokv-redis`) | [nokv-redis.md](nokv-redis.md) |
+| Configuration | [config.md](config.md) |
+| Scripts layout | [scripts.md](scripts.md) |
+| Stats / expvar / metrics | [stats.md](stats.md) |
+| Testing strategy | [testing.md](testing.md) |
+
+### Research direction
+
+Formal specifications and design decision records.
+
+| Topic | Location |
+|---|---|
+| TLA+ specifications + contrast family | [`spec/`](../spec) · [spec/README.md](../spec/README.md) |
+| Dated design decision records | [notes/README.md](notes/README.md) |
+
+Notable design notes:
+
+- [Why WAL is stdio and vlog/SST are mmap](notes/2026-01-16-mmap-choice.md)
+- [Compaction and ingest buffer design](notes/2026-02-01-compaction-and-ingest.md)
+- [Value log KV separation + HashKV buckets](notes/2026-02-05-vlog-design-and-gc.md)
+- [Arena memory kernel + adaptive index (SkipList ↔ ART)](notes/2026-02-09-memory-kernel-arena-and-adaptive-index.md)
+- [MPSC write pipeline with adaptive coalescing](notes/2026-02-09-write-pipeline-mpsc-and-adaptive-batching.md)
+- [VFS abstraction + deterministic reliability testing](notes/2026-02-15-vfs-abstraction-and-deterministic-reliability.md)
+- [Coordinator ↔ execution layering](notes/2026-03-30-coordinator-and-execution-layering.md)
+- [SST-based snapshot install](notes/2026-03-31-sst-snapshot-install.md)
+- [Delos-lite rooted-truth roadmap](notes/2026-04-03-delos-lite-metadata-root-roadmap.md)
+- [Range filter — from GRF, but not quite](notes/2026-04-05-range-filter-from-grf.md)
+
+---
+
+## 🏗️ Architecture at a Glance
+
+<p align="center">
+  <img src="../img/architecture.svg" alt="NoKV Architecture" width="100%" />
+</p>
+
+**Four boundaries that set NoKV apart from typical single-purpose KV prototypes:**
+
+- **One storage core, two deployment shapes.** Embedded and distributed modes sit on the same `DB` substrate.
+- **Migration is a protocol, not a hack.** `plan → init → seeded → expand` has explicit lifecycle state and failpoint coverage.
+- **Execution plane / control plane split.** `raftstore/` executes writes; `coordinator/` owns routing, TSO, heartbeats; `meta/root/` is the rooted truth both consume. They never share mutable state.
+- **Recovery metadata is partitioned.** Manifest (storage), local catalog (Raft), raft durable log, logical region snapshots — each owns a distinct slice of durable state.
+
+---
+
+## ⚡ Quick Start
+
+Everything hangs off one topology file: [`raft_config.example.json`](../raft_config.example.json).
 
 ```bash
-# 1. Start a local cluster from the shared topology file
+# 1. Build binaries
+make build
+
+# 2. Launch a three-node cluster with Coordinator + Redis gateway
 ./scripts/dev/cluster.sh --config ./raft_config.example.json
 
-# 2. In another terminal, front it with the Redis-compatible gateway
-go run ./cmd/nokv-redis \
-  --addr 127.0.0.1:6380 \
-  --raft-config ./raft_config.example.json
-
-# 3. Talk to NoKV with any Redis client
+# 3. Point a Redis client at the gateway
 redis-cli -p 6380 set hello world
 redis-cli -p 6380 get hello
 
-# 4. Inspect the running cluster
+# 4. Inspect live runtime
 go run ./cmd/nokv stats --expvar http://127.0.0.1:9100
-go run ./cmd/nokv regions --workdir ./artifacts/cluster/store-1
+go run ./cmd/nokv regions --workdir ./artifacts/cluster/store-1 --json
 ```
 
-<span class="section-kicker">Read This Next</span>
+Full walkthrough: [getting_started.md](getting_started.md).
 
-## Documentation Guide
+---
 
-If you only read three pages, read these first:
+## 🔗 Jump Points
 
-1. <a href="getting_started.html"><strong>Getting Started</strong></a> for the shortest path to a running cluster.
-2. <a href="raftstore.html"><strong>Raftstore</strong></a> for runtime ownership and distributed boundaries.
-3. <a href="migration.html"><strong>Migration</strong></a> for the standalone → cluster bridge that makes NoKV distinct.
+| | |
+|---|---|
+| **[CLI surface](cli.md)** | Commands for stats, manifest, regions, vlog, migrate |
+| **[Topology config](config.md)** | One JSON file shared by scripts, Docker, and CLI |
+| **[Scripts layout](scripts.md)** | Local cluster, bootstrap, ops helpers |
+| **[Coordinator](coordinator.md)** | Route / TSO / heartbeat service |
+| **[Percolator / MVCC](percolator.md)** | 2PC primitives in distributed mode |
+| **[Runtime call chains](runtime.md)** | Function-level sequence diagrams |
+| **[Testing](testing.md)** | Failpoints, chaos, restart, migration matrix |
+| **[SUMMARY.md](SUMMARY.md)** | Full mdbook table of contents |
 
-<div class="doc-grid">
-  <div class="doc-card">
-    <h3><a href="getting_started.html">Getting Started</a></h3>
-    <p>Run NoKV locally, understand the topology file, and boot your first store or local cluster.</p>
-  </div>
-  <div class="doc-card">
-    <h3><a href="raftstore.html">Raftstore</a></h3>
-    <p>Read the distributed runtime layout: server wiring, store ownership, peer lifecycle, snapshots, and recovery surfaces.</p>
-  </div>
-  <div class="doc-card">
-    <h3><a href="migration.html">Migration</a></h3>
-    <p>Follow the standalone → seeded → cluster path, including SST snapshot install and membership rollout.</p>
-  </div>
-  <div class="doc-card">
-    <h3><a href="testing.html">Testing</a></h3>
-    <p>See how deterministic integration, failpoints, restart recovery, and distributed fault matrix coverage are organized.</p>
-  </div>
-</div>
+---
 
-<span class="section-kicker">Choose Your Route</span>
-
-## Read By Interest
-
-<div class="path-grid">
-  <div class="path-card">
-    <h3>Storage Engine</h3>
-    <p>Read this route if you care about WAL discipline, MemTable/flush, manifest semantics, and ValueLog GC.</p>
-    <p><a href="architecture.html">Architecture</a> · <a href="wal.html">WAL</a> · <a href="flush.html">Flush</a> · <a href="vlog.html">Value Log</a></p>
-  </div>
-  <div class="path-card">
-    <h3>Distributed Runtime</h3>
-    <p>Read this route if Store/Peer ownership, transport, snapshots, and Coordinator are the parts you want to reason about.</p>
-    <p><a href="raftstore.html">Raftstore</a> · <a href="coordinator.html">Coordinator</a> · <a href="runtime.html">Runtime</a></p>
-  </div>
-  <div class="path-card">
-    <h3>Migration & Operations</h3>
-    <p>Read this route if the bridge from standalone workdir to replicated region is the part you want to demo or operate.</p>
-    <p><a href="migration.html">Migration</a> · <a href="scripts.html">Scripts</a> · <a href="cli.html">CLI</a></p>
-  </div>
-  <div class="path-card">
-    <h3>Testing & Validation</h3>
-    <p>Read this route if you want to see how NoKV verifies correctness under restart, degraded Coordinator, chaos, and failpoint boundaries.</p>
-    <p><a href="testing.html">Testing</a> · <a href="notes/README.html">Notes</a></p>
-  </div>
-</div>
-
-<span class="section-kicker">Common Paths</span>
-
-## Jump Points
-
-<div class="quicklink-grid">
-  <a class="quicklink" href="cli.html">CLI surface</a>
-  <a class="quicklink" href="config.html">Topology config</a>
-  <a class="quicklink" href="scripts.html">Scripts layout</a>
-  <a class="quicklink" href="coordinator.html">Coordinator</a>
-  <a class="quicklink" href="percolator.html">Percolator / MVCC</a>
-  <a class="quicklink" href="runtime.html">Runtime call chains</a>
-</div>
-
-<span class="section-kicker">Layer View</span>
-
-## Architecture Sketch
-
-```mermaid
-%%{init: {
-  "themeVariables": { "fontSize": "18px" },
-  "flowchart": { "nodeSpacing": 45, "rankSpacing": 62, "curve": "basis" }
-}}%%
-graph TD
-    Client["Client / App / Redis"] -->|RPC / RESP| Server["Node Server"]
-    Client -->|Route / TSO / control queries| Coordinator["Coordinator"]
-
-    subgraph "Distributed Runtime"
-        Server --> Store["Store runtime root"]
-        Store --> Peer["Peer runtime"]
-        Store --> Admin["RaftAdmin"]
-        Store --> Meta["Local recovery metadata"]
-        Peer --> Raft["Raft durable state"]
-        Peer --> Snap["Logical region snapshot"]
-    end
-
-    subgraph "Shared Data Plane"
-        Peer --> DB["NoKV DB"]
-        Snap --> DB
-        DB --> LSM["LSM / WAL / VLog / MVCC"]
-    end
-```
-
-<div class="arch-callout">
-  The central design choice is simple: NoKV is not a separate standalone engine and distributed product glued together later. The distributed system is built over the same storage core, with migration and snapshot semantics made explicit instead of implicit.
+<div align="center">
+  <sub>Built from scratch — no external storage engine, no external Raft library, no external coordinator.</sub>
 </div>

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -2,17 +2,20 @@
 
 - [Overview](README.md)
 - [Getting Started](getting_started.md)
+
+# Architecture
+
 - [Architecture](architecture.md)
 - [Runtime Call Chains](runtime.md)
-- [Error Handling](errors.md)
-- [Entry](entry.md)
-- [Configuration](config.md)
-- [CLI](cli.md)
+- [Control and Execution Plane Protocols](control_and_execution_protocols.md)
+
+# Storage Engine
+
+- [WAL](wal.md)
 - [Memtable](memtable.md)
 - [Flush](flush.md)
 - [Compaction](compaction.md)
 - [Ingest Buffer](ingest_buffer.md)
-- [WAL](wal.md)
 - [Value Log](vlog.md)
 - [Manifest](manifest.md)
 - [VFS](vfs.md)
@@ -20,16 +23,31 @@
 - [Cache](cache.md)
 - [Range Filter](range_filter.md)
 - [Hotring](hotring.md)
-- [Percolator](percolator.md)
+- [Entry](entry.md)
+- [Error Handling](errors.md)
+
+# Distributed Runtime
+
 - [Raftstore](raftstore.md)
 - [Coordinator](coordinator.md)
-- [Control and Execution Plane Protocols](control_and_execution_protocols.md)
+- [Rooted Truth (meta/root)](rooted_truth.md)
+- [Namespace](namespace.md)
+- [Percolator](percolator.md)
 - [Migration](migration.md)
 - [Recovery](recovery.md)
-- [Stats](stats.md)
-- [Testing](testing.md)
+
+# Operations & Tooling
+
+- [Configuration](config.md)
+- [CLI](cli.md)
+- [ccc-audit](ccc-audit.md)
 - [Scripts](scripts.md)
 - [NoKV Redis](nokv-redis.md)
+- [Stats & Observability](stats.md)
+- [Testing](testing.md)
+
+# Design Notes
+
 - [设计笔记与实现记录](notes/README.md)
   - [2026-01-16 mmap 选择](notes/2026-01-16-mmap-choice.md)
   - [2026-01-16 Hotring 设计](notes/2026-01-16-hotring-design.md)

--- a/docs/ccc-audit.md
+++ b/docs/ccc-audit.md
@@ -1,0 +1,255 @@
+# ccc-audit
+
+`nokv ccc-audit` is an offline diagnostic CLI that inspects **coordinator authority-handoff state** and **reply traces** for legality violations.
+
+It consumes two kinds of input:
+
+1. A coordinator rooted snapshot (read from a workdir) — snapshot-level audit
+2. A JSON reply trace (NoKV or external system) — reply-level audit
+
+Either or both can be provided. The tool produces a structured report of detected anomalies and is safe to run against stopped nodes or trace files archived for post-mortem review.
+
+---
+
+## 1. When to use it
+
+- **Post-mortem**: a coordinator crashed mid-handoff, and you want to know whether the rooted lease/seal/closure state is consistent before restarting
+- **Pre-restart sanity check**: before bringing a store back up, verify its rooted metadata has no dangling successor coverage / missing confirms / missing closures
+- **Trace audit**: given a dumped reply trace from an external system, check whether any accepted reply crossed an authority-transition boundary
+- **CI**: compile a reply-trace fixture from a regression scenario, run `ccc-audit`, and fail the build if the anomaly count is non-zero
+
+The tool reads only. It does not modify the workdir or publish any rooted events.
+
+---
+
+## 2. CLI flags
+
+```
+nokv ccc-audit
+  --workdir <path>                    Coordinator work directory containing rooted metadata
+  --holder <string>                   Holder id to evaluate (default: current rooted holder)
+  --now-unix-nano <int64>             Override audit time (default: real time)
+  --reply-trace <path>                Optional JSON reply trace to evaluate
+  --reply-trace-format <format>       nokv | etcd-read-index | etcd-lease-renew | crdb-lease-start
+  --json                              Emit JSON report instead of the text table
+```
+
+At least one of `--workdir` or `--reply-trace` must be provided.
+
+When only `--reply-trace` is given, snapshot-level anomalies are skipped (there is no snapshot to audit), but reply-trace anomalies are still evaluated against whatever `Report` can be constructed from the provided context.
+
+---
+
+## 3. Snapshot anomalies (from `--workdir`)
+
+Lifted directly from [`coordinator/audit/report.go`](../coordinator/audit/report.go) — when a rooted snapshot is loaded, the tool reports the following boolean/enum fields:
+
+| Field | What triggers it |
+|---|---|
+| `SuccessorLineageMismatch` | Successor lease exists but its `PredecessorDigest` doesn't match the sealed predecessor |
+| `UncoveredMonotoneFrontier` | Successor present but monotone frontier (ID/TSO) not covered |
+| `UncoveredDescriptorRevision` | Successor present but descriptor revision frontier not covered |
+| `LeaseStartCoverageViolation` | Successor `lease_start` is below the sealed served-read frontier |
+| `SealedGenerationStillLive` | A sealed generation is still marked as live-able |
+| `ClosureDefect` | Enum: `successor_incomplete` / `missing_confirm` / `missing_close` / `close_without_confirm` / `close_lineage_mismatch` / `reattach_without_confirm` / `reattach_without_close` / `reattach_lineage_mismatch` / `reattach_incomplete` |
+
+`ClosureDefect` is the canonical enum field. The legacy boolean fields (`MissingConfirm`, `MissingClose`, etc.) are kept in the struct for backward-compatible test consumption only; new code should read `ClosureDefect` directly.
+
+---
+
+## 4. Reply-trace anomalies (from `--reply-trace`)
+
+The reply trace evaluator is in [`coordinator/audit/trace.go`](../coordinator/audit/trace.go). Each accepted record is checked against the snapshot's closure state plus its own successor-generation evidence.
+
+| Kind | Meaning |
+|---|---|
+| `post_seal_accepted_reply` | Reply accepted at a generation that is already sealed in rooted state |
+| `accepted_reply_behind_successor` | Generic — accepted reply's generation is below an observed successor generation |
+| `accepted_read_index_behind_successor` | etcd-read-index specialization of the above |
+| `accepted_keepalive_success_after_revoke` | etcd-lease-renew specialization — keepalive success observed after a revoke revision |
+| `lease_start_coverage_violation` | crdb-lease-start specialization — accepted successor `lease_start` below carried served timestamp |
+| `illegal_reply_generation` | Accepted reply whose generation cannot be legal under current closure state |
+
+Anomaly kinds are stable; adapters for new external systems add more specializations to the `accepted_reply_behind_successor` family.
+
+---
+
+## 5. Trace formats
+
+The tool's trace adapter normalizes several formats into a shared `ReplyTraceRecord` schema. See [`coordinator/audit/trace_adapter.go`](../coordinator/audit/trace_adapter.go).
+
+### `nokv` (default)
+
+Native format, already in `ReplyTraceRecord` shape:
+
+```json
+[
+  {
+    "source": "nokv",
+    "duty": "alloc_id",
+    "cert_generation": 5,
+    "observed_successor_generation": 0,
+    "accepted": true
+  }
+]
+```
+
+Also accepts `{"records": [...]}` envelope.
+
+### `etcd-read-index`
+
+```json
+[
+  {
+    "member_id": "n1",
+    "read_state_generation": 12,
+    "successor_generation": 13,
+    "accepted": true
+  }
+]
+```
+
+Projected into `duty: "read_index"` with `cert_generation = read_state_generation`, `observed_successor_generation = successor_generation`.
+
+### `etcd-lease-renew`
+
+```json
+[
+  {
+    "member_id": "n1",
+    "response_revision": 42,
+    "revoke_revision": 45,
+    "accepted": true
+  }
+]
+```
+
+Projected into `duty: "lease_renew"` with `cert_generation = response_revision`, `observed_successor_generation = revoke_revision`.
+
+### `crdb-lease-start`
+
+```json
+[
+  {
+    "key": "k",
+    "successor_lease_start": 8,
+    "served_timestamp": 9,
+    "accepted": true
+  }
+]
+```
+
+Projected into `duty: "lease_start_coverage"`. Triggers `lease_start_coverage_violation` when `successor_lease_start <= served_timestamp` and `accepted=true`.
+
+---
+
+## 6. Output
+
+### Text (default)
+
+```
+HolderID                 c1
+NowUnixNano              1745158800000000000
+CatchUpState             fresh
+RootDescriptorRevision   128
+CurrentHolder            c1
+CurrentGeneration        5
+SealGeneration           4
+ClosureSatisfied         true
+ClosureStage             closed
+Anomalies                none
+ReplyTraceRecords        3
+ReplyTraceAnomalies      accepted_read_index_behind_successor
+```
+
+### JSON (`--json`)
+
+Full dump of `Report`, `Lease`, `Seal`, reply trace records, and reply-trace anomalies. Schema is the `cccAuditOutput` struct in `cmd/nokv/ccc_audit.go`.
+
+---
+
+## 7. Examples
+
+### Workdir-only audit
+
+```bash
+nokv ccc-audit --workdir ./artifacts/cluster/store-1 --json
+```
+
+Loads the rooted snapshot, evaluates closure defects, prints JSON.
+
+### Reply-trace-only audit
+
+```bash
+nokv ccc-audit \
+  --reply-trace ./traces/etcd-read-index-sample.json \
+  --reply-trace-format etcd-read-index
+```
+
+Evaluates the trace against an empty snapshot — useful when all you have is the trace file.
+
+### Combined audit with holder override
+
+```bash
+nokv ccc-audit \
+  --workdir ./artifacts/cluster/store-1 \
+  --holder c1 \
+  --now-unix-nano 1745158800000000000 \
+  --reply-trace ./traces/failover.json \
+  --json
+```
+
+Produces the full report: snapshot-level anomalies + reply-trace anomalies evaluated under the same closure context.
+
+---
+
+## 8. Programmatic API
+
+Everything the CLI does is available as a Go package. From `coordinator/audit`:
+
+```go
+import (
+    coordaudit "github.com/feichai0017/NoKV/coordinator/audit"
+    coordstorage "github.com/feichai0017/NoKV/coordinator/storage"
+)
+
+store, _ := coordstorage.OpenRootLocalStore("./workdir")
+defer store.Close()
+snapshot, _ := store.Load()
+
+report := coordaudit.BuildReport(snapshot, "c1", time.Now().UnixNano())
+
+records, _ := coordaudit.DecodeReplyTrace(traceBytes, coordaudit.ReplyTraceFormatNoKV)
+traceAnomalies := coordaudit.EvaluateReplyTrace(report, records)
+
+for _, a := range traceAnomalies {
+    fmt.Printf("%s at index %d: %s\n", a.Kind, a.Index, a.Reason)
+}
+```
+
+---
+
+## 9. Exit codes
+
+- `0` — tool ran successfully; anomalies (if any) are in the report but are **not** promoted to a non-zero exit code
+- `1` — tool failed to run (bad flags, missing workdir, malformed trace)
+
+**Note**: the tool intentionally does not exit non-zero on detected anomalies. Consuming scripts should parse the JSON output and decide themselves how to react. This makes it safe to run inside broader CI pipelines without accidentally failing them.
+
+---
+
+## 10. Source map
+
+| File | Role |
+|---|---|
+| [`cmd/nokv/ccc_audit.go`](../cmd/nokv/ccc_audit.go) | CLI entry point, flag parsing, text/JSON renderer |
+| [`coordinator/audit/report.go`](../coordinator/audit/report.go) | `BuildReport`, `SnapshotAnomalies`, `ClosureDefect` |
+| [`coordinator/audit/trace.go`](../coordinator/audit/trace.go) | `EvaluateReplyTrace`, `ReplyTraceAnomaly` |
+| [`coordinator/audit/trace_adapter.go`](../coordinator/audit/trace_adapter.go) | Format parsing + projection into `ReplyTraceRecord` |
+| [`coordinator/audit/lease_start_coverage.go`](../coordinator/audit/lease_start_coverage.go) | CRDB-style lease-start coverage helper |
+
+Related docs:
+
+- [Rooted Truth](rooted_truth.md) — what's in the snapshot this tool audits
+- [Coordinator](coordinator.md) — the service that mutates the rooted state
+- [Control and Execution Plane Protocols](control_and_execution_protocols.md) — the full contract being checked

--- a/docs/namespace.md
+++ b/docs/namespace.md
@@ -1,0 +1,194 @@
+# Namespace
+
+The `namespace/` package provides **hierarchical, paginated listing** on top of the NoKV KV substrate. It is exposed at the top level as `DB.Namespace(...)` which returns a `NamespaceHandle`.
+
+> This layer is optional. The core `DB` still uses flat keys; `namespace` only adds a path-aware listing surface for applications that need `Create` / `Lookup` / `List(parent)` semantics.
+
+---
+
+## 1. What it is, in one paragraph
+
+Many workloads store data under path-like keys (`/a/b/c`, `bucket/object`, `run/epoch_N/shard_k`). A plain prefix scan over `M|full_path` answers `List(parent)` correctly, but pays for all descendants rather than just direct children, and offers no notion of "this page is complete vs in-flight". The namespace layer keeps `M|full_path` as the only source of truth and builds a **fence-paged read plane** alongside it, together with a tiny coverage state machine. Listing hits the read plane when the interval is certified; otherwise callers get an explicit `ErrCoverageIncomplete` and must run `RepairAndList`.
+
+---
+
+## 2. Key layout
+
+Five key families live in the underlying KV:
+
+| Family | Role |
+|---|---|
+| `M\|full_path` | Authoritative metadata (the only truth) |
+| `LR\|parent` | Read-plane root: page directory + per-interval coverage state |
+| `LP\|parent\|fence` | Ordered micro-pages (children in fence interval) |
+| `LD\|parent\|shard\|child` | Bootstrap delta log (for not-yet-materialized parents) |
+| `LDP\|parent\|page\|#seq` | Page-local delta log (for recent mutations on materialized parents) |
+
+`M` is read on every `Lookup`. `LR/LP` are read on every strict `List`. `LD/LDP` are consumed by `RepairAndList` / `MaterializeDeltaPages`.
+
+Encoding lives in [`namespace/codec.go`](../namespace/codec.go).
+
+---
+
+## 3. Three-state coverage model
+
+Each page interval in `LR` carries a `PageCoverageState` (`coordinator/protocol/controlplane` terminology doesn't apply here — this is namespace-local):
+
+- **Covered** — the interval has a published page, no pending delta, and generation matches `LR`'s root generation. Strict `List` is allowed.
+- **Uncovered** — no page published yet, or publish is incomplete. Strict `List` returns `ErrCoverageIncomplete`.
+- **Dirty** — a page exists but a page-local `LDP` entry has landed after publication. Must be folded before strict `List` can answer again.
+
+Strict `List` only reads covered pages. Anything else forces the caller to choose between fail-stop and explicit `RepairAndList`.
+
+---
+
+## 4. API surface
+
+All methods are on `DB.Namespace(...)` which wraps [`namespace.Store`](../namespace/store.go).
+
+### Writes
+
+```go
+h := db.Namespace(NamespaceOptions{Shards: 16})
+defer h.Close()
+
+h.Create([]byte("/a/b/file"), namespace.EntryKindFile, metaBytes)
+h.Delete([]byte("/a/b/file"))
+```
+
+`Create` / `Delete` update `M` first, then append to the appropriate delta family:
+
+- If parent is **not yet materialized**: write goes to `LD|parent|shard|child` (bootstrap delta)
+- If parent **is materialized**: write goes to `LDP|parent|page|#seq` (page-local delta) and marks the affected page as `Dirty`
+
+### Point reads
+
+```go
+meta, err := h.Lookup([]byte("/a/b/file"))
+```
+
+`Lookup` is a direct `M|full_path` read. It never touches the read plane.
+
+### Listing
+
+```go
+// Strict — fails if interval is uncovered/dirty
+entries, next, stats, err := h.List(parent, cursor, limit)
+
+// Explicit repair then list — allowed to consult M + deltas to fix the interval
+entries, next, stats, err := h.RepairAndList(parent, cursor, limit)
+```
+
+`stats` reports whether the result came from the strict read plane or from repair, and how many pages/deltas were touched.
+
+### Maintenance
+
+```go
+// Fold all page-local deltas back into pages (global)
+stats, err := h.Materialize(parent)
+
+// Fold up to N dirty pages (bounded work)
+stats, err := h.MaterializeDeltaPages(parent, maxDeltaPages)
+
+// Rebuild entire read plane from M (expensive, rare)
+stats, err := h.Rebuild(parent)
+
+// Return internal read plane view for diagnostics
+view, ok, err := h.LoadReadPlaneView(parent)
+
+// Runtime stats for observability
+ls, err := h.Stats(parent)
+```
+
+### Verification
+
+```go
+vs, err := h.Verify(parent)
+```
+
+`Verify` walks `M`, `LR`, `LP`, `LD`, `LDP` and reports:
+
+- **Membership drift** — children in `M` that are missing from pages, or vice versa
+- **Certificate inconsistency** — page generation mismatch, wrong fence keys, wrong counts
+- **Publication mismatch** — root generation inconsistent with pages' generations, frontier rollback, root-page cohort mismatch
+
+These three reports live under `VerifyStats.Membership` / `.Certificate` / `.Publication`.
+
+---
+
+## 5. Why not just prefix scan `M|`?
+
+Prefix scan on `M|parent/...` works correctly but has two cost issues:
+
+1. **It reads all descendants.** If `parent` has 1K direct children but each has 100 grandchildren, the scan touches 100K keys to answer a 1K-item `List`.
+2. **It has no answerability state.** There is no way to express "we currently have a complete, consistent page ready to serve" vs "we're mid-rewrite". Callers have to trust whatever comes back.
+
+The read plane costs extra writes (dual-writing `M` + `LDP`/`LD`) and extra maintenance (`Materialize` / repair). In exchange, `List` becomes page-granular, and the coverage state machine gives you a clean place to fail-stop.
+
+---
+
+## 6. Cost vs. a durable parent-child secondary index
+
+A simpler alternative is a plain durable index: `S|parent|child -> {}` updated on every `Create`/`Delete`. That gives you fast `List` without fences, pages, or coverage state — but every `List` is best-effort: if the index is slightly stale or mid-rebuild, the caller either gets partial data silently or has to re-derive from `M`.
+
+`namespace/` pays more maintenance cost in exchange for:
+
+- **Page granularity** — deltas and repairs are scoped to one fence interval, not the whole parent
+- **Explicit coverage** — strict `List` never silently falls back; the caller decides whether to repair
+
+If you don't need that distinction, a flat secondary index is simpler and probably faster.
+
+---
+
+## 7. Example
+
+```go
+package main
+
+import (
+    "fmt"
+
+    NoKV "github.com/feichai0017/NoKV"
+    ns "github.com/feichai0017/NoKV/namespace"
+)
+
+func main() {
+    opt := NoKV.NewDefaultOptions()
+    opt.WorkDir = "./ns-demo"
+    db, _ := NoKV.Open(opt)
+    defer db.Close()
+
+    h := db.Namespace(NoKV.NamespaceOptions{Shards: 16})
+    defer h.Close()
+
+    h.Create([]byte("/a/b/c"), ns.EntryKindFile, []byte(`{"kind":"file"}`))
+    h.Create([]byte("/a/b/d"), ns.EntryKindFile, nil)
+
+    // Materialize the parent so strict List becomes possible.
+    _, _ = h.Materialize([]byte("/a/b"))
+
+    entries, next, stats, err := h.List([]byte("/a/b"), ns.Cursor{}, 100)
+    if err != nil {
+        fmt.Println("list err:", err)
+        return
+    }
+    fmt.Printf("got %d entries, read_pages=%d, next=%+v\n",
+        len(entries), stats.ReadPlanePages, next)
+}
+```
+
+---
+
+## 8. Source map
+
+| File | Responsibility |
+|---|---|
+| [`namespace/store.go`](../namespace/store.go) | Main `Store` with `Create`/`Delete`/`Lookup`/`List`/`RepairAndList`/`Materialize` |
+| [`namespace/readplane.go`](../namespace/readplane.go) | `ReadRoot`, `ReadPage`, `PageCertificate`, strict-read evaluator |
+| [`namespace/delta.go`](../namespace/delta.go), [`namespace/delta_state.go`](../namespace/delta_state.go) | `LD` / `LDP` encoding + per-page delta state |
+| [`namespace/page_merge.go`](../namespace/page_merge.go) | Fold page-local deltas into pages; split/merge fences |
+| [`namespace/codec.go`](../namespace/codec.go) | Key + value encoding for all five families |
+| [`namespace/types.go`](../namespace/types.go) | `Entry`, `Cursor`, `*Stats` public types |
+| [`namespace.go`](../namespace.go) (root) | Thin `DB.Namespace` wrapper exposing the module as a first-class handle |
+
+Tests: `namespace/*_test.go` cover create/delete/list, repair transitions, dirty-page handling, bootstrap, materialize, rebuild, and verification.

--- a/docs/rooted_truth.md
+++ b/docs/rooted_truth.md
@@ -1,0 +1,219 @@
+# Rooted Truth — `meta/root`
+
+The `meta/root/` tree implements NoKV's **rooted truth kernel**: a typed, append-only event log whose committed tail is the single source of truth for cluster-level metadata (coordinator leases, allocator fences, region lifecycle, pending peer/range changes).
+
+> If the distributed system has a "brain", it does **not** live in the coordinator. It lives here. The coordinator is a service+view on top of this log.
+
+---
+
+## 1. Why a separate truth layer
+
+In a typical multi-raft system, the metadata used by the control plane (routes, TSO, leases, scheduling decisions) is either:
+
+1. Stored inside one of the raft groups (mixed with user data)
+2. Owned by a single coordinator node (coordinator becomes the bottleneck)
+3. Split across ad-hoc persistence files
+
+NoKV makes it **explicit**: there is a small, typed metadata log with its own durability and replication shape, and everything control-plane-related goes through it. This matches the "virtual consensus" pattern (Delos-lite): the log is the truth; services above are views that can be rebuilt.
+
+The benefits are concrete:
+
+- **Coordinator is stateless at restart** — the only persistent thing about a coordinator is its configured holder ID; everything else is rebuilt from `meta/root` on boot
+- **The log can be swapped** between local (single-node) and replicated (embedded-raft) backends without changing coordinator code
+- **Authority handoff is auditable** — every lease grant / seal / closure event is a committed log record with a cursor
+
+---
+
+## 2. Package layout
+
+```
+meta/
+├── root/
+│   ├── protocol/       # Pure protocol types (Cursor, Frontiers, Handoff, Witness, ...)
+│   ├── event/          # Typed events (KindStoreJoined, KindCoordinatorLease, ...)
+│   ├── state/          # Compact applied state (State, Snapshot, ApplyEventToSnapshot)
+│   ├── materialize/    # Helpers that build Snapshot from raw events
+│   ├── storage/        # Virtual log file layout + checkpoint format
+│   │   └── file/       # Actual on-disk file operations
+│   ├── backend/
+│   │   ├── local/      # Single-node file-backed log
+│   │   └── replicated/ # Embedded raft-backed log (quorum durability)
+│   └── remote/         # gRPC service + client for remote rooted access
+└── wire/               # proto <-> Go conversions (Event, Snapshot, Cursor)
+```
+
+---
+
+## 3. What lives in rooted state
+
+[`meta/root/state/state.go`](../meta/root/state/state.go) defines `State`, the applied snapshot. Everything the control plane cares about is here:
+
+```go
+type State struct {
+    ClusterEpoch       uint64         // bumped on topology event
+    MembershipEpoch    uint64         // bumped on store join/leave
+    LastCommitted      Cursor         // highest committed (term, index)
+    IDFence            uint64         // globally fenced ID allocator floor
+    TSOFence           uint64         // globally fenced TSO allocator floor
+    CoordinatorLease   CoordinatorLease
+    CoordinatorSeal    CoordinatorSeal
+    CoordinatorClosure CoordinatorClosure
+}
+```
+
+`Snapshot` wraps `State` together with descriptors and pending peer/range changes:
+
+```go
+type Snapshot struct {
+    State               State
+    Descriptors         map[uint64]descriptor.Descriptor
+    PendingPeerChanges  map[uint64]PendingPeerChange
+    PendingRangeChanges map[uint64]PendingRangeChange
+}
+```
+
+Every event kind has a deterministic effect on `Snapshot`. See [`meta/root/state/snapshot_apply.go`](../meta/root/state/snapshot_apply.go) and [`meta/root/state/state.go:ApplyEventToState`](../meta/root/state/state.go).
+
+---
+
+## 4. The Append protocol
+
+The core interface any backend must satisfy:
+
+```go
+type Backend interface {
+    Snapshot() (rootstate.Snapshot, error)
+    Append(ctx context.Context, events ...rootevent.Event) (rootstate.CommitInfo, error)
+    FenceAllocator(ctx context.Context, kind AllocatorKind, min uint64) (uint64, error)
+}
+```
+
+`Append` does five things atomically:
+
+1. Validate events against the current `Snapshot` (reject duplicate region IDs, invalid transitions, stale epochs)
+2. Assign each event a committed cursor `(Term, Index)`
+3. Persist the batch to the backing log
+4. Persist an updated compact `Checkpoint`
+5. Advance in-memory `State` + `Descriptors` + pending maps
+
+After `Append` returns successfully, callers can observe the new state via `Snapshot()`. The `CommitInfo.Cursor` they get back is the globally ordered cursor for the **last** event in the batch.
+
+`FenceAllocator` is separate because it's an **authoritative minimum** — backends may promote the fence further (e.g., to account for outstanding windows) but must never return a value below `min`.
+
+---
+
+## 5. Two backends, same interface
+
+### Local (single-node)
+
+[`meta/root/backend/local/store.go`](../meta/root/backend/local/store.go) — file-backed log with an in-memory mirror.
+
+- One file per workdir, append-only segments + compact checkpoint
+- `mu` protects in-memory state; `logMu` protects the on-disk segments
+- Compaction is background (kicked by `appendLocked`, runs in its own goroutine)
+- Designed for embedded mode and single-coordinator deployments
+
+### Replicated (multi-node)
+
+[`meta/root/backend/replicated/store.go`](../meta/root/backend/replicated/store.go) — embedded raft library, quorum-durable commits.
+
+- 3 replicas typical, one leader
+- `Append` proposes a raft log entry; returns after it's committed to quorum
+- Non-leader nodes reject `Append` with `codes.FailedPrecondition`
+- Leader changes trigger `IsLeader()` / `LeaderID()` state updates that coordinator consumes
+
+---
+
+## 6. Coordinator commands — how lease/seal/closure flow in
+
+In addition to "raw" events, backends expose command APIs for control-plane-specific operations:
+
+```go
+ApplyCoordinatorLease(ctx, cmd CoordinatorLeaseCommand)
+    (CoordinatorProtocolState, error)
+
+ApplyCoordinatorClosure(ctx, cmd CoordinatorClosureCommand)
+    (CoordinatorProtocolState, error)
+```
+
+These are **validated, typed writes** that internally:
+
+1. Validate the command against current state (e.g., seal requires active lease, confirm requires prior seal)
+2. Emit the appropriate `KindCoordinatorLease` / `KindCoordinatorSeal` / `KindCoordinatorClosure` event
+3. Append through the normal log path
+4. Return the new `CoordinatorProtocolState = { Lease, Seal, Closure }`
+
+Command-level validation lives in [`meta/root/state/coordinator_lease.go`](../meta/root/state/coordinator_lease.go).
+
+---
+
+## 7. Tail subscription — how coordinator consumes
+
+Coordinators don't poll `Snapshot()` — they subscribe:
+
+```go
+sub := rootstorage.NewTailSubscription(afterToken, waitFn)
+advance, err := sub.Next(ctx, fallback)
+if advance.Action == rootstorage.TailCatchUpAction_Reload {
+    // backend advanced far; reload snapshot
+} else if advance.Action == rootstorage.TailCatchUpAction_Bootstrap {
+    // backend advanced past our retention window; install from compact state
+}
+sub.Acknowledge(advance)
+```
+
+[`meta/root/storage/virtual_log.go`](../meta/root/storage/virtual_log.go) defines:
+
+- `TailToken` — opaque position in the log
+- `TailAdvance` — either new events, a reload signal, or a bootstrap install
+- `TailSubscription` — stateful iterator that survives across reloads
+
+This is what lets `coordinator/` run as a thin service without duplicating rooted storage.
+
+---
+
+## 8. Recovery model
+
+On coordinator boot:
+
+1. Open the backend (`rootlocal.Open(workdir)` or connect to replicated cluster)
+2. Call `Snapshot()` — backend replays/bootstraps internally
+3. Build a `TailSubscription` from the snapshot's `LastCommitted`
+4. Start the lease campaign loop, which will eventually `ApplyCoordinatorLease(Issue)` when it's leader
+
+If the backend file is corrupted, the coordinator fails fast — it does **not** try to reconstruct rooted state from raftstore local metadata. The two are deliberately partitioned.
+
+---
+
+## 9. Remote access
+
+`meta/root/remote/` provides a gRPC service + client. This exists so a raftstore store can read rooted state without being colocated with the replicated backend:
+
+- `RemoteRootService` serves `Snapshot`, `Append`, `WaitForTail`, `ObserveTail`, etc.
+- `RemoteRootClient` implements the same `rootBackend` interface by calling over gRPC
+- Leader redirect is automatic: if the target returns `NotLeader`, client re-dials the returned leader
+
+This is what keeps `coordinator/` deployable separately from the rooted log, if you ever want to.
+
+---
+
+## 10. Source map
+
+| File | Responsibility |
+|---|---|
+| [`meta/root/protocol/types.go`](../meta/root/protocol/types.go) | Pure protocol types (no persistence logic) |
+| [`meta/root/event/types.go`](../meta/root/event/types.go) | Typed event constructors |
+| [`meta/root/state/state.go`](../meta/root/state/state.go) | `State`, `Snapshot`, `ApplyEventToSnapshot` |
+| [`meta/root/state/coordinator_lease.go`](../meta/root/state/coordinator_lease.go) | Lease/Seal/Closure validation + digest |
+| [`meta/root/state/transition.go`](../meta/root/state/transition.go) | Cross-event transition rules |
+| [`meta/root/storage/virtual_log.go`](../meta/root/storage/virtual_log.go) | Tail subscription + checkpoint primitives |
+| [`meta/root/backend/local/store.go`](../meta/root/backend/local/store.go) | Single-node backend |
+| [`meta/root/backend/replicated/store.go`](../meta/root/backend/replicated/store.go) | Raft-replicated backend |
+| [`meta/root/remote/service.go`](../meta/root/remote/service.go) | gRPC wrapping of either backend |
+| [`meta/wire/root.go`](../meta/wire/root.go) | proto ↔ Go conversions |
+
+Related docs:
+
+- [Coordinator](coordinator.md) — how the control plane consumes rooted state
+- [Control and Execution Plane Protocols](control_and_execution_protocols.md) — the full contract between `meta/root`, `coordinator/`, and `raftstore/`
+- [Migration](migration.md) — how the seeded→distributed flow bootstraps rooted state

--- a/img/architecture.svg
+++ b/img/architecture.svg
@@ -1,0 +1,289 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 820" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', system-ui, sans-serif">
+  <defs>
+    <!-- Gradients -->
+    <linearGradient id="g-control" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#eef2ff"/>
+      <stop offset="100%" stop-color="#e0e7ff"/>
+    </linearGradient>
+    <linearGradient id="g-execution" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#ecfdf5"/>
+      <stop offset="100%" stop-color="#d1fae5"/>
+    </linearGradient>
+    <linearGradient id="g-truth" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#faf5ff"/>
+      <stop offset="100%" stop-color="#f3e8ff"/>
+    </linearGradient>
+    <linearGradient id="g-substrate" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#fffbeb"/>
+      <stop offset="100%" stop-color="#fef3c7"/>
+    </linearGradient>
+    <linearGradient id="g-client" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#f8fafc"/>
+      <stop offset="100%" stop-color="#e2e8f0"/>
+    </linearGradient>
+    <linearGradient id="g-migration" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#fff1f2"/>
+      <stop offset="100%" stop-color="#ffe4e6"/>
+    </linearGradient>
+
+    <!-- Arrowheads -->
+    <marker id="arrow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="6" markerHeight="6" orient="auto-start-reverse">
+      <path d="M0,0 L10,5 L0,10 z" fill="#64748b"/>
+    </marker>
+    <marker id="arrow-dash" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="6" markerHeight="6" orient="auto-start-reverse">
+      <path d="M0,0 L10,5 L0,10 z" fill="#94a3b8"/>
+    </marker>
+
+    <!-- Subtle shadow -->
+    <filter id="shadow" x="-20%" y="-20%" width="140%" height="140%">
+      <feGaussianBlur in="SourceAlpha" stdDeviation="2"/>
+      <feOffset dx="0" dy="1" result="offsetblur"/>
+      <feComponentTransfer><feFuncA type="linear" slope="0.08"/></feComponentTransfer>
+      <feMerge><feMergeNode/><feMergeNode in="SourceGraphic"/></feMerge>
+    </filter>
+  </defs>
+
+  <!-- ============ TITLE ============ -->
+  <text x="600" y="38" text-anchor="middle" font-size="22" font-weight="700" fill="#0f172a" letter-spacing="0.5">
+    NoKV · Architecture
+  </text>
+  <text x="600" y="62" text-anchor="middle" font-size="13" fill="#64748b" font-weight="500">
+    Three deployment shapes · Three planes · One storage core
+  </text>
+
+  <!-- ============ TOP: CLIENTS / FRONTENDS ============ -->
+  <g filter="url(#shadow)">
+    <rect x="60" y="95" width="1080" height="70" rx="10" fill="url(#g-client)" stroke="#cbd5e1" stroke-width="1.5"/>
+  </g>
+  <text x="80" y="120" font-size="11" font-weight="700" fill="#475569" letter-spacing="1.5">CLIENTS &amp; FRONTENDS</text>
+
+  <!-- Client boxes -->
+  <g transform="translate(120, 132)">
+    <rect x="0" y="0" width="180" height="24" rx="5" fill="white" stroke="#cbd5e1" stroke-width="1"/>
+    <text x="90" y="16" text-anchor="middle" font-size="12" fill="#334155" font-weight="600">Embedded Go SDK · NoKV.Open</text>
+  </g>
+  <g transform="translate(330, 132)">
+    <rect x="0" y="0" width="160" height="24" rx="5" fill="white" stroke="#cbd5e1" stroke-width="1"/>
+    <text x="80" y="16" text-anchor="middle" font-size="12" fill="#334155" font-weight="600">Redis Gateway · RESP</text>
+  </g>
+  <g transform="translate(520, 132)">
+    <rect x="0" y="0" width="160" height="24" rx="5" fill="white" stroke="#cbd5e1" stroke-width="1"/>
+    <text x="80" y="16" text-anchor="middle" font-size="12" fill="#334155" font-weight="600">nokv · nokv-config CLI</text>
+  </g>
+  <g transform="translate(710, 132)">
+    <rect x="0" y="0" width="160" height="24" rx="5" fill="white" stroke="#cbd5e1" stroke-width="1"/>
+    <text x="80" y="16" text-anchor="middle" font-size="12" fill="#334155" font-weight="600">gRPC · raftstore/client</text>
+  </g>
+  <g transform="translate(900, 132)">
+    <rect x="0" y="0" width="200" height="24" rx="5" fill="white" stroke="#cbd5e1" stroke-width="1"/>
+    <text x="100" y="16" text-anchor="middle" font-size="12" fill="#334155" font-weight="600">expvar · Stats · Observability</text>
+  </g>
+
+  <!-- ============ THREE PLANES (parallel view) ============ -->
+  <!-- Plane group title -->
+  <text x="600" y="210" text-anchor="middle" font-size="11" font-weight="700" fill="#475569" letter-spacing="1.5">DISTRIBUTED RUNTIME — THREE PLANES, OWNED SEPARATELY</text>
+
+  <!-- Control Plane (left) -->
+  <g filter="url(#shadow)">
+    <rect x="60" y="230" width="350" height="180" rx="10" fill="url(#g-control)" stroke="#6366f1" stroke-width="2"/>
+  </g>
+  <rect x="60" y="230" width="350" height="34" rx="10" fill="#6366f1"/>
+  <rect x="60" y="258" width="350" height="6" fill="#6366f1"/>
+  <text x="80" y="252" font-size="13" font-weight="700" fill="white" letter-spacing="0.8">CONTROL PLANE</text>
+  <text x="390" y="252" text-anchor="end" font-size="11" fill="#c7d2fe" font-weight="500">coordinator/</text>
+
+  <g transform="translate(80, 280)">
+    <rect x="0" y="0" width="310" height="42" rx="6" fill="white" stroke="#a5b4fc" stroke-width="1.2"/>
+    <text x="155" y="18" text-anchor="middle" font-size="13" fill="#4338ca" font-weight="700">Coordinator Service</text>
+    <text x="155" y="33" text-anchor="middle" font-size="11" fill="#6366f1">Route lookup · TSO · Heartbeats</text>
+  </g>
+  <g transform="translate(80, 332)">
+    <rect x="0" y="0" width="150" height="58" rx="6" fill="white" stroke="#a5b4fc" stroke-width="1.2"/>
+    <text x="75" y="20" text-anchor="middle" font-size="12" fill="#4338ca" font-weight="700">Lease Manager</text>
+    <text x="75" y="36" text-anchor="middle" font-size="10" fill="#6366f1">authority handoff</text>
+    <text x="75" y="49" text-anchor="middle" font-size="10" fill="#6366f1">seal · close · reattach</text>
+  </g>
+  <g transform="translate(240, 332)">
+    <rect x="0" y="0" width="150" height="58" rx="6" fill="white" stroke="#a5b4fc" stroke-width="1.2"/>
+    <text x="75" y="20" text-anchor="middle" font-size="12" fill="#4338ca" font-weight="700">View / Scheduler</text>
+    <text x="75" y="36" text-anchor="middle" font-size="10" fill="#6366f1">region catalog</text>
+    <text x="75" y="49" text-anchor="middle" font-size="10" fill="#6366f1">transition runtime</text>
+  </g>
+
+  <!-- Truth Plane (center) -->
+  <g filter="url(#shadow)">
+    <rect x="425" y="230" width="350" height="180" rx="10" fill="url(#g-truth)" stroke="#8b5cf6" stroke-width="2"/>
+  </g>
+  <rect x="425" y="230" width="350" height="34" rx="10" fill="#8b5cf6"/>
+  <rect x="425" y="258" width="350" height="6" fill="#8b5cf6"/>
+  <text x="445" y="252" font-size="13" font-weight="700" fill="white" letter-spacing="0.8">TRUTH PLANE</text>
+  <text x="755" y="252" text-anchor="end" font-size="11" fill="#ddd6fe" font-weight="500">meta/root/</text>
+
+  <g transform="translate(445, 280)">
+    <rect x="0" y="0" width="310" height="42" rx="6" fill="white" stroke="#c4b5fd" stroke-width="1.2"/>
+    <text x="155" y="18" text-anchor="middle" font-size="13" fill="#6d28d9" font-weight="700">Delos-lite Rooted Truth Kernel</text>
+    <text x="155" y="33" text-anchor="middle" font-size="11" fill="#8b5cf6">Typed event log · Virtual log · Checkpoints</text>
+  </g>
+  <g transform="translate(445, 332)">
+    <rect x="0" y="0" width="150" height="58" rx="6" fill="white" stroke="#c4b5fd" stroke-width="1.2"/>
+    <text x="75" y="20" text-anchor="middle" font-size="12" fill="#6d28d9" font-weight="700">Local Backend</text>
+    <text x="75" y="36" text-anchor="middle" font-size="10" fill="#8b5cf6">single-node truth</text>
+    <text x="75" y="49" text-anchor="middle" font-size="10" fill="#8b5cf6">file + checkpoint</text>
+  </g>
+  <g transform="translate(605, 332)">
+    <rect x="0" y="0" width="150" height="58" rx="6" fill="white" stroke="#c4b5fd" stroke-width="1.2"/>
+    <text x="75" y="20" text-anchor="middle" font-size="12" fill="#6d28d9" font-weight="700">Replicated Backend</text>
+    <text x="75" y="36" text-anchor="middle" font-size="10" fill="#8b5cf6">embedded Raft</text>
+    <text x="75" y="49" text-anchor="middle" font-size="10" fill="#8b5cf6">quorum durability</text>
+  </g>
+
+  <!-- Execution Plane (right) -->
+  <g filter="url(#shadow)">
+    <rect x="790" y="230" width="350" height="180" rx="10" fill="url(#g-execution)" stroke="#10b981" stroke-width="2"/>
+  </g>
+  <rect x="790" y="230" width="350" height="34" rx="10" fill="#10b981"/>
+  <rect x="790" y="258" width="350" height="6" fill="#10b981"/>
+  <text x="810" y="252" font-size="13" font-weight="700" fill="white" letter-spacing="0.8">EXECUTION PLANE</text>
+  <text x="1120" y="252" text-anchor="end" font-size="11" fill="#a7f3d0" font-weight="500">raftstore/</text>
+
+  <g transform="translate(810, 280)">
+    <rect x="0" y="0" width="310" height="42" rx="6" fill="white" stroke="#6ee7b7" stroke-width="1.2"/>
+    <text x="155" y="18" text-anchor="middle" font-size="13" fill="#047857" font-weight="700">Store · Peer · RaftAdmin</text>
+    <text x="155" y="33" text-anchor="middle" font-size="11" fill="#10b981">Multi-Raft region management</text>
+  </g>
+  <g transform="translate(810, 332)">
+    <rect x="0" y="0" width="150" height="58" rx="6" fill="white" stroke="#6ee7b7" stroke-width="1.2"/>
+    <text x="75" y="20" text-anchor="middle" font-size="12" fill="#047857" font-weight="700">LocalMeta</text>
+    <text x="75" y="36" text-anchor="middle" font-size="10" fill="#10b981">replica catalog</text>
+    <text x="75" y="49" text-anchor="middle" font-size="10" fill="#10b981">raft pointers</text>
+  </g>
+  <g transform="translate(970, 332)">
+    <rect x="0" y="0" width="150" height="58" rx="6" fill="white" stroke="#6ee7b7" stroke-width="1.2"/>
+    <text x="75" y="20" text-anchor="middle" font-size="12" fill="#047857" font-weight="700">Snapshot / Transport</text>
+    <text x="75" y="36" text-anchor="middle" font-size="10" fill="#10b981">SST-based install</text>
+    <text x="75" y="49" text-anchor="middle" font-size="10" fill="#10b981">gRPC raft transport</text>
+  </g>
+
+  <!-- Connection lines between planes -->
+  <!-- Control ↔ Truth -->
+  <path d="M 410 320 L 425 320" stroke="#64748b" stroke-width="1.5" fill="none" marker-end="url(#arrow)" marker-start="url(#arrow)"/>
+  <!-- Truth ↔ Execution -->
+  <path d="M 775 320 L 790 320" stroke="#64748b" stroke-width="1.5" fill="none" marker-end="url(#arrow)" marker-start="url(#arrow)"/>
+
+  <!-- Clients → Planes -->
+  <path d="M 210 156 L 210 230" stroke="#94a3b8" stroke-width="1.2" fill="none" marker-end="url(#arrow-dash)" stroke-dasharray="3,3"/>
+  <path d="M 600 156 L 600 230" stroke="#94a3b8" stroke-width="1.2" fill="none" marker-end="url(#arrow-dash)" stroke-dasharray="3,3"/>
+  <path d="M 990 156 L 990 230" stroke="#94a3b8" stroke-width="1.2" fill="none" marker-end="url(#arrow-dash)" stroke-dasharray="3,3"/>
+
+  <!-- ============ STORAGE SUBSTRATE ============ -->
+  <text x="600" y="455" text-anchor="middle" font-size="11" font-weight="700" fill="#475569" letter-spacing="1.5">SHARED STORAGE SUBSTRATE — USED BY EVERY SHAPE</text>
+
+  <g filter="url(#shadow)">
+    <rect x="60" y="470" width="1080" height="140" rx="10" fill="url(#g-substrate)" stroke="#f59e0b" stroke-width="2"/>
+  </g>
+  <rect x="60" y="470" width="1080" height="34" rx="10" fill="#f59e0b"/>
+  <rect x="60" y="498" width="1080" height="6" fill="#f59e0b"/>
+  <text x="80" y="492" font-size="13" font-weight="700" fill="white" letter-spacing="0.8">NoKV DB · engine/</text>
+  <text x="1120" y="492" text-anchor="end" font-size="11" fill="#fde68a" font-weight="500">one substrate, all modes</text>
+
+  <!-- Substrate modules -->
+  <g transform="translate(80, 520)">
+    <rect x="0" y="0" width="160" height="76" rx="6" fill="white" stroke="#fcd34d" stroke-width="1.2"/>
+    <text x="80" y="22" text-anchor="middle" font-size="13" fill="#b45309" font-weight="700">WAL</text>
+    <text x="80" y="40" text-anchor="middle" font-size="10" fill="#d97706">append-only segments</text>
+    <text x="80" y="54" text-anchor="middle" font-size="10" fill="#d97706">CRC · rotation · watchdog</text>
+    <text x="80" y="68" text-anchor="middle" font-size="9" fill="#92400e" font-style="italic">engine/wal/</text>
+  </g>
+  <g transform="translate(260, 520)">
+    <rect x="0" y="0" width="160" height="76" rx="6" fill="white" stroke="#fcd34d" stroke-width="1.2"/>
+    <text x="80" y="22" text-anchor="middle" font-size="13" fill="#b45309" font-weight="700">LSM</text>
+    <text x="80" y="40" text-anchor="middle" font-size="10" fill="#d97706">MemTable · Flush · SST</text>
+    <text x="80" y="54" text-anchor="middle" font-size="10" fill="#d97706">Leveled + Ingest Buffer</text>
+    <text x="80" y="68" text-anchor="middle" font-size="9" fill="#92400e" font-style="italic">engine/lsm/</text>
+  </g>
+  <g transform="translate(440, 520)">
+    <rect x="0" y="0" width="160" height="76" rx="6" fill="white" stroke="#fcd34d" stroke-width="1.2"/>
+    <text x="80" y="22" text-anchor="middle" font-size="13" fill="#b45309" font-weight="700">ValueLog</text>
+    <text x="80" y="40" text-anchor="middle" font-size="10" fill="#d97706">KV separation · buckets</text>
+    <text x="80" y="54" text-anchor="middle" font-size="10" fill="#d97706">parallel GC · discard stats</text>
+    <text x="80" y="68" text-anchor="middle" font-size="9" fill="#92400e" font-style="italic">engine/vlog/</text>
+  </g>
+  <g transform="translate(620, 520)">
+    <rect x="0" y="0" width="160" height="76" rx="6" fill="white" stroke="#fcd34d" stroke-width="1.2"/>
+    <text x="80" y="22" text-anchor="middle" font-size="13" fill="#b45309" font-weight="700">Manifest</text>
+    <text x="80" y="40" text-anchor="middle" font-size="10" fill="#d97706">VersionEdit log</text>
+    <text x="80" y="54" text-anchor="middle" font-size="10" fill="#d97706">atomic CURRENT handoff</text>
+    <text x="80" y="68" text-anchor="middle" font-size="9" fill="#92400e" font-style="italic">engine/manifest/</text>
+  </g>
+  <g transform="translate(800, 520)">
+    <rect x="0" y="0" width="160" height="76" rx="6" fill="white" stroke="#fcd34d" stroke-width="1.2"/>
+    <text x="80" y="22" text-anchor="middle" font-size="13" fill="#b45309" font-weight="700">VFS + FaultFS</text>
+    <text x="80" y="40" text-anchor="middle" font-size="10" fill="#d97706">cross-platform rename</text>
+    <text x="80" y="54" text-anchor="middle" font-size="10" fill="#d97706">18-op fault injection</text>
+    <text x="80" y="68" text-anchor="middle" font-size="9" fill="#92400e" font-style="italic">engine/vfs/</text>
+  </g>
+  <g transform="translate(980, 520)">
+    <rect x="0" y="0" width="140" height="76" rx="6" fill="white" stroke="#fcd34d" stroke-width="1.2"/>
+    <text x="70" y="22" text-anchor="middle" font-size="13" fill="#b45309" font-weight="700">Percolator MVCC</text>
+    <text x="70" y="40" text-anchor="middle" font-size="10" fill="#d97706">prewrite / commit</text>
+    <text x="70" y="54" text-anchor="middle" font-size="10" fill="#d97706">resolve · rollback</text>
+    <text x="70" y="68" text-anchor="middle" font-size="9" fill="#92400e" font-style="italic">percolator/</text>
+  </g>
+
+  <!-- Connection: planes → substrate -->
+  <path d="M 230 410 L 230 470" stroke="#94a3b8" stroke-width="1.2" fill="none" marker-end="url(#arrow-dash)" stroke-dasharray="3,3"/>
+  <path d="M 600 410 L 600 470" stroke="#94a3b8" stroke-width="1.2" fill="none" marker-end="url(#arrow-dash)" stroke-dasharray="3,3"/>
+  <path d="M 960 410 L 960 470" stroke="#94a3b8" stroke-width="1.2" fill="none" marker-end="url(#arrow-dash)" stroke-dasharray="3,3"/>
+
+  <!-- ============ BOTTOM: DEPLOYMENT SHAPES & MIGRATION ============ -->
+  <text x="600" y="650" text-anchor="middle" font-size="11" font-weight="700" fill="#475569" letter-spacing="1.5">THREE DEPLOYMENT SHAPES · ONE MIGRATION PROTOCOL</text>
+
+  <!-- Embedded -->
+  <g filter="url(#shadow)">
+    <rect x="60" y="670" width="280" height="120" rx="10" fill="white" stroke="#94a3b8" stroke-width="1.5"/>
+  </g>
+  <text x="200" y="697" text-anchor="middle" font-size="14" font-weight="700" fill="#0f172a">🧩  Embedded</text>
+  <line x1="85" y1="707" x2="315" y2="707" stroke="#e2e8f0" stroke-width="1"/>
+  <text x="200" y="728" text-anchor="middle" font-size="11" fill="#475569" font-weight="500">Library in a Go program</text>
+  <text x="200" y="746" text-anchor="middle" font-size="10" fill="#64748b">NoKV.Open(opt) · same DB substrate</text>
+  <text x="200" y="760" text-anchor="middle" font-size="10" fill="#64748b">no distributed cost, full engine features</text>
+  <text x="200" y="778" text-anchor="middle" font-size="10" fill="#6366f1" font-weight="600">→ docs/getting_started.md</text>
+
+  <!-- Seeded (middle) -->
+  <g filter="url(#shadow)">
+    <rect x="360" y="670" width="280" height="120" rx="10" fill="url(#g-migration)" stroke="#f43f5e" stroke-width="1.5"/>
+  </g>
+  <text x="500" y="697" text-anchor="middle" font-size="14" font-weight="700" fill="#0f172a">🔀  Seeded · Migration Bridge</text>
+  <line x1="385" y1="707" x2="615" y2="707" stroke="#fecdd3" stroke-width="1"/>
+  <text x="500" y="728" text-anchor="middle" font-size="11" fill="#475569" font-weight="500">plan → init → seeded → expand</text>
+  <text x="500" y="746" text-anchor="middle" font-size="10" fill="#64748b">existing workdir promoted into cluster</text>
+  <text x="500" y="760" text-anchor="middle" font-size="10" fill="#64748b">lifecycle + failpoint at every stage</text>
+  <text x="500" y="778" text-anchor="middle" font-size="10" fill="#e11d48" font-weight="600">→ docs/migration.md</text>
+
+  <!-- Distributed -->
+  <g filter="url(#shadow)">
+    <rect x="660" y="670" width="280" height="120" rx="10" fill="white" stroke="#94a3b8" stroke-width="1.5"/>
+  </g>
+  <text x="800" y="697" text-anchor="middle" font-size="14" font-weight="700" fill="#0f172a">🌐  Distributed</text>
+  <line x1="685" y1="707" x2="915" y2="707" stroke="#e2e8f0" stroke-width="1"/>
+  <text x="800" y="728" text-anchor="middle" font-size="11" fill="#475569" font-weight="500">Multi-Raft replicated mesh</text>
+  <text x="800" y="746" text-anchor="middle" font-size="10" fill="#64748b">three planes active · region-sharded</text>
+  <text x="800" y="760" text-anchor="middle" font-size="10" fill="#64748b">Redis gateway + Coordinator + stores</text>
+  <text x="800" y="778" text-anchor="middle" font-size="10" fill="#6366f1" font-weight="600">→ docs/raftstore.md</text>
+
+  <!-- Formal spec side note -->
+  <g filter="url(#shadow)">
+    <rect x="960" y="670" width="180" height="120" rx="10" fill="#f8fafc" stroke="#8b5cf6" stroke-width="1.5" stroke-dasharray="4,3"/>
+  </g>
+  <text x="1050" y="697" text-anchor="middle" font-size="13" font-weight="700" fill="#6d28d9">📐  Formally Specified</text>
+  <line x1="985" y1="707" x2="1115" y2="707" stroke="#e9d5ff" stroke-width="1"/>
+  <text x="1050" y="726" text-anchor="middle" font-size="10" fill="#475569">6 TLA+ specifications</text>
+  <text x="1050" y="740" text-anchor="middle" font-size="10" fill="#475569">positive + contrast family</text>
+  <text x="1050" y="754" text-anchor="middle" font-size="10" fill="#475569">TLC machine-checked</text>
+  <text x="1050" y="778" text-anchor="middle" font-size="10" fill="#8b5cf6" font-weight="600">→ spec/</text>
+
+  <!-- Arrows: shapes → storage -->
+  <path d="M 200 670 L 200 610" stroke="#cbd5e1" stroke-width="1" fill="none" marker-end="url(#arrow-dash)" stroke-dasharray="3,3"/>
+  <path d="M 500 670 L 500 610" stroke="#fca5a5" stroke-width="1" fill="none" marker-end="url(#arrow-dash)" stroke-dasharray="3,3"/>
+  <path d="M 800 670 L 800 610" stroke="#cbd5e1" stroke-width="1" fill="none" marker-end="url(#arrow-dash)" stroke-dasharray="3,3"/>
+</svg>


### PR DESCRIPTION
- Rewrite root README: punchier hero, front-loaded YCSB benchmarks, Why-NoKV-vs-X table, notable design points with design-note links, formal specs section, simplified modules table
- Rewrite docs/README: GitHub-safe markdown (dropped mdbook-only CSS classes), three-modes table, by-interest navigation, design notes index
- Regroup docs/SUMMARY into six chapters (overview, architecture, storage engine, distributed runtime, operations, design notes); add namespace, rooted_truth, ccc-audit entries
- Add img/architecture.svg: hand-crafted diagram showing three planes (control/truth/execution), shared storage substrate, three deployment shapes, formal specs sidecar
- Embed the new SVG in both READMEs (replaces auto-laid-out Mermaid)
- New docs/namespace.md: LR/LP/LD/LDP layout, coverage state machine, API surface, cost tradeoffs, code map
- New docs/rooted_truth.md: meta/root kernel, two backends, coordinator command path, tail subscription, recovery model
- New docs/ccc-audit.md: snapshot + reply-trace audit CLI, all four trace formats, every anomaly kind, CI usage patterns
- Fix ~12k LOC documentation gap (namespace/meta-root/ccc-audit were previously undocumented)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Redesigned primary README with clearer value positioning, expanded feature descriptions, and integrated benchmark information.
  * Reorganized documentation hub with improved navigation, streamlined sections, and enhanced topic-to-document mapping.
  * Added comprehensive guides for diagnostic tools and distributed runtime components.
  * Enhanced quick-start instructions with updated CLI examples and configuration workflows.
  * Updated architecture documentation with visual references and operational guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->