### PR TITLE
feat(fsmeta): add staged publish helper

### DIFF
--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -118,6 +118,23 @@ Then compare:
 - `hotspot-fanin` with `-fsmeta_readdirplus=true` for the DirPage cache path.
 - `negative-lookup` for repeated missing dentry probes and the NegativeCache path.
 
+For a fixed on/off comparison, run the helper from the repository root after
+the coordinator and stores are already up:
+
+```bash
+NOKV_FSMETA_COORDINATOR_ADDR=127.0.0.1:2390,127.0.0.1:2391,127.0.0.1:2392 \
+  scripts/run_fsmeta_derived_cache_bench.sh
+```
+
+The helper starts two fsmeta gateways against the same cluster:
+
+- cache-off at `127.0.0.1:8090`
+- cache-on at `127.0.0.1:8091` with both `--negative-cache-dir` and
+  `--dirpage-cache-dir`
+
+It writes two CSV files named `fsmeta_derived_cache_off_*` and
+`fsmeta_derived_cache_on_*` under `data/fsmeta/results/`.
+
 The summary CSV is written under `data/fsmeta/results/` unless
 `-fsmeta_output` is set. Rows include a `driver` column so native and generic
 results can be plotted from one file.

--- a/docs/fsmeta.md
+++ b/docs/fsmeta.md
@@ -128,6 +128,23 @@ The extra semantics live in the authority layer:
 
 This design prioritizes guaranteeing that rooted authority can never get stuck in an unknown state forever. In extreme cases it may advance an empty era — but it will not leave behind an orphaned pending handoff that no one will repair.
 
+### Staged publish
+
+Large artifact bodies live outside fsmeta, but the namespace commit point can be
+made atomic. The Go typed client provides
+`client.PublishStagedNamespaceEntry` for the standard pattern:
+
+1. create a staged dentry/inode, usually under a private staging parent or
+   hidden staging name;
+2. let the caller write or validate the external body reference;
+3. rename the staged entry to the final path with `RenameSubtree`.
+
+If body preparation fails, the helper best-effort unlinks the staged entry. If
+the final rename fails, it leaves staging in place so the caller can inspect or
+retry without losing prepared external state. NoKV still does not parse or write
+the object body; callers can store compact body references in
+`InodeRecord.opaque_attrs`.
+
 ### Link / Unlink
 
 `Link` is allowed only for non-directory inodes. It creates a new dentry and increments `InodeRecord.LinkCount` in the same transaction.

