### PR TITLE
feat(fsmeta): close substrate semantics gaps

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ NoKV is that layer, open-sourced and namespace-native: server-side `ReadDirPlus`
 
 - 🗂️ **Distributed filesystems** — DFS frontends (FUSE / NFS / SMB drivers, JuiceFS / CubeFS-style services) consume `fsmeta` for inode / dentry / mount / subtree authority instead of writing their own metadata layer on top of Redis / TiKV / FoundationDB
 - 🪣 **Object storage namespace layers** — S3-compatible gateways consume the same `fsmeta` for bucket / prefix / version metadata, getting fast `LIST` (server-side `ReadDirPlus`) and prefix-scoped event streams without client-side stitching
-- 🧪 **AI dataset metadata** — checkpoint storms (atomic multi-key `AssertionNotExist`), dataset versioning (`SnapshotSubtree`), prefix-scoped change feeds for training pipelines (`WatchSubtree`) — without retrofitting them onto a generic KV
+- 🧪 **AI dataset and agent workspace metadata** — checkpoint storms (atomic multi-key `AssertionNotExist`), point-in-time namespace reads (`SnapshotSubtree`; long-lived retention is a GC boundary), prefix-scoped change feeds for training pipelines and shared agent workspaces (`WatchSubtree`) — without retrofitting them onto a generic KV
 
 > NoKV does for namespace metadata what etcd did for cluster state: a purpose-built coordination layer instead of forcing engineers to re-derive namespace semantics on every project.
 
