### PR TITLE
fix(percolator): clean up stale lock on idempotent commit

### DIFF
--- a/percolator/txn.go
+++ b/percolator/txn.go
@@ -322,10 +322,7 @@ func keyErrorCommitTsExpired(key []byte, commitTs, minCommitTs uint64) *kvrpcpb.
 }
 
 func commitKey(db NoKV.MVCCStore, reader *Reader, key []byte, lock *Lock, commitVersion uint64) *kvrpcpb.KeyError {
-	if lock.MinCommitTs > commitVersion {
-		return keyErrorCommitTsExpired(key, commitVersion, lock.MinCommitTs)
-	}
-	write, commitTs, err := reader.GetWriteByStartTs(key, lock.Ts)
+	write, _, err := reader.GetWriteByStartTs(key, lock.Ts)
 	if err != nil {
 		return keyErrorRetryable(err)
 	}
@@ -333,19 +330,19 @@ func commitKey(db NoKV.MVCCStore, reader *Reader, key []byte, lock *Lock, commit
 		if write.Kind == kvrpcpb.Mutation_Rollback {
 			return keyErrorAbort("transaction already rolled back")
 		}
-		if commitTs != commitVersion {
-			// Already committed with a different commit version; treat as success.
-			if err := applyVersionedOps(db, versionedOp{
-				cf:      kv.CFLock,
-				key:     key,
-				version: lockColumnTs,
-				meta:    kv.BitDelete,
-			}); err != nil {
-				return keyErrorRetryable(err)
-			}
-			return nil
+		if err := applyVersionedOps(db, versionedOp{
+			cf:      kv.CFLock,
+			key:     key,
+			version: lockColumnTs,
+			meta:    kv.BitDelete,
+		}); err != nil {
+			return keyErrorRetryable(err)
 		}
 		return nil
+	}
+
+	if lock.MinCommitTs > commitVersion {
+		return keyErrorCommitTsExpired(key, commitVersion, lock.MinCommitTs)
 	}
 
 	entry := EncodeWrite(Write{Kind: lock.Kind, StartTs: lock.Ts})

--- a/percolator/txn_test.go
+++ b/percolator/txn_test.go
@@ -1111,3 +1111,64 @@ func TestCommitTsExpired(t *testing.T) {
 	}
 	require.Nil(t, Commit(db, latches, commitReq))
 }
+
+// TestIdempotentCommitCleansUpLock verifies that a duplicate commit with the same startTs and commitVersion deletes the lock.
+func TestIdempotentCommitCleansUpLock(t *testing.T) {
+	db := openTestDB(t)
+	latches := latch.NewManager(32)
+	key := []byte("k")
+
+	lockVal := EncodeLock(Lock{
+		Primary: key,
+		Ts:      11,
+		TTL:     3000,
+		Kind:    kvrpcpb.Mutation_Put,
+	})
+	applyVersionedEntryForTxnTest(t, db, kv.CFLock, key, lockColumnTs, lockVal, 0)
+
+	writeVal := EncodeWrite(Write{Kind: kvrpcpb.Mutation_Put, StartTs: 11})
+	applyVersionedEntryForTxnTest(t, db, kv.CFWrite, key, 22, writeVal, 0)
+
+	commitReq := &kvrpcpb.CommitRequest{
+		Keys:          [][]byte{key},
+		StartVersion:  11,
+		CommitVersion: 22,
+	}
+	require.Nil(t, Commit(db, latches, commitReq))
+
+	reader := NewReader(db)
+	lock, err := reader.GetLock(key)
+	require.NoError(t, err)
+	require.Nil(t, lock, "idempotent commit must not leave a stale lock")
+}
+
+// TestIdempotentCommitWithPushedMinCommitTs verifies that an idempotent commit cleans up the lock even when MinCommitTs has been pushed past the original commitVersion.
+func TestIdempotentCommitWithPushedMinCommitTs(t *testing.T) {
+	db := openTestDB(t)
+	latches := latch.NewManager(32)
+	key := []byte("k")
+
+	lockVal := EncodeLock(Lock{
+		Primary:     key,
+		Ts:          11,
+		TTL:         3000,
+		Kind:        kvrpcpb.Mutation_Put,
+		MinCommitTs: 30,
+	})
+	applyVersionedEntryForTxnTest(t, db, kv.CFLock, key, lockColumnTs, lockVal, 0)
+
+	writeVal := EncodeWrite(Write{Kind: kvrpcpb.Mutation_Put, StartTs: 11})
+	applyVersionedEntryForTxnTest(t, db, kv.CFWrite, key, 22, writeVal, 0)
+
+	commitReq := &kvrpcpb.CommitRequest{
+		Keys:          [][]byte{key},
+		StartVersion:  11,
+		CommitVersion: 22,
+	}
+	require.Nil(t, Commit(db, latches, commitReq))
+
+	reader := NewReader(db)
+	lock, err := reader.GetLock(key)
+	require.NoError(t, err)
+	require.Nil(t, lock, "idempotent commit must clean lock even when MinCommitTs was pushed")
+}


### PR DESCRIPTION
## Summary
- fix `commitKey` leaving a stale lock in the lock CF when a write with the same `startTs` and `commitVersion` already exists (idempotent commit path)
- always delete the lock when a non-rollback write is found, regardless of commit version match

Closes #42

## Testing
- `go test ./percolator/ -v` (all 43 tests pass, including new `TestIdempotentCommitCleansUpLock`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced idempotent commit handling to ensure proper lock cleanup during transaction retries. The system now correctly identifies and removes stale locks when re-committing the same transaction, improving transaction reliability and preventing lock contention issues that could occur from incomplete cleanup in previous commit attempts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->