--- a/fsmeta/client/staged_publish.go
+++ b/fsmeta/client/staged_publish.go
@@ -1,0 +1,96 @@
+package client
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/feichai0017/NoKV/fsmeta"
+)
+
+// StagedPublishClient is the narrow namespace surface needed for staged
+// publish. GRPCClient satisfies it.
+type StagedPublishClient interface {
+	Create(context.Context, fsmeta.CreateRequest, fsmeta.InodeRecord) error
+	RenameSubtree(context.Context, fsmeta.RenameSubtreeRequest) error
+	Unlink(context.Context, fsmeta.UnlinkRequest) error
+}
+
+// StagedPublishRequest describes one namespace-only stage -> commit publish.
+//
+// The helper creates (StageParent, StageName), lets the caller prepare any
+// external body/object state, then atomically renames the staged entry to
+// (FinalParent, FinalName). NoKV does not write or validate the body itself;
+// callers typically store body references inside Inode.OpaqueAttrs.
+type StagedPublishRequest struct {
+	Mount       fsmeta.MountID
+	StageParent fsmeta.InodeID
+	StageName   string
+	FinalParent fsmeta.InodeID
+	FinalName   string
+	InodeID     fsmeta.InodeID
+	Inode       fsmeta.InodeRecord
+}
+
+// PrepareStagedFunc is called after the staged namespace entry is created and
+// before the final rename. The callback is where a caller writes external body
+// data, uploads an object, or validates a content-addressed reference.
+type PrepareStagedFunc func(context.Context, fsmeta.CreateRequest) error
+
+// PublishStagedNamespaceEntry implements the stage -> commit namespace pattern.
+//
+// Failure semantics:
+//   - create failure: no callback is called;
+//   - prepare failure: the staged entry is best-effort unlinked before
+//     returning the original error, joined with cleanup failure if any;
+//   - final rename failure: the staged entry is intentionally left in place so
+//     the caller can inspect or retry without losing prepared external state.
+func PublishStagedNamespaceEntry(ctx context.Context, cli StagedPublishClient, req StagedPublishRequest, prepare PrepareStagedFunc) error {
+	if cli == nil {
+		return errors.New("fsmeta/client: staged publish client is required")
+	}
+	create := req.createRequest()
+	if _, err := fsmeta.PlanCreate(create); err != nil {
+		return err
+	}
+	rename := req.renameRequest()
+	if _, err := fsmeta.PlanRenameSubtree(rename); err != nil {
+		return err
+	}
+
+	if err := cli.Create(ctx, create, req.Inode); err != nil {
+		return err
+	}
+	if prepare != nil {
+		if err := prepare(ctx, create); err != nil {
+			if cleanupErr := cli.Unlink(ctx, fsmeta.UnlinkRequest{
+				Mount:  req.Mount,
+				Parent: req.StageParent,
+				Name:   req.StageName,
+			}); cleanupErr != nil {
+				return errors.Join(err, fmt.Errorf("cleanup staged namespace entry: %w", cleanupErr))
+			}
+			return err
+		}
+	}
+	return cli.RenameSubtree(ctx, rename)
+}
+
+func (r StagedPublishRequest) createRequest() fsmeta.CreateRequest {
+	return fsmeta.CreateRequest{
+		Mount:  r.Mount,
+		Parent: r.StageParent,
+		Name:   r.StageName,
+		Inode:  r.InodeID,
+	}
+}
+
+func (r StagedPublishRequest) renameRequest() fsmeta.RenameSubtreeRequest {
+	return fsmeta.RenameSubtreeRequest{
+		Mount:      r.Mount,
+		FromParent: r.StageParent,
+		FromName:   r.StageName,
+		ToParent:   r.FinalParent,
+		ToName:     r.FinalName,
+	}
+}

