### PR TITLE
ci: stabilize coverage workflow

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -18,7 +18,8 @@ jobs:
           go-version: '1.26.2'
       - name: Test with coverage
         run: |
-          go test ./... -coverprofile=coverage.out
+          mapfile -t packages < <(go list ./... | grep -v '/integration$')
+          go test "${packages[@]}" -coverprofile=coverage.out
           awk 'NR == 1 || $0 !~ /(\.pb\.go:|_grpc\.pb\.go:)/' coverage.out > coverage.filtered.out
           mv coverage.filtered.out coverage.out
       # Upload coverage only from trusted public-repo contexts. The private

--- a/Makefile
+++ b/Makefile
@@ -57,7 +57,7 @@ test-race:
 # Run tests with coverage
 test-coverage:
 	@echo "Running tests with coverage..."
-	go test -v -coverprofile=coverage.out -covermode=atomic ./...
+	go test -v -coverprofile=coverage.out -covermode=atomic $$(go list ./... | grep -v '/integration$$')
 	@echo "✓ Coverage report generated: coverage.out"
 	@echo "  View with: go tool cover -html=coverage.out"
 

--- a/coordinator/testcluster/cluster.go
+++ b/coordinator/testcluster/cluster.go
@@ -27,12 +27,17 @@ type Cluster struct {
 	Services   map[uint64]*coordserver.Service
 }
 
+const stableRootTickInterval = 250 * time.Millisecond
+
 func OpenReplicated(tb testing.TB) *Cluster {
 	return OpenReplicatedWithTickIntervals(tb, nil)
 }
 
 func OpenReplicatedWithTickIntervals(tb testing.TB, tickIntervals map[uint64]time.Duration) *Cluster {
 	tb.Helper()
+	if tickIntervals == nil {
+		tickIntervals = stableRootTickIntervals()
+	}
 
 	peerAddrs := make(map[uint64]string, 3)
 	transports := make(map[uint64]rootreplicated.Transport, 3)
@@ -79,6 +84,16 @@ func OpenReplicatedWithTickIntervals(tb testing.TB, tickIntervals map[uint64]tim
 	}
 	tb.Cleanup(func() { c.Close() })
 	return c
+}
+
+func stableRootTickIntervals() map[uint64]time.Duration {
+	// Coverage builds and heavily parallel CI runs add enough scheduler jitter
+	// to make the production-like 100ms tick produce split elections in tests.
+	return map[uint64]time.Duration{
+		1: stableRootTickInterval,
+		2: stableRootTickInterval,
+		3: stableRootTickInterval,
+	}
 }
 
 func (c *Cluster) Close() {

--- a/meta/root/replicated/test_helpers_test.go
+++ b/meta/root/replicated/test_helpers_test.go
@@ -27,10 +27,11 @@ func openNetworkTestCluster(t *testing.T, maxRetainedRecords int) (map[uint64]*S
 	drivers := map[uint64]*NetworkDriver{}
 	for _, id := range []uint64{1, 2, 3} {
 		driver, err := NewNetworkDriver(NetworkConfig{
-			ID:        id,
-			WorkDir:   t.TempDir(),
-			PeerIDs:   []uint64{1, 2, 3},
-			Transport: transports[id],
+			ID:           id,
+			WorkDir:      t.TempDir(),
+			PeerIDs:      []uint64{1, 2, 3},
+			Transport:    transports[id],
+			TickInterval: 250 * time.Millisecond,
 		})
 		require.NoError(t, err)
 		drivers[id] = driver


### PR DESCRIPTION
## Summary
- exclude integration-only packages from the coverage job; the Go workflow still runs them normally
- use slower test-only replicated-root ticks in coordinator and meta/root helpers to avoid coverage/scheduler-induced split elections
- keep production replicated-root tick defaults unchanged

## Validation
- make fmt
- make lint
- go test ./meta/root/replicated -coverprofile=/tmp/rootrep.cover -count=3
- bash -lc 'mapfile -t packages < <(go list ./... | grep -v "/integration$"); go test "${packages[@]}" -coverprofile=/tmp/nokv.coverage.out'
- make test

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test cluster initialization to use stable, deterministic tick interval defaults for improved test reproducibility.
  * Modified test helper network driver configuration to include explicit timing parameters.

* **Chores**
  * Coverage testing now excludes integration test packages from analysis.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->