### PR TITLE
perf(lsm): add shard hint cache for memtable reads

### DIFF
--- a/engine/lsm/lsm.go
+++ b/engine/lsm/lsm.go
@@ -44,6 +44,7 @@ import (
 // sharding rationale and routing/recovery/flush invariants.
 type LSM struct {
 	shards     []*lsmShard
+	shardHints *shardHintTable
 	levels     *levelManager
 	option     *Options
 	closer     *utils.Closer
@@ -326,10 +327,11 @@ func NewLSM(opt *Options, walMgrs []*wal.Manager) (*LSM, error) {
 		shards[i] = newLSMShard(i, mgr)
 	}
 	lsm := &LSM{
-		option: frozen,
-		shards: shards,
-		closer: utils.NewCloser(),
-		logger: frozen.Logger,
+		option:     frozen,
+		shards:     shards,
+		shardHints: newShardHintTable(),
+		closer:     utils.NewCloser(),
+		logger:     frozen.Logger,
 	}
 	if lsm.logger == nil {
 		lsm.logger = slog.Default()
@@ -468,6 +470,7 @@ func (lsm *LSM) writeSome(s *lsmShard, batches []*writeBatch) (int, error) {
 		s.lock.RUnlock()
 		panic(fmt.Sprintf("lsm: durable WAL batch could not be applied to memtable: %v", err))
 	}
+	lsm.recordShardHints(s.id, entries)
 	s.lock.RUnlock()
 	return n, nil
 }
@@ -616,15 +619,21 @@ func (lsm *LSM) Get(key []byte) (*kv.Entry, error) {
 	}
 	lsm.closer.Add(1)
 	defer lsm.closer.Done()
+
+	if shardID, ok := lsm.lookupShardHint(key); ok && !lsm.hasRangeTombstones() {
+		tables, release := lsm.getMemTablesForShard(shardID)
+		best := bestMemtableEntry(key, tables)
+		if release != nil {
+			release()
+		}
+		if best != nil {
+			return best, nil
+		}
+	}
+
 	tables, release := lsm.getMemTables()
 	if release != nil {
 		defer release()
-	}
-	isMemHit := func(entry *kv.Entry) bool {
-		if entry == nil {
-			return false
-		}
-		return entry.Value != nil || entry.Meta != 0 || entry.ExpiresAt != 0
 	}
 
 	// isCovered checks range tombstone coverage for a found entry using
@@ -644,27 +653,7 @@ func (lsm *LSM) Get(key []byte) (*kv.Entry, error) {
 	// same userKey may live on more than one shard at different versions.
 	// Walk every memtable and keep the highest-version hit so MVCC reads
 	// see the most recent write regardless of which shard accepted it.
-	var best *kv.Entry
-	for _, mt := range tables {
-		if mt == nil {
-			continue
-		}
-		entry, _ := mt.Get(key)
-		if !isMemHit(entry) {
-			if entry != nil {
-				entry.DecrRef()
-			}
-			continue
-		}
-		if best == nil || entry.Version > best.Version {
-			if best != nil {
-				best.DecrRef()
-			}
-			best = entry
-		} else {
-			entry.DecrRef()
-		}
-	}
+	best := bestMemtableEntry(key, tables)
 	if best != nil {
 		if isCovered(best) {
 			best.DecrRef()
@@ -682,6 +671,61 @@ func (lsm *LSM) Get(key []byte) (*kv.Entry, error) {
 		return nil, utils.ErrKeyNotFound
 	}
 	return entry, nil
+}
+
+func (lsm *LSM) lookupShardHint(key []byte) (int, bool) {
+	if lsm == nil || len(lsm.shards) <= 1 || lsm.shardHints == nil {
+		return 0, false
+	}
+	shardID, ok := lsm.shardHints.lookup(key)
+	if !ok || shardID < 0 || shardID >= len(lsm.shards) {
+		return 0, false
+	}
+	return shardID, true
+}
+
+func (lsm *LSM) recordShardHints(shardID int, entries []*kv.Entry) {
+	if lsm == nil || len(lsm.shards) <= 1 || lsm.shardHints == nil {
+		return
+	}
+	for _, entry := range entries {
+		if entry == nil || len(entry.Key) == 0 {
+			continue
+		}
+		lsm.shardHints.remember(entry.Key, shardID)
+	}
+}
+
+func bestMemtableEntry(key []byte, tables []*memTable) *kv.Entry {
+	var best *kv.Entry
+	for _, mt := range tables {
+		if mt == nil {
+			continue
+		}
+		entry, _ := mt.Get(key)
+		if !isMemtableHit(entry) {
+			if entry != nil {
+				entry.DecrRef()
+			}
+			continue
+		}
+		if best == nil || entry.Version > best.Version {
+			if best != nil {
+				best.DecrRef()
+			}
+			best = entry
+		} else {
+			entry.DecrRef()
+		}
+	}
+	return best
+}
+
+func isMemtableHit(entry *kv.Entry) bool {
+	if entry == nil {
+		return false
+	}
+	return entry.Value != nil || entry.Meta != 0 || entry.ExpiresAt != 0
 }
 
 // MemSize returns the active memtable memory usage summed across shards.
@@ -763,6 +807,54 @@ func (lsm *LSM) getMemTables() ([]*memTable, func()) {
 			tbl.DecrRef()
 		}
 	}
+}
+
+func (lsm *LSM) getMemTablesForShard(shardID int) ([]*memTable, func()) {
+	if lsm == nil || shardID < 0 || shardID >= len(lsm.shards) {
+		return nil, nil
+	}
+	s := lsm.shards[shardID]
+	s.lock.RLock()
+	defer s.lock.RUnlock()
+	tables := make([]*memTable, 0, 1+len(s.immutables))
+	if s.memTable != nil {
+		tables = append(tables, s.memTable)
+		s.memTable.IncrRef()
+	}
+	last := len(s.immutables) - 1
+	for i := range s.immutables {
+		tables = append(tables, s.immutables[last-i])
+		s.immutables[last-i].IncrRef()
+	}
+	return tables, func() {
+		for _, tbl := range tables {
+			tbl.DecrRef()
+		}
+	}
+}
+
+func (lsm *LSM) hasRangeTombstones() bool {
+	if lsm == nil {
+		return false
+	}
+	if lsm.levels != nil && lsm.levels.rtCollector != nil && lsm.levels.rtCollector.Count() > 0 {
+		return true
+	}
+	for _, s := range lsm.shards {
+		s.lock.RLock()
+		if s.memTable != nil && s.memTable.hasRangeTombstones() {
+			s.lock.RUnlock()
+			return true
+		}
+		for _, mt := range s.immutables {
+			if mt != nil && mt.hasRangeTombstones() {
+				s.lock.RUnlock()
+				return true
+			}
+		}
+		s.lock.RUnlock()
+	}
+	return false
 }
 
 func (lsm *LSM) submitFlush(mt *memTable) error {

--- a/engine/lsm/shard_hint.go
+++ b/engine/lsm/shard_hint.go
@@ -1,0 +1,73 @@
+package lsm
+
+import (
+	"bytes"
+	"sync"
+
+	xxhash "github.com/cespare/xxhash/v2"
+	"github.com/feichai0017/NoKV/engine/kv"
+)
+
+const defaultShardHintBuckets = 1 << 16
+
+type shardHintTable struct {
+	mask    uint64
+	buckets []shardHintBucket
+}
+
+type shardHintBucket struct {
+	mu    sync.RWMutex
+	hash  uint64
+	key   []byte
+	shard int
+	valid bool
+}
+
+func newShardHintTable() *shardHintTable {
+	return &shardHintTable{
+		mask:    defaultShardHintBuckets - 1,
+		buckets: make([]shardHintBucket, defaultShardHintBuckets),
+	}
+}
+
+func (h *shardHintTable) lookup(internalKey []byte) (int, bool) {
+	if h == nil || len(h.buckets) == 0 {
+		return 0, false
+	}
+	baseKey, hash, ok := shardHintKey(internalKey)
+	if !ok {
+		return 0, false
+	}
+	b := &h.buckets[hash&h.mask]
+	b.mu.RLock()
+	defer b.mu.RUnlock()
+	if !b.valid || b.hash != hash || !bytes.Equal(b.key, baseKey) {
+		return 0, false
+	}
+	return b.shard, true
+}
+
+func (h *shardHintTable) remember(internalKey []byte, shardID int) {
+	if h == nil || len(h.buckets) == 0 || shardID < 0 {
+		return
+	}
+	baseKey, hash, ok := shardHintKey(internalKey)
+	if !ok {
+		return
+	}
+	b := &h.buckets[hash&h.mask]
+	b.mu.Lock()
+	b.hash = hash
+	b.key = append(b.key[:0], baseKey...)
+	b.shard = shardID
+	b.valid = true
+	b.mu.Unlock()
+}
+
+func shardHintKey(internalKey []byte) ([]byte, uint64, bool) {
+	baseKey := kv.InternalToBaseKey(internalKey)
+	if len(baseKey) == 0 {
+		return nil, 0, false
+	}
+	return baseKey, xxhash.Sum64(baseKey), true
+}

--- a/engine/lsm/shard_hint_test.go
+++ b/engine/lsm/shard_hint_test.go
@@ -1,0 +1,106 @@
+package lsm
+
+import (
+	"fmt"
+	"path/filepath"
+	"testing"
+
+	"github.com/feichai0017/NoKV/engine/kv"
+	"github.com/feichai0017/NoKV/engine/wal"
+	"github.com/feichai0017/NoKV/utils"
+	"github.com/stretchr/testify/require"
+)
+
+func openShardHintTestLSM(t *testing.T, shardCount int) (*LSM, []*wal.Manager) {
+	t.Helper()
+	dir := t.TempDir()
+	opts := newTestLSMOptions(dir, nil)
+	wals := make([]*wal.Manager, shardCount)
+	for i := range wals {
+		mgr, err := wal.Open(wal.Config{Dir: filepath.Join(dir, fmt.Sprintf("wal-%02d", i))})
+		require.NoError(t, err)
+		wals[i] = mgr
+	}
+	lsm, err := NewLSM(opts, wals)
+	require.NoError(t, err)
+	return lsm, wals
+}
+
+func closeShardHintTestLSM(t *testing.T, lsm *LSM, wals []*wal.Manager) {
+	t.Helper()
+	require.NoError(t, lsm.Close())
+	for _, mgr := range wals {
+		require.NoError(t, mgr.Close())
+	}
+}
+
+func TestShardHintTracksSuccessfulWrites(t *testing.T) {
+	lsm, wals := openShardHintTestLSM(t, 4)
+	defer closeShardHintTestLSM(t, lsm, wals)
+
+	userKey := []byte("hint-key")
+	v1 := kv.NewInternalEntry(kv.CFDefault, userKey, 1, []byte("v1"), 0, 0)
+	_, err := lsm.SetBatchGroup(1, [][]*kv.Entry{{v1}})
+	require.NoError(t, err)
+
+	query := kv.InternalKey(kv.CFDefault, userKey, kv.MaxVersion)
+	shardID, ok := lsm.lookupShardHint(query)
+	require.True(t, ok)
+	require.Equal(t, 1, shardID)
+
+	v2 := kv.NewInternalEntry(kv.CFDefault, userKey, 2, []byte("v2"), 0, 0)
+	_, err = lsm.SetBatchGroup(3, [][]*kv.Entry{{v2}})
+	require.NoError(t, err)
+
+	shardID, ok = lsm.lookupShardHint(query)
+	require.True(t, ok)
+	require.Equal(t, 3, shardID)
+
+	got, err := lsm.Get(query)
+	require.NoError(t, err)
+	require.Equal(t, []byte("v2"), got.Value)
+	got.DecrRef()
+}
+
+func TestShardHintFallsBackWhenHintMissesMemtable(t *testing.T) {
+	lsm, wals := openShardHintTestLSM(t, 4)
+	defer closeShardHintTestLSM(t, lsm, wals)
+
+	userKey := []byte("fallback-key")
+	entry := kv.NewInternalEntry(kv.CFDefault, userKey, 7, []byte("visible"), 0, 0)
+	_, err := lsm.SetBatchGroup(2, [][]*kv.Entry{{entry}})
+	require.NoError(t, err)
+
+	query := kv.InternalKey(kv.CFDefault, userKey, kv.MaxVersion)
+	lsm.shardHints.remember(query, 0)
+
+	got, err := lsm.Get(query)
+	require.NoError(t, err)
+	require.Equal(t, []byte("visible"), got.Value)
+	got.DecrRef()
+}
+
+func TestShardHintDoesNotBypassRangeTombstones(t *testing.T) {
+	lsm, wals := openShardHintTestLSM(t, 4)
+	defer closeShardHintTestLSM(t, lsm, wals)
+
+	point := kv.NewInternalEntry(kv.CFDefault, []byte("m"), 1, []byte("old"), 0, 0)
+	_, err := lsm.SetBatchGroup(1, [][]*kv.Entry{{point}})
+	require.NoError(t, err)
+	query := kv.InternalKey(kv.CFDefault, []byte("m"), kv.MaxVersion)
+	shardID, ok := lsm.lookupShardHint(query)
+	require.True(t, ok)
+	require.Equal(t, 1, shardID)
+
+	rt := kv.NewEntry(kv.InternalKey(kv.CFDefault, []byte("a"), 10), []byte("z"))
+	rt.Meta = kv.BitRangeDelete
+	_, err = lsm.SetBatchGroup(3, [][]*kv.Entry{{rt}})
+	require.NoError(t, err)
+	require.True(t, lsm.hasRangeTombstones())
+
+	got, err := lsm.Get(query)
+	if got != nil {
+		got.DecrRef()
+	}
+	require.ErrorIs(t, err, utils.ErrKeyNotFound)
+}


### PR DESCRIPTION
## Summary
- add an exact-match base-key shard hint table for sharded LSM memtable reads
- update hints only after a WAL batch has been durably applied to the target memtable
- use hints only as a fast path: misses, stale hints, collisions, or range tombstones fall back to the existing all-shard merge path

## Tests
- `make fmt`
- `make lint`
- `go test ./engine/lsm -run 'ShardHint|SetBatchGroup|RangeTombstone' -count=1`\n- `go test ./engine/lsm ./engine/wal . -count=1`\n