--- a/fsmeta/client/staged_publish_test.go
+++ b/fsmeta/client/staged_publish_test.go
@@ -1,0 +1,123 @@
+package client
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/feichai0017/NoKV/fsmeta"
+	"github.com/stretchr/testify/require"
+)
+
+type stagedPublishFake struct {
+	createErr error
+	renameErr error
+	unlinkErr error
+
+	calls    []string
+	created  fsmeta.CreateRequest
+	renamed  fsmeta.RenameSubtreeRequest
+	unlinked fsmeta.UnlinkRequest
+}
+
+func (f *stagedPublishFake) Create(_ context.Context, req fsmeta.CreateRequest, _ fsmeta.InodeRecord) error {
+	f.calls = append(f.calls, "create")
+	f.created = req
+	return f.createErr
+}
+
+func (f *stagedPublishFake) RenameSubtree(_ context.Context, req fsmeta.RenameSubtreeRequest) error {
+	f.calls = append(f.calls, "rename")
+	f.renamed = req
+	return f.renameErr
+}
+
+func (f *stagedPublishFake) Unlink(_ context.Context, req fsmeta.UnlinkRequest) error {
+	f.calls = append(f.calls, "unlink")
+	f.unlinked = req
+	return f.unlinkErr
+}
+
+func TestPublishStagedNamespaceEntryCommitsAfterPrepare(t *testing.T) {
+	cli := &stagedPublishFake{}
+	var prepared fsmeta.CreateRequest
+	req := stagedPublishRequest()
+
+	err := PublishStagedNamespaceEntry(context.Background(), cli, req, func(_ context.Context, stage fsmeta.CreateRequest) error {
+		cli.calls = append(cli.calls, "prepare")
+		prepared = stage
+		return nil
+	})
+	require.NoError(t, err)
+	require.Equal(t, []string{"create", "prepare", "rename"}, cli.calls)
+	require.Equal(t, fsmeta.CreateRequest{Mount: "vol", Parent: 7, Name: ".stage-artifact", Inode: 99}, cli.created)
+	require.Equal(t, cli.created, prepared)
+	require.Equal(t, fsmeta.RenameSubtreeRequest{
+		Mount:      "vol",
+		FromParent: 7,
+		FromName:   ".stage-artifact",
+		ToParent:   8,
+		ToName:     "artifact",
+	}, cli.renamed)
+}
+
+func TestPublishStagedNamespaceEntryCleansUpWhenPrepareFails(t *testing.T) {
+	cli := &stagedPublishFake{}
+	prepareErr := errors.New("body upload failed")
+	req := stagedPublishRequest()
+
+	err := PublishStagedNamespaceEntry(context.Background(), cli, req, func(context.Context, fsmeta.CreateRequest) error {
+		cli.calls = append(cli.calls, "prepare")
+		return prepareErr
+	})
+	require.ErrorIs(t, err, prepareErr)
+	require.Equal(t, []string{"create", "prepare", "unlink"}, cli.calls)
+	require.Equal(t, fsmeta.UnlinkRequest{Mount: "vol", Parent: 7, Name: ".stage-artifact"}, cli.unlinked)
+}
+
+func TestPublishStagedNamespaceEntryReportsCleanupFailure(t *testing.T) {
+	cli := &stagedPublishFake{unlinkErr: errors.New("unlink failed")}
+	prepareErr := errors.New("prepare failed")
+
+	err := PublishStagedNamespaceEntry(context.Background(), cli, stagedPublishRequest(), func(context.Context, fsmeta.CreateRequest) error {
+		return prepareErr
+	})
+	require.ErrorIs(t, err, prepareErr)
+	require.ErrorIs(t, err, cli.unlinkErr)
+}
+
+func TestPublishStagedNamespaceEntryLeavesStageOnRenameFailure(t *testing.T) {
+	renameErr := errors.New("rename failed")
+	cli := &stagedPublishFake{renameErr: renameErr}
+
+	err := PublishStagedNamespaceEntry(context.Background(), cli, stagedPublishRequest(), nil)
+	require.ErrorIs(t, err, renameErr)
+	require.Equal(t, []string{"create", "rename"}, cli.calls)
+	require.Zero(t, cli.unlinked)
+}
+
+func TestPublishStagedNamespaceEntryRejectsInvalidRequestBeforeCreate(t *testing.T) {
+	cli := &stagedPublishFake{}
+	req := stagedPublishRequest()
+	req.StageName = ""
+
+	err := PublishStagedNamespaceEntry(context.Background(), cli, req, nil)
+	require.Error(t, err)
+	require.Empty(t, cli.calls)
+}
+
+func stagedPublishRequest() StagedPublishRequest {
+	return StagedPublishRequest{
+		Mount:       "vol",
+		StageParent: 7,
+		StageName:   ".stage-artifact",
+		FinalParent: 8,
+		FinalName:   "artifact",
+		InodeID:     99,
+		Inode: fsmeta.InodeRecord{
+			Type:      fsmeta.InodeTypeFile,
+			Mode:      0o644,
+			LinkCount: 1,
+		},
+	}
+}