@@ -112,7 +112,7 @@ Native API surface (gRPC at `nokv-fsmeta:8090`, also embedded Go via `fsmeta/exe
 |---|---|
 | `ReadDirPlus` | Fused directory scan + batch inode fetch under one snapshot, avoiding client-side N+1 metadata reads |
 | `WatchSubtree` | Prefix-scoped live change feed with ready signal, cursor replay, and flow-control acks |
-| `SnapshotSubtree` | MVCC read-version token for stable dataset / bucket / directory views |
+| `SnapshotSubtree` | MVCC read-version token for point-in-time dataset / bucket / directory reads; long-lived retention is a GC-layer boundary |
 | `RenameSubtree` | Cross-region atomic namespace move backed by Percolator 2PC |
 | Basic namespace ops | `Create`, `Lookup`, `ReadDir`, `Link`, `Unlink`, quota usage, and mount lifecycle |
 

--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -101,9 +101,22 @@ NOKV_FSMETA_BENCH=1 go test ./fsmeta -run TestBenchmarkFSMeta -count=1 -v -args 
   -fsmeta_drivers native-fsmeta,generic-kv \
   -fsmeta_addr 127.0.0.1:8090 \
   -fsmeta_coordinator_addr 127.0.0.1:2379 \
-  -fsmeta_workloads checkpoint-storm,hotspot-fanin \
+  -fsmeta_workloads checkpoint-storm,hotspot-fanin,negative-lookup \
   -fsmeta_readdirplus=true
 ```
+
+For derived-cache runs, start `nokv-fsmeta` with:
+
+```bash
+nokv-fsmeta \
+  --negative-cache-dir /tmp/nokv-fsmeta-negative \
+  --dirpage-cache-dir /tmp/nokv-fsmeta-dirpage
+```
+
+Then compare:
+
+- `hotspot-fanin` with `-fsmeta_readdirplus=true` for the DirPage cache path.
+- `negative-lookup` for repeated missing dentry probes and the NegativeCache path.
 
 The summary CSV is written under `data/fsmeta/results/` unless
 `-fsmeta_output` is set. Rows include a `driver` column so native and generic

--- a/benchmark/cmd/fsmeta-demo/main.go
+++ b/benchmark/cmd/fsmeta-demo/main.go
@@ -16,7 +16,7 @@ import (
 func main() {
 	var (
 		addr           = flag.String("addr", "127.0.0.1:8090", "FSMetadata gRPC endpoint")
-		workloadName   = flag.String("workload", workload.CheckpointStorm, "workload: checkpoint-storm|hotspot-fanin|watch-subtree")
+		workloadName   = flag.String("workload", workload.CheckpointStorm, "workload: checkpoint-storm|hotspot-fanin|watch-subtree|negative-lookup")
 		mount          = flag.String("mount", "fsmeta-demo", "fsmeta mount id")
 		runID          = flag.String("run-id", "", "run id suffix; defaults to current UTC timestamp")
 		clients        = flag.Int("clients", 4, "concurrent clients")
@@ -117,6 +117,15 @@ func run(ctx context.Context, cli workload.Client, cfg runConfig) (workload.Resu
 			Files:              cfg.files,
 			StartInode:         cfg.startInode,
 			BackPressureWindow: cfg.watchWindow,
+		})
+	case workload.NegativeLookup:
+		return workload.RunNegativeLookup(ctx, cli, workload.NegativeLookupConfig{
+			Mount:          cfg.mount,
+			RunID:          cfg.runID,
+			Clients:        cfg.clients,
+			Keys:           cfg.files,
+			ReadsPerClient: cfg.readsPerClient,
+			Parent:         fsmeta.RootInode,
 		})
 	default:
 		return workload.Result{}, fmt.Errorf("unknown workload %q", cfg.name)

--- a/benchmark/fsmeta/fsmeta_bench_test.go
+++ b/benchmark/fsmeta/fsmeta_bench_test.go
@@ -29,7 +29,7 @@ var (
 	fsmetaDrivers        = flag.String("fsmeta_drivers", workload.DriverNativeFSMetadata, "comma-separated drivers: native-fsmeta,generic-kv")
 	fsmetaAddr           = flag.String("fsmeta_addr", "127.0.0.1:8090", "FSMetadata gRPC endpoint")
 	fsmetaCoordAddr      = flag.String("fsmeta_coordinator_addr", "127.0.0.1:2379", "Coordinator gRPC endpoint for generic-kv driver")
-	fsmetaWorkloads      = flag.String("fsmeta_workloads", "checkpoint-storm,hotspot-fanin", "comma-separated workloads")
+	fsmetaWorkloads      = flag.String("fsmeta_workloads", "checkpoint-storm,hotspot-fanin", "comma-separated workloads: checkpoint-storm,hotspot-fanin,watch-subtree,negative-lookup")
 	fsmetaMount          = flag.String("fsmeta_mount", "fsmeta-bench", "fsmeta mount id")
 	fsmetaClients        = flag.Int("fsmeta_clients", 8, "concurrent clients")
 	fsmetaDirs           = flag.Int("fsmeta_dirs", 16, "checkpoint-storm directory count")
@@ -217,6 +217,15 @@ func runBenchmarkWorkload(ctx context.Context, cli workload.Client, driverName, 
 			Files:              *fsmetaFiles,
 			StartInode:         startInode + 2_000_000,
 			BackPressureWindow: uint32(*fsmetaWatchWindow),
+		})
+	case workload.NegativeLookup:
+		result, err = workload.RunNegativeLookup(ctx, cli, workload.NegativeLookupConfig{
+			Mount:          fsmeta.MountID(*fsmetaMount),
+			RunID:          runID,
+			Clients:        *fsmetaClients,
+			Keys:           *fsmetaFiles,
+			ReadsPerClient: *fsmetaReadsPerClient,
+			Parent:         fsmeta.RootInode,
 		})
 	default:
 		return workload.Result{}, fmt.Errorf("unknown workload %q", workloadName)

--- a/benchmark/fsmeta/workload/generic_kv.go
+++ b/benchmark/fsmeta/workload/generic_kv.go
@@ -108,6 +108,30 @@ func (d *GenericKVDriver) Create(ctx context.Context, req fsmeta.CreateRequest, 
 	return d.runner.Mutate(ctx, plan.PrimaryKey, mutations, startVersion, commitVersion, d.lockTTL)
 }
 
+// Lookup models a schema-over-KV point lookup for one dentry.
+func (d *GenericKVDriver) Lookup(ctx context.Context, req fsmeta.LookupRequest) (fsmeta.DentryRecord, error) {
+	plan, err := fsmeta.PlanLookup(req)
+	if err != nil {
+		return fsmeta.DentryRecord{}, err
+	}
+	version, err := d.reserveReadVersion(ctx)
+	if err != nil {
+		return fsmeta.DentryRecord{}, err
+	}
+	value, ok, err := d.runner.Get(ctx, plan.PrimaryKey, version)
+	if err != nil {
+		return fsmeta.DentryRecord{}, err
+	}
+	if !ok {
+		return fsmeta.DentryRecord{}, fsmeta.ErrNotFound
+	}
+	record, err := fsmeta.DecodeDentryValue(value)
+	if err != nil {
+		return fsmeta.DentryRecord{}, err
+	}
+	return record, nil
+}
+
 // ReadDir scans the dentry prefix directly from the generic KV schema.
 func (d *GenericKVDriver) ReadDir(ctx context.Context, req fsmeta.ReadDirRequest) ([]fsmeta.DentryRecord, error) {
 	plan, err := fsmeta.PlanReadDir(req)

--- a/benchmark/fsmeta/workload/generic_kv_test.go
+++ b/benchmark/fsmeta/workload/generic_kv_test.go
@@ -74,6 +74,25 @@ func TestGenericKVDriverReadDirPlusUsesPointGets(t *testing.T) {
 	require.Zero(t, runner.batchGetCalls, "generic ReadDirPlus should not use native BatchGet fusion")
 }
 
+func TestGenericKVDriverLookup(t *testing.T) {
+	runner := newFakeTxnRunner()
+	driver, err := NewGenericKVDriver(runner)
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	req := fsmeta.CreateRequest{Mount: "vol", Parent: fsmeta.RootInode, Name: "file-a", Inode: 42}
+	require.NoError(t, driver.Create(ctx, req, fsmeta.InodeRecord{Type: fsmeta.InodeTypeFile, LinkCount: 1}))
+	runner.resetCallCounters()
+
+	got, err := driver.Lookup(ctx, fsmeta.LookupRequest{Mount: "vol", Parent: fsmeta.RootInode, Name: "file-a"})
+	require.NoError(t, err)
+	require.Equal(t, "file-a", got.Name)
+	require.Len(t, runner.getCalls, 1)
+
+	_, err = driver.Lookup(ctx, fsmeta.LookupRequest{Mount: "vol", Parent: fsmeta.RootInode, Name: "missing"})
+	require.ErrorIs(t, err, fsmeta.ErrNotFound)
+}
+
 func TestGenericKVDriverReadDirPlusReturnsNotFoundForDanglingDentry(t *testing.T) {
 	runner := newFakeTxnRunner()
 	driver, err := NewGenericKVDriver(runner)

--- a/benchmark/fsmeta/workload/workload.go
+++ b/benchmark/fsmeta/workload/workload.go
@@ -362,6 +362,9 @@ func RunNegativeLookup(ctx context.Context, cli Client, cfg NegativeLookupConfig
 					if errors.Is(err, fsmeta.ErrNotFound) {
 						return nil
 					}
+					if err == nil {
+						return fmt.Errorf("negative lookup unexpectedly found %q", name)
+					}
 					return err
 				})
 			}

--- a/benchmark/fsmeta/workload/workload.go
+++ b/benchmark/fsmeta/workload/workload.go
@@ -21,6 +21,7 @@ const (
 	CheckpointStorm = "checkpoint-storm"
 	HotspotFanIn    = "hotspot-fanin"
 	WatchSubtree    = "watch-subtree"
+	NegativeLookup  = "negative-lookup"
 
 	DriverNativeFSMetadata = "native-fsmeta"
 	DriverGenericKV        = "generic-kv"
@@ -32,6 +33,7 @@ var ErrWorkloadFailed = errors.New("benchmark/fsmeta/workload: workload complete
 // fsmeta/client.GRPCClient satisfies this interface.
 type Client interface {
 	Create(ctx context.Context, req fsmeta.CreateRequest, inode fsmeta.InodeRecord) error
+	Lookup(ctx context.Context, req fsmeta.LookupRequest) (fsmeta.DentryRecord, error)
 	ReadDir(ctx context.Context, req fsmeta.ReadDirRequest) ([]fsmeta.DentryRecord, error)
 	ReadDirPlus(ctx context.Context, req fsmeta.ReadDirRequest) ([]fsmeta.DentryAttrPair, error)
 }
@@ -63,6 +65,15 @@ type WatchSubtreeConfig struct {
 	Files              int
 	StartInode         fsmeta.InodeID
 	BackPressureWindow uint32
+}
+
+type NegativeLookupConfig struct {
+	Mount          fsmeta.MountID
+	RunID          string
+	Clients        int
+	Keys           int
+	ReadsPerClient int
+	Parent         fsmeta.InodeID
 }
 
 type Result struct {
@@ -327,6 +338,38 @@ func RunWatchSubtree(ctx context.Context, cli Client, cfg WatchSubtreeConfig) (R
 	}
 
 	return finishResult(WatchSubtree, cfg.RunID, started, rec.snapshot())
+}
+
+func RunNegativeLookup(ctx context.Context, cli Client, cfg NegativeLookupConfig) (Result, error) {
+	cfg = normalizeNegativeLookupConfig(cfg)
+	started := time.Now()
+	rec := newRecorder()
+
+	var wg sync.WaitGroup
+	for worker := 0; worker < cfg.Clients; worker++ {
+		wg.Add(1)
+		go func(worker int) {
+			defer wg.Done()
+			for i := 0; i < cfg.ReadsPerClient; i++ {
+				idx := (worker*cfg.ReadsPerClient + i) % cfg.Keys
+				name := fmt.Sprintf("missing-%s-%08d", cfg.RunID, idx)
+				rec.recordCall("lookup_missing", func() error {
+					_, err := cli.Lookup(ctx, fsmeta.LookupRequest{
+						Mount:  cfg.Mount,
+						Parent: cfg.Parent,
+						Name:   name,
+					})
+					if errors.Is(err, fsmeta.ErrNotFound) {
+						return nil
+					}
+					return err
+				})
+			}
+		}(worker)
+	}
+	wg.Wait()
+
+	return finishResult(NegativeLookup, cfg.RunID, started, rec.snapshot())
 }
 
 func SummaryRows(result Result) []SummaryRow {
@@ -636,6 +679,28 @@ func normalizeHotspotFanInConfig(cfg HotspotFanInConfig) HotspotFanInConfig {
 	}
 	if cfg.StartInode == 0 {
 		cfg.StartInode = 2_000_000
+	}
+	return cfg
+}
+
+func normalizeNegativeLookupConfig(cfg NegativeLookupConfig) NegativeLookupConfig {
+	if cfg.Mount == "" {
+		cfg.Mount = "fsmeta-workload"
+	}
+	if cfg.RunID == "" {
+		cfg.RunID = NewRunID()
+	}
+	if cfg.Clients <= 0 {
+		cfg.Clients = 4
+	}
+	if cfg.Keys <= 0 {
+		cfg.Keys = 1024
+	}
+	if cfg.ReadsPerClient <= 0 {
+		cfg.ReadsPerClient = 64
+	}
+	if cfg.Parent == 0 {
+		cfg.Parent = fsmeta.RootInode
 	}
 	return cfg
 }

--- a/benchmark/fsmeta/workload/workload_test.go
+++ b/benchmark/fsmeta/workload/workload_test.go
@@ -29,6 +29,14 @@ func (c *fakeClient) Create(_ context.Context, req fsmeta.CreateRequest, inode f
 	return nil
 }
 
+func (c *fakeClient) Lookup(_ context.Context, req fsmeta.LookupRequest) (fsmeta.DentryRecord, error) {
+	entry, ok := c.dentries[dentryID(req.Parent, req.Name)]
+	if !ok {
+		return fsmeta.DentryRecord{}, fsmeta.ErrNotFound
+	}
+	return entry, nil
+}
+
 func (c *fakeClient) ReadDir(_ context.Context, req fsmeta.ReadDirRequest) ([]fsmeta.DentryRecord, error) {
 	return c.readDir(req), nil
 }
@@ -112,6 +120,24 @@ func TestRunWatchSubtree(t *testing.T) {
 		}
 	}
 	require.True(t, sawNotify)
+}
+
+func TestRunNegativeLookup(t *testing.T) {
+	result, err := RunNegativeLookup(context.Background(), newFakeClient(), NegativeLookupConfig{
+		Mount:          "vol",
+		RunID:          "test",
+		Clients:        2,
+		Keys:           3,
+		ReadsPerClient: 4,
+		Parent:         fsmeta.RootInode,
+	})
+	require.NoError(t, err)
+	require.Equal(t, NegativeLookup, result.Name)
+	require.Equal(t, 8, result.Ops)
+	require.Zero(t, result.Errors)
+	rows := SummaryRows(result)
+	require.Len(t, rows, 1)
+	require.Equal(t, "lookup_missing", rows[0].Operation)
 }
 
 func TestWriteSummaryCSVIncludesDriver(t *testing.T) {

--- a/cmd/nokv-fsmeta/main.go
+++ b/cmd/nokv-fsmeta/main.go
@@ -33,13 +33,19 @@ func main() {
 		addr        = flag.String("addr", "127.0.0.1:8090", "listen address for FSMetadata gRPC server")
 		coordAddr   = flag.String("coordinator-addr", "", "coordinator gRPC endpoint used for TSO, routing, and store discovery")
 		metricsAddr = flag.String("metrics-addr", "", "optional HTTP address to expose /debug/vars expvar endpoint")
+		negCacheDir = flag.String("negative-cache-dir", "", "optional slab directory for persistent negative dentry cache")
+		dirPageDir  = flag.String("dirpage-cache-dir", "", "optional slab directory for ReadDirPlus page cache")
 	)
 	flag.Parse()
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	rt, err := openRuntime(ctx, fsmetaexec.Options{CoordinatorAddr: *coordAddr})
+	rt, err := openRuntime(ctx, fsmetaexec.Options{
+		CoordinatorAddr:  *coordAddr,
+		NegativeCacheDir: *negCacheDir,
+		DirPageCacheDir:  *dirPageDir,
+	})
 	if err != nil {
 		fatalf("open fsmeta runtime: %v", err)
 		return

--- a/coordinator/rootview/root_test.go
+++ b/coordinator/rootview/root_test.go
@@ -204,7 +204,15 @@ func TestSnapshotHelpersAndBootstrap(t *testing.T) {
 		RootToken:    rootstorage.TailToken{Cursor: rootstate.Cursor{Term: 1, Index: 4}, Revision: 2},
 		CatchUpState: CatchUpStateLagging,
 		Stores:       map[uint64]rootstate.StoreMembership{},
-		Mounts:       map[string]rootstate.MountRecord{},
+		SnapshotEpochs: map[string]rootstate.SnapshotEpoch{
+			"vol/9/25": {
+				SnapshotID:  "vol/9/25",
+				Mount:       "vol",
+				RootInode:   9,
+				ReadVersion: 25,
+			},
+		},
+		Mounts: map[string]rootstate.MountRecord{},
 		Descriptors: map[uint64]descriptor.Descriptor{
 			desc2.RegionID: desc2,
 			desc1.RegionID: desc1,
@@ -225,7 +233,9 @@ func TestSnapshotHelpersAndBootstrap(t *testing.T) {
 
 	cloned := CloneSnapshot(snapshot)
 	cloned.Descriptors[desc1.RegionID].StartKey[0] = 'x'
+	cloned.SnapshotEpochs["vol/9/25"] = rootstate.SnapshotEpoch{ReadVersion: 99}
 	require.Equal(t, byte('a'), snapshot.Descriptors[desc1.RegionID].StartKey[0])
+	require.Equal(t, uint64(25), snapshot.SnapshotEpochs["vol/9/25"].ReadVersion)
 
 	rootSnapshot := rootstate.Snapshot{
 		State: rootstate.State{
@@ -238,6 +248,7 @@ func TestSnapshotHelpersAndBootstrap(t *testing.T) {
 		Stores: map[uint64]rootstate.StoreMembership{
 			7: {StoreID: 7, State: rootstate.StoreMembershipActive, JoinedAt: rootstate.Cursor{Term: 2, Index: 3}},
 		},
+		SnapshotEpochs:      snapshot.SnapshotEpochs,
 		Descriptors:         snapshot.Descriptors,
 		PendingPeerChanges:  snapshot.PendingPeerChanges,
 		PendingRangeChanges: snapshot.PendingRangeChanges,
@@ -247,6 +258,10 @@ func TestSnapshotHelpersAndBootstrap(t *testing.T) {
 	require.Equal(t, rootstate.StoreMembershipActive, fromRoot.Stores[7].State)
 	require.Equal(t, uint64(40), fromRoot.Allocator.IDCurrent)
 	require.Equal(t, rootstate.Cursor{Term: 3, Index: 10}, fromRoot.RootToken.Cursor)
+	floor, ok := fromRoot.SnapshotRetentionFloor()
+	require.True(t, ok)
+	require.Equal(t, uint64(25), floor)
+	require.Equal(t, rootSnapshot.SnapshotEpochs, fromRoot.RootSnapshot().SnapshotEpochs)
 
 	idStart, tsStart := ResolveAllocatorStarts(5, 6, AllocatorState{IDCurrent: 10, TSCurrent: 20})
 	require.Equal(t, uint64(11), idStart)

--- a/coordinator/rootview/snapshot.go
+++ b/coordinator/rootview/snapshot.go
@@ -47,6 +47,7 @@ type Snapshot struct {
 	RootToken           rootstorage.TailToken
 	CatchUpState        CatchUpState
 	Stores              map[uint64]rootstate.StoreMembership
+	SnapshotEpochs      map[string]rootstate.SnapshotEpoch
 	Mounts              map[string]rootstate.MountRecord
 	Subtrees            map[string]rootstate.SubtreeAuthority
 	Quotas              map[string]rootstate.QuotaFence
@@ -65,6 +66,7 @@ func CloneSnapshot(snapshot Snapshot) Snapshot {
 		RootToken:           snapshot.RootToken,
 		CatchUpState:        snapshot.CatchUpState,
 		Stores:              rootstate.CloneStoreMemberships(snapshot.Stores),
+		SnapshotEpochs:      rootstate.CloneSnapshotEpochs(snapshot.SnapshotEpochs),
 		Mounts:              rootstate.CloneMounts(snapshot.Mounts),
 		Subtrees:            rootstate.CloneSubtreeAuthorities(snapshot.Subtrees),
 		Quotas:              rootstate.CloneQuotaFences(snapshot.Quotas),
@@ -87,6 +89,7 @@ func SnapshotFromRoot(snapshot rootstate.Snapshot) Snapshot {
 		},
 		CatchUpState:        CatchUpStateFresh,
 		Stores:              rootstate.CloneStoreMemberships(snapshot.Stores),
+		SnapshotEpochs:      rootstate.CloneSnapshotEpochs(snapshot.SnapshotEpochs),
 		Mounts:              rootstate.CloneMounts(snapshot.Mounts),
 		Subtrees:            rootstate.CloneSubtreeAuthorities(snapshot.Subtrees),
 		Quotas:              rootstate.CloneQuotaFences(snapshot.Quotas),
@@ -115,6 +118,7 @@ func (s Snapshot) RootSnapshot() rootstate.Snapshot {
 			Handover:      s.Handover,
 		},
 		Stores:              rootstate.CloneStoreMemberships(s.Stores),
+		SnapshotEpochs:      rootstate.CloneSnapshotEpochs(s.SnapshotEpochs),
 		Mounts:              rootstate.CloneMounts(s.Mounts),
 		Subtrees:            rootstate.CloneSubtreeAuthorities(s.Subtrees),
 		Quotas:              rootstate.CloneQuotaFences(s.Quotas),
@@ -122,6 +126,12 @@ func (s Snapshot) RootSnapshot() rootstate.Snapshot {
 		PendingPeerChanges:  rootstate.ClonePendingPeerChanges(s.PendingPeerChanges),
 		PendingRangeChanges: rootstate.ClonePendingRangeChanges(s.PendingRangeChanges),
 	}
+}
+
+// SnapshotRetentionFloor returns the oldest active fsmeta snapshot read version
+// currently materialized in this root view.
+func (s Snapshot) SnapshotRetentionFloor() (uint64, bool) {
+	return rootstate.SnapshotRetentionFloor(s.SnapshotEpochs)
 }
 
 // BootstrapInfo captures rooted Coordinator bootstrap results.

--- a/coordinator/server/diagnostics.go
+++ b/coordinator/server/diagnostics.go
@@ -45,6 +45,7 @@ func (s *Service) DiagnosticsSnapshot() map[string]any {
 			rootSnapshot = snapshot
 		}
 	}
+	snapshotFloor, snapshotFloorActive := rootSnapshot.SnapshotRetentionFloor()
 
 	nowUnixNano, _, holderID, renewIn, clockSkew := s.leaseCampaignBounds()
 	lease, _ := s.currentTenureView()
@@ -118,6 +119,12 @@ func (s *Service) DiagnosticsSnapshot() map[string]any {
 			"last_reload_unix_nano": lastReload,
 			"last_reload_error":     lastReloadErr,
 			"read_state_load_error": loadErr,
+			"snapshot_epochs":       len(rootSnapshot.SnapshotEpochs),
+			"snapshot_retention": map[string]any{
+				"active":             snapshotFloorActive,
+				"min_read_version":   snapshotFloor,
+				"enforcement_target": "mvcc_gc",
+			},
 		},
 		"lease": map[string]any{
 			"enabled":            s.coordinatorLeaseEnabled(),

--- a/coordinator/server/service_test.go
+++ b/coordinator/server/service_test.go
@@ -515,6 +515,14 @@ func TestServiceDiagnosticsSnapshot(t *testing.T) {
 				Frontiers: eunomia.Frontiers(rootstate.State{IDFence: 44, TSOFence: 77}, 5),
 				SealedAt:  rootstate.Cursor{Term: 2, Index: 8},
 			},
+			SnapshotEpochs: map[string]rootstate.SnapshotEpoch{
+				"vol/9/33": {
+					SnapshotID:  "vol/9/33",
+					Mount:       "vol",
+					RootInode:   9,
+					ReadVersion: 33,
+				},
+			},
 			Descriptors: map[uint64]descriptor.Descriptor{
 				11: testDescriptor(11, []byte("a"), []byte("z"), metaregion.Epoch{Version: 1, ConfVersion: 1}, []metaregion.Peer{{StoreID: 1, PeerID: 101}}),
 			},
@@ -549,6 +557,12 @@ func TestServiceDiagnosticsSnapshot(t *testing.T) {
 	require.Equal(t, "DEGRADED_MODE_HEALTHY", root["degraded_mode"])
 	require.Equal(t, uint64(7), root["storage_leader_id"])
 	require.NotZero(t, root["last_reload_unix_nano"])
+	require.Equal(t, 1, root["snapshot_epochs"])
+	require.Equal(t, map[string]any{
+		"active":             true,
+		"min_read_version":   uint64(33),
+		"enforcement_target": "mvcc_gc",
+	}, root["snapshot_retention"])
 	require.Equal(t, true, lease["enabled"])
 	require.Equal(t, "c1", lease["holder_id"])
 	require.Equal(t, true, lease["active"])

--- a/docs/fsmeta.md
+++ b/docs/fsmeta.md
@@ -23,8 +23,8 @@ The current v1 API is defined by `pb/fsmeta/fsmeta.proto`. `fsmeta/server` expos
 | `Lookup` | Read a dentry by `(mount, parent_inode, name)`. |
 | `ReadDir` | Scan one directory page by dentry prefix. |
 | `ReadDirPlus` | Scan dentries and batch-read inode attrs under the same snapshot version. |
-| `WatchSubtree` | A prefix-scoped change feed; supports ready, ack, back-pressure, and cursor replay. |
-| `SnapshotSubtree` | Publishes a stable MVCC read version; subsequent `ReadDir` / `ReadDirPlus` can use it to read the snapshot. |
+| `WatchSubtree` | A prefix-scoped change feed; supports ready, ack, back-pressure, and bounded cursor replay. Cursor expiry requires full-state reconcile. |
+| `SnapshotSubtree` | Publishes an MVCC read-version token; subsequent `ReadDir` / `ReadDirPlus` can use it to read that version. Data-plane GC retention is a separate boundary. |
 | `RetireSnapshotSubtree` | Proactively retire a snapshot epoch. |
 | `GetQuotaUsage` | Read the persistent quota usage counter for a mount/scope. |
 | `RenameSubtree` | Atomically move the root dentry of a subtree; descendants follow naturally via inode references. |
@@ -62,6 +62,13 @@ type TxnRunner interface {
 
 The default runtime uses `OpenWithRaftstore` to wire up coordinator, raftstore client, TSO, watch source, mount/quota cache, snapshot publisher, and subtree handoff publisher. Embedded users can use this entry point directly; tests and custom deployments can keep passing in their own `TxnRunner`.
 
+`OpenWithRaftstore` can also wire two derived slab caches when explicitly configured:
+
+- `NegativeCacheDir` enables a persistent negative dentry cache. It remembers recent lookup misses and invalidates on namespace mutations.
+- `DirPageCacheDir` enables a ReadDirPlus page cache. It materializes fused dentry+inode pages and invalidates by parent directory epoch.
+
+Both caches are derived state. They can be dropped or rebuilt without changing authoritative namespace truth.
+
 The layering constraints are:
 
 - `Executor` does not directly know about raft region / store routing.
@@ -94,6 +101,11 @@ v1 already supports:
 - per-region recent ring;
 - resume cursor replay;
 - `ErrWatchCursorExpired` when a cursor has expired.
+
+`ErrWatchCursorExpired` is not a fatal protocol state. The client-side recovery
+pattern is: open a fresh watch without the old cursor, take a full `ReadDirPlus`
+baseline for the watched directory, then apply live events idempotently. The Go
+typed client exposes this as `client.WatchDirectoryWithReconcile`.
 
 ### SnapshotSubtree
 
@@ -162,7 +174,9 @@ Start the fsmeta gateway directly:
 go run ./cmd/nokv-fsmeta \
   --addr 127.0.0.1:8090 \
   --coordinator-addr 127.0.0.1:2390,127.0.0.1:2391,127.0.0.1:2392 \
-  --metrics-addr 127.0.0.1:9400
+  --metrics-addr 127.0.0.1:9400 \
+  --negative-cache-dir ./artifacts/fsmeta/negative-cache \
+  --dirpage-cache-dir ./artifacts/fsmeta/dirpage-cache
 ```
 
 Register a mount:
@@ -195,6 +209,9 @@ nokv quota set \
 | `nokv_fsmeta_watch` | subscribers, events, delivered, dropped, overflow, remote source state. |
 | `nokv_fsmeta_mount` | mount cache hit/miss, admission rejects. |
 | `nokv_fsmeta_quota` | fence check/reject, cache hit/miss, fence updates, usage mutations. |
+
+When the derived caches are enabled, `nokv_fsmeta_executor` also reports whether
+NegativeCache / DirPage are active and the DirPage hit/miss/store counters.
 
 ## 9. Benchmarks
 

--- a/docs/fsmeta.md
+++ b/docs/fsmeta.md
@@ -111,7 +111,7 @@ typed client exposes this as `client.WatchDirectoryWithReconcile`.
 
 `SnapshotSubtree` only publishes a read epoch — it does not copy the directory tree. The token shape is `(mount, root_inode, read_version)`. Subsequent `ReadDir` / `ReadDirPlus` use `snapshot_version` to read the same MVCC view.
 
-`SnapshotEpochPublished` / `SnapshotEpochRetired` rooted events are already in place. The data-plane MVCC GC does not yet use these epochs as a retention lower bound — that's the next piece of work for the GC layer.
+`SnapshotEpochPublished` / `SnapshotEpochRetired` rooted events are already in place. Coordinator root views now carry active snapshot epochs and expose the oldest active `read_version` as the MVCC-GC retention floor. The current data-plane compactor does not yet drop MVCC history by read-version, so this is the enforcement hook for a future version-GC worker rather than a destructive cleanup path today.
 
 ### RenameSubtree
 
@@ -226,10 +226,15 @@ Stage 1 headline: `ReadDirPlus` average latency 12.0 ms vs 510.3 ms — about 42
 
 The WatchSubtree evidence workload lives in the same benchmark package; `watch_notify` reaches sub-second p95 on a Docker Compose 3-node cluster.
 
+Derived-cache evidence uses the same harness:
+
+- `hotspot-fanin` with `ReadDirPlus` measures the DirPage path when `nokv-fsmeta --dirpage-cache-dir ...` is enabled.
+- `negative-lookup` repeatedly probes missing dentries and measures the NegativeCache path when `nokv-fsmeta --negative-cache-dir ...` is enabled.
+
 ## 10. Non-goals
 
 - No FUSE / NFS / SMB frontend.
 - No S3 HTTP gateway or object body I/O.
 - No write of every inode/dentry mutation into `meta/root`.
 - No recursive materialized snapshot — `SnapshotSubtree` is an MVCC read epoch.
-- No claim that data-plane MVCC GC already retains by snapshot epoch.
+- No claim that data-plane MVCC version GC already deletes or retains by snapshot epoch; active epochs are materialized as a retention floor for the future GC worker.

--- a/docs/fsmeta.md
+++ b/docs/fsmeta.md
@@ -38,13 +38,15 @@ The current v1 API is defined by `pb/fsmeta/fsmeta.proto`. `fsmeta/server` expos
 | Object | Storage location | Notes |
 |---|---|---|
 | Mount metadata key | `EncodeMountKey` | Reserved mount-level data key; mount lifecycle truth does not live here. |
-| Inode | `EncodeInodeKey(mount, inode)` | File/directory attributes, including `size`, `mode`, `link_count`. |
+| Inode | `EncodeInodeKey(mount, inode)` | File/directory attributes, including `size`, `mode`, `link_count`, and a bounded `opaque_attrs` payload. |
 | Dentry | `EncodeDentryKey(mount, parent, name)` | Mapping from parent/name to inode. |
 | Chunk | `EncodeChunkKey(mount, inode, chunk)` | Schema is in place; the current fsmeta API doesn't expose object body / chunk I/O. |
 | Session | `EncodeSessionKey(mount, session)` | Schema reserved for later session/lease use. |
 | Usage | `EncodeUsageKey(mount, scope)` | Quota usage counter; scope=0 means mount-wide, non-zero means a direct accounting scope. |
 
 Both keys and values carry a magic + schema version. Values use a hand-written binary layout — not JSON.
+
+`InodeRecord.opaque_attrs` is application-owned bytes capped at 16 KiB. It is intended for compact body references, checksums, content type, or a caller-defined protobuf payload. NoKV stores and returns it, but does not parse, index, authorize, or quota it separately.
 
 ## 4. Execution boundary
 
@@ -235,6 +237,7 @@ Derived-cache evidence uses the same harness:
 
 - No FUSE / NFS / SMB frontend.
 - No S3 HTTP gateway or object body I/O.
+- No indexing or interpretation of `InodeRecord.opaque_attrs`.
 - No write of every inode/dentry mutation into `meta/root`.
 - No recursive materialized snapshot — `SnapshotSubtree` is an MVCC read epoch.
 - No claim that data-plane MVCC version GC already deletes or retains by snapshot epoch; active epochs are materialized as a retention floor for the future GC worker.

--- a/fsmeta/client/client_test.go
+++ b/fsmeta/client/client_test.go
@@ -46,7 +46,14 @@ func (e *fakeExecutor) ReadDirPlus(context.Context, fsmeta.ReadDirRequest) ([]fs
 	}
 	return []fsmeta.DentryAttrPair{{
 		Dentry: fsmeta.DentryRecord{Parent: fsmeta.RootInode, Name: "checkpoint", Inode: 42, Type: fsmeta.InodeTypeFile},
-		Inode:  fsmeta.InodeRecord{Inode: 42, Type: fsmeta.InodeTypeFile, Size: 4096, Mode: 0o644, LinkCount: 1},
+		Inode: fsmeta.InodeRecord{
+			Inode:       42,
+			Type:        fsmeta.InodeTypeFile,
+			Size:        4096,
+			Mode:        0o644,
+			LinkCount:   1,
+			OpaqueAttrs: []byte(`{"body_ref":"cas://checkpoint"}`),
+		},
 	}}, nil
 }
 
@@ -115,7 +122,14 @@ func TestTypedClientRoundTrip(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, []fsmeta.DentryAttrPair{{
 		Dentry: fsmeta.DentryRecord{Parent: fsmeta.RootInode, Name: "checkpoint", Inode: 42, Type: fsmeta.InodeTypeFile},
-		Inode:  fsmeta.InodeRecord{Inode: 42, Type: fsmeta.InodeTypeFile, Size: 4096, Mode: 0o644, LinkCount: 1},
+		Inode: fsmeta.InodeRecord{
+			Inode:       42,
+			Type:        fsmeta.InodeTypeFile,
+			Size:        4096,
+			Mode:        0o644,
+			LinkCount:   1,
+			OpaqueAttrs: []byte(`{"body_ref":"cas://checkpoint"}`),
+		},
 	}}, pairs)
 }
 

--- a/fsmeta/client/reconcile.go
+++ b/fsmeta/client/reconcile.go
@@ -71,6 +71,9 @@ func WatchDirectoryWithReconcile(ctx context.Context, cli DirectoryWatchClient, 
 	if len(watchReq.KeyPrefix) != 0 || watchReq.DescendRecursively || watchReq.Mount != readReq.Mount || watchReq.RootInode != readReq.Parent {
 		return WatchReconcileResult{}, fmt.Errorf("%w: watch/read directory mismatch", fsmeta.ErrInvalidRequest)
 	}
+	if readReq.StartAfter != "" || readReq.SnapshotVersion != 0 {
+		return WatchReconcileResult{}, fmt.Errorf("%w: watch reconcile requires a fresh full-directory read", fsmeta.ErrInvalidRequest)
+	}
 	sub, err := cli.WatchSubtree(ctx, watchReq)
 	if err == nil {
 		return WatchReconcileResult{Subscription: sub}, nil

--- a/fsmeta/client/reconcile.go
+++ b/fsmeta/client/reconcile.go
@@ -1,0 +1,98 @@
+package client
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/feichai0017/NoKV/fsmeta"
+)
+
+// DirectoryWatchClient is the narrow client surface needed for directory
+// watch recovery. GRPCClient satisfies it.
+type DirectoryWatchClient interface {
+	ReadDirPlus(context.Context, fsmeta.ReadDirRequest) ([]fsmeta.DentryAttrPair, error)
+	WatchSubtree(context.Context, fsmeta.WatchRequest) (WatchSubscription, error)
+}
+
+// WatchReconcileResult is returned by WatchDirectoryWithReconcile.
+type WatchReconcileResult struct {
+	Subscription WatchSubscription
+	// Snapshot is populated only when the server rejected ResumeCursor and
+	// the helper had to re-baseline the directory.
+	Snapshot []fsmeta.DentryAttrPair
+	// Reconciled reports whether Snapshot contains a fresh full directory
+	// view. Live events may overlap that view and must be applied
+	// idempotently by callers.
+	Reconciled bool
+}
+
+// ReadDirPlusAll scans one directory through ReadDirPlus pagination.
+func ReadDirPlusAll(ctx context.Context, cli interface {
+	ReadDirPlus(context.Context, fsmeta.ReadDirRequest) ([]fsmeta.DentryAttrPair, error)
+}, req fsmeta.ReadDirRequest) ([]fsmeta.DentryAttrPair, error) {
+	if cli == nil {
+		return nil, errors.New("fsmeta/client: directory reader is required")
+	}
+	limit := req.Limit
+	if limit == 0 {
+		limit = fsmeta.DefaultReadDirLimit
+	}
+	if limit > fsmeta.MaxReadDirLimit {
+		limit = fsmeta.MaxReadDirLimit
+	}
+	req.Limit = limit
+	var out []fsmeta.DentryAttrPair
+	for {
+		page, err := cli.ReadDirPlus(ctx, req)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, page...)
+		if uint32(len(page)) < limit {
+			return out, nil
+		}
+		req.StartAfter = page[len(page)-1].Dentry.Name
+	}
+}
+
+// WatchDirectoryWithReconcile opens a WatchSubtree stream for one direct
+// directory. If the resume cursor has expired, it opens a fresh stream first
+// and then returns a full ReadDirPlus baseline for the caller to reconcile.
+//
+// Ordering rule: the fresh watch is established before the full directory
+// read. Events that race with the baseline can therefore be duplicated, but
+// they are not silently lost; callers should treat the returned Snapshot as
+// the new base state and apply subsequent events idempotently.
+func WatchDirectoryWithReconcile(ctx context.Context, cli DirectoryWatchClient, watchReq fsmeta.WatchRequest, readReq fsmeta.ReadDirRequest) (WatchReconcileResult, error) {
+	if cli == nil {
+		return WatchReconcileResult{}, errors.New("fsmeta/client: watch client is required")
+	}
+	if len(watchReq.KeyPrefix) != 0 || watchReq.DescendRecursively || watchReq.Mount != readReq.Mount || watchReq.RootInode != readReq.Parent {
+		return WatchReconcileResult{}, fmt.Errorf("%w: watch/read directory mismatch", fsmeta.ErrInvalidRequest)
+	}
+	sub, err := cli.WatchSubtree(ctx, watchReq)
+	if err == nil {
+		return WatchReconcileResult{Subscription: sub}, nil
+	}
+	if !errors.Is(err, fsmeta.ErrWatchCursorExpired) {
+		return WatchReconcileResult{}, err
+	}
+
+	freshReq := watchReq
+	freshReq.ResumeCursor = fsmeta.WatchCursor{}
+	sub, err = cli.WatchSubtree(ctx, freshReq)
+	if err != nil {
+		return WatchReconcileResult{}, err
+	}
+	snapshot, err := ReadDirPlusAll(ctx, cli, readReq)
+	if err != nil {
+		_ = sub.Close()
+		return WatchReconcileResult{}, err
+	}
+	return WatchReconcileResult{
+		Subscription: sub,
+		Snapshot:     snapshot,
+		Reconciled:   true,
+	}, nil
+}

--- a/fsmeta/client/reconcile_test.go
+++ b/fsmeta/client/reconcile_test.go
@@ -1,0 +1,95 @@
+package client
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/feichai0017/NoKV/fsmeta"
+	"github.com/stretchr/testify/require"
+)
+
+type reconcileClient struct {
+	watchErrs []error
+	watches   []fsmeta.WatchRequest
+	pages     [][]fsmeta.DentryAttrPair
+	reads     []fsmeta.ReadDirRequest
+}
+
+func (c *reconcileClient) WatchSubtree(_ context.Context, req fsmeta.WatchRequest) (WatchSubscription, error) {
+	c.watches = append(c.watches, req)
+	if len(c.watchErrs) > 0 {
+		err := c.watchErrs[0]
+		c.watchErrs = c.watchErrs[1:]
+		if err != nil {
+			return nil, err
+		}
+	}
+	return &stubWatchSubscription{ready: fsmeta.WatchCursor{RegionID: 1, Term: 1, Index: uint64(len(c.watches))}}, nil
+}
+
+func (c *reconcileClient) ReadDirPlus(_ context.Context, req fsmeta.ReadDirRequest) ([]fsmeta.DentryAttrPair, error) {
+	c.reads = append(c.reads, req)
+	if len(c.pages) == 0 {
+		return nil, fmt.Errorf("unexpected ReadDirPlus")
+	}
+	page := c.pages[0]
+	c.pages = c.pages[1:]
+	return page, nil
+}
+
+func TestReadDirPlusAllPaginates(t *testing.T) {
+	cli := &reconcileClient{
+		pages: [][]fsmeta.DentryAttrPair{
+			{
+				{Dentry: fsmeta.DentryRecord{Name: "a"}},
+				{Dentry: fsmeta.DentryRecord{Name: "b"}},
+			},
+			{
+				{Dentry: fsmeta.DentryRecord{Name: "c"}},
+			},
+		},
+	}
+	got, err := ReadDirPlusAll(context.Background(), cli, fsmeta.ReadDirRequest{
+		Mount: "vol", Parent: fsmeta.RootInode, Limit: 2,
+	})
+	require.NoError(t, err)
+	require.Len(t, got, 3)
+	require.Len(t, cli.reads, 2)
+	require.Equal(t, "", cli.reads[0].StartAfter)
+	require.Equal(t, "b", cli.reads[1].StartAfter)
+}
+
+func TestWatchDirectoryWithReconcileOnExpiredCursor(t *testing.T) {
+	cli := &reconcileClient{
+		watchErrs: []error{fmt.Errorf("%w: stale", fsmeta.ErrWatchCursorExpired), nil},
+		pages: [][]fsmeta.DentryAttrPair{
+			{{Dentry: fsmeta.DentryRecord{Name: "artifact"}}},
+		},
+	}
+	watchReq := fsmeta.WatchRequest{
+		Mount:        "vol",
+		RootInode:    fsmeta.RootInode,
+		ResumeCursor: fsmeta.WatchCursor{RegionID: 7, Term: 1, Index: 100},
+	}
+	readReq := fsmeta.ReadDirRequest{Mount: "vol", Parent: fsmeta.RootInode, Limit: 100}
+
+	result, err := WatchDirectoryWithReconcile(context.Background(), cli, watchReq, readReq)
+	require.NoError(t, err)
+	require.True(t, result.Reconciled)
+	require.Len(t, result.Snapshot, 1)
+	require.NotNil(t, result.Subscription)
+	require.Len(t, cli.watches, 2)
+	require.Equal(t, watchReq.ResumeCursor, cli.watches[0].ResumeCursor)
+	require.Equal(t, fsmeta.WatchCursor{}, cli.watches[1].ResumeCursor,
+		"fresh watch must drop the expired cursor before full-state reconcile")
+	require.Len(t, cli.reads, 1)
+}
+
+func TestWatchDirectoryWithReconcileRejectsMismatchedRequest(t *testing.T) {
+	_, err := WatchDirectoryWithReconcile(context.Background(), &reconcileClient{},
+		fsmeta.WatchRequest{Mount: "vol", RootInode: 10},
+		fsmeta.ReadDirRequest{Mount: "vol", Parent: 11},
+	)
+	require.ErrorIs(t, err, fsmeta.ErrInvalidRequest)
+}

--- a/fsmeta/client/reconcile_test.go
+++ b/fsmeta/client/reconcile_test.go
@@ -93,3 +93,20 @@ func TestWatchDirectoryWithReconcileRejectsMismatchedRequest(t *testing.T) {
 	)
 	require.ErrorIs(t, err, fsmeta.ErrInvalidRequest)
 }
+
+func TestWatchDirectoryWithReconcileRejectsPartialBaseline(t *testing.T) {
+	cli := &reconcileClient{}
+	watchReq := fsmeta.WatchRequest{Mount: "vol", RootInode: fsmeta.RootInode}
+
+	_, err := WatchDirectoryWithReconcile(context.Background(), cli, watchReq,
+		fsmeta.ReadDirRequest{Mount: "vol", Parent: fsmeta.RootInode, StartAfter: "a"},
+	)
+	require.ErrorIs(t, err, fsmeta.ErrInvalidRequest)
+
+	_, err = WatchDirectoryWithReconcile(context.Background(), cli, watchReq,
+		fsmeta.ReadDirRequest{Mount: "vol", Parent: fsmeta.RootInode, SnapshotVersion: 10},
+	)
+	require.ErrorIs(t, err, fsmeta.ErrInvalidRequest)
+	require.Empty(t, cli.watches)
+	require.Empty(t, cli.reads)
+}

--- a/fsmeta/client/wire.go
+++ b/fsmeta/client/wire.go
@@ -125,6 +125,7 @@ func inodeFromProto(pb *fsmetapb.InodeRecord) fsmeta.InodeRecord {
 		LinkCount:     pb.GetLinkCount(),
 		CreatedUnixNs: pb.GetCreatedUnixNs(),
 		UpdatedUnixNs: pb.GetUpdatedUnixNs(),
+		OpaqueAttrs:   append([]byte(nil), pb.GetOpaqueAttrs()...),
 	}
 }
 
@@ -137,6 +138,7 @@ func inodeToProto(record fsmeta.InodeRecord) *fsmetapb.InodeRecord {
 		LinkCount:     record.LinkCount,
 		CreatedUnixNs: record.CreatedUnixNs,
 		UpdatedUnixNs: record.UpdatedUnixNs,
+		OpaqueAttrs:   append([]byte(nil), record.OpaqueAttrs...),
 	}
 }
 

--- a/fsmeta/exec/open.go
+++ b/fsmeta/exec/open.go
@@ -8,6 +8,8 @@ import (
 	"time"
 
 	coordclient "github.com/feichai0017/NoKV/coordinator/client"
+	"github.com/feichai0017/NoKV/engine/slab/dirpage"
+	"github.com/feichai0017/NoKV/engine/slab/negativecache"
 	"github.com/feichai0017/NoKV/fsmeta"
 	fsmetawatch "github.com/feichai0017/NoKV/fsmeta/exec/watch"
 	"github.com/feichai0017/NoKV/raftstore/client"
@@ -28,6 +30,16 @@ type Options struct {
 	// MonitorInterval controls rooted lifecycle stream reconnect backoff.
 	// Zero uses the package default; negative disables the monitor.
 	MonitorInterval time.Duration
+
+	// NegativeCacheDir enables the slab-backed negative dentry cache. Empty
+	// disables it. This is a Derived cache: authoritative reads still fall
+	// back to raftstore/percolator on miss or invalidation.
+	NegativeCacheDir string
+
+	// DirPageCacheDir enables the slab-backed ReadDirPlus page cache. Empty
+	// disables it. Pages are derived from authoritative LSM reads and are
+	// invalidated by fsmeta mutations.
+	DirPageCacheDir string
 }
 
 // Runtime is a complete fsmeta runtime backed by the NoKV raftstore. It owns
@@ -106,8 +118,42 @@ func OpenWithRaftstore(ctx context.Context, opts Options) (*Runtime, error) {
 	}
 	quotas := &quotaCache{coord: coord, ttl: quotaTTL}
 	pub := rootPublisher{coord: coord}
-	exec, err := New(runner, WithMountResolver(mounts), WithQuotaResolver(quotas), WithSubtreeHandoffPublisher(pub))
+	execOpts := []Option{WithMountResolver(mounts), WithQuotaResolver(quotas), WithSubtreeHandoffPublisher(pub)}
+	var negPersist *negativecache.Persistence
+	if opts.NegativeCacheDir != "" {
+		neg, persist, err := negativecache.OpenWithPersistence(
+			negativecache.Config{
+				GroupKeyFn: func(k []byte) []byte { return k },
+			},
+			negativecache.PersistConfig{
+				Dir: opts.NegativeCacheDir,
+			},
+		)
+		if err != nil {
+			_ = kv.Close()
+			_ = coord.Close()
+			return nil, fmt.Errorf("init negative cache: %w", err)
+		}
+		negPersist = persist
+		execOpts = append(execOpts, WithNegativeCache(neg))
+	}
+	var dirPages *dirpage.Cache
+	if opts.DirPageCacheDir != "" {
+		dirPages, err = dirpage.Open(dirpage.Config{
+			Dir: opts.DirPageCacheDir,
+		})
+		if err != nil {
+			_ = kv.Close()
+			_ = coord.Close()
+			return nil, fmt.Errorf("init dirpage cache: %w", err)
+		}
+		execOpts = append(execOpts, WithDirPageCache(dirPages))
+	}
+	exec, err := New(runner, execOpts...)
 	if err != nil {
+		if dirPages != nil {
+			_ = dirPages.Close()
+		}
 		_ = kv.Close()
 		_ = coord.Close()
 		return nil, fmt.Errorf("init executor: %w", err)
@@ -116,6 +162,9 @@ func OpenWithRaftstore(ctx context.Context, opts Options) (*Runtime, error) {
 	router := fsmetawatch.NewRouter()
 	source, err := fsmetawatch.StartRemoteSource(ctx, coord, router, dialOpts...)
 	if err != nil {
+		if dirPages != nil {
+			_ = dirPages.Close()
+		}
 		_ = kv.Close()
 		_ = coord.Close()
 		return nil, fmt.Errorf("init watch source: %w", err)
@@ -142,6 +191,16 @@ func OpenWithRaftstore(ctx context.Context, opts Options) (*Runtime, error) {
 		}
 		if err := source.Close(); err != nil && first == nil {
 			first = err
+		}
+		if negPersist != nil {
+			if _, err := negPersist.Snapshot(); err != nil && first == nil {
+				first = err
+			}
+		}
+		if dirPages != nil {
+			if err := dirPages.Close(); err != nil && first == nil {
+				first = err
+			}
 		}
 		if err := kv.Close(); err != nil && first == nil {
 			first = err

--- a/fsmeta/exec/runner.go
+++ b/fsmeta/exec/runner.go
@@ -167,10 +167,21 @@ func (e *Executor) Stats() map[string]any {
 			"txn_retry_exhausted_total": uint64(0),
 		}
 	}
-	return map[string]any{
+	out := map[string]any{
 		"txn_retries_total":         e.txnRetriesTotal.Load(),
 		"txn_retry_exhausted_total": e.txnRetryExhaustedTotal.Load(),
+		"negative_cache_enabled":    e.negCache != nil,
+		"dirpage_cache_enabled":     e.dirPages != nil,
 	}
+	if e.dirPages != nil {
+		stats := e.dirPages.Stats()
+		out["dirpage_hits"] = stats.Hits
+		out["dirpage_misses"] = stats.Misses
+		out["dirpage_stale"] = stats.Stale
+		out["dirpage_store_ok"] = stats.StoreOK
+		out["dirpage_dropped"] = stats.Dropped
+	}
+	return out
 }
 
 // Create creates one dentry and its inode record in a single transaction.

--- a/fsmeta/integration/e2e_test.go
+++ b/fsmeta/integration/e2e_test.go
@@ -279,6 +279,61 @@ func TestFSMetadataWatchSubtreeReplaysAfterResumeCursor(t *testing.T) {
 	}, 5*time.Second, 20*time.Millisecond)
 }
 
+func TestFSMetadataWatchSubtreeReconcilesAfterExpiredCursor(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	runtime := openRealClusterRuntime(t, ctx)
+	router := fswatch.NewRouter()
+	reg, err := runtime.node.Server.Store().RegisterApplyObserver(router, 256)
+	require.NoError(t, err)
+	defer reg.Close()
+
+	cli, cleanup := openFSMetadataClient(t, ctx, runtime.executor, fsmetaserver.WithWatcher(router))
+	defer cleanup()
+
+	warmup, err := cli.WatchSubtree(ctx, fsmeta.WatchRequest{
+		Mount:              "vol",
+		RootInode:          fsmeta.RootInode,
+		BackPressureWindow: 8,
+	})
+	require.NoError(t, err)
+
+	baseline := fsmeta.CreateRequest{Mount: "vol", Parent: fsmeta.RootInode, Name: "baseline-artifact", Inode: 811}
+	require.NoError(t, cli.Create(ctx, baseline, fsmeta.InodeRecord{Type: fsmeta.InodeTypeFile, LinkCount: 1}))
+	baselineKey, err := fsmeta.EncodeDentryKey(baseline.Mount, baseline.Parent, baseline.Name)
+	require.NoError(t, err)
+	baselineEvent := recvWatchKey(t, warmup, baselineKey)
+	require.NotZero(t, baselineEvent.Cursor.RegionID)
+	require.NotZero(t, baselineEvent.Cursor.Index)
+	require.NoError(t, warmup.Ack(baselineEvent.Cursor))
+	require.NoError(t, warmup.Close())
+
+	expired := baselineEvent.Cursor
+	expired.Index--
+
+	result, err := fsmetaclient.WatchDirectoryWithReconcile(ctx, cli,
+		fsmeta.WatchRequest{
+			Mount:              "vol",
+			RootInode:          fsmeta.RootInode,
+			ResumeCursor:       expired,
+			BackPressureWindow: 8,
+		},
+		fsmeta.ReadDirRequest{Mount: "vol", Parent: fsmeta.RootInode, Limit: 8},
+	)
+	require.NoError(t, err)
+	defer func() { _ = result.Subscription.Close() }()
+	require.True(t, result.Reconciled)
+	require.Equal(t, []string{"baseline-artifact"}, dentryNames(result.Snapshot))
+
+	live := fsmeta.CreateRequest{Mount: "vol", Parent: fsmeta.RootInode, Name: "live-after-reconcile", Inode: 812}
+	require.NoError(t, cli.Create(ctx, live, fsmeta.InodeRecord{Type: fsmeta.InodeTypeFile, LinkCount: 1}))
+	liveKey, err := fsmeta.EncodeDentryKey(live.Mount, live.Parent, live.Name)
+	require.NoError(t, err)
+	got := recvWatchKey(t, result.Subscription, liveKey)
+	require.NoError(t, result.Subscription.Ack(got.Cursor))
+}
+
 func TestFSMetadataSnapshotSubtreeOnRealCluster(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
@@ -332,6 +387,68 @@ func TestFSMetadataSnapshotSubtreeOnRealCluster(t *testing.T) {
 
 	require.NoError(t, cli.RetireSnapshotSubtree(ctx, token))
 	require.Equal(t, token, publisher.retired)
+}
+
+func TestFSMetadataStageCommitArtifactPublishOnRealCluster(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	executor := openRealClusterExecutor(t, ctx)
+	cli, cleanup := openFSMetadataClient(t, ctx, executor)
+	defer cleanup()
+
+	const (
+		stagingInode fsmeta.InodeID = 9010
+		runInode     fsmeta.InodeID = 9011
+		fileInode    fsmeta.InodeID = 9012
+	)
+	mount := fsmeta.MountID("vol")
+	require.NoError(t, cli.Create(ctx, fsmeta.CreateRequest{
+		Mount:  mount,
+		Parent: fsmeta.RootInode,
+		Name:   ".staging",
+		Inode:  stagingInode,
+	}, fsmeta.InodeRecord{Type: fsmeta.InodeTypeDirectory, LinkCount: 1}))
+	require.NoError(t, cli.Create(ctx, fsmeta.CreateRequest{
+		Mount:  mount,
+		Parent: stagingInode,
+		Name:   "run-tmp",
+		Inode:  runInode,
+	}, fsmeta.InodeRecord{Type: fsmeta.InodeTypeDirectory, LinkCount: 1}))
+	require.NoError(t, cli.Create(ctx, fsmeta.CreateRequest{
+		Mount:  mount,
+		Parent: runInode,
+		Name:   "manifest.json",
+		Inode:  fileInode,
+	}, fsmeta.InodeRecord{Type: fsmeta.InodeTypeFile, Size: 128, LinkCount: 1}))
+
+	_, err := cli.Lookup(ctx, fsmeta.LookupRequest{Mount: mount, Parent: fsmeta.RootInode, Name: "run-001"})
+	require.ErrorIs(t, err, fsmeta.ErrNotFound)
+	staged, err := cli.ReadDirPlus(ctx, fsmeta.ReadDirRequest{Mount: mount, Parent: runInode, Limit: 8})
+	require.NoError(t, err)
+	require.Equal(t, []string{"manifest.json"}, dentryNames(staged))
+
+	require.NoError(t, cli.RenameSubtree(ctx, fsmeta.RenameSubtreeRequest{
+		Mount:      mount,
+		FromParent: stagingInode,
+		FromName:   "run-tmp",
+		ToParent:   fsmeta.RootInode,
+		ToName:     "run-001",
+	}))
+
+	_, err = cli.Lookup(ctx, fsmeta.LookupRequest{Mount: mount, Parent: stagingInode, Name: "run-tmp"})
+	require.ErrorIs(t, err, fsmeta.ErrNotFound)
+	published, err := cli.Lookup(ctx, fsmeta.LookupRequest{Mount: mount, Parent: fsmeta.RootInode, Name: "run-001"})
+	require.NoError(t, err)
+	require.Equal(t, fsmeta.DentryRecord{
+		Parent: fsmeta.RootInode,
+		Name:   "run-001",
+		Inode:  runInode,
+		Type:   fsmeta.InodeTypeDirectory,
+	}, published)
+	children, err := cli.ReadDirPlus(ctx, fsmeta.ReadDirRequest{Mount: mount, Parent: runInode, Limit: 8})
+	require.NoError(t, err)
+	require.Equal(t, []string{"manifest.json"}, dentryNames(children))
 }
 
 type snapshotRecorder struct {

--- a/fsmeta/integration/e2e_test.go
+++ b/fsmeta/integration/e2e_test.go
@@ -312,7 +312,7 @@ func TestFSMetadataWatchSubtreeReconcilesAfterExpiredCursor(t *testing.T) {
 	require.NoError(t, warmup.Close())
 
 	expired := baselineEvent.Cursor
-	expired.Index--
+	expired.Index = 0
 
 	result, err := fsmetaclient.WatchDirectoryWithReconcile(ctx, cli,
 		fsmeta.WatchRequest{

--- a/fsmeta/integration/e2e_test.go
+++ b/fsmeta/integration/e2e_test.go
@@ -30,10 +30,11 @@ func TestFSMetadataClientServerOnRealCluster(t *testing.T) {
 		Inode:  42,
 	}
 	require.NoError(t, cli.Create(ctx, req, fsmeta.InodeRecord{
-		Type:      fsmeta.InodeTypeFile,
-		Size:      4096,
-		Mode:      0o644,
-		LinkCount: 1,
+		Type:        fsmeta.InodeTypeFile,
+		Size:        4096,
+		Mode:        0o644,
+		LinkCount:   1,
+		OpaqueAttrs: []byte(`{"body_ref":"cas://checkpoint-0001","sha256":"abc"}`),
 	}))
 
 	record, err := cli.Lookup(ctx, fsmeta.LookupRequest{
@@ -63,11 +64,12 @@ func TestFSMetadataClientServerOnRealCluster(t *testing.T) {
 			Type:   fsmeta.InodeTypeFile,
 		},
 		Inode: fsmeta.InodeRecord{
-			Inode:     req.Inode,
-			Type:      fsmeta.InodeTypeFile,
-			Size:      4096,
-			Mode:      0o644,
-			LinkCount: 1,
+			Inode:       req.Inode,
+			Type:        fsmeta.InodeTypeFile,
+			Size:        4096,
+			Mode:        0o644,
+			LinkCount:   1,
+			OpaqueAttrs: []byte(`{"body_ref":"cas://checkpoint-0001","sha256":"abc"}`),
 		},
 	}}, pairs)
 

--- a/fsmeta/server/service_test.go
+++ b/fsmeta/server/service_test.go
@@ -123,11 +123,12 @@ func TestGRPCServiceCreateAndReadDirPlus(t *testing.T) {
 		Parent: uint64(fsmeta.RootInode),
 		Name:   "checkpoint",
 		Inode: &fsmetapb.InodeRecord{
-			Inode:     42,
-			Type:      fsmetapb.InodeType_INODE_TYPE_FILE,
-			Size:      4096,
-			Mode:      0o644,
-			LinkCount: 1,
+			Inode:       42,
+			Type:        fsmetapb.InodeType_INODE_TYPE_FILE,
+			Size:        4096,
+			Mode:        0o644,
+			LinkCount:   1,
+			OpaqueAttrs: []byte(`{"body_ref":"cas://checkpoint"}`),
 		},
 	})
 	require.NoError(t, err)
@@ -138,11 +139,12 @@ func TestGRPCServiceCreateAndReadDirPlus(t *testing.T) {
 		Inode:  42,
 	}, executor.createReq)
 	require.Equal(t, fsmeta.InodeRecord{
-		Inode:     42,
-		Type:      fsmeta.InodeTypeFile,
-		Size:      4096,
-		Mode:      0o644,
-		LinkCount: 1,
+		Inode:       42,
+		Type:        fsmeta.InodeTypeFile,
+		Size:        4096,
+		Mode:        0o644,
+		LinkCount:   1,
+		OpaqueAttrs: []byte(`{"body_ref":"cas://checkpoint"}`),
 	}, executor.createInode)
 
 	resp, err := client.ReadDirPlus(context.Background(), &fsmetapb.ReadDirRequest{
@@ -161,6 +163,7 @@ func TestGRPCServiceCreateAndReadDirPlus(t *testing.T) {
 	require.Len(t, resp.GetEntries(), 1)
 	require.Equal(t, "checkpoint", resp.GetEntries()[0].GetDentry().GetName())
 	require.Equal(t, uint64(4096), resp.GetEntries()[0].GetInode().GetSize())
+	require.Equal(t, []byte(nil), resp.GetEntries()[0].GetInode().GetOpaqueAttrs())
 }
 
 func TestGRPCServiceReadDirAndMutationRPCs(t *testing.T) {

--- a/fsmeta/server/wire.go
+++ b/fsmeta/server/wire.go
@@ -119,6 +119,7 @@ func inodeFromProto(pb *fsmetapb.InodeRecord) fsmeta.InodeRecord {
 		LinkCount:     pb.GetLinkCount(),
 		CreatedUnixNs: pb.GetCreatedUnixNs(),
 		UpdatedUnixNs: pb.GetUpdatedUnixNs(),
+		OpaqueAttrs:   append([]byte(nil), pb.GetOpaqueAttrs()...),
 	}
 }
 
@@ -140,6 +141,7 @@ func inodeToProto(record fsmeta.InodeRecord) *fsmetapb.InodeRecord {
 		LinkCount:     record.LinkCount,
 		CreatedUnixNs: record.CreatedUnixNs,
 		UpdatedUnixNs: record.UpdatedUnixNs,
+		OpaqueAttrs:   append([]byte(nil), record.OpaqueAttrs...),
 	}
 }
 

--- a/fsmeta/types.go
+++ b/fsmeta/types.go
@@ -80,6 +80,10 @@ const (
 	// RootInode is the conventional root inode for one mount.
 	RootInode InodeID = 1
 
+	// MaxInodeOpaqueAttrsBytes bounds the application-owned inode payload.
+	// It is for compact body references and custom attributes, not object bodies.
+	MaxInodeOpaqueAttrsBytes = 16 * 1024
+
 	// DefaultReadDirLimit bounds one ReadDir planning request when callers do not
 	// supply an explicit page size.
 	DefaultReadDirLimit uint32 = 1024

--- a/fsmeta/value.go
+++ b/fsmeta/value.go
@@ -36,6 +36,7 @@ type InodeRecord struct {
 	LinkCount     uint32    `json:"link_count,omitempty"`
 	CreatedUnixNs int64     `json:"created_unix_ns,omitempty"`
 	UpdatedUnixNs int64     `json:"updated_unix_ns,omitempty"`
+	OpaqueAttrs   []byte    `json:"opaque_attrs,omitempty"`
 }
 
 // DentryRecord is the value stored under a parent/name dentry key.
@@ -83,7 +84,10 @@ func EncodeInodeValue(record InodeRecord) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-	body := make([]byte, 0, 41)
+	if len(record.OpaqueAttrs) > MaxInodeOpaqueAttrsBytes {
+		return nil, ErrInvalidValue
+	}
+	body := make([]byte, 0, 41+binary.MaxVarintLen64+len(record.OpaqueAttrs))
 	body = binary.BigEndian.AppendUint64(body, uint64(record.Inode))
 	body = append(body, typ)
 	body = binary.BigEndian.AppendUint64(body, record.Size)
@@ -91,6 +95,8 @@ func EncodeInodeValue(record InodeRecord) ([]byte, error) {
 	body = binary.BigEndian.AppendUint32(body, record.LinkCount)
 	body = binary.BigEndian.AppendUint64(body, uint64(record.CreatedUnixNs))
 	body = binary.BigEndian.AppendUint64(body, uint64(record.UpdatedUnixNs))
+	body = binary.AppendUvarint(body, uint64(len(record.OpaqueAttrs)))
+	body = append(body, record.OpaqueAttrs...)
 	return encodeValue(ValueKindInode, body), nil
 }
 
@@ -266,8 +272,8 @@ func decodeValue(value []byte, expected ValueKind, out any) error {
 }
 
 func decodeInodeBody(body []byte) (InodeRecord, error) {
-	const size = 8 + 1 + 8 + 4 + 4 + 8 + 8
-	if len(body) != size {
+	const fixedSize = 8 + 1 + 8 + 4 + 4 + 8 + 8
+	if len(body) < fixedSize+1 {
 		return InodeRecord{}, ErrInvalidValue
 	}
 	record := InodeRecord{
@@ -286,6 +292,16 @@ func decodeInodeBody(body []byte) (InodeRecord, error) {
 	if err := validateInodeID(record.Inode); err != nil {
 		return InodeRecord{}, err
 	}
+	pos := fixedSize
+	attrsLen, n := binary.Uvarint(body[pos:])
+	if n <= 0 {
+		return InodeRecord{}, ErrInvalidValue
+	}
+	pos += n
+	if attrsLen > MaxInodeOpaqueAttrsBytes || attrsLen != uint64(len(body)-pos) {
+		return InodeRecord{}, ErrInvalidValue
+	}
+	record.OpaqueAttrs = append([]byte(nil), body[pos:]...)
 	return record, nil
 }
 

--- a/fsmeta/value_test.go
+++ b/fsmeta/value_test.go
@@ -33,21 +33,23 @@ func TestDentryValueRoundTrip(t *testing.T) {
 
 func TestInodeValueRoundTrip(t *testing.T) {
 	value, err := EncodeInodeValue(InodeRecord{
-		Inode:     22,
-		Type:      InodeTypeFile,
-		Size:      4096,
-		LinkCount: 1,
+		Inode:       22,
+		Type:        InodeTypeFile,
+		Size:        4096,
+		LinkCount:   1,
+		OpaqueAttrs: []byte(`{"body_ref":"s3://bucket/checkpoint"}`),
 	})
 	require.NoError(t, err)
-	require.Equal(t, "6673760001690000000000000016010000000000001000000000000000000100000000000000000000000000000000", hex.EncodeToString(value))
+	require.Equal(t, "6673760001690000000000000016010000000000001000000000000000000100000000000000000000000000000000257b22626f64795f726566223a2273333a2f2f6275636b65742f636865636b706f696e74227d", hex.EncodeToString(value))
 
 	record, err := DecodeInodeValue(value)
 	require.NoError(t, err)
 	require.Equal(t, InodeRecord{
-		Inode:     22,
-		Type:      InodeTypeFile,
-		Size:      4096,
-		LinkCount: 1,
+		Inode:       22,
+		Type:        InodeTypeFile,
+		Size:        4096,
+		LinkCount:   1,
+		OpaqueAttrs: []byte(`{"body_ref":"s3://bucket/checkpoint"}`),
 	}, record)
 }
 
@@ -107,9 +109,23 @@ func TestValueCodecsRejectInvalidType(t *testing.T) {
 	_, err := EncodeInodeValue(InodeRecord{Inode: 22, Type: InodeType("symlink")})
 	require.ErrorIs(t, err, ErrInvalidValue)
 
+	_, err = EncodeInodeValue(InodeRecord{
+		Inode:       22,
+		Type:        InodeTypeFile,
+		OpaqueAttrs: make([]byte, MaxInodeOpaqueAttrsBytes+1),
+	})
+	require.ErrorIs(t, err, ErrInvalidValue)
+
 	value := encodeValue(ValueKindInode, append([]byte{
 		0, 0, 0, 0, 0, 0, 0, 22,
 		99,
+	}, make([]byte, 32)...))
+	_, err = DecodeInodeValue(value)
+	require.ErrorIs(t, err, ErrInvalidValue)
+
+	value = encodeValue(ValueKindInode, append([]byte{
+		0, 0, 0, 0, 0, 0, 0, 22,
+		1,
 	}, make([]byte, 32)...))
 	_, err = DecodeInodeValue(value)
 	require.ErrorIs(t, err, ErrInvalidValue)

--- a/fsmeta/value_test.go
+++ b/fsmeta/value_test.go
@@ -116,10 +116,12 @@ func TestValueCodecsRejectInvalidType(t *testing.T) {
 	})
 	require.ErrorIs(t, err, ErrInvalidValue)
 
-	value := encodeValue(ValueKindInode, append([]byte{
+	body := append([]byte{
 		0, 0, 0, 0, 0, 0, 0, 22,
 		99,
-	}, make([]byte, 32)...))
+	}, make([]byte, 32)...)
+	body = append(body, 0)
+	value := encodeValue(ValueKindInode, body)
 	_, err = DecodeInodeValue(value)
 	require.ErrorIs(t, err, ErrInvalidValue)
 

--- a/meta/root/state/state.go
+++ b/meta/root/state/state.go
@@ -288,6 +288,27 @@ type SnapshotEpoch struct {
 	PublishedAt Cursor
 }
 
+// SnapshotRetentionFloor returns the oldest active snapshot read version.
+// Data-plane MVCC GC must not discard versions needed by any active snapshot
+// below this floor. The bool is false when no snapshot epoch is active.
+func SnapshotRetentionFloor(epochs map[string]SnapshotEpoch) (uint64, bool) {
+	var floor uint64
+	for _, epoch := range epochs {
+		if epoch.ReadVersion == 0 {
+			continue
+		}
+		if floor == 0 || epoch.ReadVersion < floor {
+			floor = epoch.ReadVersion
+		}
+	}
+	return floor, floor != 0
+}
+
+// SnapshotRetentionFloor returns the oldest active snapshot read version in s.
+func (s Snapshot) SnapshotRetentionFloor() (uint64, bool) {
+	return SnapshotRetentionFloor(s.SnapshotEpochs)
+}
+
 func CloneSnapshotEpochs(in map[string]SnapshotEpoch) map[string]SnapshotEpoch {
 	if len(in) == 0 {
 		return make(map[string]SnapshotEpoch)

--- a/meta/root/state/state_test.go
+++ b/meta/root/state/state_test.go
@@ -309,6 +309,23 @@ func TestCloneSnapshotEpochsDetachesMap(t *testing.T) {
 	require.Equal(t, uint64(9), out["vol/7/9"].ReadVersion)
 }
 
+func TestSnapshotRetentionFloor(t *testing.T) {
+	floor, ok := (rootstate.Snapshot{}).SnapshotRetentionFloor()
+	require.False(t, ok)
+	require.Zero(t, floor)
+
+	snapshot := rootstate.Snapshot{
+		SnapshotEpochs: map[string]rootstate.SnapshotEpoch{
+			"newer": {ReadVersion: 90},
+			"old":   {ReadVersion: 30},
+			"zero":  {ReadVersion: 0},
+		},
+	}
+	floor, ok = snapshot.SnapshotRetentionFloor()
+	require.True(t, ok)
+	require.Equal(t, uint64(30), floor)
+}
+
 func testDescriptor(id uint64, start, end []byte) descriptor.Descriptor {
 	desc := descriptor.Descriptor{
 		RegionID:  id,

--- a/pb/fsmeta/fsmeta.pb.go
+++ b/pb/fsmeta/fsmeta.pb.go
@@ -130,6 +130,7 @@ type InodeRecord struct {
 	LinkCount     uint32                 `protobuf:"varint,5,opt,name=link_count,json=linkCount,proto3" json:"link_count,omitempty"`
 	CreatedUnixNs int64                  `protobuf:"varint,6,opt,name=created_unix_ns,json=createdUnixNs,proto3" json:"created_unix_ns,omitempty"`
 	UpdatedUnixNs int64                  `protobuf:"varint,7,opt,name=updated_unix_ns,json=updatedUnixNs,proto3" json:"updated_unix_ns,omitempty"`
+	OpaqueAttrs   []byte                 `protobuf:"bytes,8,opt,name=opaque_attrs,json=opaqueAttrs,proto3" json:"opaque_attrs,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -211,6 +212,13 @@ func (x *InodeRecord) GetUpdatedUnixNs() int64 {
 		return x.UpdatedUnixNs
 	}
 	return 0
+}
+
+func (x *InodeRecord) GetOpaqueAttrs() []byte {
+	if x != nil {
+		return x.OpaqueAttrs
+	}
+	return nil
 }
 
 type DentryRecord struct {
@@ -1943,7 +1951,7 @@ var File_fsmeta_fsmeta_proto protoreflect.FileDescriptor
 
 const file_fsmeta_fsmeta_proto_rawDesc = "" +
 	"\n" +
-	"\x13fsmeta/fsmeta.proto\x12\x0enokv.fsmeta.v1\"\xe9\x01\n" +
+	"\x13fsmeta/fsmeta.proto\x12\x0enokv.fsmeta.v1\"\x8c\x02\n" +
 	"\vInodeRecord\x12\x14\n" +
 	"\x05inode\x18\x01 \x01(\x04R\x05inode\x12-\n" +
 	"\x04type\x18\x02 \x01(\x0e2\x19.nokv.fsmeta.v1.InodeTypeR\x04type\x12\x12\n" +
@@ -1952,7 +1960,8 @@ const file_fsmeta_fsmeta_proto_rawDesc = "" +
 	"\n" +
 	"link_count\x18\x05 \x01(\rR\tlinkCount\x12&\n" +
 	"\x0fcreated_unix_ns\x18\x06 \x01(\x03R\rcreatedUnixNs\x12&\n" +
-	"\x0fupdated_unix_ns\x18\a \x01(\x03R\rupdatedUnixNs\"\x7f\n" +
+	"\x0fupdated_unix_ns\x18\a \x01(\x03R\rupdatedUnixNs\x12!\n" +
+	"\fopaque_attrs\x18\b \x01(\fR\vopaqueAttrs\"\x7f\n" +
 	"\fDentryRecord\x12\x16\n" +
 	"\x06parent\x18\x01 \x01(\x04R\x06parent\x12\x12\n" +
 	"\x04name\x18\x02 \x01(\tR\x04name\x12\x14\n" +

--- a/pb/fsmeta/fsmeta.proto
+++ b/pb/fsmeta/fsmeta.proto
@@ -19,6 +19,7 @@ message InodeRecord {
   uint32 link_count = 5;
   int64 created_unix_ns = 6;
   int64 updated_unix_ns = 7;
+  bytes opaque_attrs = 8;
 }
 
 message DentryRecord {


### PR DESCRIPTION
## Summary

- wire fsmeta derived caches and expose bounded watch reconcile as runtime/product behavior
- add real integration coverage for expired watch cursor reconcile and stage-to-commit artifact publish
- surface active SnapshotSubtree epochs as an MVCC GC retention floor in root views/diagnostics
- add `negative-lookup` fsmeta benchmark workload for NegativeCache evidence
- add bounded `InodeRecord.opaque_attrs` for compact application-owned body refs/checksums/custom metadata

## Validation

- `make fmt`
- `make lint`
- `make proto-check`
- `go test ./fsmeta -run 'TestInodeValueRoundTrip|TestValueCodecsRejectInvalidType' -count=1`
- `go test ./fsmeta/... -count=1`
- `cd benchmark && go test ./fsmeta/... ./cmd/fsmeta-demo -count=1`
- `make test` reached the known flaky `TestClientTwoPhaseCommitHonorsContextAcrossSplitRegionsUnderPartialQuorumLoss`; isolated rerun passed with `go test ./raftstore/integration -run TestClientTwoPhaseCommitHonorsContextAcrossSplitRegionsUnderPartialQuorumLoss -count=3 -v`

## Notes

`SnapshotSubtree` now has a propagated retention floor, but destructive MVCC version-GC enforcement is intentionally left for the next PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added negative-lookup benchmark workload for cache performance measurement
  * Added automatic watch reconciliation when cursors expire
  * Added snapshot retention floor tracking for garbage collection
  * Added optional derived caches configurable via CLI flags
  * Added inode opaque attributes for storing application-defined metadata
  * Added directory artifact staging and publishing support

* **Documentation**
  * Updated snapshot and watch documentation with clarified semantics and retention boundaries

<!-- end of auto-generated comment: release notes by coderabbit.ai -->