### PR TITLE
fix(wal): fence batched fsync during segment rotation

### DIFF
--- a/engine/wal/group_commit_test.go
+++ b/engine/wal/group_commit_test.go
@@ -94,3 +94,55 @@ func TestManagerFsyncBatchedPropagatesSyncErrorToBatch(t *testing.T) {
 	})
 	require.ErrorIs(t, err, injected)
 }
+
+func TestManagerRotateWaitsForInflightBatchedFsync(t *testing.T) {
+	dir := t.TempDir()
+	segment := filepath.Join(dir, "00001.wal")
+	releaseSync := make(chan struct{})
+	syncSeen := make(chan struct{})
+	var once sync.Once
+	policy := vfs.NewFaultPolicy()
+	policy.SetHook(func(op vfs.Op, path string) error {
+		if op == vfs.OpFileSync && path == segment {
+			once.Do(func() {
+				close(syncSeen)
+				<-releaseSync
+			})
+		}
+		return nil
+	})
+	mgr, err := wal.Open(wal.Config{Dir: dir, FS: vfs.NewFaultFSWithPolicy(vfs.OSFS{}, policy)})
+	require.NoError(t, err)
+	defer func() { _ = mgr.Close() }()
+
+	appendDone := make(chan error, 1)
+	go func() {
+		_, err := mgr.AppendRecords(wal.DurabilityFsyncBatched, wal.Record{
+			Type:    wal.RecordTypeRaftEntry,
+			Payload: []byte("pinned"),
+		})
+		appendDone <- err
+	}()
+
+	select {
+	case <-syncSeen:
+	case <-time.After(time.Second):
+		t.Fatalf("expected batched fsync to start")
+	}
+
+	rotateDone := make(chan error, 1)
+	go func() {
+		rotateDone <- mgr.Rotate()
+	}()
+
+	select {
+	case err := <-rotateDone:
+		t.Fatalf("rotate completed while batched fsync still held active segment: %v", err)
+	case <-time.After(20 * time.Millisecond):
+	}
+
+	close(releaseSync)
+	require.NoError(t, <-appendDone)
+	require.NoError(t, <-rotateDone)
+	require.Equal(t, uint32(2), mgr.ActiveSegment())
+}

--- a/engine/wal/manager.go
+++ b/engine/wal/manager.go
@@ -138,10 +138,12 @@ type Manager struct {
 	segmentTotals   map[uint32]RecordMetrics
 	retention       map[string]RetentionFunc
 	fsyncCond       *sync.Cond
+	activeFileCond  *sync.Cond
 	fsyncClosed     bool
 	fsyncBatchSeq   uint64
 	fsyncDurableSeq uint64
 	fsyncErr        error
+	activeSyncRefs  int
 }
 
 // Open creates or resumes a WAL manager.
@@ -162,6 +164,7 @@ func Open(cfg Config) (*Manager, error) {
 		segmentTotals: make(map[uint32]RecordMetrics, 16),
 	}
 	m.fsyncCond = sync.NewCond(&m.mu)
+	m.activeFileCond = sync.NewCond(&m.mu)
 	if err := m.openLatestSegment(); err != nil {
 		return nil, err
 	}
@@ -237,6 +240,7 @@ func (m *Manager) switchSegmentLocked(id uint32, truncate bool) error {
 		if err := m.rebuildActiveCatalogLocked(); err != nil {
 			return err
 		}
+		m.waitActiveSyncRefsLocked()
 		if err := m.active.Close(); err != nil {
 			return err
 		}
@@ -477,7 +481,7 @@ func (m *Manager) runFsyncBatch() {
 		// new appended after this point belongs to a future seq and will be
 		// covered by a subsequent fsync cycle.
 		flushErr := m.flushBufioLocked()
-		active := m.active
+		active := m.pinActiveForSyncLocked(flushErr)
 		m.mu.Unlock()
 
 		// Phase 2 (no lock): the slow fsync syscall runs concurrently with new
@@ -491,6 +495,9 @@ func (m *Manager) runFsyncBatch() {
 		}
 
 		m.mu.Lock()
+		if active != nil {
+			m.unpinActiveSyncLocked()
+		}
 		err := flushErr
 		if err == nil {
 			err = syncErr
@@ -503,6 +510,30 @@ func (m *Manager) runFsyncBatch() {
 		if !more {
 			return
 		}
+	}
+}
+
+func (m *Manager) pinActiveForSyncLocked(flushErr error) vfs.File {
+	if flushErr != nil || m.active == nil {
+		return nil
+	}
+	m.activeSyncRefs++
+	return m.active
+}
+
+func (m *Manager) unpinActiveSyncLocked() {
+	m.activeSyncRefs--
+	if m.activeSyncRefs < 0 {
+		panic("wal: active sync refs underflow")
+	}
+	if m.activeSyncRefs == 0 && m.activeFileCond != nil {
+		m.activeFileCond.Broadcast()
+	}
+}
+
+func (m *Manager) waitActiveSyncRefsLocked() {
+	for m.activeSyncRefs > 0 {
+		m.activeFileCond.Wait()
 	}
 }
 
@@ -649,6 +680,7 @@ func (m *Manager) Close() error {
 	}
 	if m.writer != nil {
 		if err := m.writer.Flush(); err != nil {
+			m.waitActiveSyncRefsLocked()
 			closeErr := m.active.Close()
 			m.active = nil
 			m.writer = nil
@@ -657,6 +689,7 @@ func (m *Manager) Close() error {
 		}
 	}
 	if err := m.active.Sync(); err != nil {
+		m.waitActiveSyncRefsLocked()
 		closeErr := m.active.Close()
 		m.active = nil
 		m.writer = nil
@@ -664,12 +697,14 @@ func (m *Manager) Close() error {
 		return errors.Join(err, closeErr)
 	}
 	if err := m.rebuildActiveCatalogLocked(); err != nil {
+		m.waitActiveSyncRefsLocked()
 		closeErr := m.active.Close()
 		m.active = nil
 		m.writer = nil
 		m.closed = true
 		return errors.Join(err, closeErr)
 	}
+	m.waitActiveSyncRefsLocked()
 	if err := m.active.Close(); err != nil {
 		// Keep state intact so callers can retry Close() on transient close failures.
 		return err


### PR DESCRIPTION
## Summary
- pin the active WAL segment while `DurabilityFsyncBatched` runs an unlocked fsync
- make segment rotation and manager close wait for in-flight batched fsync before closing the fd
- add a regression test that blocks fsync and verifies `Rotate` cannot close the active segment early

## Tests
- `make lint`
- `go test ./engine/wal ./raftstore/raftlog ./raftstore/store -count=1`
