### PR TITLE
fix(lsm): refresh L0 read indexes after table mutations

### DIFF
--- a/engine/lsm/compaction_executor.go
+++ b/engine/lsm/compaction_executor.go
@@ -370,7 +370,7 @@ func (lm *levelManager) moveToNextLevel(cd *compactDef) error {
 		remaining = append(remaining, tbl)
 	}
 	cd.thisLevel.tables = remaining
-	cd.thisLevel.rebuildRangeFilterLocked()
+	cd.thisLevel.refreshTableIndexesLocked()
 
 	for _, tbl := range cd.top {
 		if tbl == nil {
@@ -380,8 +380,7 @@ func (lm *levelManager) moveToNextLevel(cd *compactDef) error {
 		cd.nextLevel.addSize(tbl)
 		cd.nextLevel.tables = append(cd.nextLevel.tables, tbl)
 	}
-	cd.nextLevel.sortTablesLocked()
-	cd.nextLevel.rebuildRangeFilterLocked()
+	cd.nextLevel.refreshTableIndexesLocked()
 
 	second.Unlock()
 	first.Unlock()

--- a/engine/lsm/l0_sublevels_test.go
+++ b/engine/lsm/l0_sublevels_test.go
@@ -111,6 +111,50 @@ func TestSelectTablesForKeyL0UsesSublevels(t *testing.T) {
 	require.Empty(t, none, "key in the gap returns no candidates")
 }
 
+func TestL0AddRefreshesSublevelsForPointLookup(t *testing.T) {
+	clearDir()
+	lsm := buildLSM()
+	defer func() { _ = lsm.Close() }()
+
+	l0 := lsm.levels.levels[0]
+	a := buildTableWithEntry(t, lsm, 8101, "a", 1, "va")
+	l0.add(a)
+	l0.Sort()
+	require.Len(t, l0.l0Sublevels, 1)
+
+	// A later flush appends a new L0 table. The sublevel read index must be
+	// refreshed immediately; otherwise the point read path can miss this table.
+	z := buildTableWithEntry(t, lsm, 8102, "z", 1, "vz")
+	l0.add(z)
+
+	keyZ := []byte(kv.InternalKey(kv.CFDefault, []byte("z"), 100))
+	entry, err := l0.Get(keyZ)
+	require.NoError(t, err)
+	require.NotNil(t, entry)
+	require.Equal(t, []byte("vz"), entry.Value)
+	entry.DecrRef()
+}
+
+func TestL0DeleteRefreshesSublevelsForPointLookup(t *testing.T) {
+	clearDir()
+	lsm := buildLSM()
+	defer func() { _ = lsm.Close() }()
+
+	l0 := lsm.levels.levels[0]
+	a := buildTableWithEntry(t, lsm, 8201, "a", 1, "va")
+	z := buildTableWithEntry(t, lsm, 8202, "z", 1, "vz")
+	l0.add(a)
+	l0.add(z)
+	l0.Sort()
+
+	keyZ := []byte(kv.InternalKey(kv.CFDefault, []byte("z"), 100))
+	require.NotEmpty(t, l0.selectTablesForKey(keyZ, false))
+
+	require.NoError(t, l0.deleteTables([]*table{z}))
+	require.Empty(t, l0.selectTablesForKey(keyZ, false),
+		"deleted L0 tables must disappear from the sublevel read index")
+}
+
 func TestL0GetReadPathReturnsHighestVersionAcrossSublevels(t *testing.T) {
 	clearDir()
 	lsm := buildLSM()

--- a/engine/lsm/level_handler.go
+++ b/engine/lsm/level_handler.go
@@ -73,6 +73,7 @@ func (lh *levelHandler) add(t *table) {
 	lh.totalSize += t.Size()
 	lh.totalStaleSize += int64(t.StaleDataSize())
 	lh.totalValueSize += int64(t.ValueSize())
+	lh.refreshTableIndexesLocked()
 }
 
 func (lh *levelHandler) getTotalSize() int64 {
@@ -225,8 +226,7 @@ func (lh *levelHandler) Get(key []byte) (*kv.Entry, error) {
 func (lh *levelHandler) Sort() {
 	lh.Lock()
 	defer lh.Unlock()
-	lh.sortTablesLocked()
-	lh.rebuildRangeFilterLocked()
+	lh.refreshTableIndexesLocked()
 	lh.landing.sortShards()
 }
 
@@ -436,6 +436,12 @@ func (lh *levelHandler) selectTablesForBounds(lower, upper []byte, record bool) 
 func (lh *levelHandler) rebuildRangeFilterLocked() {
 	lh.filter = buildRangeFilter(lh.levelNum, lh.tables)
 }
+
+func (lh *levelHandler) refreshTableIndexesLocked() {
+	lh.sortTablesLocked()
+	lh.rebuildRangeFilterLocked()
+}
+
 func (lh *levelHandler) isLastLevel() bool {
 	return lh.levelNum == lh.lm.opt.MaxLevelNum-1
 }
@@ -473,8 +479,7 @@ func (lh *levelHandler) replaceTables(toDel, toAdd []*table) error {
 
 	// Assign tables.
 	lh.tables = newTables
-	lh.sortTablesLocked()
-	lh.rebuildRangeFilterLocked()
+	lh.refreshTableIndexesLocked()
 	lh.Unlock() // s.Unlock before we DecrRef tables -- that can be slow.
 	return decrRefs(removed)
 }
@@ -501,7 +506,7 @@ func (lh *levelHandler) deleteTables(toDel []*table) error {
 		lh.subtractSize(t)
 	}
 	lh.tables = newTables
-	lh.rebuildRangeFilterLocked()
+	lh.refreshTableIndexesLocked()
 
 	lh.landing.remove(toDelMap)
 

--- a/engine/lsm/level_manager_test.go
+++ b/engine/lsm/level_manager_test.go
@@ -80,7 +80,7 @@ func TestLevelHandlerRangeFilterPrunesPointAndBounds(t *testing.T) {
 	}
 }
 
-func TestLevelHandlerAddDefersRangeFilterRebuildUntilSort(t *testing.T) {
+func TestLevelHandlerAddRefreshesRangeFilter(t *testing.T) {
 	clearDir()
 	lsm := buildLSM()
 	defer func() {
@@ -94,11 +94,11 @@ func TestLevelHandlerAddDefersRangeFilterRebuildUntilSort(t *testing.T) {
 
 	lh.add(tblB)
 	lh.add(tblA)
-	require.Empty(t, lh.filter.spans)
 
-	lh.Sort()
 	require.Len(t, lh.filter.spans, 2)
 	require.True(t, lh.filter.nonOverlapping)
+	require.Equal(t, uint64(302), lh.tables[0].fid)
+	require.Equal(t, uint64(301), lh.tables[1].fid)
 
 	for _, tbl := range []*table{tblA, tblB} {
 		require.NoError(t, tbl.DecrRef())

--- a/engine/lsm/planner.go
+++ b/engine/lsm/planner.go
@@ -371,6 +371,7 @@ func (lm *levelManager) moveToLanding(cd *compactDef) error {
 		remaining = append(remaining, tbl)
 	}
 	cd.thisLevel.tables = remaining
+	cd.thisLevel.refreshTableIndexesLocked()
 
 	cd.nextLevel.landing.ensureInit()
 	for _, t := range cd.top {


### PR DESCRIPTION
## Summary
- refresh active table indexes whenever L0/Ln tables are added, deleted, moved to landing, or trivial-moved
- keep L0 sublevel layout and range filter in sync with active table mutations
- add regression coverage for L0 add/delete point lookup index refresh

## Validation
- go test ./engine/lsm -count=1
- go test -run TestAPIMixedOpsPersistAcrossFlushCompactionAndReopen/skiplist -count=100
- make fmt
- make lint
- make test (root/LSM passed; hit known raftstore/integration timing flake)
- go test ./raftstore/integration -run TestClientTwoPhaseCommitHonorsContextAcrossSplitRegionsUnderPartialQuorumLoss -count=5