--- a/scripts/run_fsmeta_derived_cache_bench.sh
+++ b/scripts/run_fsmeta_derived_cache_bench.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT"
+
+coord_addr="${NOKV_FSMETA_COORDINATOR_ADDR:-127.0.0.1:2390,127.0.0.1:2391,127.0.0.1:2392}"
+plain_addr="${NOKV_FSMETA_PLAIN_ADDR:-127.0.0.1:8090}"
+cached_addr="${NOKV_FSMETA_CACHED_ADDR:-127.0.0.1:8091}"
+clients="${NOKV_FSMETA_CLIENTS:-8}"
+files="${NOKV_FSMETA_FILES:-2048}"
+reads="${NOKV_FSMETA_READS_PER_CLIENT:-128}"
+timeout="${NOKV_FSMETA_TIMEOUT:-5m}"
+run_id="$(date -u +%Y%m%dT%H%M%SZ)"
+out_dir="${NOKV_FSMETA_OUTPUT_DIR:-$ROOT/data/fsmeta/results}"
+tmp_dir="${NOKV_FSMETA_CACHE_TMPDIR:-$(mktemp -d "${TMPDIR:-/tmp}/nokv-fsmeta-cache.XXXXXX")}"
+
+plain_pid=""
+cached_pid=""
+
+cleanup() {
+	if [[ -n "$plain_pid" ]]; then
+		kill "$plain_pid" 2>/dev/null || true
+	fi
+	if [[ -n "$cached_pid" ]]; then
+		kill "$cached_pid" 2>/dev/null || true
+	fi
+	wait "$plain_pid" "$cached_pid" 2>/dev/null || true
+	if [[ -z "${NOKV_FSMETA_CACHE_TMPDIR:-}" ]]; then
+		rm -rf "$tmp_dir"
+	fi
+}
+trap cleanup EXIT
+
+mkdir -p "$out_dir" "$tmp_dir/plain" "$tmp_dir/cached" "$tmp_dir/negative" "$tmp_dir/dirpage"
+
+wait_port() {
+	local addr="$1"
+	local host="${addr%:*}"
+	local port="${addr##*:}"
+	for _ in $(seq 1 80); do
+		if nc -z "$host" "$port" >/dev/null 2>&1; then
+			return 0
+		fi
+		sleep 0.25
+	done
+	echo "timed out waiting for $addr" >&2
+	return 1
+}
+
+echo "starting plain fsmeta gateway on $plain_addr"
+go run ./cmd/nokv-fsmeta \
+	--addr "$plain_addr" \
+	--coordinator-addr "$coord_addr" \
+	>"$tmp_dir/plain/fsmeta.log" 2>&1 &
+plain_pid="$!"
+wait_port "$plain_addr"
+
+echo "starting cached fsmeta gateway on $cached_addr"
+go run ./cmd/nokv-fsmeta \
+	--addr "$cached_addr" \
+	--coordinator-addr "$coord_addr" \
+	--negative-cache-dir "$tmp_dir/negative" \
+	--dirpage-cache-dir "$tmp_dir/dirpage" \
+	>"$tmp_dir/cached/fsmeta.log" 2>&1 &
+cached_pid="$!"
+wait_port "$cached_addr"
+
+run_bench() {
+	local label="$1"
+	local addr="$2"
+	local output="$out_dir/fsmeta_derived_cache_${label}_${run_id}.csv"
+	echo "running $label benchmark -> $output"
+	(
+		cd benchmark
+		NOKV_FSMETA_BENCH=1 go test ./fsmeta -run TestBenchmarkFSMeta -count=1 -v -args \
+			-fsmeta_drivers native-fsmeta \
+			-fsmeta_addr "$addr" \
+			-fsmeta_coordinator_addr "$coord_addr" \
+			-fsmeta_workloads hotspot-fanin,negative-lookup \
+			-fsmeta_readdirplus=true \
+			-fsmeta_clients "$clients" \
+			-fsmeta_files "$files" \
+			-fsmeta_reads_per_client "$reads" \
+			-fsmeta_timeout "$timeout" \
+			-fsmeta_output "$output"
+	)
+}
+
+run_bench "off" "$plain_addr"
+run_bench "on" "$cached_addr"
+
+echo "done"


### PR DESCRIPTION
## Summary

- add a typed fsmeta staged publish helper for namespace-only stage -> commit flows
- document the external-body boundary and staged publish failure semantics
- add a reproducible DirPage/NegativeCache on/off benchmark runner

## Notes

This is intentionally stacked on #195 so the review diff only contains this follow-up commit. After #195 lands, this PR should be rebased/retargeted onto main.

Snapshot retention note: this change does not add destructive MVCC version GC. The current LSM does not drop historical MVCC versions by read timestamp, so snapshot epochs are not yet threatened by version-GC. A future destructive GC needs a separate safe point and must clamp it by active snapshot floors.

## Validation

- make fmt
- make lint
- bash -n scripts/run_fsmeta_derived_cache_bench.sh
- go test ./fsmeta/client -count=1
- go test ./fsmeta/... -count=1
- cd benchmark && go test ./fsmeta/... ./cmd/fsmeta-demo -count=1
- go test ./raftstore/integration -run TestClientTwoPhaseCommitHonorsContextAcrossSplitRegionsUnderPartialQuorumLoss -count=3 -v

Full make test previously hit the known raftstore timing flake TestClientTwoPhaseCommitHonorsContextAcrossSplitRegionsUnderPartialQuorumLoss; the isolated rerun above passed 3/3.