### PR TITLE
ci: skip Codecov upload in private mirror

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -21,13 +21,13 @@ jobs:
           go test ./... -coverprofile=coverage.out
           awk 'NR == 1 || $0 !~ /(\.pb\.go:|_grpc\.pb\.go:)/' coverage.out > coverage.filtered.out
           mv coverage.filtered.out coverage.out
-      # Upload coverage only from the public repository. The private mirror
-      # carries research artifacts and Codecov rejects tokenless uploads from
-      # private repositories; tests still run there, but coverage upload is not
-      # part of the private CI contract. Also skip Dependabot because GitHub does
-      # not expose repo secrets to Dependabot-triggered runs by default.
+      # Upload coverage only from trusted public-repo contexts. The private
+      # mirror carries research artifacts and Codecov rejects tokenless uploads
+      # from private repositories; fork and Dependabot PRs also do not receive
+      # CODECOV_TOKEN. Tests still run in those contexts, but coverage upload is
+      # not part of their CI contract.
       - name: Upload coverage to Codecov
-        if: github.repository == 'feichai0017/NoKV' && github.actor != 'dependabot[bot]'
+        if: github.repository == 'feichai0017/NoKV' && github.actor != 'dependabot[bot]' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
         uses: codecov/codecov-action@v6
         with:
           files: coverage.out

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -21,15 +21,13 @@ jobs:
           go test ./... -coverprofile=coverage.out
           awk 'NR == 1 || $0 !~ /(\.pb\.go:|_grpc\.pb\.go:)/' coverage.out > coverage.filtered.out
           mv coverage.filtered.out coverage.out
-      # Skip codecov upload on Dependabot PRs: GitHub does not expose
-      # repo secrets to Dependabot-triggered workflow runs by default
-      # (security policy), so secrets.CODECOV_TOKEN is empty there and
-      # codecov-action's pre-check fails with a misleading 'missing
-      # dependency: gpg' error. We still gate codecov hard on push-to-
-      # main and human-authored PRs via fail_ci_if_error: true, so
-      # coverage regressions stay blocking on the actual code paths.
+      # Upload coverage only from the public repository. The private mirror
+      # carries research artifacts and Codecov rejects tokenless uploads from
+      # private repositories; tests still run there, but coverage upload is not
+      # part of the private CI contract. Also skip Dependabot because GitHub does
+      # not expose repo secrets to Dependabot-triggered runs by default.
       - name: Upload coverage to Codecov
-        if: github.actor != 'dependabot[bot]'
+        if: github.repository == 'feichai0017/NoKV' && github.actor != 'dependabot[bot]'
         uses: codecov/codecov-action@v6
         with:
           files: coverage.out


### PR DESCRIPTION
## Summary
- upload Codecov reports only from the public `feichai0017/NoKV` repository
- keep Go coverage tests running in the private mirror while skipping Codecov upload there
- preserve the existing Dependabot skip condition

## Why
The private mirror does not have a valid Codecov token for tokenless private uploads, so `test-and-coverage` fails after tests pass. The public repository remains the only coverage upload source.

## Validation
- `git diff --check HEAD~1..HEAD`
- verified the target tree contains none of the private-only paths before pushing

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**No user-facing changes.** This release contains internal infrastructure updates to continuous integration workflows only.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->