### PR TITLE
[codex] Fix percolator committed lock read visibility

### DIFF
--- a/percolator/reader.go
+++ b/percolator/reader.go
@@ -123,6 +123,9 @@ func (r *Reader) getWriteForRead(key []byte, readTs uint64) (*mvcc.Write, uint64
 	var result *mvcc.Write
 	var commitTs uint64
 	if err := r.scanWrites(key, func(w mvcc.Write, ts uint64) bool {
+		if ts <= readTs && w.Kind == kvrpcpb.Mutation_Lock {
+			return true
+		}
 		if ts <= readTs && (result == nil || ts > commitTs) {
 			copy := w
 			result = &copy

--- a/percolator/txn_test.go
+++ b/percolator/txn_test.go
@@ -175,6 +175,84 @@ func TestPrewriteAndCommitPut(t *testing.T) {
 	require.Nil(t, lock)
 }
 
+func TestCommittedLockDoesNotHideVisiblePut(t *testing.T) {
+	db := openTestDB(t)
+	latches := latch.NewManager(32)
+	key := []byte("lock-visible-put")
+
+	put := &kvrpcpb.PrewriteRequest{
+		Mutations: []*kvrpcpb.Mutation{{
+			Op:    kvrpcpb.Mutation_Put,
+			Key:   key,
+			Value: []byte("value1"),
+		}},
+		PrimaryLock:  key,
+		StartVersion: 10,
+		LockTtl:      3000,
+	}
+	require.Empty(t, Prewrite(db, latches, put))
+	require.Nil(t, Commit(db, latches, &kvrpcpb.CommitRequest{
+		Keys:          [][]byte{key},
+		StartVersion:  put.StartVersion,
+		CommitVersion: 20,
+	}))
+
+	lock := &kvrpcpb.PrewriteRequest{
+		Mutations: []*kvrpcpb.Mutation{{
+			Op:  kvrpcpb.Mutation_Lock,
+			Key: key,
+		}},
+		PrimaryLock:  key,
+		StartVersion: 30,
+		LockTtl:      3000,
+	}
+	require.Empty(t, Prewrite(db, latches, lock))
+	require.Nil(t, Commit(db, latches, &kvrpcpb.CommitRequest{
+		Keys:          [][]byte{key},
+		StartVersion:  lock.StartVersion,
+		CommitVersion: 40,
+	}))
+
+	reader := NewReader(db)
+	val, _, err := reader.GetValue(key, 50)
+	require.NoError(t, err)
+	require.Equal(t, []byte("value1"), val)
+
+	exists, err := keyExistsAt(reader, key, 50)
+	require.NoError(t, err)
+	require.True(t, exists)
+}
+
+func TestCommittedLockDoesNotCreateVisibleKey(t *testing.T) {
+	db := openTestDB(t)
+	latches := latch.NewManager(32)
+	key := []byte("lock-only")
+
+	lock := &kvrpcpb.PrewriteRequest{
+		Mutations: []*kvrpcpb.Mutation{{
+			Op:  kvrpcpb.Mutation_Lock,
+			Key: key,
+		}},
+		PrimaryLock:  key,
+		StartVersion: 10,
+		LockTtl:      3000,
+	}
+	require.Empty(t, Prewrite(db, latches, lock))
+	require.Nil(t, Commit(db, latches, &kvrpcpb.CommitRequest{
+		Keys:          [][]byte{key},
+		StartVersion:  lock.StartVersion,
+		CommitVersion: 20,
+	}))
+
+	reader := NewReader(db)
+	_, _, err := reader.GetValue(key, 30)
+	require.ErrorIs(t, err, utils.ErrKeyNotFound)
+
+	exists, err := keyExistsAt(reader, key, 30)
+	require.NoError(t, err)
+	require.False(t, exists)
+}
+
 func TestPrewriteAssertionNotExistRejectsVisibleValue(t *testing.T) {
 	db := openTestDB(t)
 	latches := latch.NewManager(32)


### PR DESCRIPTION
## Summary

- Skip committed `Mutation_Lock` records when choosing the visible write for snapshot reads.
- Add coverage for committed locks preserving an older visible Put and for lock-only keys remaining invisible.

## Why

Committed Percolator locks are read-set/conflict markers. They should participate in MVCC ordering and conflict detection, but they do not carry a user value and must not change value visibility. Without this, a committed read lock can hide an older Put from later snapshot reads.

## Validation

- `go test ./percolator -count=1`
- `go test ./... -count=1`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of concurrent transaction locks to ensure correct visibility of committed writes during read operations.

* **Tests**
  * Added test cases to verify proper behavior of locks in transaction isolation, including scenarios where locks do not incorrectly hide previously committed values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->