### PR TITLE
Remove redundant emphasis from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,10 +8,6 @@
   </p>
 
   <p>
-    <em>Native fsmeta primitives · Own LSM · Own Raft · Own MVCC · Own control plane</em>
-  </p>
-
-  <p>
     <a href="https://github.com/feichai0017/NoKV/actions"><img alt="CI" src="https://img.shields.io/github/actions/workflow/status/feichai0017/NoKV/go.yml?branch=main" /></a>
     <a href="https://codecov.io/gh/feichai0017/NoKV"><img alt="Coverage" src="https://img.shields.io/codecov/c/gh/feichai0017/NoKV" /></a>
     <a href="https://goreportcard.com/report/github.com/feichai0017/NoKV"><img alt="Go Report Card" src="https://img.shields.io/badge/go%20report-A+-brightgreen" /></a>


### PR DESCRIPTION
Removed unnecessary emphasis on native fsmeta primitives and related features.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the README by removing a highlighted italicized descriptor paragraph about technologies and primitives from the header section. All core introduction elements—including the project logo, main title, primary description, and supporting badge links—remain fully intact, resulting in a cleaner and more streamlined first impression.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->