### PR TITLE
Harden Percolator transaction liveness and recovery

### DIFF
--- a/cmd/nokv/cmd_serve.go
+++ b/cmd/nokv/cmd_serve.go
@@ -257,6 +257,9 @@ func runServeCmd(w io.Writer, args []string) error {
 				}
 				return tsoSource.Current()
 			},
+			CurrentTime: func() uint64 {
+				return uint64(time.Now().UnixMilli())
+			},
 			Retention: func() rootstate.SnapshotRetentionIndex {
 				if retentionSource == nil {
 					return rootstate.SnapshotRetentionIndex{}

--- a/cmd/nokv/cmd_serve.go
+++ b/cmd/nokv/cmd_serve.go
@@ -20,6 +20,7 @@ import (
 	"github.com/feichai0017/NoKV/fsmeta"
 	rootstate "github.com/feichai0017/NoKV/meta/root/state"
 	myraft "github.com/feichai0017/NoKV/raft"
+	raftclient "github.com/feichai0017/NoKV/raftstore/client"
 	"github.com/feichai0017/NoKV/raftstore/kv"
 	localmeta "github.com/feichai0017/NoKV/raftstore/localmeta"
 	raftmode "github.com/feichai0017/NoKV/raftstore/mode"
@@ -155,6 +156,15 @@ func runServeCmd(w io.Writer, args []string) error {
 	}
 	defer func() { _ = coordCli.Close() }()
 
+	txnClient, err := raftclient.New(raftclient.Config{
+		RegionResolver: coordCli,
+		StoreResolver:  coordCli,
+	})
+	if err != nil {
+		return fmt.Errorf("create transaction lock resolver: %w", err)
+	}
+	defer func() { _ = txnClient.Close() }()
+
 	var tsoSource *serveTSOSource
 	var retentionSource *serveRootRetentionSource
 	mvccGCEnabled := *mvccGCPlanInterval > 0 || *mvccGCMaintenanceInterval > 0
@@ -262,6 +272,7 @@ func runServeCmd(w io.Writer, args []string) error {
 				BatchLocks: *mvccGCResolveBatchLocks,
 				MaxLocks:   *mvccGCResolveMaxLocks,
 			},
+			LockResolver:      txnClient,
 			RunOrphanDefaults: *mvccGCMaintenanceInterval > 0,
 			OrphanDefaults: storemvcc.OrphanDefaultOptions{
 				BatchEntries: *mvccGCBatchEntries,

--- a/docs/errors.md
+++ b/docs/errors.md
@@ -48,6 +48,14 @@ Examples:
 - `engine/vfs/vfs.go`: `ErrRenameNoReplaceUnsupported`
 - `engine/lsm/compaction.go`: compaction planner/runtime domain errors
 - `raftstore/peer/errors.go`: peer lifecycle/state errors
+- `percolator/errors.go`: transaction protocol key-error builders and
+  Percolator protocol sentinels
+- `raftstore/client/errors.go`: transaction client typed errors, route errors,
+  retry-budget exhaustion, and protocol-contract violations
+- `raftstore/store/errors.go`: raftstore lifecycle sentinels plus typed
+  transaction-maintenance region routing and protocol errors
+- `raftstore/mvcc/errors.go`: replicated MVCC maintenance and lock-resolution
+  sentinels
 - `pb/errorpb.proto`: region/store routing protobuf errors (`RegionError`,
   `StoreNotMatch`, `RegionNotFound`, `KeyNotInRegion`, ...)
 - `engine/wal/errors.go`: WAL encode/decode and segment errors

--- a/docs/percolator.md
+++ b/docs/percolator.md
@@ -9,6 +9,7 @@ The scope here is the current code path:
 - `BatchRollback`
 - `ResolveLock`
 - `CheckTxnStatus`
+- `TxnHeartBeat`
 - MVCC read visibility (`KvGet`/`KvScan` through `percolator.Reader`)
 
 ---
@@ -57,6 +58,7 @@ Key files:
 | `KvBatchRollback` | `CMD_BATCH_ROLLBACK` | `BatchRollback` |
 | `KvResolveLock` | `CMD_RESOLVE_LOCK` | `ResolveLock` |
 | `KvCheckTxnStatus` | `CMD_CHECK_TXN_STATUS` | `CheckTxnStatus` |
+| `KvTxnHeartBeat` | `CMD_TXN_HEART_BEAT` | `TxnHeartBeat` |
 | `KvGet` | `CMD_GET` | `Reader.GetLock` + `Reader.GetValue` |
 | `KvScan` | `CMD_SCAN` | `Reader.GetLock` + CFWrite iteration + `GetInternalEntry` |
 
@@ -76,7 +78,8 @@ NoKV uses three MVCC column families:
 
 - `Primary`
 - `Ts` (start timestamp)
-- `TTL`
+- `StartTime` (physical Unix millisecond lock creation time)
+- `TTL` (milliseconds from `StartTime`)
 - `Kind` (`Put/Delete/Lock`)
 - `MinCommitTs`
 
@@ -182,15 +185,19 @@ For each key:
 
 ---
 
-## 6. Transaction Status Check
+## 6. Transaction Liveness and Status
 
 `CheckTxnStatus` targets the primary key and decides whether txn is alive, committed, or should be rolled back.
+For RPC callers, `kv.Service` stamps `current_time` with the store's physical
+clock before proposing the raft command when the caller leaves it unset. The
+replicated command still carries a concrete timestamp, so apply remains
+deterministic across replicas.
 
 Decision order:
 
 1. Read lock on primary
 2. If lock exists but `lock.ts != req.lock_ts` -> `KeyError.Locked`
-3. If lock exists and TTL expired (`current_ts >= lock.ts + ttl`):
+3. If lock exists and TTL expired (`current_time >= lock.start_time + ttl`):
    - rollback primary
    - action = `TTLExpireRollback`
 4. If lock exists and caller pushes timestamp:
@@ -202,6 +209,20 @@ Decision order:
 6. If no lock and no write, and `rollback_if_not_exist` is true:
    - write rollback marker
    - action `LockNotExistRollback`
+
+`TxnHeartBeat` is the owner-side liveness path for long transactions:
+
+1. It targets only the primary lock.
+2. It rejects missing primary key/start version/current time/TTL extension at
+   the Percolator command boundary. RPC and store callers can omit
+   `current_time`; the store fills it before raft proposal.
+3. It never resurrects expired locks. If the primary is already expired, it
+   rolls back the primary and returns `TxnHeartBeatTTLExpireRollback`.
+4. For a live primary lock, it extends the physical deadline by setting
+   `ttl = max(ttl, current_time - start_time + ttl_extension)`.
+5. If the primary is already committed, it reports `commit_version`; if the
+   primary lock is absent with no commit record, it writes a rollback marker to
+   fence late commits.
 
 ---
 

--- a/fsmeta/exec/runner.go
+++ b/fsmeta/exec/runner.go
@@ -37,7 +37,7 @@ type TxnRunner interface {
 	Mutate(ctx context.Context, primary []byte, mutations []*kvrpcpb.Mutation, startVersion, commitVersion, lockTTL uint64) error
 }
 
-type keyConflictError interface {
+type keyErrorCarrier interface {
 	KeyErrors() []*kvrpcpb.KeyError
 }
 
@@ -1288,9 +1288,9 @@ func translateMutateError(err error) error {
 	if errors.Is(err, fsmeta.ErrExists) {
 		return err
 	}
-	var conflict keyConflictError
-	if errors.As(err, &conflict) {
-		for _, keyErr := range conflict.KeyErrors() {
+	var keyErrs keyErrorCarrier
+	if errors.As(err, &keyErrs) {
+		for _, keyErr := range keyErrs.KeyErrors() {
 			if keyErr != nil && keyErr.GetAlreadyExists() != nil {
 				return fmt.Errorf("%w: %v", fsmeta.ErrExists, err)
 			}
@@ -1300,11 +1300,11 @@ func translateMutateError(err error) error {
 }
 
 func isCommitTsExpired(err error) bool {
-	var conflict keyConflictError
-	if !errors.As(err, &conflict) {
+	var keyErrs keyErrorCarrier
+	if !errors.As(err, &keyErrs) {
 		return false
 	}
-	for _, keyErr := range conflict.KeyErrors() {
+	for _, keyErr := range keyErrs.KeyErrors() {
 		if keyErr != nil && keyErr.GetCommitTsExpired() != nil {
 			return true
 		}

--- a/fsmeta/exec/runner_test.go
+++ b/fsmeta/exec/runner_test.go
@@ -648,7 +648,7 @@ func TestExecutorLinkRejectsDirectory(t *testing.T) {
 
 func TestExecutorCreateTranslatesAlreadyExistsConflict(t *testing.T) {
 	runner := newFakeRunner()
-	runner.mutateErr = fakeKeyConflictError{errors: []*kvrpcpb.KeyError{{
+	runner.mutateErr = fakeTxnKeyError{errors: []*kvrpcpb.KeyError{{
 		AlreadyExists: &kvrpcpb.KeyAlreadyExists{Key: []byte("dentry")},
 	}}}
 	executor, err := New(runner)
@@ -667,7 +667,7 @@ func TestExecutorCreateTranslatesAlreadyExistsConflict(t *testing.T) {
 func TestExecutorRetriesCommitTsExpired(t *testing.T) {
 	runner := newFakeRunner()
 	runner.mutateErrs = []error{
-		fakeKeyConflictError{errors: []*kvrpcpb.KeyError{{
+		fakeTxnKeyError{errors: []*kvrpcpb.KeyError{{
 			CommitTsExpired: &kvrpcpb.CommitTsExpired{
 				Key:         []byte("dentry"),
 				CommitTs:    2,
@@ -1036,15 +1036,15 @@ func cloneMutation(mut *kvrpcpb.Mutation) *kvrpcpb.Mutation {
 	}
 }
 
-type fakeKeyConflictError struct {
+type fakeTxnKeyError struct {
 	errors []*kvrpcpb.KeyError
 }
 
-func (e fakeKeyConflictError) Error() string {
-	return "fake key conflict"
+func (e fakeTxnKeyError) Error() string {
+	return "fake txn key error"
 }
 
-func (e fakeKeyConflictError) KeyErrors() []*kvrpcpb.KeyError {
+func (e fakeTxnKeyError) KeyErrors() []*kvrpcpb.KeyError {
 	return e.errors
 }
 

--- a/pb/kv/kv.pb.go
+++ b/pb/kv/kv.pb.go
@@ -170,6 +170,58 @@ func (CheckTxnStatusAction) EnumDescriptor() ([]byte, []int) {
 	return file_kv_kv_proto_rawDescGZIP(), []int{2}
 }
 
+type TxnHeartBeatAction int32
+
+const (
+	TxnHeartBeatAction_TxnHeartBeatNoAction             TxnHeartBeatAction = 0
+	TxnHeartBeatAction_TxnHeartBeatTTLExtended          TxnHeartBeatAction = 1
+	TxnHeartBeatAction_TxnHeartBeatTTLExpireRollback    TxnHeartBeatAction = 2
+	TxnHeartBeatAction_TxnHeartBeatLockNotExistRollback TxnHeartBeatAction = 3
+)
+
+// Enum value maps for TxnHeartBeatAction.
+var (
+	TxnHeartBeatAction_name = map[int32]string{
+		0: "TxnHeartBeatNoAction",
+		1: "TxnHeartBeatTTLExtended",
+		2: "TxnHeartBeatTTLExpireRollback",
+		3: "TxnHeartBeatLockNotExistRollback",
+	}
+	TxnHeartBeatAction_value = map[string]int32{
+		"TxnHeartBeatNoAction":             0,
+		"TxnHeartBeatTTLExtended":          1,
+		"TxnHeartBeatTTLExpireRollback":    2,
+		"TxnHeartBeatLockNotExistRollback": 3,
+	}
+)
+
+func (x TxnHeartBeatAction) Enum() *TxnHeartBeatAction {
+	p := new(TxnHeartBeatAction)
+	*p = x
+	return p
+}
+
+func (x TxnHeartBeatAction) String() string {
+	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
+}
+
+func (TxnHeartBeatAction) Descriptor() protoreflect.EnumDescriptor {
+	return file_kv_kv_proto_enumTypes[3].Descriptor()
+}
+
+func (TxnHeartBeatAction) Type() protoreflect.EnumType {
+	return &file_kv_kv_proto_enumTypes[3]
+}
+
+func (x TxnHeartBeatAction) Number() protoreflect.EnumNumber {
+	return protoreflect.EnumNumber(x)
+}
+
+// Deprecated: Use TxnHeartBeatAction.Descriptor instead.
+func (TxnHeartBeatAction) EnumDescriptor() ([]byte, []int) {
+	return file_kv_kv_proto_rawDescGZIP(), []int{3}
+}
+
 type ApplyWatchEventSource int32
 
 const (
@@ -203,11 +255,11 @@ func (x ApplyWatchEventSource) String() string {
 }
 
 func (ApplyWatchEventSource) Descriptor() protoreflect.EnumDescriptor {
-	return file_kv_kv_proto_enumTypes[3].Descriptor()
+	return file_kv_kv_proto_enumTypes[4].Descriptor()
 }
 
 func (ApplyWatchEventSource) Type() protoreflect.EnumType {
-	return &file_kv_kv_proto_enumTypes[3]
+	return &file_kv_kv_proto_enumTypes[4]
 }
 
 func (x ApplyWatchEventSource) Number() protoreflect.EnumNumber {
@@ -216,7 +268,7 @@ func (x ApplyWatchEventSource) Number() protoreflect.EnumNumber {
 
 // Deprecated: Use ApplyWatchEventSource.Descriptor instead.
 func (ApplyWatchEventSource) EnumDescriptor() ([]byte, []int) {
-	return file_kv_kv_proto_rawDescGZIP(), []int{3}
+	return file_kv_kv_proto_rawDescGZIP(), []int{4}
 }
 
 type Mutation_Op int32
@@ -255,11 +307,11 @@ func (x Mutation_Op) String() string {
 }
 
 func (Mutation_Op) Descriptor() protoreflect.EnumDescriptor {
-	return file_kv_kv_proto_enumTypes[4].Descriptor()
+	return file_kv_kv_proto_enumTypes[5].Descriptor()
 }
 
 func (Mutation_Op) Type() protoreflect.EnumType {
-	return &file_kv_kv_proto_enumTypes[4]
+	return &file_kv_kv_proto_enumTypes[5]
 }
 
 func (x Mutation_Op) Number() protoreflect.EnumNumber {
@@ -301,11 +353,11 @@ func (x InternalEntryTombstone_ColumnFamily) String() string {
 }
 
 func (InternalEntryTombstone_ColumnFamily) Descriptor() protoreflect.EnumDescriptor {
-	return file_kv_kv_proto_enumTypes[5].Descriptor()
+	return file_kv_kv_proto_enumTypes[6].Descriptor()
 }
 
 func (InternalEntryTombstone_ColumnFamily) Type() protoreflect.EnumType {
-	return &file_kv_kv_proto_enumTypes[5]
+	return &file_kv_kv_proto_enumTypes[6]
 }
 
 func (x InternalEntryTombstone_ColumnFamily) Number() protoreflect.EnumNumber {
@@ -314,7 +366,7 @@ func (x InternalEntryTombstone_ColumnFamily) Number() protoreflect.EnumNumber {
 
 // Deprecated: Use InternalEntryTombstone_ColumnFamily.Descriptor instead.
 func (InternalEntryTombstone_ColumnFamily) EnumDescriptor() ([]byte, []int) {
-	return file_kv_kv_proto_rawDescGZIP(), []int{19, 0}
+	return file_kv_kv_proto_rawDescGZIP(), []int{21, 0}
 }
 
 // KV is the logical key/value tuple used in distributed RPC payloads
@@ -1461,6 +1513,150 @@ func (x *CheckTxnStatusResponse) GetAction() CheckTxnStatusAction {
 	return CheckTxnStatusAction_CheckTxnStatusNoAction
 }
 
+type TxnHeartBeatRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	PrimaryKey    []byte                 `protobuf:"bytes,1,opt,name=primary_key,json=primaryKey,proto3" json:"primary_key,omitempty"`
+	StartVersion  uint64                 `protobuf:"varint,2,opt,name=start_version,json=startVersion,proto3" json:"start_version,omitempty"`
+	TtlExtension  uint64                 `protobuf:"varint,3,opt,name=ttl_extension,json=ttlExtension,proto3" json:"ttl_extension,omitempty"`
+	CurrentTime   uint64                 `protobuf:"varint,4,opt,name=current_time,json=currentTime,proto3" json:"current_time,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *TxnHeartBeatRequest) Reset() {
+	*x = TxnHeartBeatRequest{}
+	mi := &file_kv_kv_proto_msgTypes[19]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *TxnHeartBeatRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*TxnHeartBeatRequest) ProtoMessage() {}
+
+func (x *TxnHeartBeatRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_kv_kv_proto_msgTypes[19]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use TxnHeartBeatRequest.ProtoReflect.Descriptor instead.
+func (*TxnHeartBeatRequest) Descriptor() ([]byte, []int) {
+	return file_kv_kv_proto_rawDescGZIP(), []int{19}
+}
+
+func (x *TxnHeartBeatRequest) GetPrimaryKey() []byte {
+	if x != nil {
+		return x.PrimaryKey
+	}
+	return nil
+}
+
+func (x *TxnHeartBeatRequest) GetStartVersion() uint64 {
+	if x != nil {
+		return x.StartVersion
+	}
+	return 0
+}
+
+func (x *TxnHeartBeatRequest) GetTtlExtension() uint64 {
+	if x != nil {
+		return x.TtlExtension
+	}
+	return 0
+}
+
+func (x *TxnHeartBeatRequest) GetCurrentTime() uint64 {
+	if x != nil {
+		return x.CurrentTime
+	}
+	return 0
+}
+
+type TxnHeartBeatResponse struct {
+	state          protoimpl.MessageState `protogen:"open.v1"`
+	Error          *KeyError              `protobuf:"bytes,1,opt,name=error,proto3" json:"error,omitempty"`
+	LockTtl        uint64                 `protobuf:"varint,2,opt,name=lock_ttl,json=lockTtl,proto3" json:"lock_ttl,omitempty"`
+	LockExpireTime uint64                 `protobuf:"varint,3,opt,name=lock_expire_time,json=lockExpireTime,proto3" json:"lock_expire_time,omitempty"`
+	CommitVersion  uint64                 `protobuf:"varint,4,opt,name=commit_version,json=commitVersion,proto3" json:"commit_version,omitempty"`
+	Action         TxnHeartBeatAction     `protobuf:"varint,5,opt,name=action,proto3,enum=nokv.kv.v1.TxnHeartBeatAction" json:"action,omitempty"`
+	unknownFields  protoimpl.UnknownFields
+	sizeCache      protoimpl.SizeCache
+}
+
+func (x *TxnHeartBeatResponse) Reset() {
+	*x = TxnHeartBeatResponse{}
+	mi := &file_kv_kv_proto_msgTypes[20]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *TxnHeartBeatResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*TxnHeartBeatResponse) ProtoMessage() {}
+
+func (x *TxnHeartBeatResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_kv_kv_proto_msgTypes[20]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use TxnHeartBeatResponse.ProtoReflect.Descriptor instead.
+func (*TxnHeartBeatResponse) Descriptor() ([]byte, []int) {
+	return file_kv_kv_proto_rawDescGZIP(), []int{20}
+}
+
+func (x *TxnHeartBeatResponse) GetError() *KeyError {
+	if x != nil {
+		return x.Error
+	}
+	return nil
+}
+
+func (x *TxnHeartBeatResponse) GetLockTtl() uint64 {
+	if x != nil {
+		return x.LockTtl
+	}
+	return 0
+}
+
+func (x *TxnHeartBeatResponse) GetLockExpireTime() uint64 {
+	if x != nil {
+		return x.LockExpireTime
+	}
+	return 0
+}
+
+func (x *TxnHeartBeatResponse) GetCommitVersion() uint64 {
+	if x != nil {
+		return x.CommitVersion
+	}
+	return 0
+}
+
+func (x *TxnHeartBeatResponse) GetAction() TxnHeartBeatAction {
+	if x != nil {
+		return x.Action
+	}
+	return TxnHeartBeatAction_TxnHeartBeatNoAction
+}
+
 type InternalEntryTombstone struct {
 	state         protoimpl.MessageState              `protogen:"open.v1"`
 	ColumnFamily  InternalEntryTombstone_ColumnFamily `protobuf:"varint,1,opt,name=column_family,json=columnFamily,proto3,enum=nokv.kv.v1.InternalEntryTombstone_ColumnFamily" json:"column_family,omitempty"`
@@ -1472,7 +1668,7 @@ type InternalEntryTombstone struct {
 
 func (x *InternalEntryTombstone) Reset() {
 	*x = InternalEntryTombstone{}
-	mi := &file_kv_kv_proto_msgTypes[19]
+	mi := &file_kv_kv_proto_msgTypes[21]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1484,7 +1680,7 @@ func (x *InternalEntryTombstone) String() string {
 func (*InternalEntryTombstone) ProtoMessage() {}
 
 func (x *InternalEntryTombstone) ProtoReflect() protoreflect.Message {
-	mi := &file_kv_kv_proto_msgTypes[19]
+	mi := &file_kv_kv_proto_msgTypes[21]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1497,7 +1693,7 @@ func (x *InternalEntryTombstone) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use InternalEntryTombstone.ProtoReflect.Descriptor instead.
 func (*InternalEntryTombstone) Descriptor() ([]byte, []int) {
-	return file_kv_kv_proto_rawDescGZIP(), []int{19}
+	return file_kv_kv_proto_rawDescGZIP(), []int{21}
 }
 
 func (x *InternalEntryTombstone) GetColumnFamily() InternalEntryTombstone_ColumnFamily {
@@ -1530,7 +1726,7 @@ type MVCCMaintenanceRequest struct {
 
 func (x *MVCCMaintenanceRequest) Reset() {
 	*x = MVCCMaintenanceRequest{}
-	mi := &file_kv_kv_proto_msgTypes[20]
+	mi := &file_kv_kv_proto_msgTypes[22]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1542,7 +1738,7 @@ func (x *MVCCMaintenanceRequest) String() string {
 func (*MVCCMaintenanceRequest) ProtoMessage() {}
 
 func (x *MVCCMaintenanceRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_kv_kv_proto_msgTypes[20]
+	mi := &file_kv_kv_proto_msgTypes[22]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1555,7 +1751,7 @@ func (x *MVCCMaintenanceRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use MVCCMaintenanceRequest.ProtoReflect.Descriptor instead.
 func (*MVCCMaintenanceRequest) Descriptor() ([]byte, []int) {
-	return file_kv_kv_proto_rawDescGZIP(), []int{20}
+	return file_kv_kv_proto_rawDescGZIP(), []int{22}
 }
 
 func (x *MVCCMaintenanceRequest) GetTombstones() []*InternalEntryTombstone {
@@ -1575,7 +1771,7 @@ type MVCCMaintenanceResponse struct {
 
 func (x *MVCCMaintenanceResponse) Reset() {
 	*x = MVCCMaintenanceResponse{}
-	mi := &file_kv_kv_proto_msgTypes[21]
+	mi := &file_kv_kv_proto_msgTypes[23]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1587,7 +1783,7 @@ func (x *MVCCMaintenanceResponse) String() string {
 func (*MVCCMaintenanceResponse) ProtoMessage() {}
 
 func (x *MVCCMaintenanceResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_kv_kv_proto_msgTypes[21]
+	mi := &file_kv_kv_proto_msgTypes[23]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1600,7 +1796,7 @@ func (x *MVCCMaintenanceResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use MVCCMaintenanceResponse.ProtoReflect.Descriptor instead.
 func (*MVCCMaintenanceResponse) Descriptor() ([]byte, []int) {
-	return file_kv_kv_proto_rawDescGZIP(), []int{21}
+	return file_kv_kv_proto_rawDescGZIP(), []int{23}
 }
 
 func (x *MVCCMaintenanceResponse) GetError() *KeyError {
@@ -1632,7 +1828,7 @@ type Context struct {
 
 func (x *Context) Reset() {
 	*x = Context{}
-	mi := &file_kv_kv_proto_msgTypes[22]
+	mi := &file_kv_kv_proto_msgTypes[24]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1644,7 +1840,7 @@ func (x *Context) String() string {
 func (*Context) ProtoMessage() {}
 
 func (x *Context) ProtoReflect() protoreflect.Message {
-	mi := &file_kv_kv_proto_msgTypes[22]
+	mi := &file_kv_kv_proto_msgTypes[24]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1657,7 +1853,7 @@ func (x *Context) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Context.ProtoReflect.Descriptor instead.
 func (*Context) Descriptor() ([]byte, []int) {
-	return file_kv_kv_proto_rawDescGZIP(), []int{22}
+	return file_kv_kv_proto_rawDescGZIP(), []int{24}
 }
 
 func (x *Context) GetRegionId() uint64 {
@@ -1719,7 +1915,7 @@ type KvGetRequest struct {
 
 func (x *KvGetRequest) Reset() {
 	*x = KvGetRequest{}
-	mi := &file_kv_kv_proto_msgTypes[23]
+	mi := &file_kv_kv_proto_msgTypes[25]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1731,7 +1927,7 @@ func (x *KvGetRequest) String() string {
 func (*KvGetRequest) ProtoMessage() {}
 
 func (x *KvGetRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_kv_kv_proto_msgTypes[23]
+	mi := &file_kv_kv_proto_msgTypes[25]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1744,7 +1940,7 @@ func (x *KvGetRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use KvGetRequest.ProtoReflect.Descriptor instead.
 func (*KvGetRequest) Descriptor() ([]byte, []int) {
-	return file_kv_kv_proto_rawDescGZIP(), []int{23}
+	return file_kv_kv_proto_rawDescGZIP(), []int{25}
 }
 
 func (x *KvGetRequest) GetContext() *Context {
@@ -1771,7 +1967,7 @@ type KvGetResponse struct {
 
 func (x *KvGetResponse) Reset() {
 	*x = KvGetResponse{}
-	mi := &file_kv_kv_proto_msgTypes[24]
+	mi := &file_kv_kv_proto_msgTypes[26]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1783,7 +1979,7 @@ func (x *KvGetResponse) String() string {
 func (*KvGetResponse) ProtoMessage() {}
 
 func (x *KvGetResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_kv_kv_proto_msgTypes[24]
+	mi := &file_kv_kv_proto_msgTypes[26]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1796,7 +1992,7 @@ func (x *KvGetResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use KvGetResponse.ProtoReflect.Descriptor instead.
 func (*KvGetResponse) Descriptor() ([]byte, []int) {
-	return file_kv_kv_proto_rawDescGZIP(), []int{24}
+	return file_kv_kv_proto_rawDescGZIP(), []int{26}
 }
 
 func (x *KvGetResponse) GetResponse() *GetResponse {
@@ -1823,7 +2019,7 @@ type KvBatchGetRequest struct {
 
 func (x *KvBatchGetRequest) Reset() {
 	*x = KvBatchGetRequest{}
-	mi := &file_kv_kv_proto_msgTypes[25]
+	mi := &file_kv_kv_proto_msgTypes[27]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1835,7 +2031,7 @@ func (x *KvBatchGetRequest) String() string {
 func (*KvBatchGetRequest) ProtoMessage() {}
 
 func (x *KvBatchGetRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_kv_kv_proto_msgTypes[25]
+	mi := &file_kv_kv_proto_msgTypes[27]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1848,7 +2044,7 @@ func (x *KvBatchGetRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use KvBatchGetRequest.ProtoReflect.Descriptor instead.
 func (*KvBatchGetRequest) Descriptor() ([]byte, []int) {
-	return file_kv_kv_proto_rawDescGZIP(), []int{25}
+	return file_kv_kv_proto_rawDescGZIP(), []int{27}
 }
 
 func (x *KvBatchGetRequest) GetContext() *Context {
@@ -1875,7 +2071,7 @@ type KvBatchGetResponse struct {
 
 func (x *KvBatchGetResponse) Reset() {
 	*x = KvBatchGetResponse{}
-	mi := &file_kv_kv_proto_msgTypes[26]
+	mi := &file_kv_kv_proto_msgTypes[28]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1887,7 +2083,7 @@ func (x *KvBatchGetResponse) String() string {
 func (*KvBatchGetResponse) ProtoMessage() {}
 
 func (x *KvBatchGetResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_kv_kv_proto_msgTypes[26]
+	mi := &file_kv_kv_proto_msgTypes[28]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1900,7 +2096,7 @@ func (x *KvBatchGetResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use KvBatchGetResponse.ProtoReflect.Descriptor instead.
 func (*KvBatchGetResponse) Descriptor() ([]byte, []int) {
-	return file_kv_kv_proto_rawDescGZIP(), []int{26}
+	return file_kv_kv_proto_rawDescGZIP(), []int{28}
 }
 
 func (x *KvBatchGetResponse) GetResponse() *BatchGetResponse {
@@ -1927,7 +2123,7 @@ type KvScanRequest struct {
 
 func (x *KvScanRequest) Reset() {
 	*x = KvScanRequest{}
-	mi := &file_kv_kv_proto_msgTypes[27]
+	mi := &file_kv_kv_proto_msgTypes[29]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1939,7 +2135,7 @@ func (x *KvScanRequest) String() string {
 func (*KvScanRequest) ProtoMessage() {}
 
 func (x *KvScanRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_kv_kv_proto_msgTypes[27]
+	mi := &file_kv_kv_proto_msgTypes[29]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1952,7 +2148,7 @@ func (x *KvScanRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use KvScanRequest.ProtoReflect.Descriptor instead.
 func (*KvScanRequest) Descriptor() ([]byte, []int) {
-	return file_kv_kv_proto_rawDescGZIP(), []int{27}
+	return file_kv_kv_proto_rawDescGZIP(), []int{29}
 }
 
 func (x *KvScanRequest) GetContext() *Context {
@@ -1979,7 +2175,7 @@ type KvScanResponse struct {
 
 func (x *KvScanResponse) Reset() {
 	*x = KvScanResponse{}
-	mi := &file_kv_kv_proto_msgTypes[28]
+	mi := &file_kv_kv_proto_msgTypes[30]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1991,7 +2187,7 @@ func (x *KvScanResponse) String() string {
 func (*KvScanResponse) ProtoMessage() {}
 
 func (x *KvScanResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_kv_kv_proto_msgTypes[28]
+	mi := &file_kv_kv_proto_msgTypes[30]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2004,7 +2200,7 @@ func (x *KvScanResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use KvScanResponse.ProtoReflect.Descriptor instead.
 func (*KvScanResponse) Descriptor() ([]byte, []int) {
-	return file_kv_kv_proto_rawDescGZIP(), []int{28}
+	return file_kv_kv_proto_rawDescGZIP(), []int{30}
 }
 
 func (x *KvScanResponse) GetResponse() *ScanResponse {
@@ -2031,7 +2227,7 @@ type KvPrewriteRequest struct {
 
 func (x *KvPrewriteRequest) Reset() {
 	*x = KvPrewriteRequest{}
-	mi := &file_kv_kv_proto_msgTypes[29]
+	mi := &file_kv_kv_proto_msgTypes[31]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2043,7 +2239,7 @@ func (x *KvPrewriteRequest) String() string {
 func (*KvPrewriteRequest) ProtoMessage() {}
 
 func (x *KvPrewriteRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_kv_kv_proto_msgTypes[29]
+	mi := &file_kv_kv_proto_msgTypes[31]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2056,7 +2252,7 @@ func (x *KvPrewriteRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use KvPrewriteRequest.ProtoReflect.Descriptor instead.
 func (*KvPrewriteRequest) Descriptor() ([]byte, []int) {
-	return file_kv_kv_proto_rawDescGZIP(), []int{29}
+	return file_kv_kv_proto_rawDescGZIP(), []int{31}
 }
 
 func (x *KvPrewriteRequest) GetContext() *Context {
@@ -2083,7 +2279,7 @@ type KvPrewriteResponse struct {
 
 func (x *KvPrewriteResponse) Reset() {
 	*x = KvPrewriteResponse{}
-	mi := &file_kv_kv_proto_msgTypes[30]
+	mi := &file_kv_kv_proto_msgTypes[32]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2095,7 +2291,7 @@ func (x *KvPrewriteResponse) String() string {
 func (*KvPrewriteResponse) ProtoMessage() {}
 
 func (x *KvPrewriteResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_kv_kv_proto_msgTypes[30]
+	mi := &file_kv_kv_proto_msgTypes[32]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2108,7 +2304,7 @@ func (x *KvPrewriteResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use KvPrewriteResponse.ProtoReflect.Descriptor instead.
 func (*KvPrewriteResponse) Descriptor() ([]byte, []int) {
-	return file_kv_kv_proto_rawDescGZIP(), []int{30}
+	return file_kv_kv_proto_rawDescGZIP(), []int{32}
 }
 
 func (x *KvPrewriteResponse) GetResponse() *PrewriteResponse {
@@ -2135,7 +2331,7 @@ type KvCommitRequest struct {
 
 func (x *KvCommitRequest) Reset() {
 	*x = KvCommitRequest{}
-	mi := &file_kv_kv_proto_msgTypes[31]
+	mi := &file_kv_kv_proto_msgTypes[33]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2147,7 +2343,7 @@ func (x *KvCommitRequest) String() string {
 func (*KvCommitRequest) ProtoMessage() {}
 
 func (x *KvCommitRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_kv_kv_proto_msgTypes[31]
+	mi := &file_kv_kv_proto_msgTypes[33]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2160,7 +2356,7 @@ func (x *KvCommitRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use KvCommitRequest.ProtoReflect.Descriptor instead.
 func (*KvCommitRequest) Descriptor() ([]byte, []int) {
-	return file_kv_kv_proto_rawDescGZIP(), []int{31}
+	return file_kv_kv_proto_rawDescGZIP(), []int{33}
 }
 
 func (x *KvCommitRequest) GetContext() *Context {
@@ -2187,7 +2383,7 @@ type KvCommitResponse struct {
 
 func (x *KvCommitResponse) Reset() {
 	*x = KvCommitResponse{}
-	mi := &file_kv_kv_proto_msgTypes[32]
+	mi := &file_kv_kv_proto_msgTypes[34]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2199,7 +2395,7 @@ func (x *KvCommitResponse) String() string {
 func (*KvCommitResponse) ProtoMessage() {}
 
 func (x *KvCommitResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_kv_kv_proto_msgTypes[32]
+	mi := &file_kv_kv_proto_msgTypes[34]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2212,7 +2408,7 @@ func (x *KvCommitResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use KvCommitResponse.ProtoReflect.Descriptor instead.
 func (*KvCommitResponse) Descriptor() ([]byte, []int) {
-	return file_kv_kv_proto_rawDescGZIP(), []int{32}
+	return file_kv_kv_proto_rawDescGZIP(), []int{34}
 }
 
 func (x *KvCommitResponse) GetResponse() *CommitResponse {
@@ -2239,7 +2435,7 @@ type KvBatchRollbackRequest struct {
 
 func (x *KvBatchRollbackRequest) Reset() {
 	*x = KvBatchRollbackRequest{}
-	mi := &file_kv_kv_proto_msgTypes[33]
+	mi := &file_kv_kv_proto_msgTypes[35]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2251,7 +2447,7 @@ func (x *KvBatchRollbackRequest) String() string {
 func (*KvBatchRollbackRequest) ProtoMessage() {}
 
 func (x *KvBatchRollbackRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_kv_kv_proto_msgTypes[33]
+	mi := &file_kv_kv_proto_msgTypes[35]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2264,7 +2460,7 @@ func (x *KvBatchRollbackRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use KvBatchRollbackRequest.ProtoReflect.Descriptor instead.
 func (*KvBatchRollbackRequest) Descriptor() ([]byte, []int) {
-	return file_kv_kv_proto_rawDescGZIP(), []int{33}
+	return file_kv_kv_proto_rawDescGZIP(), []int{35}
 }
 
 func (x *KvBatchRollbackRequest) GetContext() *Context {
@@ -2291,7 +2487,7 @@ type KvBatchRollbackResponse struct {
 
 func (x *KvBatchRollbackResponse) Reset() {
 	*x = KvBatchRollbackResponse{}
-	mi := &file_kv_kv_proto_msgTypes[34]
+	mi := &file_kv_kv_proto_msgTypes[36]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2303,7 +2499,7 @@ func (x *KvBatchRollbackResponse) String() string {
 func (*KvBatchRollbackResponse) ProtoMessage() {}
 
 func (x *KvBatchRollbackResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_kv_kv_proto_msgTypes[34]
+	mi := &file_kv_kv_proto_msgTypes[36]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2316,7 +2512,7 @@ func (x *KvBatchRollbackResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use KvBatchRollbackResponse.ProtoReflect.Descriptor instead.
 func (*KvBatchRollbackResponse) Descriptor() ([]byte, []int) {
-	return file_kv_kv_proto_rawDescGZIP(), []int{34}
+	return file_kv_kv_proto_rawDescGZIP(), []int{36}
 }
 
 func (x *KvBatchRollbackResponse) GetResponse() *BatchRollbackResponse {
@@ -2343,7 +2539,7 @@ type KvResolveLockRequest struct {
 
 func (x *KvResolveLockRequest) Reset() {
 	*x = KvResolveLockRequest{}
-	mi := &file_kv_kv_proto_msgTypes[35]
+	mi := &file_kv_kv_proto_msgTypes[37]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2355,7 +2551,7 @@ func (x *KvResolveLockRequest) String() string {
 func (*KvResolveLockRequest) ProtoMessage() {}
 
 func (x *KvResolveLockRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_kv_kv_proto_msgTypes[35]
+	mi := &file_kv_kv_proto_msgTypes[37]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2368,7 +2564,7 @@ func (x *KvResolveLockRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use KvResolveLockRequest.ProtoReflect.Descriptor instead.
 func (*KvResolveLockRequest) Descriptor() ([]byte, []int) {
-	return file_kv_kv_proto_rawDescGZIP(), []int{35}
+	return file_kv_kv_proto_rawDescGZIP(), []int{37}
 }
 
 func (x *KvResolveLockRequest) GetContext() *Context {
@@ -2395,7 +2591,7 @@ type KvResolveLockResponse struct {
 
 func (x *KvResolveLockResponse) Reset() {
 	*x = KvResolveLockResponse{}
-	mi := &file_kv_kv_proto_msgTypes[36]
+	mi := &file_kv_kv_proto_msgTypes[38]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2407,7 +2603,7 @@ func (x *KvResolveLockResponse) String() string {
 func (*KvResolveLockResponse) ProtoMessage() {}
 
 func (x *KvResolveLockResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_kv_kv_proto_msgTypes[36]
+	mi := &file_kv_kv_proto_msgTypes[38]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2420,7 +2616,7 @@ func (x *KvResolveLockResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use KvResolveLockResponse.ProtoReflect.Descriptor instead.
 func (*KvResolveLockResponse) Descriptor() ([]byte, []int) {
-	return file_kv_kv_proto_rawDescGZIP(), []int{36}
+	return file_kv_kv_proto_rawDescGZIP(), []int{38}
 }
 
 func (x *KvResolveLockResponse) GetResponse() *ResolveLockResponse {
@@ -2447,7 +2643,7 @@ type KvCheckTxnStatusRequest struct {
 
 func (x *KvCheckTxnStatusRequest) Reset() {
 	*x = KvCheckTxnStatusRequest{}
-	mi := &file_kv_kv_proto_msgTypes[37]
+	mi := &file_kv_kv_proto_msgTypes[39]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2459,7 +2655,7 @@ func (x *KvCheckTxnStatusRequest) String() string {
 func (*KvCheckTxnStatusRequest) ProtoMessage() {}
 
 func (x *KvCheckTxnStatusRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_kv_kv_proto_msgTypes[37]
+	mi := &file_kv_kv_proto_msgTypes[39]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2472,7 +2668,7 @@ func (x *KvCheckTxnStatusRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use KvCheckTxnStatusRequest.ProtoReflect.Descriptor instead.
 func (*KvCheckTxnStatusRequest) Descriptor() ([]byte, []int) {
-	return file_kv_kv_proto_rawDescGZIP(), []int{37}
+	return file_kv_kv_proto_rawDescGZIP(), []int{39}
 }
 
 func (x *KvCheckTxnStatusRequest) GetContext() *Context {
@@ -2499,7 +2695,7 @@ type KvCheckTxnStatusResponse struct {
 
 func (x *KvCheckTxnStatusResponse) Reset() {
 	*x = KvCheckTxnStatusResponse{}
-	mi := &file_kv_kv_proto_msgTypes[38]
+	mi := &file_kv_kv_proto_msgTypes[40]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2511,7 +2707,7 @@ func (x *KvCheckTxnStatusResponse) String() string {
 func (*KvCheckTxnStatusResponse) ProtoMessage() {}
 
 func (x *KvCheckTxnStatusResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_kv_kv_proto_msgTypes[38]
+	mi := &file_kv_kv_proto_msgTypes[40]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2524,7 +2720,7 @@ func (x *KvCheckTxnStatusResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use KvCheckTxnStatusResponse.ProtoReflect.Descriptor instead.
 func (*KvCheckTxnStatusResponse) Descriptor() ([]byte, []int) {
-	return file_kv_kv_proto_rawDescGZIP(), []int{38}
+	return file_kv_kv_proto_rawDescGZIP(), []int{40}
 }
 
 func (x *KvCheckTxnStatusResponse) GetResponse() *CheckTxnStatusResponse {
@@ -2541,6 +2737,110 @@ func (x *KvCheckTxnStatusResponse) GetRegionError() *error1.RegionError {
 	return nil
 }
 
+type KvTxnHeartBeatRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Context       *Context               `protobuf:"bytes,1,opt,name=context,proto3" json:"context,omitempty"`
+	Request       *TxnHeartBeatRequest   `protobuf:"bytes,2,opt,name=request,proto3" json:"request,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *KvTxnHeartBeatRequest) Reset() {
+	*x = KvTxnHeartBeatRequest{}
+	mi := &file_kv_kv_proto_msgTypes[41]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *KvTxnHeartBeatRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*KvTxnHeartBeatRequest) ProtoMessage() {}
+
+func (x *KvTxnHeartBeatRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_kv_kv_proto_msgTypes[41]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use KvTxnHeartBeatRequest.ProtoReflect.Descriptor instead.
+func (*KvTxnHeartBeatRequest) Descriptor() ([]byte, []int) {
+	return file_kv_kv_proto_rawDescGZIP(), []int{41}
+}
+
+func (x *KvTxnHeartBeatRequest) GetContext() *Context {
+	if x != nil {
+		return x.Context
+	}
+	return nil
+}
+
+func (x *KvTxnHeartBeatRequest) GetRequest() *TxnHeartBeatRequest {
+	if x != nil {
+		return x.Request
+	}
+	return nil
+}
+
+type KvTxnHeartBeatResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Response      *TxnHeartBeatResponse  `protobuf:"bytes,1,opt,name=response,proto3" json:"response,omitempty"`
+	RegionError   *error1.RegionError    `protobuf:"bytes,2,opt,name=region_error,json=regionError,proto3" json:"region_error,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *KvTxnHeartBeatResponse) Reset() {
+	*x = KvTxnHeartBeatResponse{}
+	mi := &file_kv_kv_proto_msgTypes[42]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *KvTxnHeartBeatResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*KvTxnHeartBeatResponse) ProtoMessage() {}
+
+func (x *KvTxnHeartBeatResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_kv_kv_proto_msgTypes[42]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use KvTxnHeartBeatResponse.ProtoReflect.Descriptor instead.
+func (*KvTxnHeartBeatResponse) Descriptor() ([]byte, []int) {
+	return file_kv_kv_proto_rawDescGZIP(), []int{42}
+}
+
+func (x *KvTxnHeartBeatResponse) GetResponse() *TxnHeartBeatResponse {
+	if x != nil {
+		return x.Response
+	}
+	return nil
+}
+
+func (x *KvTxnHeartBeatResponse) GetRegionError() *error1.RegionError {
+	if x != nil {
+		return x.RegionError
+	}
+	return nil
+}
+
 type ApplyWatchRequest struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	KeyPrefix     []byte                 `protobuf:"bytes,1,opt,name=key_prefix,json=keyPrefix,proto3" json:"key_prefix,omitempty"`
@@ -2551,7 +2851,7 @@ type ApplyWatchRequest struct {
 
 func (x *ApplyWatchRequest) Reset() {
 	*x = ApplyWatchRequest{}
-	mi := &file_kv_kv_proto_msgTypes[39]
+	mi := &file_kv_kv_proto_msgTypes[43]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2563,7 +2863,7 @@ func (x *ApplyWatchRequest) String() string {
 func (*ApplyWatchRequest) ProtoMessage() {}
 
 func (x *ApplyWatchRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_kv_kv_proto_msgTypes[39]
+	mi := &file_kv_kv_proto_msgTypes[43]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2576,7 +2876,7 @@ func (x *ApplyWatchRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ApplyWatchRequest.ProtoReflect.Descriptor instead.
 func (*ApplyWatchRequest) Descriptor() ([]byte, []int) {
-	return file_kv_kv_proto_rawDescGZIP(), []int{39}
+	return file_kv_kv_proto_rawDescGZIP(), []int{43}
 }
 
 func (x *ApplyWatchRequest) GetKeyPrefix() []byte {
@@ -2607,7 +2907,7 @@ type ApplyWatchEvent struct {
 
 func (x *ApplyWatchEvent) Reset() {
 	*x = ApplyWatchEvent{}
-	mi := &file_kv_kv_proto_msgTypes[40]
+	mi := &file_kv_kv_proto_msgTypes[44]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2619,7 +2919,7 @@ func (x *ApplyWatchEvent) String() string {
 func (*ApplyWatchEvent) ProtoMessage() {}
 
 func (x *ApplyWatchEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_kv_kv_proto_msgTypes[40]
+	mi := &file_kv_kv_proto_msgTypes[44]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2632,7 +2932,7 @@ func (x *ApplyWatchEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ApplyWatchEvent.ProtoReflect.Descriptor instead.
 func (*ApplyWatchEvent) Descriptor() ([]byte, []int) {
-	return file_kv_kv_proto_rawDescGZIP(), []int{40}
+	return file_kv_kv_proto_rawDescGZIP(), []int{44}
 }
 
 func (x *ApplyWatchEvent) GetRegionId() uint64 {
@@ -2687,7 +2987,7 @@ type ApplyWatchResponse struct {
 
 func (x *ApplyWatchResponse) Reset() {
 	*x = ApplyWatchResponse{}
-	mi := &file_kv_kv_proto_msgTypes[41]
+	mi := &file_kv_kv_proto_msgTypes[45]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2699,7 +2999,7 @@ func (x *ApplyWatchResponse) String() string {
 func (*ApplyWatchResponse) ProtoMessage() {}
 
 func (x *ApplyWatchResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_kv_kv_proto_msgTypes[41]
+	mi := &file_kv_kv_proto_msgTypes[45]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2712,7 +3012,7 @@ func (x *ApplyWatchResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ApplyWatchResponse.ProtoReflect.Descriptor instead.
 func (*ApplyWatchResponse) Descriptor() ([]byte, []int) {
-	return file_kv_kv_proto_rawDescGZIP(), []int{41}
+	return file_kv_kv_proto_rawDescGZIP(), []int{45}
 }
 
 func (x *ApplyWatchResponse) GetEvent() *ApplyWatchEvent {
@@ -2743,7 +3043,7 @@ type KeyError struct {
 
 func (x *KeyError) Reset() {
 	*x = KeyError{}
-	mi := &file_kv_kv_proto_msgTypes[42]
+	mi := &file_kv_kv_proto_msgTypes[46]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2755,7 +3055,7 @@ func (x *KeyError) String() string {
 func (*KeyError) ProtoMessage() {}
 
 func (x *KeyError) ProtoReflect() protoreflect.Message {
-	mi := &file_kv_kv_proto_msgTypes[42]
+	mi := &file_kv_kv_proto_msgTypes[46]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2768,7 +3068,7 @@ func (x *KeyError) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use KeyError.ProtoReflect.Descriptor instead.
 func (*KeyError) Descriptor() ([]byte, []int) {
-	return file_kv_kv_proto_rawDescGZIP(), []int{42}
+	return file_kv_kv_proto_rawDescGZIP(), []int{46}
 }
 
 func (x *KeyError) GetLocked() *Locked {
@@ -2827,7 +3127,7 @@ type Locked struct {
 
 func (x *Locked) Reset() {
 	*x = Locked{}
-	mi := &file_kv_kv_proto_msgTypes[43]
+	mi := &file_kv_kv_proto_msgTypes[47]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2839,7 +3139,7 @@ func (x *Locked) String() string {
 func (*Locked) ProtoMessage() {}
 
 func (x *Locked) ProtoReflect() protoreflect.Message {
-	mi := &file_kv_kv_proto_msgTypes[43]
+	mi := &file_kv_kv_proto_msgTypes[47]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2852,7 +3152,7 @@ func (x *Locked) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Locked.ProtoReflect.Descriptor instead.
 func (*Locked) Descriptor() ([]byte, []int) {
-	return file_kv_kv_proto_rawDescGZIP(), []int{43}
+	return file_kv_kv_proto_rawDescGZIP(), []int{47}
 }
 
 func (x *Locked) GetPrimaryLock() []byte {
@@ -2910,7 +3210,7 @@ type WriteConflict struct {
 
 func (x *WriteConflict) Reset() {
 	*x = WriteConflict{}
-	mi := &file_kv_kv_proto_msgTypes[44]
+	mi := &file_kv_kv_proto_msgTypes[48]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2922,7 +3222,7 @@ func (x *WriteConflict) String() string {
 func (*WriteConflict) ProtoMessage() {}
 
 func (x *WriteConflict) ProtoReflect() protoreflect.Message {
-	mi := &file_kv_kv_proto_msgTypes[44]
+	mi := &file_kv_kv_proto_msgTypes[48]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2935,7 +3235,7 @@ func (x *WriteConflict) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use WriteConflict.ProtoReflect.Descriptor instead.
 func (*WriteConflict) Descriptor() ([]byte, []int) {
-	return file_kv_kv_proto_rawDescGZIP(), []int{44}
+	return file_kv_kv_proto_rawDescGZIP(), []int{48}
 }
 
 func (x *WriteConflict) GetKey() []byte {
@@ -2982,7 +3282,7 @@ type KeyAlreadyExists struct {
 
 func (x *KeyAlreadyExists) Reset() {
 	*x = KeyAlreadyExists{}
-	mi := &file_kv_kv_proto_msgTypes[45]
+	mi := &file_kv_kv_proto_msgTypes[49]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2994,7 +3294,7 @@ func (x *KeyAlreadyExists) String() string {
 func (*KeyAlreadyExists) ProtoMessage() {}
 
 func (x *KeyAlreadyExists) ProtoReflect() protoreflect.Message {
-	mi := &file_kv_kv_proto_msgTypes[45]
+	mi := &file_kv_kv_proto_msgTypes[49]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3007,7 +3307,7 @@ func (x *KeyAlreadyExists) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use KeyAlreadyExists.ProtoReflect.Descriptor instead.
 func (*KeyAlreadyExists) Descriptor() ([]byte, []int) {
-	return file_kv_kv_proto_rawDescGZIP(), []int{45}
+	return file_kv_kv_proto_rawDescGZIP(), []int{49}
 }
 
 func (x *KeyAlreadyExists) GetKey() []byte {
@@ -3028,7 +3328,7 @@ type CommitTsExpired struct {
 
 func (x *CommitTsExpired) Reset() {
 	*x = CommitTsExpired{}
-	mi := &file_kv_kv_proto_msgTypes[46]
+	mi := &file_kv_kv_proto_msgTypes[50]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3040,7 +3340,7 @@ func (x *CommitTsExpired) String() string {
 func (*CommitTsExpired) ProtoMessage() {}
 
 func (x *CommitTsExpired) ProtoReflect() protoreflect.Message {
-	mi := &file_kv_kv_proto_msgTypes[46]
+	mi := &file_kv_kv_proto_msgTypes[50]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3053,7 +3353,7 @@ func (x *CommitTsExpired) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CommitTsExpired.ProtoReflect.Descriptor instead.
 func (*CommitTsExpired) Descriptor() ([]byte, []int) {
-	return file_kv_kv_proto_rawDescGZIP(), []int{46}
+	return file_kv_kv_proto_rawDescGZIP(), []int{50}
 }
 
 func (x *CommitTsExpired) GetKey() []byte {
@@ -3171,7 +3471,19 @@ const file_kv_kv_proto_rawDesc = "" +
 	"\x05error\x18\x01 \x01(\v2\x14.nokv.kv.v1.KeyErrorR\x05error\x12\x19\n" +
 	"\block_ttl\x18\x02 \x01(\x04R\alockTtl\x12%\n" +
 	"\x0ecommit_version\x18\x03 \x01(\x04R\rcommitVersion\x128\n" +
-	"\x06action\x18\x04 \x01(\x0e2 .nokv.kv.v1.CheckTxnStatusActionR\x06action\"\xc2\x01\n" +
+	"\x06action\x18\x04 \x01(\x0e2 .nokv.kv.v1.CheckTxnStatusActionR\x06action\"\xa3\x01\n" +
+	"\x13TxnHeartBeatRequest\x12\x1f\n" +
+	"\vprimary_key\x18\x01 \x01(\fR\n" +
+	"primaryKey\x12#\n" +
+	"\rstart_version\x18\x02 \x01(\x04R\fstartVersion\x12#\n" +
+	"\rttl_extension\x18\x03 \x01(\x04R\fttlExtension\x12!\n" +
+	"\fcurrent_time\x18\x04 \x01(\x04R\vcurrentTime\"\xe6\x01\n" +
+	"\x14TxnHeartBeatResponse\x12*\n" +
+	"\x05error\x18\x01 \x01(\v2\x14.nokv.kv.v1.KeyErrorR\x05error\x12\x19\n" +
+	"\block_ttl\x18\x02 \x01(\x04R\alockTtl\x12(\n" +
+	"\x10lock_expire_time\x18\x03 \x01(\x04R\x0elockExpireTime\x12%\n" +
+	"\x0ecommit_version\x18\x04 \x01(\x04R\rcommitVersion\x126\n" +
+	"\x06action\x18\x05 \x01(\x0e2\x1e.nokv.kv.v1.TxnHeartBeatActionR\x06action\"\xc2\x01\n" +
 	"\x16InternalEntryTombstone\x12T\n" +
 	"\rcolumn_family\x18\x01 \x01(\x0e2/.nokv.kv.v1.InternalEntryTombstone.ColumnFamilyR\fcolumnFamily\x12\x10\n" +
 	"\x03key\x18\x02 \x01(\fR\x03key\x12\x18\n" +
@@ -3241,6 +3553,12 @@ const file_kv_kv_proto_rawDesc = "" +
 	"\arequest\x18\x02 \x01(\v2!.nokv.kv.v1.CheckTxnStatusRequestR\arequest\"\x99\x01\n" +
 	"\x18KvCheckTxnStatusResponse\x12>\n" +
 	"\bresponse\x18\x01 \x01(\v2\".nokv.kv.v1.CheckTxnStatusResponseR\bresponse\x12=\n" +
+	"\fregion_error\x18\x02 \x01(\v2\x1a.nokv.error.v1.RegionErrorR\vregionError\"\x81\x01\n" +
+	"\x15KvTxnHeartBeatRequest\x12-\n" +
+	"\acontext\x18\x01 \x01(\v2\x13.nokv.kv.v1.ContextR\acontext\x129\n" +
+	"\arequest\x18\x02 \x01(\v2\x1f.nokv.kv.v1.TxnHeartBeatRequestR\arequest\"\x95\x01\n" +
+	"\x16KvTxnHeartBeatResponse\x12<\n" +
+	"\bresponse\x18\x01 \x01(\v2 .nokv.kv.v1.TxnHeartBeatResponseR\bresponse\x12=\n" +
 	"\fregion_error\x18\x02 \x01(\v2\x1a.nokv.error.v1.RegionErrorR\vregionError\"J\n" +
 	"\x11ApplyWatchRequest\x12\x1d\n" +
 	"\n" +
@@ -3293,11 +3611,16 @@ const file_kv_kv_proto_rawDesc = "" +
 	"\x16CheckTxnStatusNoAction\x10\x00\x12#\n" +
 	"\x1fCheckTxnStatusTTLExpireRollback\x10\x01\x12&\n" +
 	"\"CheckTxnStatusLockNotExistRollback\x10\x02\x12#\n" +
-	"\x1fCheckTxnStatusMinCommitTsPushed\x10\x03*\x91\x01\n" +
+	"\x1fCheckTxnStatusMinCommitTsPushed\x10\x03*\x94\x01\n" +
+	"\x12TxnHeartBeatAction\x12\x18\n" +
+	"\x14TxnHeartBeatNoAction\x10\x00\x12\x1b\n" +
+	"\x17TxnHeartBeatTTLExtended\x10\x01\x12!\n" +
+	"\x1dTxnHeartBeatTTLExpireRollback\x10\x02\x12$\n" +
+	" TxnHeartBeatLockNotExistRollback\x10\x03*\x91\x01\n" +
 	"\x15ApplyWatchEventSource\x12(\n" +
 	"$APPLY_WATCH_EVENT_SOURCE_UNSPECIFIED\x10\x00\x12#\n" +
 	"\x1fAPPLY_WATCH_EVENT_SOURCE_COMMIT\x10\x01\x12)\n" +
-	"%APPLY_WATCH_EVENT_SOURCE_RESOLVE_LOCK\x10\x022\xc8\x05\n" +
+	"%APPLY_WATCH_EVENT_SOURCE_RESOLVE_LOCK\x10\x022\xa1\x06\n" +
 	"\x04NoKV\x12<\n" +
 	"\x05KvGet\x12\x18.nokv.kv.v1.KvGetRequest\x1a\x19.nokv.kv.v1.KvGetResponse\x12K\n" +
 	"\n" +
@@ -3308,7 +3631,8 @@ const file_kv_kv_proto_rawDesc = "" +
 	"\bKvCommit\x12\x1b.nokv.kv.v1.KvCommitRequest\x1a\x1c.nokv.kv.v1.KvCommitResponse\x12Z\n" +
 	"\x0fKvBatchRollback\x12\".nokv.kv.v1.KvBatchRollbackRequest\x1a#.nokv.kv.v1.KvBatchRollbackResponse\x12T\n" +
 	"\rKvResolveLock\x12 .nokv.kv.v1.KvResolveLockRequest\x1a!.nokv.kv.v1.KvResolveLockResponse\x12]\n" +
-	"\x10KvCheckTxnStatus\x12#.nokv.kv.v1.KvCheckTxnStatusRequest\x1a$.nokv.kv.v1.KvCheckTxnStatusResponse\x12O\n" +
+	"\x10KvCheckTxnStatus\x12#.nokv.kv.v1.KvCheckTxnStatusRequest\x1a$.nokv.kv.v1.KvCheckTxnStatusResponse\x12W\n" +
+	"\x0eKvTxnHeartBeat\x12!.nokv.kv.v1.KvTxnHeartBeatRequest\x1a\".nokv.kv.v1.KvTxnHeartBeatResponse\x12O\n" +
 	"\fKvWatchApply\x12\x1d.nokv.kv.v1.ApplyWatchRequest\x1a\x1e.nokv.kv.v1.ApplyWatchResponse0\x01B+Z)github.com/feichai0017/NoKV/pb/kv;kvrpcpbb\x06proto3"
 
 var (
@@ -3323,150 +3647,163 @@ func file_kv_kv_proto_rawDescGZIP() []byte {
 	return file_kv_kv_proto_rawDescData
 }
 
-var file_kv_kv_proto_enumTypes = make([]protoimpl.EnumInfo, 6)
-var file_kv_kv_proto_msgTypes = make([]protoimpl.MessageInfo, 47)
+var file_kv_kv_proto_enumTypes = make([]protoimpl.EnumInfo, 7)
+var file_kv_kv_proto_msgTypes = make([]protoimpl.MessageInfo, 51)
 var file_kv_kv_proto_goTypes = []any{
 	(ReadConsistency)(0),                     // 0: nokv.kv.v1.ReadConsistency
 	(ReadPreference)(0),                      // 1: nokv.kv.v1.ReadPreference
 	(CheckTxnStatusAction)(0),                // 2: nokv.kv.v1.CheckTxnStatusAction
-	(ApplyWatchEventSource)(0),               // 3: nokv.kv.v1.ApplyWatchEventSource
-	(Mutation_Op)(0),                         // 4: nokv.kv.v1.Mutation.Op
-	(InternalEntryTombstone_ColumnFamily)(0), // 5: nokv.kv.v1.InternalEntryTombstone.ColumnFamily
-	(*KV)(nil),                               // 6: nokv.kv.v1.KV
-	(*KVList)(nil),                           // 7: nokv.kv.v1.KVList
-	(*GetRequest)(nil),                       // 8: nokv.kv.v1.GetRequest
-	(*GetResponse)(nil),                      // 9: nokv.kv.v1.GetResponse
-	(*BatchGetRequest)(nil),                  // 10: nokv.kv.v1.BatchGetRequest
-	(*BatchGetResponse)(nil),                 // 11: nokv.kv.v1.BatchGetResponse
-	(*ScanRequest)(nil),                      // 12: nokv.kv.v1.ScanRequest
-	(*ScanResponse)(nil),                     // 13: nokv.kv.v1.ScanResponse
-	(*Mutation)(nil),                         // 14: nokv.kv.v1.Mutation
-	(*PrewriteRequest)(nil),                  // 15: nokv.kv.v1.PrewriteRequest
-	(*PrewriteResponse)(nil),                 // 16: nokv.kv.v1.PrewriteResponse
-	(*CommitRequest)(nil),                    // 17: nokv.kv.v1.CommitRequest
-	(*CommitResponse)(nil),                   // 18: nokv.kv.v1.CommitResponse
-	(*BatchRollbackRequest)(nil),             // 19: nokv.kv.v1.BatchRollbackRequest
-	(*BatchRollbackResponse)(nil),            // 20: nokv.kv.v1.BatchRollbackResponse
-	(*ResolveLockRequest)(nil),               // 21: nokv.kv.v1.ResolveLockRequest
-	(*ResolveLockResponse)(nil),              // 22: nokv.kv.v1.ResolveLockResponse
-	(*CheckTxnStatusRequest)(nil),            // 23: nokv.kv.v1.CheckTxnStatusRequest
-	(*CheckTxnStatusResponse)(nil),           // 24: nokv.kv.v1.CheckTxnStatusResponse
-	(*InternalEntryTombstone)(nil),           // 25: nokv.kv.v1.InternalEntryTombstone
-	(*MVCCMaintenanceRequest)(nil),           // 26: nokv.kv.v1.MVCCMaintenanceRequest
-	(*MVCCMaintenanceResponse)(nil),          // 27: nokv.kv.v1.MVCCMaintenanceResponse
-	(*Context)(nil),                          // 28: nokv.kv.v1.Context
-	(*KvGetRequest)(nil),                     // 29: nokv.kv.v1.KvGetRequest
-	(*KvGetResponse)(nil),                    // 30: nokv.kv.v1.KvGetResponse
-	(*KvBatchGetRequest)(nil),                // 31: nokv.kv.v1.KvBatchGetRequest
-	(*KvBatchGetResponse)(nil),               // 32: nokv.kv.v1.KvBatchGetResponse
-	(*KvScanRequest)(nil),                    // 33: nokv.kv.v1.KvScanRequest
-	(*KvScanResponse)(nil),                   // 34: nokv.kv.v1.KvScanResponse
-	(*KvPrewriteRequest)(nil),                // 35: nokv.kv.v1.KvPrewriteRequest
-	(*KvPrewriteResponse)(nil),               // 36: nokv.kv.v1.KvPrewriteResponse
-	(*KvCommitRequest)(nil),                  // 37: nokv.kv.v1.KvCommitRequest
-	(*KvCommitResponse)(nil),                 // 38: nokv.kv.v1.KvCommitResponse
-	(*KvBatchRollbackRequest)(nil),           // 39: nokv.kv.v1.KvBatchRollbackRequest
-	(*KvBatchRollbackResponse)(nil),          // 40: nokv.kv.v1.KvBatchRollbackResponse
-	(*KvResolveLockRequest)(nil),             // 41: nokv.kv.v1.KvResolveLockRequest
-	(*KvResolveLockResponse)(nil),            // 42: nokv.kv.v1.KvResolveLockResponse
-	(*KvCheckTxnStatusRequest)(nil),          // 43: nokv.kv.v1.KvCheckTxnStatusRequest
-	(*KvCheckTxnStatusResponse)(nil),         // 44: nokv.kv.v1.KvCheckTxnStatusResponse
-	(*ApplyWatchRequest)(nil),                // 45: nokv.kv.v1.ApplyWatchRequest
-	(*ApplyWatchEvent)(nil),                  // 46: nokv.kv.v1.ApplyWatchEvent
-	(*ApplyWatchResponse)(nil),               // 47: nokv.kv.v1.ApplyWatchResponse
-	(*KeyError)(nil),                         // 48: nokv.kv.v1.KeyError
-	(*Locked)(nil),                           // 49: nokv.kv.v1.Locked
-	(*WriteConflict)(nil),                    // 50: nokv.kv.v1.WriteConflict
-	(*KeyAlreadyExists)(nil),                 // 51: nokv.kv.v1.KeyAlreadyExists
-	(*CommitTsExpired)(nil),                  // 52: nokv.kv.v1.CommitTsExpired
-	(*meta.RegionEpoch)(nil),                 // 53: nokv.meta.v1.RegionEpoch
-	(*meta.RegionPeer)(nil),                  // 54: nokv.meta.v1.RegionPeer
-	(*error1.RegionError)(nil),               // 55: nokv.error.v1.RegionError
+	(TxnHeartBeatAction)(0),                  // 3: nokv.kv.v1.TxnHeartBeatAction
+	(ApplyWatchEventSource)(0),               // 4: nokv.kv.v1.ApplyWatchEventSource
+	(Mutation_Op)(0),                         // 5: nokv.kv.v1.Mutation.Op
+	(InternalEntryTombstone_ColumnFamily)(0), // 6: nokv.kv.v1.InternalEntryTombstone.ColumnFamily
+	(*KV)(nil),                               // 7: nokv.kv.v1.KV
+	(*KVList)(nil),                           // 8: nokv.kv.v1.KVList
+	(*GetRequest)(nil),                       // 9: nokv.kv.v1.GetRequest
+	(*GetResponse)(nil),                      // 10: nokv.kv.v1.GetResponse
+	(*BatchGetRequest)(nil),                  // 11: nokv.kv.v1.BatchGetRequest
+	(*BatchGetResponse)(nil),                 // 12: nokv.kv.v1.BatchGetResponse
+	(*ScanRequest)(nil),                      // 13: nokv.kv.v1.ScanRequest
+	(*ScanResponse)(nil),                     // 14: nokv.kv.v1.ScanResponse
+	(*Mutation)(nil),                         // 15: nokv.kv.v1.Mutation
+	(*PrewriteRequest)(nil),                  // 16: nokv.kv.v1.PrewriteRequest
+	(*PrewriteResponse)(nil),                 // 17: nokv.kv.v1.PrewriteResponse
+	(*CommitRequest)(nil),                    // 18: nokv.kv.v1.CommitRequest
+	(*CommitResponse)(nil),                   // 19: nokv.kv.v1.CommitResponse
+	(*BatchRollbackRequest)(nil),             // 20: nokv.kv.v1.BatchRollbackRequest
+	(*BatchRollbackResponse)(nil),            // 21: nokv.kv.v1.BatchRollbackResponse
+	(*ResolveLockRequest)(nil),               // 22: nokv.kv.v1.ResolveLockRequest
+	(*ResolveLockResponse)(nil),              // 23: nokv.kv.v1.ResolveLockResponse
+	(*CheckTxnStatusRequest)(nil),            // 24: nokv.kv.v1.CheckTxnStatusRequest
+	(*CheckTxnStatusResponse)(nil),           // 25: nokv.kv.v1.CheckTxnStatusResponse
+	(*TxnHeartBeatRequest)(nil),              // 26: nokv.kv.v1.TxnHeartBeatRequest
+	(*TxnHeartBeatResponse)(nil),             // 27: nokv.kv.v1.TxnHeartBeatResponse
+	(*InternalEntryTombstone)(nil),           // 28: nokv.kv.v1.InternalEntryTombstone
+	(*MVCCMaintenanceRequest)(nil),           // 29: nokv.kv.v1.MVCCMaintenanceRequest
+	(*MVCCMaintenanceResponse)(nil),          // 30: nokv.kv.v1.MVCCMaintenanceResponse
+	(*Context)(nil),                          // 31: nokv.kv.v1.Context
+	(*KvGetRequest)(nil),                     // 32: nokv.kv.v1.KvGetRequest
+	(*KvGetResponse)(nil),                    // 33: nokv.kv.v1.KvGetResponse
+	(*KvBatchGetRequest)(nil),                // 34: nokv.kv.v1.KvBatchGetRequest
+	(*KvBatchGetResponse)(nil),               // 35: nokv.kv.v1.KvBatchGetResponse
+	(*KvScanRequest)(nil),                    // 36: nokv.kv.v1.KvScanRequest
+	(*KvScanResponse)(nil),                   // 37: nokv.kv.v1.KvScanResponse
+	(*KvPrewriteRequest)(nil),                // 38: nokv.kv.v1.KvPrewriteRequest
+	(*KvPrewriteResponse)(nil),               // 39: nokv.kv.v1.KvPrewriteResponse
+	(*KvCommitRequest)(nil),                  // 40: nokv.kv.v1.KvCommitRequest
+	(*KvCommitResponse)(nil),                 // 41: nokv.kv.v1.KvCommitResponse
+	(*KvBatchRollbackRequest)(nil),           // 42: nokv.kv.v1.KvBatchRollbackRequest
+	(*KvBatchRollbackResponse)(nil),          // 43: nokv.kv.v1.KvBatchRollbackResponse
+	(*KvResolveLockRequest)(nil),             // 44: nokv.kv.v1.KvResolveLockRequest
+	(*KvResolveLockResponse)(nil),            // 45: nokv.kv.v1.KvResolveLockResponse
+	(*KvCheckTxnStatusRequest)(nil),          // 46: nokv.kv.v1.KvCheckTxnStatusRequest
+	(*KvCheckTxnStatusResponse)(nil),         // 47: nokv.kv.v1.KvCheckTxnStatusResponse
+	(*KvTxnHeartBeatRequest)(nil),            // 48: nokv.kv.v1.KvTxnHeartBeatRequest
+	(*KvTxnHeartBeatResponse)(nil),           // 49: nokv.kv.v1.KvTxnHeartBeatResponse
+	(*ApplyWatchRequest)(nil),                // 50: nokv.kv.v1.ApplyWatchRequest
+	(*ApplyWatchEvent)(nil),                  // 51: nokv.kv.v1.ApplyWatchEvent
+	(*ApplyWatchResponse)(nil),               // 52: nokv.kv.v1.ApplyWatchResponse
+	(*KeyError)(nil),                         // 53: nokv.kv.v1.KeyError
+	(*Locked)(nil),                           // 54: nokv.kv.v1.Locked
+	(*WriteConflict)(nil),                    // 55: nokv.kv.v1.WriteConflict
+	(*KeyAlreadyExists)(nil),                 // 56: nokv.kv.v1.KeyAlreadyExists
+	(*CommitTsExpired)(nil),                  // 57: nokv.kv.v1.CommitTsExpired
+	(*meta.RegionEpoch)(nil),                 // 58: nokv.meta.v1.RegionEpoch
+	(*meta.RegionPeer)(nil),                  // 59: nokv.meta.v1.RegionPeer
+	(*error1.RegionError)(nil),               // 60: nokv.error.v1.RegionError
 }
 var file_kv_kv_proto_depIdxs = []int32{
-	6,  // 0: nokv.kv.v1.KVList.kv:type_name -> nokv.kv.v1.KV
-	48, // 1: nokv.kv.v1.GetResponse.error:type_name -> nokv.kv.v1.KeyError
-	8,  // 2: nokv.kv.v1.BatchGetRequest.requests:type_name -> nokv.kv.v1.GetRequest
-	9,  // 3: nokv.kv.v1.BatchGetResponse.responses:type_name -> nokv.kv.v1.GetResponse
-	6,  // 4: nokv.kv.v1.ScanResponse.kvs:type_name -> nokv.kv.v1.KV
-	48, // 5: nokv.kv.v1.ScanResponse.error:type_name -> nokv.kv.v1.KeyError
-	4,  // 6: nokv.kv.v1.Mutation.op:type_name -> nokv.kv.v1.Mutation.Op
-	14, // 7: nokv.kv.v1.PrewriteRequest.mutations:type_name -> nokv.kv.v1.Mutation
-	48, // 8: nokv.kv.v1.PrewriteResponse.errors:type_name -> nokv.kv.v1.KeyError
-	48, // 9: nokv.kv.v1.CommitResponse.error:type_name -> nokv.kv.v1.KeyError
-	48, // 10: nokv.kv.v1.BatchRollbackResponse.error:type_name -> nokv.kv.v1.KeyError
-	48, // 11: nokv.kv.v1.ResolveLockResponse.error:type_name -> nokv.kv.v1.KeyError
-	48, // 12: nokv.kv.v1.CheckTxnStatusResponse.error:type_name -> nokv.kv.v1.KeyError
+	7,  // 0: nokv.kv.v1.KVList.kv:type_name -> nokv.kv.v1.KV
+	53, // 1: nokv.kv.v1.GetResponse.error:type_name -> nokv.kv.v1.KeyError
+	9,  // 2: nokv.kv.v1.BatchGetRequest.requests:type_name -> nokv.kv.v1.GetRequest
+	10, // 3: nokv.kv.v1.BatchGetResponse.responses:type_name -> nokv.kv.v1.GetResponse
+	7,  // 4: nokv.kv.v1.ScanResponse.kvs:type_name -> nokv.kv.v1.KV
+	53, // 5: nokv.kv.v1.ScanResponse.error:type_name -> nokv.kv.v1.KeyError
+	5,  // 6: nokv.kv.v1.Mutation.op:type_name -> nokv.kv.v1.Mutation.Op
+	15, // 7: nokv.kv.v1.PrewriteRequest.mutations:type_name -> nokv.kv.v1.Mutation
+	53, // 8: nokv.kv.v1.PrewriteResponse.errors:type_name -> nokv.kv.v1.KeyError
+	53, // 9: nokv.kv.v1.CommitResponse.error:type_name -> nokv.kv.v1.KeyError
+	53, // 10: nokv.kv.v1.BatchRollbackResponse.error:type_name -> nokv.kv.v1.KeyError
+	53, // 11: nokv.kv.v1.ResolveLockResponse.error:type_name -> nokv.kv.v1.KeyError
+	53, // 12: nokv.kv.v1.CheckTxnStatusResponse.error:type_name -> nokv.kv.v1.KeyError
 	2,  // 13: nokv.kv.v1.CheckTxnStatusResponse.action:type_name -> nokv.kv.v1.CheckTxnStatusAction
-	5,  // 14: nokv.kv.v1.InternalEntryTombstone.column_family:type_name -> nokv.kv.v1.InternalEntryTombstone.ColumnFamily
-	25, // 15: nokv.kv.v1.MVCCMaintenanceRequest.tombstones:type_name -> nokv.kv.v1.InternalEntryTombstone
-	48, // 16: nokv.kv.v1.MVCCMaintenanceResponse.error:type_name -> nokv.kv.v1.KeyError
-	53, // 17: nokv.kv.v1.Context.region_epoch:type_name -> nokv.meta.v1.RegionEpoch
-	54, // 18: nokv.kv.v1.Context.peer:type_name -> nokv.meta.v1.RegionPeer
-	0,  // 19: nokv.kv.v1.Context.read_consistency:type_name -> nokv.kv.v1.ReadConsistency
-	1,  // 20: nokv.kv.v1.Context.read_preference:type_name -> nokv.kv.v1.ReadPreference
-	28, // 21: nokv.kv.v1.KvGetRequest.context:type_name -> nokv.kv.v1.Context
-	8,  // 22: nokv.kv.v1.KvGetRequest.request:type_name -> nokv.kv.v1.GetRequest
-	9,  // 23: nokv.kv.v1.KvGetResponse.response:type_name -> nokv.kv.v1.GetResponse
-	55, // 24: nokv.kv.v1.KvGetResponse.region_error:type_name -> nokv.error.v1.RegionError
-	28, // 25: nokv.kv.v1.KvBatchGetRequest.context:type_name -> nokv.kv.v1.Context
-	10, // 26: nokv.kv.v1.KvBatchGetRequest.request:type_name -> nokv.kv.v1.BatchGetRequest
-	11, // 27: nokv.kv.v1.KvBatchGetResponse.response:type_name -> nokv.kv.v1.BatchGetResponse
-	55, // 28: nokv.kv.v1.KvBatchGetResponse.region_error:type_name -> nokv.error.v1.RegionError
-	28, // 29: nokv.kv.v1.KvScanRequest.context:type_name -> nokv.kv.v1.Context
-	12, // 30: nokv.kv.v1.KvScanRequest.request:type_name -> nokv.kv.v1.ScanRequest
-	13, // 31: nokv.kv.v1.KvScanResponse.response:type_name -> nokv.kv.v1.ScanResponse
-	55, // 32: nokv.kv.v1.KvScanResponse.region_error:type_name -> nokv.error.v1.RegionError
-	28, // 33: nokv.kv.v1.KvPrewriteRequest.context:type_name -> nokv.kv.v1.Context
-	15, // 34: nokv.kv.v1.KvPrewriteRequest.request:type_name -> nokv.kv.v1.PrewriteRequest
-	16, // 35: nokv.kv.v1.KvPrewriteResponse.response:type_name -> nokv.kv.v1.PrewriteResponse
-	55, // 36: nokv.kv.v1.KvPrewriteResponse.region_error:type_name -> nokv.error.v1.RegionError
-	28, // 37: nokv.kv.v1.KvCommitRequest.context:type_name -> nokv.kv.v1.Context
-	17, // 38: nokv.kv.v1.KvCommitRequest.request:type_name -> nokv.kv.v1.CommitRequest
-	18, // 39: nokv.kv.v1.KvCommitResponse.response:type_name -> nokv.kv.v1.CommitResponse
-	55, // 40: nokv.kv.v1.KvCommitResponse.region_error:type_name -> nokv.error.v1.RegionError
-	28, // 41: nokv.kv.v1.KvBatchRollbackRequest.context:type_name -> nokv.kv.v1.Context
-	19, // 42: nokv.kv.v1.KvBatchRollbackRequest.request:type_name -> nokv.kv.v1.BatchRollbackRequest
-	20, // 43: nokv.kv.v1.KvBatchRollbackResponse.response:type_name -> nokv.kv.v1.BatchRollbackResponse
-	55, // 44: nokv.kv.v1.KvBatchRollbackResponse.region_error:type_name -> nokv.error.v1.RegionError
-	28, // 45: nokv.kv.v1.KvResolveLockRequest.context:type_name -> nokv.kv.v1.Context
-	21, // 46: nokv.kv.v1.KvResolveLockRequest.request:type_name -> nokv.kv.v1.ResolveLockRequest
-	22, // 47: nokv.kv.v1.KvResolveLockResponse.response:type_name -> nokv.kv.v1.ResolveLockResponse
-	55, // 48: nokv.kv.v1.KvResolveLockResponse.region_error:type_name -> nokv.error.v1.RegionError
-	28, // 49: nokv.kv.v1.KvCheckTxnStatusRequest.context:type_name -> nokv.kv.v1.Context
-	23, // 50: nokv.kv.v1.KvCheckTxnStatusRequest.request:type_name -> nokv.kv.v1.CheckTxnStatusRequest
-	24, // 51: nokv.kv.v1.KvCheckTxnStatusResponse.response:type_name -> nokv.kv.v1.CheckTxnStatusResponse
-	55, // 52: nokv.kv.v1.KvCheckTxnStatusResponse.region_error:type_name -> nokv.error.v1.RegionError
-	3,  // 53: nokv.kv.v1.ApplyWatchEvent.source:type_name -> nokv.kv.v1.ApplyWatchEventSource
-	46, // 54: nokv.kv.v1.ApplyWatchResponse.event:type_name -> nokv.kv.v1.ApplyWatchEvent
-	49, // 55: nokv.kv.v1.KeyError.locked:type_name -> nokv.kv.v1.Locked
-	50, // 56: nokv.kv.v1.KeyError.write_conflict:type_name -> nokv.kv.v1.WriteConflict
-	51, // 57: nokv.kv.v1.KeyError.already_exists:type_name -> nokv.kv.v1.KeyAlreadyExists
-	52, // 58: nokv.kv.v1.KeyError.commit_ts_expired:type_name -> nokv.kv.v1.CommitTsExpired
-	4,  // 59: nokv.kv.v1.Locked.lock_type:type_name -> nokv.kv.v1.Mutation.Op
-	29, // 60: nokv.kv.v1.NoKV.KvGet:input_type -> nokv.kv.v1.KvGetRequest
-	31, // 61: nokv.kv.v1.NoKV.KvBatchGet:input_type -> nokv.kv.v1.KvBatchGetRequest
-	33, // 62: nokv.kv.v1.NoKV.KvScan:input_type -> nokv.kv.v1.KvScanRequest
-	35, // 63: nokv.kv.v1.NoKV.KvPrewrite:input_type -> nokv.kv.v1.KvPrewriteRequest
-	37, // 64: nokv.kv.v1.NoKV.KvCommit:input_type -> nokv.kv.v1.KvCommitRequest
-	39, // 65: nokv.kv.v1.NoKV.KvBatchRollback:input_type -> nokv.kv.v1.KvBatchRollbackRequest
-	41, // 66: nokv.kv.v1.NoKV.KvResolveLock:input_type -> nokv.kv.v1.KvResolveLockRequest
-	43, // 67: nokv.kv.v1.NoKV.KvCheckTxnStatus:input_type -> nokv.kv.v1.KvCheckTxnStatusRequest
-	45, // 68: nokv.kv.v1.NoKV.KvWatchApply:input_type -> nokv.kv.v1.ApplyWatchRequest
-	30, // 69: nokv.kv.v1.NoKV.KvGet:output_type -> nokv.kv.v1.KvGetResponse
-	32, // 70: nokv.kv.v1.NoKV.KvBatchGet:output_type -> nokv.kv.v1.KvBatchGetResponse
-	34, // 71: nokv.kv.v1.NoKV.KvScan:output_type -> nokv.kv.v1.KvScanResponse
-	36, // 72: nokv.kv.v1.NoKV.KvPrewrite:output_type -> nokv.kv.v1.KvPrewriteResponse
-	38, // 73: nokv.kv.v1.NoKV.KvCommit:output_type -> nokv.kv.v1.KvCommitResponse
-	40, // 74: nokv.kv.v1.NoKV.KvBatchRollback:output_type -> nokv.kv.v1.KvBatchRollbackResponse
-	42, // 75: nokv.kv.v1.NoKV.KvResolveLock:output_type -> nokv.kv.v1.KvResolveLockResponse
-	44, // 76: nokv.kv.v1.NoKV.KvCheckTxnStatus:output_type -> nokv.kv.v1.KvCheckTxnStatusResponse
-	47, // 77: nokv.kv.v1.NoKV.KvWatchApply:output_type -> nokv.kv.v1.ApplyWatchResponse
-	69, // [69:78] is the sub-list for method output_type
-	60, // [60:69] is the sub-list for method input_type
-	60, // [60:60] is the sub-list for extension type_name
-	60, // [60:60] is the sub-list for extension extendee
-	0,  // [0:60] is the sub-list for field type_name
+	53, // 14: nokv.kv.v1.TxnHeartBeatResponse.error:type_name -> nokv.kv.v1.KeyError
+	3,  // 15: nokv.kv.v1.TxnHeartBeatResponse.action:type_name -> nokv.kv.v1.TxnHeartBeatAction
+	6,  // 16: nokv.kv.v1.InternalEntryTombstone.column_family:type_name -> nokv.kv.v1.InternalEntryTombstone.ColumnFamily
+	28, // 17: nokv.kv.v1.MVCCMaintenanceRequest.tombstones:type_name -> nokv.kv.v1.InternalEntryTombstone
+	53, // 18: nokv.kv.v1.MVCCMaintenanceResponse.error:type_name -> nokv.kv.v1.KeyError
+	58, // 19: nokv.kv.v1.Context.region_epoch:type_name -> nokv.meta.v1.RegionEpoch
+	59, // 20: nokv.kv.v1.Context.peer:type_name -> nokv.meta.v1.RegionPeer
+	0,  // 21: nokv.kv.v1.Context.read_consistency:type_name -> nokv.kv.v1.ReadConsistency
+	1,  // 22: nokv.kv.v1.Context.read_preference:type_name -> nokv.kv.v1.ReadPreference
+	31, // 23: nokv.kv.v1.KvGetRequest.context:type_name -> nokv.kv.v1.Context
+	9,  // 24: nokv.kv.v1.KvGetRequest.request:type_name -> nokv.kv.v1.GetRequest
+	10, // 25: nokv.kv.v1.KvGetResponse.response:type_name -> nokv.kv.v1.GetResponse
+	60, // 26: nokv.kv.v1.KvGetResponse.region_error:type_name -> nokv.error.v1.RegionError
+	31, // 27: nokv.kv.v1.KvBatchGetRequest.context:type_name -> nokv.kv.v1.Context
+	11, // 28: nokv.kv.v1.KvBatchGetRequest.request:type_name -> nokv.kv.v1.BatchGetRequest
+	12, // 29: nokv.kv.v1.KvBatchGetResponse.response:type_name -> nokv.kv.v1.BatchGetResponse
+	60, // 30: nokv.kv.v1.KvBatchGetResponse.region_error:type_name -> nokv.error.v1.RegionError
+	31, // 31: nokv.kv.v1.KvScanRequest.context:type_name -> nokv.kv.v1.Context
+	13, // 32: nokv.kv.v1.KvScanRequest.request:type_name -> nokv.kv.v1.ScanRequest
+	14, // 33: nokv.kv.v1.KvScanResponse.response:type_name -> nokv.kv.v1.ScanResponse
+	60, // 34: nokv.kv.v1.KvScanResponse.region_error:type_name -> nokv.error.v1.RegionError
+	31, // 35: nokv.kv.v1.KvPrewriteRequest.context:type_name -> nokv.kv.v1.Context
+	16, // 36: nokv.kv.v1.KvPrewriteRequest.request:type_name -> nokv.kv.v1.PrewriteRequest
+	17, // 37: nokv.kv.v1.KvPrewriteResponse.response:type_name -> nokv.kv.v1.PrewriteResponse
+	60, // 38: nokv.kv.v1.KvPrewriteResponse.region_error:type_name -> nokv.error.v1.RegionError
+	31, // 39: nokv.kv.v1.KvCommitRequest.context:type_name -> nokv.kv.v1.Context
+	18, // 40: nokv.kv.v1.KvCommitRequest.request:type_name -> nokv.kv.v1.CommitRequest
+	19, // 41: nokv.kv.v1.KvCommitResponse.response:type_name -> nokv.kv.v1.CommitResponse
+	60, // 42: nokv.kv.v1.KvCommitResponse.region_error:type_name -> nokv.error.v1.RegionError
+	31, // 43: nokv.kv.v1.KvBatchRollbackRequest.context:type_name -> nokv.kv.v1.Context
+	20, // 44: nokv.kv.v1.KvBatchRollbackRequest.request:type_name -> nokv.kv.v1.BatchRollbackRequest
+	21, // 45: nokv.kv.v1.KvBatchRollbackResponse.response:type_name -> nokv.kv.v1.BatchRollbackResponse
+	60, // 46: nokv.kv.v1.KvBatchRollbackResponse.region_error:type_name -> nokv.error.v1.RegionError
+	31, // 47: nokv.kv.v1.KvResolveLockRequest.context:type_name -> nokv.kv.v1.Context
+	22, // 48: nokv.kv.v1.KvResolveLockRequest.request:type_name -> nokv.kv.v1.ResolveLockRequest
+	23, // 49: nokv.kv.v1.KvResolveLockResponse.response:type_name -> nokv.kv.v1.ResolveLockResponse
+	60, // 50: nokv.kv.v1.KvResolveLockResponse.region_error:type_name -> nokv.error.v1.RegionError
+	31, // 51: nokv.kv.v1.KvCheckTxnStatusRequest.context:type_name -> nokv.kv.v1.Context
+	24, // 52: nokv.kv.v1.KvCheckTxnStatusRequest.request:type_name -> nokv.kv.v1.CheckTxnStatusRequest
+	25, // 53: nokv.kv.v1.KvCheckTxnStatusResponse.response:type_name -> nokv.kv.v1.CheckTxnStatusResponse
+	60, // 54: nokv.kv.v1.KvCheckTxnStatusResponse.region_error:type_name -> nokv.error.v1.RegionError
+	31, // 55: nokv.kv.v1.KvTxnHeartBeatRequest.context:type_name -> nokv.kv.v1.Context
+	26, // 56: nokv.kv.v1.KvTxnHeartBeatRequest.request:type_name -> nokv.kv.v1.TxnHeartBeatRequest
+	27, // 57: nokv.kv.v1.KvTxnHeartBeatResponse.response:type_name -> nokv.kv.v1.TxnHeartBeatResponse
+	60, // 58: nokv.kv.v1.KvTxnHeartBeatResponse.region_error:type_name -> nokv.error.v1.RegionError
+	4,  // 59: nokv.kv.v1.ApplyWatchEvent.source:type_name -> nokv.kv.v1.ApplyWatchEventSource
+	51, // 60: nokv.kv.v1.ApplyWatchResponse.event:type_name -> nokv.kv.v1.ApplyWatchEvent
+	54, // 61: nokv.kv.v1.KeyError.locked:type_name -> nokv.kv.v1.Locked
+	55, // 62: nokv.kv.v1.KeyError.write_conflict:type_name -> nokv.kv.v1.WriteConflict
+	56, // 63: nokv.kv.v1.KeyError.already_exists:type_name -> nokv.kv.v1.KeyAlreadyExists
+	57, // 64: nokv.kv.v1.KeyError.commit_ts_expired:type_name -> nokv.kv.v1.CommitTsExpired
+	5,  // 65: nokv.kv.v1.Locked.lock_type:type_name -> nokv.kv.v1.Mutation.Op
+	32, // 66: nokv.kv.v1.NoKV.KvGet:input_type -> nokv.kv.v1.KvGetRequest
+	34, // 67: nokv.kv.v1.NoKV.KvBatchGet:input_type -> nokv.kv.v1.KvBatchGetRequest
+	36, // 68: nokv.kv.v1.NoKV.KvScan:input_type -> nokv.kv.v1.KvScanRequest
+	38, // 69: nokv.kv.v1.NoKV.KvPrewrite:input_type -> nokv.kv.v1.KvPrewriteRequest
+	40, // 70: nokv.kv.v1.NoKV.KvCommit:input_type -> nokv.kv.v1.KvCommitRequest
+	42, // 71: nokv.kv.v1.NoKV.KvBatchRollback:input_type -> nokv.kv.v1.KvBatchRollbackRequest
+	44, // 72: nokv.kv.v1.NoKV.KvResolveLock:input_type -> nokv.kv.v1.KvResolveLockRequest
+	46, // 73: nokv.kv.v1.NoKV.KvCheckTxnStatus:input_type -> nokv.kv.v1.KvCheckTxnStatusRequest
+	48, // 74: nokv.kv.v1.NoKV.KvTxnHeartBeat:input_type -> nokv.kv.v1.KvTxnHeartBeatRequest
+	50, // 75: nokv.kv.v1.NoKV.KvWatchApply:input_type -> nokv.kv.v1.ApplyWatchRequest
+	33, // 76: nokv.kv.v1.NoKV.KvGet:output_type -> nokv.kv.v1.KvGetResponse
+	35, // 77: nokv.kv.v1.NoKV.KvBatchGet:output_type -> nokv.kv.v1.KvBatchGetResponse
+	37, // 78: nokv.kv.v1.NoKV.KvScan:output_type -> nokv.kv.v1.KvScanResponse
+	39, // 79: nokv.kv.v1.NoKV.KvPrewrite:output_type -> nokv.kv.v1.KvPrewriteResponse
+	41, // 80: nokv.kv.v1.NoKV.KvCommit:output_type -> nokv.kv.v1.KvCommitResponse
+	43, // 81: nokv.kv.v1.NoKV.KvBatchRollback:output_type -> nokv.kv.v1.KvBatchRollbackResponse
+	45, // 82: nokv.kv.v1.NoKV.KvResolveLock:output_type -> nokv.kv.v1.KvResolveLockResponse
+	47, // 83: nokv.kv.v1.NoKV.KvCheckTxnStatus:output_type -> nokv.kv.v1.KvCheckTxnStatusResponse
+	49, // 84: nokv.kv.v1.NoKV.KvTxnHeartBeat:output_type -> nokv.kv.v1.KvTxnHeartBeatResponse
+	52, // 85: nokv.kv.v1.NoKV.KvWatchApply:output_type -> nokv.kv.v1.ApplyWatchResponse
+	76, // [76:86] is the sub-list for method output_type
+	66, // [66:76] is the sub-list for method input_type
+	66, // [66:66] is the sub-list for extension type_name
+	66, // [66:66] is the sub-list for extension extendee
+	0,  // [0:66] is the sub-list for field type_name
 }
 
 func init() { file_kv_kv_proto_init() }
@@ -3479,8 +3816,8 @@ func file_kv_kv_proto_init() {
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_kv_kv_proto_rawDesc), len(file_kv_kv_proto_rawDesc)),
-			NumEnums:      6,
-			NumMessages:   47,
+			NumEnums:      7,
+			NumMessages:   51,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/pb/kv/kv.proto
+++ b/pb/kv/kv.proto
@@ -138,6 +138,13 @@ enum CheckTxnStatusAction {
   CheckTxnStatusMinCommitTsPushed = 3;
 }
 
+enum TxnHeartBeatAction {
+  TxnHeartBeatNoAction = 0;
+  TxnHeartBeatTTLExtended = 1;
+  TxnHeartBeatTTLExpireRollback = 2;
+  TxnHeartBeatLockNotExistRollback = 3;
+}
+
 message CheckTxnStatusRequest {
   bytes primary_key = 1;
   uint64 lock_ts = 2;
@@ -152,6 +159,21 @@ message CheckTxnStatusResponse {
   uint64 lock_ttl = 2;
   uint64 commit_version = 3;
   CheckTxnStatusAction action = 4;
+}
+
+message TxnHeartBeatRequest {
+  bytes primary_key = 1;
+  uint64 start_version = 2;
+  uint64 ttl_extension = 3;
+  uint64 current_time = 4;
+}
+
+message TxnHeartBeatResponse {
+  KeyError error = 1;
+  uint64 lock_ttl = 2;
+  uint64 lock_expire_time = 3;
+  uint64 commit_version = 4;
+  TxnHeartBeatAction action = 5;
 }
 
 message InternalEntryTombstone {
@@ -265,6 +287,16 @@ message KvCheckTxnStatusResponse {
   nokv.error.v1.RegionError region_error = 2;
 }
 
+message KvTxnHeartBeatRequest {
+  Context context = 1;
+  TxnHeartBeatRequest request = 2;
+}
+
+message KvTxnHeartBeatResponse {
+  TxnHeartBeatResponse response = 1;
+  nokv.error.v1.RegionError region_error = 2;
+}
+
 enum ApplyWatchEventSource {
   APPLY_WATCH_EVENT_SOURCE_UNSPECIFIED = 0;
   APPLY_WATCH_EVENT_SOURCE_COMMIT = 1;
@@ -299,6 +331,7 @@ service NoKV {
   rpc KvBatchRollback(KvBatchRollbackRequest) returns (KvBatchRollbackResponse);
   rpc KvResolveLock(KvResolveLockRequest) returns (KvResolveLockResponse);
   rpc KvCheckTxnStatus(KvCheckTxnStatusRequest) returns (KvCheckTxnStatusResponse);
+  rpc KvTxnHeartBeat(KvTxnHeartBeatRequest) returns (KvTxnHeartBeatResponse);
   rpc KvWatchApply(ApplyWatchRequest) returns (stream ApplyWatchResponse);
 }
 

--- a/pb/kv/kv_grpc.pb.go
+++ b/pb/kv/kv_grpc.pb.go
@@ -29,6 +29,7 @@ const (
 	NoKV_KvBatchRollback_FullMethodName  = "/nokv.kv.v1.NoKV/KvBatchRollback"
 	NoKV_KvResolveLock_FullMethodName    = "/nokv.kv.v1.NoKV/KvResolveLock"
 	NoKV_KvCheckTxnStatus_FullMethodName = "/nokv.kv.v1.NoKV/KvCheckTxnStatus"
+	NoKV_KvTxnHeartBeat_FullMethodName   = "/nokv.kv.v1.NoKV/KvTxnHeartBeat"
 	NoKV_KvWatchApply_FullMethodName     = "/nokv.kv.v1.NoKV/KvWatchApply"
 )
 
@@ -44,6 +45,7 @@ type NoKVClient interface {
 	KvBatchRollback(ctx context.Context, in *KvBatchRollbackRequest, opts ...grpc.CallOption) (*KvBatchRollbackResponse, error)
 	KvResolveLock(ctx context.Context, in *KvResolveLockRequest, opts ...grpc.CallOption) (*KvResolveLockResponse, error)
 	KvCheckTxnStatus(ctx context.Context, in *KvCheckTxnStatusRequest, opts ...grpc.CallOption) (*KvCheckTxnStatusResponse, error)
+	KvTxnHeartBeat(ctx context.Context, in *KvTxnHeartBeatRequest, opts ...grpc.CallOption) (*KvTxnHeartBeatResponse, error)
 	KvWatchApply(ctx context.Context, in *ApplyWatchRequest, opts ...grpc.CallOption) (grpc.ServerStreamingClient[ApplyWatchResponse], error)
 }
 
@@ -135,6 +137,16 @@ func (c *noKVClient) KvCheckTxnStatus(ctx context.Context, in *KvCheckTxnStatusR
 	return out, nil
 }
 
+func (c *noKVClient) KvTxnHeartBeat(ctx context.Context, in *KvTxnHeartBeatRequest, opts ...grpc.CallOption) (*KvTxnHeartBeatResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(KvTxnHeartBeatResponse)
+	err := c.cc.Invoke(ctx, NoKV_KvTxnHeartBeat_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 func (c *noKVClient) KvWatchApply(ctx context.Context, in *ApplyWatchRequest, opts ...grpc.CallOption) (grpc.ServerStreamingClient[ApplyWatchResponse], error) {
 	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
 	stream, err := c.cc.NewStream(ctx, &NoKV_ServiceDesc.Streams[0], NoKV_KvWatchApply_FullMethodName, cOpts...)
@@ -166,6 +178,7 @@ type NoKVServer interface {
 	KvBatchRollback(context.Context, *KvBatchRollbackRequest) (*KvBatchRollbackResponse, error)
 	KvResolveLock(context.Context, *KvResolveLockRequest) (*KvResolveLockResponse, error)
 	KvCheckTxnStatus(context.Context, *KvCheckTxnStatusRequest) (*KvCheckTxnStatusResponse, error)
+	KvTxnHeartBeat(context.Context, *KvTxnHeartBeatRequest) (*KvTxnHeartBeatResponse, error)
 	KvWatchApply(*ApplyWatchRequest, grpc.ServerStreamingServer[ApplyWatchResponse]) error
 }
 
@@ -199,6 +212,9 @@ func (UnimplementedNoKVServer) KvResolveLock(context.Context, *KvResolveLockRequ
 }
 func (UnimplementedNoKVServer) KvCheckTxnStatus(context.Context, *KvCheckTxnStatusRequest) (*KvCheckTxnStatusResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method KvCheckTxnStatus not implemented")
+}
+func (UnimplementedNoKVServer) KvTxnHeartBeat(context.Context, *KvTxnHeartBeatRequest) (*KvTxnHeartBeatResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method KvTxnHeartBeat not implemented")
 }
 func (UnimplementedNoKVServer) KvWatchApply(*ApplyWatchRequest, grpc.ServerStreamingServer[ApplyWatchResponse]) error {
 	return status.Error(codes.Unimplemented, "method KvWatchApply not implemented")
@@ -367,6 +383,24 @@ func _NoKV_KvCheckTxnStatus_Handler(srv interface{}, ctx context.Context, dec fu
 	return interceptor(ctx, in, info, handler)
 }
 
+func _NoKV_KvTxnHeartBeat_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(KvTxnHeartBeatRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(NoKVServer).KvTxnHeartBeat(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: NoKV_KvTxnHeartBeat_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(NoKVServer).KvTxnHeartBeat(ctx, req.(*KvTxnHeartBeatRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
 func _NoKV_KvWatchApply_Handler(srv interface{}, stream grpc.ServerStream) error {
 	m := new(ApplyWatchRequest)
 	if err := stream.RecvMsg(m); err != nil {
@@ -416,6 +450,10 @@ var NoKV_ServiceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "KvCheckTxnStatus",
 			Handler:    _NoKV_KvCheckTxnStatus_Handler,
+		},
+		{
+			MethodName: "KvTxnHeartBeat",
+			Handler:    _NoKV_KvTxnHeartBeat_Handler,
 		},
 	},
 	Streams: []grpc.StreamDesc{

--- a/pb/raft/cmd.pb.go
+++ b/pb/raft/cmd.pb.go
@@ -38,6 +38,7 @@ const (
 	CmdType_CMD_RESOLVE_LOCK     CmdType = 6
 	CmdType_CMD_CHECK_TXN_STATUS CmdType = 7
 	CmdType_CMD_MVCC_MAINTENANCE CmdType = 8
+	CmdType_CMD_TXN_HEART_BEAT   CmdType = 9
 )
 
 // Enum value maps for CmdType.
@@ -52,6 +53,7 @@ var (
 		6: "CMD_RESOLVE_LOCK",
 		7: "CMD_CHECK_TXN_STATUS",
 		8: "CMD_MVCC_MAINTENANCE",
+		9: "CMD_TXN_HEART_BEAT",
 	}
 	CmdType_value = map[string]int32{
 		"CMD_INVALID":          0,
@@ -63,6 +65,7 @@ var (
 		"CMD_RESOLVE_LOCK":     6,
 		"CMD_CHECK_TXN_STATUS": 7,
 		"CMD_MVCC_MAINTENANCE": 8,
+		"CMD_TXN_HEART_BEAT":   9,
 	}
 )
 
@@ -444,6 +447,7 @@ type Request struct {
 	//	*Request_ResolveLock
 	//	*Request_CheckTxnStatus
 	//	*Request_MvccMaintenance
+	//	*Request_TxnHeartBeat
 	Cmd           isRequest_Cmd `protobuf_oneof:"cmd"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
@@ -565,6 +569,15 @@ func (x *Request) GetMvccMaintenance() *kv.MVCCMaintenanceRequest {
 	return nil
 }
 
+func (x *Request) GetTxnHeartBeat() *kv.TxnHeartBeatRequest {
+	if x != nil {
+		if x, ok := x.Cmd.(*Request_TxnHeartBeat); ok {
+			return x.TxnHeartBeat
+		}
+	}
+	return nil
+}
+
 type isRequest_Cmd interface {
 	isRequest_Cmd()
 }
@@ -601,6 +614,10 @@ type Request_MvccMaintenance struct {
 	MvccMaintenance *kv.MVCCMaintenanceRequest `protobuf:"bytes,9,opt,name=mvcc_maintenance,json=mvccMaintenance,proto3,oneof"`
 }
 
+type Request_TxnHeartBeat struct {
+	TxnHeartBeat *kv.TxnHeartBeatRequest `protobuf:"bytes,10,opt,name=txn_heart_beat,json=txnHeartBeat,proto3,oneof"`
+}
+
 func (*Request_Get) isRequest_Cmd() {}
 
 func (*Request_Scan) isRequest_Cmd() {}
@@ -617,6 +634,8 @@ func (*Request_CheckTxnStatus) isRequest_Cmd() {}
 
 func (*Request_MvccMaintenance) isRequest_Cmd() {}
 
+func (*Request_TxnHeartBeat) isRequest_Cmd() {}
+
 type Response struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// Types that are valid to be assigned to Cmd:
@@ -629,6 +648,7 @@ type Response struct {
 	//	*Response_ResolveLock
 	//	*Response_CheckTxnStatus
 	//	*Response_MvccMaintenance
+	//	*Response_TxnHeartBeat
 	Cmd           isResponse_Cmd `protobuf_oneof:"cmd"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
@@ -743,6 +763,15 @@ func (x *Response) GetMvccMaintenance() *kv.MVCCMaintenanceResponse {
 	return nil
 }
 
+func (x *Response) GetTxnHeartBeat() *kv.TxnHeartBeatResponse {
+	if x != nil {
+		if x, ok := x.Cmd.(*Response_TxnHeartBeat); ok {
+			return x.TxnHeartBeat
+		}
+	}
+	return nil
+}
+
 type isResponse_Cmd interface {
 	isResponse_Cmd()
 }
@@ -779,6 +808,10 @@ type Response_MvccMaintenance struct {
 	MvccMaintenance *kv.MVCCMaintenanceResponse `protobuf:"bytes,8,opt,name=mvcc_maintenance,json=mvccMaintenance,proto3,oneof"`
 }
 
+type Response_TxnHeartBeat struct {
+	TxnHeartBeat *kv.TxnHeartBeatResponse `protobuf:"bytes,9,opt,name=txn_heart_beat,json=txnHeartBeat,proto3,oneof"`
+}
+
 func (*Response_Get) isResponse_Cmd() {}
 
 func (*Response_Scan) isResponse_Cmd() {}
@@ -794,6 +827,8 @@ func (*Response_ResolveLock) isResponse_Cmd() {}
 func (*Response_CheckTxnStatus) isResponse_Cmd() {}
 
 func (*Response_MvccMaintenance) isResponse_Cmd() {}
+
+func (*Response_TxnHeartBeat) isResponse_Cmd() {}
 
 type RaftCmdRequest struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
@@ -940,7 +975,7 @@ const file_raft_cmd_proto_rawDesc = "" +
 	"\x14max_stale_read_index\x18\b \x01(\x04R\x11maxStaleReadIndex\x12)\n" +
 	"\x11max_stale_read_ms\x18\t \x01(\x04R\x0emaxStaleReadMs\x12\x19\n" +
 	"\bstore_id\x18\n" +
-	" \x01(\x04R\astoreId\"\xbd\x04\n" +
+	" \x01(\x04R\astoreId\"\x86\x05\n" +
 	"\aRequest\x120\n" +
 	"\bcmd_type\x18\x01 \x01(\x0e2\x15.nokv.raft.v1.CmdTypeR\acmdType\x12*\n" +
 	"\x03get\x18\x02 \x01(\v2\x16.nokv.kv.v1.GetRequestH\x00R\x03get\x12-\n" +
@@ -950,8 +985,10 @@ const file_raft_cmd_proto_rawDesc = "" +
 	"\x0ebatch_rollback\x18\x06 \x01(\v2 .nokv.kv.v1.BatchRollbackRequestH\x00R\rbatchRollback\x12C\n" +
 	"\fresolve_lock\x18\a \x01(\v2\x1e.nokv.kv.v1.ResolveLockRequestH\x00R\vresolveLock\x12M\n" +
 	"\x10check_txn_status\x18\b \x01(\v2!.nokv.kv.v1.CheckTxnStatusRequestH\x00R\x0echeckTxnStatus\x12O\n" +
-	"\x10mvcc_maintenance\x18\t \x01(\v2\".nokv.kv.v1.MVCCMaintenanceRequestH\x00R\x0fmvccMaintenanceB\x05\n" +
-	"\x03cmd\"\x94\x04\n" +
+	"\x10mvcc_maintenance\x18\t \x01(\v2\".nokv.kv.v1.MVCCMaintenanceRequestH\x00R\x0fmvccMaintenance\x12G\n" +
+	"\x0etxn_heart_beat\x18\n" +
+	" \x01(\v2\x1f.nokv.kv.v1.TxnHeartBeatRequestH\x00R\ftxnHeartBeatB\x05\n" +
+	"\x03cmd\"\xde\x04\n" +
 	"\bResponse\x12+\n" +
 	"\x03get\x18\x01 \x01(\v2\x17.nokv.kv.v1.GetResponseH\x00R\x03get\x12.\n" +
 	"\x04scan\x18\x02 \x01(\v2\x18.nokv.kv.v1.ScanResponseH\x00R\x04scan\x12:\n" +
@@ -960,7 +997,8 @@ const file_raft_cmd_proto_rawDesc = "" +
 	"\x0ebatch_rollback\x18\x05 \x01(\v2!.nokv.kv.v1.BatchRollbackResponseH\x00R\rbatchRollback\x12D\n" +
 	"\fresolve_lock\x18\x06 \x01(\v2\x1f.nokv.kv.v1.ResolveLockResponseH\x00R\vresolveLock\x12N\n" +
 	"\x10check_txn_status\x18\a \x01(\v2\".nokv.kv.v1.CheckTxnStatusResponseH\x00R\x0echeckTxnStatus\x12P\n" +
-	"\x10mvcc_maintenance\x18\b \x01(\v2#.nokv.kv.v1.MVCCMaintenanceResponseH\x00R\x0fmvccMaintenanceB\x05\n" +
+	"\x10mvcc_maintenance\x18\b \x01(\v2#.nokv.kv.v1.MVCCMaintenanceResponseH\x00R\x0fmvccMaintenance\x12H\n" +
+	"\x0etxn_heart_beat\x18\t \x01(\v2 .nokv.kv.v1.TxnHeartBeatResponseH\x00R\ftxnHeartBeatB\x05\n" +
 	"\x03cmd\"t\n" +
 	"\x0eRaftCmdRequest\x12/\n" +
 	"\x06header\x18\x01 \x01(\v2\x17.nokv.raft.v1.CmdHeaderR\x06header\x121\n" +
@@ -968,7 +1006,7 @@ const file_raft_cmd_proto_rawDesc = "" +
 	"\x0fRaftCmdResponse\x12/\n" +
 	"\x06header\x18\x01 \x01(\v2\x17.nokv.raft.v1.CmdHeaderR\x06header\x124\n" +
 	"\tresponses\x18\x02 \x03(\v2\x16.nokv.raft.v1.ResponseR\tresponses\x12=\n" +
-	"\fregion_error\x18\x03 \x01(\v2\x1a.nokv.error.v1.RegionErrorR\vregionError*\xb9\x01\n" +
+	"\fregion_error\x18\x03 \x01(\v2\x1a.nokv.error.v1.RegionErrorR\vregionError*\xd1\x01\n" +
 	"\aCmdType\x12\x0f\n" +
 	"\vCMD_INVALID\x10\x00\x12\v\n" +
 	"\aCMD_GET\x10\x01\x12\f\n" +
@@ -979,7 +1017,8 @@ const file_raft_cmd_proto_rawDesc = "" +
 	"\x12CMD_BATCH_ROLLBACK\x10\x05\x12\x14\n" +
 	"\x10CMD_RESOLVE_LOCK\x10\x06\x12\x18\n" +
 	"\x14CMD_CHECK_TXN_STATUS\x10\a\x12\x18\n" +
-	"\x14CMD_MVCC_MAINTENANCE\x10\bB/Z-github.com/feichai0017/NoKV/pb/raft;raftcmdpbb\x06proto3"
+	"\x14CMD_MVCC_MAINTENANCE\x10\b\x12\x16\n" +
+	"\x12CMD_TXN_HEART_BEAT\x10\tB/Z-github.com/feichai0017/NoKV/pb/raft;raftcmdpbb\x06proto3"
 
 var (
 	file_raft_cmd_proto_rawDescOnce sync.Once
@@ -1018,15 +1057,17 @@ var file_raft_cmd_proto_goTypes = []any{
 	(*kv.ResolveLockRequest)(nil),      // 19: nokv.kv.v1.ResolveLockRequest
 	(*kv.CheckTxnStatusRequest)(nil),   // 20: nokv.kv.v1.CheckTxnStatusRequest
 	(*kv.MVCCMaintenanceRequest)(nil),  // 21: nokv.kv.v1.MVCCMaintenanceRequest
-	(*kv.GetResponse)(nil),             // 22: nokv.kv.v1.GetResponse
-	(*kv.ScanResponse)(nil),            // 23: nokv.kv.v1.ScanResponse
-	(*kv.PrewriteResponse)(nil),        // 24: nokv.kv.v1.PrewriteResponse
-	(*kv.CommitResponse)(nil),          // 25: nokv.kv.v1.CommitResponse
-	(*kv.BatchRollbackResponse)(nil),   // 26: nokv.kv.v1.BatchRollbackResponse
-	(*kv.ResolveLockResponse)(nil),     // 27: nokv.kv.v1.ResolveLockResponse
-	(*kv.CheckTxnStatusResponse)(nil),  // 28: nokv.kv.v1.CheckTxnStatusResponse
-	(*kv.MVCCMaintenanceResponse)(nil), // 29: nokv.kv.v1.MVCCMaintenanceResponse
-	(*error1.RegionError)(nil),         // 30: nokv.error.v1.RegionError
+	(*kv.TxnHeartBeatRequest)(nil),     // 22: nokv.kv.v1.TxnHeartBeatRequest
+	(*kv.GetResponse)(nil),             // 23: nokv.kv.v1.GetResponse
+	(*kv.ScanResponse)(nil),            // 24: nokv.kv.v1.ScanResponse
+	(*kv.PrewriteResponse)(nil),        // 25: nokv.kv.v1.PrewriteResponse
+	(*kv.CommitResponse)(nil),          // 26: nokv.kv.v1.CommitResponse
+	(*kv.BatchRollbackResponse)(nil),   // 27: nokv.kv.v1.BatchRollbackResponse
+	(*kv.ResolveLockResponse)(nil),     // 28: nokv.kv.v1.ResolveLockResponse
+	(*kv.CheckTxnStatusResponse)(nil),  // 29: nokv.kv.v1.CheckTxnStatusResponse
+	(*kv.MVCCMaintenanceResponse)(nil), // 30: nokv.kv.v1.MVCCMaintenanceResponse
+	(*kv.TxnHeartBeatResponse)(nil),    // 31: nokv.kv.v1.TxnHeartBeatResponse
+	(*error1.RegionError)(nil),         // 32: nokv.error.v1.RegionError
 }
 var file_raft_cmd_proto_depIdxs = []int32{
 	10, // 0: nokv.raft.v1.SplitCommand.child:type_name -> nokv.meta.v1.RegionDescriptor
@@ -1045,24 +1086,26 @@ var file_raft_cmd_proto_depIdxs = []int32{
 	19, // 13: nokv.raft.v1.Request.resolve_lock:type_name -> nokv.kv.v1.ResolveLockRequest
 	20, // 14: nokv.raft.v1.Request.check_txn_status:type_name -> nokv.kv.v1.CheckTxnStatusRequest
 	21, // 15: nokv.raft.v1.Request.mvcc_maintenance:type_name -> nokv.kv.v1.MVCCMaintenanceRequest
-	22, // 16: nokv.raft.v1.Response.get:type_name -> nokv.kv.v1.GetResponse
-	23, // 17: nokv.raft.v1.Response.scan:type_name -> nokv.kv.v1.ScanResponse
-	24, // 18: nokv.raft.v1.Response.prewrite:type_name -> nokv.kv.v1.PrewriteResponse
-	25, // 19: nokv.raft.v1.Response.commit:type_name -> nokv.kv.v1.CommitResponse
-	26, // 20: nokv.raft.v1.Response.batch_rollback:type_name -> nokv.kv.v1.BatchRollbackResponse
-	27, // 21: nokv.raft.v1.Response.resolve_lock:type_name -> nokv.kv.v1.ResolveLockResponse
-	28, // 22: nokv.raft.v1.Response.check_txn_status:type_name -> nokv.kv.v1.CheckTxnStatusResponse
-	29, // 23: nokv.raft.v1.Response.mvcc_maintenance:type_name -> nokv.kv.v1.MVCCMaintenanceResponse
-	5,  // 24: nokv.raft.v1.RaftCmdRequest.header:type_name -> nokv.raft.v1.CmdHeader
-	6,  // 25: nokv.raft.v1.RaftCmdRequest.requests:type_name -> nokv.raft.v1.Request
-	5,  // 26: nokv.raft.v1.RaftCmdResponse.header:type_name -> nokv.raft.v1.CmdHeader
-	7,  // 27: nokv.raft.v1.RaftCmdResponse.responses:type_name -> nokv.raft.v1.Response
-	30, // 28: nokv.raft.v1.RaftCmdResponse.region_error:type_name -> nokv.error.v1.RegionError
-	29, // [29:29] is the sub-list for method output_type
-	29, // [29:29] is the sub-list for method input_type
-	29, // [29:29] is the sub-list for extension type_name
-	29, // [29:29] is the sub-list for extension extendee
-	0,  // [0:29] is the sub-list for field type_name
+	22, // 16: nokv.raft.v1.Request.txn_heart_beat:type_name -> nokv.kv.v1.TxnHeartBeatRequest
+	23, // 17: nokv.raft.v1.Response.get:type_name -> nokv.kv.v1.GetResponse
+	24, // 18: nokv.raft.v1.Response.scan:type_name -> nokv.kv.v1.ScanResponse
+	25, // 19: nokv.raft.v1.Response.prewrite:type_name -> nokv.kv.v1.PrewriteResponse
+	26, // 20: nokv.raft.v1.Response.commit:type_name -> nokv.kv.v1.CommitResponse
+	27, // 21: nokv.raft.v1.Response.batch_rollback:type_name -> nokv.kv.v1.BatchRollbackResponse
+	28, // 22: nokv.raft.v1.Response.resolve_lock:type_name -> nokv.kv.v1.ResolveLockResponse
+	29, // 23: nokv.raft.v1.Response.check_txn_status:type_name -> nokv.kv.v1.CheckTxnStatusResponse
+	30, // 24: nokv.raft.v1.Response.mvcc_maintenance:type_name -> nokv.kv.v1.MVCCMaintenanceResponse
+	31, // 25: nokv.raft.v1.Response.txn_heart_beat:type_name -> nokv.kv.v1.TxnHeartBeatResponse
+	5,  // 26: nokv.raft.v1.RaftCmdRequest.header:type_name -> nokv.raft.v1.CmdHeader
+	6,  // 27: nokv.raft.v1.RaftCmdRequest.requests:type_name -> nokv.raft.v1.Request
+	5,  // 28: nokv.raft.v1.RaftCmdResponse.header:type_name -> nokv.raft.v1.CmdHeader
+	7,  // 29: nokv.raft.v1.RaftCmdResponse.responses:type_name -> nokv.raft.v1.Response
+	32, // 30: nokv.raft.v1.RaftCmdResponse.region_error:type_name -> nokv.error.v1.RegionError
+	31, // [31:31] is the sub-list for method output_type
+	31, // [31:31] is the sub-list for method input_type
+	31, // [31:31] is the sub-list for extension type_name
+	31, // [31:31] is the sub-list for extension extendee
+	0,  // [0:31] is the sub-list for field type_name
 }
 
 func init() { file_raft_cmd_proto_init() }
@@ -1079,6 +1122,7 @@ func file_raft_cmd_proto_init() {
 		(*Request_ResolveLock)(nil),
 		(*Request_CheckTxnStatus)(nil),
 		(*Request_MvccMaintenance)(nil),
+		(*Request_TxnHeartBeat)(nil),
 	}
 	file_raft_cmd_proto_msgTypes[5].OneofWrappers = []any{
 		(*Response_Get)(nil),
@@ -1089,6 +1133,7 @@ func file_raft_cmd_proto_init() {
 		(*Response_ResolveLock)(nil),
 		(*Response_CheckTxnStatus)(nil),
 		(*Response_MvccMaintenance)(nil),
+		(*Response_TxnHeartBeat)(nil),
 	}
 	type x struct{}
 	out := protoimpl.TypeBuilder{

--- a/pb/raft/cmd.proto
+++ b/pb/raft/cmd.proto
@@ -58,6 +58,7 @@ enum CmdType {
   CMD_RESOLVE_LOCK = 6;
   CMD_CHECK_TXN_STATUS = 7;
   CMD_MVCC_MAINTENANCE = 8;
+  CMD_TXN_HEART_BEAT = 9;
 }
 
 message Request {
@@ -72,6 +73,7 @@ message Request {
     nokv.kv.v1.ResolveLockRequest resolve_lock = 7;
     nokv.kv.v1.CheckTxnStatusRequest check_txn_status = 8;
     nokv.kv.v1.MVCCMaintenanceRequest mvcc_maintenance = 9;
+    nokv.kv.v1.TxnHeartBeatRequest txn_heart_beat = 10;
   }
 }
 
@@ -85,6 +87,7 @@ message Response {
     nokv.kv.v1.ResolveLockResponse resolve_lock = 6;
     nokv.kv.v1.CheckTxnStatusResponse check_txn_status = 7;
     nokv.kv.v1.MVCCMaintenanceResponse mvcc_maintenance = 8;
+    nokv.kv.v1.TxnHeartBeatResponse txn_heart_beat = 9;
   }
 }
 

--- a/percolator/errors.go
+++ b/percolator/errors.go
@@ -1,0 +1,76 @@
+package percolator
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/feichai0017/NoKV/engine/kv"
+	kvrpcpb "github.com/feichai0017/NoKV/pb/kv"
+	"github.com/feichai0017/NoKV/percolator/mvcc"
+)
+
+var (
+	errEmptyMutationKey            = errors.New("percolator: empty key in mutation")
+	errEmptyCommitKey              = errors.New("percolator: empty key in commit")
+	errEmptyRollbackKey            = errors.New("percolator: empty key in rollback")
+	errUnsupportedMutationOp       = errors.New("percolator: unsupported mutation op")
+	errCommitVersionNotAfterStart  = errors.New("percolator: commit version must be greater than start version")
+	errTxnAlreadyRolledBack        = errors.New("percolator: transaction already rolled back")
+	errLockNotFound                = errors.New("percolator: lock not found")
+	errTxnHeartbeatPrimaryRequired = errors.New("percolator: heartbeat primary key is required")
+	errTxnHeartbeatStartRequired   = errors.New("percolator: heartbeat start version is required")
+	errTxnHeartbeatTTLRequired     = errors.New("percolator: heartbeat ttl extension is required")
+	errTxnHeartbeatTimeRequired    = errors.New("percolator: heartbeat current time is required")
+	errTxnHeartbeatPrimaryMismatch = errors.New("percolator: heartbeat primary key does not match lock primary")
+)
+
+func keyErrorLocked(key []byte, lock *mvcc.Lock) *kvrpcpb.KeyError {
+	return &kvrpcpb.KeyError{
+		Locked: &kvrpcpb.Locked{
+			PrimaryLock: lock.Primary,
+			Key:         kv.SafeCopy(nil, key),
+			LockVersion: lock.Ts,
+			LockTtl:     lock.TTL,
+			LockType:    lock.Kind,
+			MinCommitTs: lock.MinCommitTs,
+		},
+	}
+}
+
+func keyErrorWriteConflict(key, primary []byte, conflictTs, startTs, currentTs uint64) *kvrpcpb.KeyError {
+	return &kvrpcpb.KeyError{
+		WriteConflict: &kvrpcpb.WriteConflict{
+			Key:        kv.SafeCopy(nil, key),
+			Primary:    kv.SafeCopy(nil, primary),
+			ConflictTs: conflictTs,
+			StartTs:    startTs,
+			CommitTs:   currentTs,
+		},
+	}
+}
+
+func keyErrorRetryable(err error) *kvrpcpb.KeyError {
+	return &kvrpcpb.KeyError{Retryable: err.Error()}
+}
+
+func keyErrorAlreadyExists(key []byte) *kvrpcpb.KeyError {
+	return &kvrpcpb.KeyError{AlreadyExists: &kvrpcpb.KeyAlreadyExists{Key: kv.SafeCopy(nil, key)}}
+}
+
+func keyErrorAbort(err error) *kvrpcpb.KeyError {
+	return &kvrpcpb.KeyError{Abort: err.Error()}
+}
+
+func keyErrorAbortf(cause error, format string, args ...any) *kvrpcpb.KeyError {
+	return keyErrorAbort(fmt.Errorf("%w: %s", cause, fmt.Sprintf(format, args...)))
+}
+
+func keyErrorCommitTsExpired(key []byte, commitTs, minCommitTs uint64) *kvrpcpb.KeyError {
+	return &kvrpcpb.KeyError{
+		CommitTsExpired: &kvrpcpb.CommitTsExpired{
+			Key:         kv.SafeCopy(nil, key),
+			CommitTs:    commitTs,
+			MinCommitTs: minCommitTs,
+		},
+	}
+}

--- a/percolator/mvcc/codec.go
+++ b/percolator/mvcc/codec.go
@@ -12,15 +12,18 @@ const (
 	writeCodecVersion byte = 1
 )
 
-// Codec versions are monotonic. Readers reject unknown future versions; any
-// future v2 reader must continue to accept v1 payloads until a deliberate
-// format break rewrites all MVCC state.
+// Readers reject unsupported codec versions. The current lock v1 layout is
+// allowed to change destructively before a production data-format guarantee.
 
 // Lock captures the metadata recorded in the lock column family during
 // prewrite.
 type Lock struct {
-	Primary     []byte
-	Ts          uint64
+	Primary []byte
+	// Ts is the logical transaction start timestamp from the TSO.
+	Ts uint64
+	// StartTime is the physical Unix millisecond time when the lock was
+	// created. TTL is measured from StartTime, never from Ts.
+	StartTime   uint64
 	TTL         uint64
 	Kind        kvrpcpb.Mutation_Op
 	MinCommitTs uint64
@@ -29,11 +32,12 @@ type Lock struct {
 // EncodeLock serialises a lock entry.
 func EncodeLock(lock Lock) []byte {
 	primaryLen := len(lock.Primary)
-	buf := make([]byte, 0, 1+binary.MaxVarintLen64*4+primaryLen)
+	buf := make([]byte, 0, 1+binary.MaxVarintLen64*5+primaryLen)
 	buf = append(buf, lockCodecVersion)
 	buf = binary.AppendUvarint(buf, uint64(primaryLen))
 	buf = append(buf, lock.Primary...)
 	buf = binary.AppendUvarint(buf, lock.Ts)
+	buf = binary.AppendUvarint(buf, lock.StartTime)
 	buf = binary.AppendUvarint(buf, lock.TTL)
 	buf = append(buf, byte(lock.Kind))
 	buf = binary.AppendUvarint(buf, lock.MinCommitTs)
@@ -71,8 +75,14 @@ func DecodeLock(data []byte) (Lock, error) {
 	if lock.Ts, err = readUvarint(); err != nil {
 		return Lock{}, err
 	}
+	if lock.StartTime, err = readUvarint(); err != nil {
+		return Lock{}, err
+	}
 	if lock.TTL, err = readUvarint(); err != nil {
 		return Lock{}, err
+	}
+	if lock.TTL > 0 && lock.StartTime == 0 {
+		return Lock{}, fmt.Errorf("mvcc: lock start time missing")
 	}
 	if pos >= len(data) {
 		return Lock{}, fmt.Errorf("mvcc: lock kind missing")

--- a/percolator/mvcc/codec_test.go
+++ b/percolator/mvcc/codec_test.go
@@ -12,6 +12,7 @@ func TestEncodeDecodeLockRoundTrip(t *testing.T) {
 	lock := Lock{
 		Primary:     []byte("primary"),
 		Ts:          10,
+		StartTime:   1000,
 		TTL:         20,
 		Kind:        kvrpcpb.Mutation_Put,
 		MinCommitTs: 30,
@@ -21,6 +22,7 @@ func TestEncodeDecodeLockRoundTrip(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, lock.Primary, got.Primary)
 	require.Equal(t, lock.Ts, got.Ts)
+	require.Equal(t, lock.StartTime, got.StartTime)
 	require.Equal(t, lock.TTL, got.TTL)
 	require.Equal(t, lock.Kind, got.Kind)
 	require.Equal(t, lock.MinCommitTs, got.MinCommitTs)
@@ -38,6 +40,15 @@ func TestDecodeLockErrors(t *testing.T) {
 
 	_, err = DecodeLock([]byte{lockCodecVersion, 0x05, 'a'})
 	require.Error(t, err)
+
+	raw := make([]byte, 0, 16)
+	raw = append(raw, lockCodecVersion, 0)
+	raw = binary.AppendUvarint(raw, 10)
+	raw = binary.AppendUvarint(raw, 0)
+	raw = binary.AppendUvarint(raw, 20)
+	raw = append(raw, byte(kvrpcpb.Mutation_Put))
+	_, err = DecodeLock(raw)
+	require.ErrorContains(t, err, "lock start time missing")
 }
 
 func TestEncodeDecodeWriteRoundTrip(t *testing.T) {

--- a/percolator/reader.go
+++ b/percolator/reader.go
@@ -123,6 +123,9 @@ func (r *Reader) getWriteForRead(key []byte, readTs uint64) (*mvcc.Write, uint64
 	var result *mvcc.Write
 	var commitTs uint64
 	if err := r.scanWrites(key, func(w mvcc.Write, ts uint64) bool {
+		if ts <= readTs && w.Kind == kvrpcpb.Mutation_Lock {
+			return true
+		}
 		if ts <= readTs && (result == nil || ts > commitTs) {
 			copy := w
 			result = &copy

--- a/percolator/txn.go
+++ b/percolator/txn.go
@@ -14,6 +14,8 @@ package percolator
 
 import (
 	"fmt"
+	"time"
+
 	kvrpcpb "github.com/feichai0017/NoKV/pb/kv"
 
 	"github.com/feichai0017/NoKV/engine/kv"
@@ -92,6 +94,7 @@ func prewriteMutation(db txnstore.Store, reader *Reader, req *kvrpcpb.PrewriteRe
 	newLock := mvcc.Lock{
 		Primary:     kv.SafeCopy(nil, req.PrimaryLock),
 		Ts:          req.StartVersion,
+		StartTime:   currentPhysicalTimeMillis(),
 		TTL:         req.LockTtl,
 		Kind:        mut.Op,
 		MinCommitTs: req.MinCommitTs,
@@ -238,7 +241,7 @@ func CheckTxnStatus(db txnstore.Store, latches *latch.Manager, req *kvrpcpb.Chec
 			resp.Error = keyErrorLocked(req.PrimaryKey, lock)
 			return resp
 		}
-		if isLockExpired(lock, req.CurrentTs) {
+		if isLockExpired(lock, req.CurrentTime) {
 			if err := rollbackKey(db, reader, req.PrimaryKey, req.LockTs); err != nil {
 				resp.Error = err
 				return resp
@@ -440,12 +443,16 @@ func applyVersionedOps(db txnstore.Store, ops ...versionedOp) error {
 	return err
 }
 
-func isLockExpired(lock *mvcc.Lock, currentTs uint64) bool {
+func currentPhysicalTimeMillis() uint64 {
+	return uint64(time.Now().UnixMilli())
+}
+
+func isLockExpired(lock *mvcc.Lock, currentTime uint64) bool {
 	if lock == nil {
 		return false
 	}
-	if lock.TTL == 0 {
+	if lock.TTL == 0 || lock.StartTime == 0 || currentTime == 0 {
 		return false
 	}
-	return currentTs >= lock.Ts+lock.TTL
+	return currentTime >= lock.StartTime && currentTime-lock.StartTime >= lock.TTL
 }

--- a/percolator/txn.go
+++ b/percolator/txn.go
@@ -1,7 +1,8 @@
 // Package percolator implements Google-Percolator-style distributed
 // MVCC two-phase commit over NoKV's key/value substrate.
 //
-// Protocol ops: Prewrite, Commit, Rollback, ResolveLock, CheckTxnStatus.
+// Protocol ops: Prewrite, Commit, Rollback, ResolveLock, CheckTxnStatus,
+// TxnHeartBeat.
 // Concurrency is controlled by a striped-mutex latch manager
 // (percolator/latch) shared per raftstore/kv service instance.
 // The timestamp oracle is provided by coordinator/tso.
@@ -13,7 +14,7 @@
 package percolator
 
 import (
-	"fmt"
+	"bytes"
 	"time"
 
 	kvrpcpb "github.com/feichai0017/NoKV/pb/kv"
@@ -54,7 +55,7 @@ func Prewrite(db txnstore.Store, latches *latch.Manager, req *kvrpcpb.PrewriteRe
 func prewriteMutation(db txnstore.Store, reader *Reader, req *kvrpcpb.PrewriteRequest, mut *kvrpcpb.Mutation) *kvrpcpb.KeyError {
 	key := mut.GetKey()
 	if len(key) == 0 {
-		return keyErrorAbort("empty key in mutation")
+		return keyErrorAbort(errEmptyMutationKey)
 	}
 	lock, err := reader.GetLock(key)
 	if err != nil {
@@ -89,7 +90,7 @@ func prewriteMutation(db txnstore.Store, reader *Reader, req *kvrpcpb.PrewriteRe
 			versionedOp{cf: kv.CFDefault, key: key, version: req.StartVersion, meta: kv.BitDelete},
 		)
 	default:
-		return keyErrorAbort(fmt.Sprintf("unsupported mutation op %v", mut.Op))
+		return keyErrorAbortf(errUnsupportedMutationOp, "%v", mut.Op)
 	}
 	newLock := mvcc.Lock{
 		Primary:     kv.SafeCopy(nil, req.PrimaryLock),
@@ -110,7 +111,7 @@ func prewriteMutation(db txnstore.Store, reader *Reader, req *kvrpcpb.PrewriteRe
 // validateCommitVersion rejects commits that would violate MVCC ordering.
 func validateCommitVersion(StartVersion uint64, CommitVersion uint64) *kvrpcpb.KeyError {
 	if CommitVersion <= StartVersion {
-		return keyErrorAbort("commit version must be greater than start version")
+		return keyErrorAbort(errCommitVersionNotAfterStart)
 	}
 	return nil
 }
@@ -130,7 +131,7 @@ func Commit(db txnstore.Store, latches *latch.Manager, req *kvrpcpb.CommitReques
 	reader := NewReader(db)
 	for _, key := range req.Keys {
 		if len(key) == 0 {
-			return keyErrorAbort("empty key in commit")
+			return keyErrorAbort(errEmptyCommitKey)
 		}
 		lock, err := reader.GetLock(key)
 		if err != nil {
@@ -143,11 +144,11 @@ func Commit(db txnstore.Store, latches *latch.Manager, req *kvrpcpb.CommitReques
 			}
 			if write != nil {
 				if write.Kind == kvrpcpb.Mutation_Rollback {
-					return keyErrorAbort("transaction already rolled back")
+					return keyErrorAbort(errTxnAlreadyRolledBack)
 				}
 				continue
 			}
-			return keyErrorAbort("lock not found")
+			return keyErrorAbort(errLockNotFound)
 		}
 		if lock.Ts != req.StartVersion {
 			return keyErrorLocked(key, lock)
@@ -169,7 +170,7 @@ func BatchRollback(db txnstore.Store, latches *latch.Manager, req *kvrpcpb.Batch
 	reader := NewReader(db)
 	for _, key := range req.Keys {
 		if len(key) == 0 {
-			return keyErrorAbort("empty key in rollback")
+			return keyErrorAbort(errEmptyRollbackKey)
 		}
 		if err := rollbackKey(db, reader, key, req.StartVersion); err != nil {
 			return err
@@ -290,52 +291,93 @@ func CheckTxnStatus(db txnstore.Store, latches *latch.Manager, req *kvrpcpb.Chec
 	return resp
 }
 
-// keyErrorLocked builds a KeyError for a locked key.
-func keyErrorLocked(key []byte, lock *mvcc.Lock) *kvrpcpb.KeyError {
-	return &kvrpcpb.KeyError{
-		Locked: &kvrpcpb.Locked{
-			PrimaryLock: lock.Primary,
-			Key:         kv.SafeCopy(nil, key),
-			LockVersion: lock.Ts,
-			LockTtl:     lock.TTL,
-			LockType:    lock.Kind,
-			MinCommitTs: lock.MinCommitTs,
-		},
+// TxnHeartBeat extends the primary lock TTL for a live transaction. It never
+// resurrects an expired or already-resolved primary lock.
+func TxnHeartBeat(db txnstore.Store, latches *latch.Manager, req *kvrpcpb.TxnHeartBeatRequest) *kvrpcpb.TxnHeartBeatResponse {
+	resp := &kvrpcpb.TxnHeartBeatResponse{}
+	if req == nil {
+		return resp
 	}
-}
-
-func keyErrorWriteConflict(key, primary []byte, conflictTs, startTs, currentTs uint64) *kvrpcpb.KeyError {
-	return &kvrpcpb.KeyError{
-		WriteConflict: &kvrpcpb.WriteConflict{
-			Key:        kv.SafeCopy(nil, key),
-			Primary:    kv.SafeCopy(nil, primary),
-			ConflictTs: conflictTs,
-			StartTs:    startTs,
-			CommitTs:   currentTs,
-		},
+	if len(req.PrimaryKey) == 0 {
+		resp.Error = keyErrorAbort(errTxnHeartbeatPrimaryRequired)
+		return resp
 	}
-}
-
-func keyErrorRetryable(err error) *kvrpcpb.KeyError {
-	return &kvrpcpb.KeyError{Retryable: err.Error()}
-}
-
-func keyErrorAlreadyExists(key []byte) *kvrpcpb.KeyError {
-	return &kvrpcpb.KeyError{AlreadyExists: &kvrpcpb.KeyAlreadyExists{Key: kv.SafeCopy(nil, key)}}
-}
-
-func keyErrorAbort(msg string) *kvrpcpb.KeyError {
-	return &kvrpcpb.KeyError{Abort: msg}
-}
-
-func keyErrorCommitTsExpired(key []byte, commitTs, minCommitTs uint64) *kvrpcpb.KeyError {
-	return &kvrpcpb.KeyError{
-		CommitTsExpired: &kvrpcpb.CommitTsExpired{
-			Key:         kv.SafeCopy(nil, key),
-			CommitTs:    commitTs,
-			MinCommitTs: minCommitTs,
-		},
+	if req.StartVersion == 0 {
+		resp.Error = keyErrorAbort(errTxnHeartbeatStartRequired)
+		return resp
 	}
+	if req.TtlExtension == 0 {
+		resp.Error = keyErrorAbort(errTxnHeartbeatTTLRequired)
+		return resp
+	}
+	if req.CurrentTime == 0 {
+		resp.Error = keyErrorAbort(errTxnHeartbeatTimeRequired)
+		return resp
+	}
+
+	guard := latches.Acquire([][]byte{req.PrimaryKey})
+	defer guard.Release()
+
+	reader := NewReader(db)
+	lock, err := reader.GetLock(req.PrimaryKey)
+	if err != nil {
+		resp.Error = keyErrorRetryable(err)
+		return resp
+	}
+	if lock != nil {
+		if lock.Ts != req.StartVersion {
+			resp.Error = keyErrorLocked(req.PrimaryKey, lock)
+			return resp
+		}
+		if !bytes.Equal(lock.Primary, req.PrimaryKey) {
+			resp.Error = keyErrorAbort(errTxnHeartbeatPrimaryMismatch)
+			return resp
+		}
+		if isLockExpired(lock, req.CurrentTime) {
+			if err := rollbackKey(db, reader, req.PrimaryKey, req.StartVersion); err != nil {
+				resp.Error = err
+				return resp
+			}
+			resp.Action = kvrpcpb.TxnHeartBeatAction_TxnHeartBeatTTLExpireRollback
+			return resp
+		}
+		desiredTTL := req.TtlExtension
+		if req.CurrentTime > lock.StartTime {
+			desiredTTL = req.CurrentTime - lock.StartTime + req.TtlExtension
+		}
+		if desiredTTL > lock.TTL {
+			lock.TTL = desiredTTL
+			if err := applyVersionedOps(db, versionedOp{
+				cf:      kv.CFLock,
+				key:     req.PrimaryKey,
+				version: lockColumnTs,
+				value:   mvcc.EncodeLock(*lock),
+			}); err != nil {
+				resp.Error = keyErrorRetryable(err)
+				return resp
+			}
+			resp.Action = kvrpcpb.TxnHeartBeatAction_TxnHeartBeatTTLExtended
+		}
+		resp.LockTtl = lock.TTL
+		resp.LockExpireTime = lockExpireTime(lock)
+		return resp
+	}
+
+	write, commitTs, err := reader.GetWriteByStartTs(req.PrimaryKey, req.StartVersion)
+	if err != nil {
+		resp.Error = keyErrorRetryable(err)
+		return resp
+	}
+	if write != nil && write.Kind != kvrpcpb.Mutation_Rollback {
+		resp.CommitVersion = commitTs
+		return resp
+	}
+	if err := rollbackKey(db, reader, req.PrimaryKey, req.StartVersion); err != nil {
+		resp.Error = err
+		return resp
+	}
+	resp.Action = kvrpcpb.TxnHeartBeatAction_TxnHeartBeatLockNotExistRollback
+	return resp
 }
 
 func keyExistsAt(reader *Reader, key []byte, readTs uint64) (bool, error) {
@@ -361,7 +403,7 @@ func commitKey(db txnstore.Store, reader *Reader, key []byte, lock *mvcc.Lock, c
 	}
 	if write != nil {
 		if write.Kind == kvrpcpb.Mutation_Rollback {
-			return keyErrorAbort("transaction already rolled back")
+			return keyErrorAbort(errTxnAlreadyRolledBack)
 		}
 		if err := applyVersionedOps(db, versionedOp{
 			cf:      kv.CFLock,
@@ -455,4 +497,14 @@ func isLockExpired(lock *mvcc.Lock, currentTime uint64) bool {
 		return false
 	}
 	return currentTime >= lock.StartTime && currentTime-lock.StartTime >= lock.TTL
+}
+
+func lockExpireTime(lock *mvcc.Lock) uint64 {
+	if lock == nil || lock.StartTime == 0 || lock.TTL == 0 {
+		return 0
+	}
+	if ^uint64(0)-lock.StartTime < lock.TTL {
+		return ^uint64(0)
+	}
+	return lock.StartTime + lock.TTL
 }

--- a/percolator/txn.go
+++ b/percolator/txn.go
@@ -106,8 +106,8 @@ func prewriteMutation(db txnstore.Store, reader *Reader, req *kvrpcpb.PrewriteRe
 
 // validateCommitVersion rejects commits that would violate MVCC ordering.
 func validateCommitVersion(StartVersion uint64, CommitVersion uint64) *kvrpcpb.KeyError {
-	if CommitVersion < StartVersion {
-		return keyErrorAbort("commit version is earlier than start version")
+	if CommitVersion <= StartVersion {
+		return keyErrorAbort("commit version must be greater than start version")
 	}
 	return nil
 }

--- a/percolator/txn_test.go
+++ b/percolator/txn_test.go
@@ -175,6 +175,84 @@ func TestPrewriteAndCommitPut(t *testing.T) {
 	require.Nil(t, lock)
 }
 
+func TestCommittedLockDoesNotHideVisiblePut(t *testing.T) {
+	db := openTestDB(t)
+	latches := latch.NewManager(32)
+	key := []byte("lock-visible-put")
+
+	put := &kvrpcpb.PrewriteRequest{
+		Mutations: []*kvrpcpb.Mutation{{
+			Op:    kvrpcpb.Mutation_Put,
+			Key:   key,
+			Value: []byte("value1"),
+		}},
+		PrimaryLock:  key,
+		StartVersion: 10,
+		LockTtl:      3000,
+	}
+	require.Empty(t, Prewrite(db, latches, put))
+	require.Nil(t, Commit(db, latches, &kvrpcpb.CommitRequest{
+		Keys:          [][]byte{key},
+		StartVersion:  put.StartVersion,
+		CommitVersion: 20,
+	}))
+
+	lock := &kvrpcpb.PrewriteRequest{
+		Mutations: []*kvrpcpb.Mutation{{
+			Op:  kvrpcpb.Mutation_Lock,
+			Key: key,
+		}},
+		PrimaryLock:  key,
+		StartVersion: 30,
+		LockTtl:      3000,
+	}
+	require.Empty(t, Prewrite(db, latches, lock))
+	require.Nil(t, Commit(db, latches, &kvrpcpb.CommitRequest{
+		Keys:          [][]byte{key},
+		StartVersion:  lock.StartVersion,
+		CommitVersion: 40,
+	}))
+
+	reader := NewReader(db)
+	val, _, err := reader.GetValue(key, 50)
+	require.NoError(t, err)
+	require.Equal(t, []byte("value1"), val)
+
+	exists, err := keyExistsAt(reader, key, 50)
+	require.NoError(t, err)
+	require.True(t, exists)
+}
+
+func TestCommittedLockDoesNotCreateVisibleKey(t *testing.T) {
+	db := openTestDB(t)
+	latches := latch.NewManager(32)
+	key := []byte("lock-only")
+
+	lock := &kvrpcpb.PrewriteRequest{
+		Mutations: []*kvrpcpb.Mutation{{
+			Op:  kvrpcpb.Mutation_Lock,
+			Key: key,
+		}},
+		PrimaryLock:  key,
+		StartVersion: 10,
+		LockTtl:      3000,
+	}
+	require.Empty(t, Prewrite(db, latches, lock))
+	require.Nil(t, Commit(db, latches, &kvrpcpb.CommitRequest{
+		Keys:          [][]byte{key},
+		StartVersion:  lock.StartVersion,
+		CommitVersion: 20,
+	}))
+
+	reader := NewReader(db)
+	_, _, err := reader.GetValue(key, 30)
+	require.ErrorIs(t, err, utils.ErrKeyNotFound)
+
+	exists, err := keyExistsAt(reader, key, 30)
+	require.NoError(t, err)
+	require.False(t, exists)
+}
+
 func TestPrewriteAssertionNotExistRejectsVisibleValue(t *testing.T) {
 	db := openTestDB(t)
 	latches := latch.NewManager(32)
@@ -330,13 +408,12 @@ func TestCommitRejectsEmptyKey(t *testing.T) {
 	require.Contains(t, err.GetAbort(), "empty key in commit")
 }
 
-// TestCommitRejectsCommitVersionEarlierThanStartVersion preserves MVCC ordering.
-func TestCommitRejectsCommitVersionEarlierThanStartVersion(t *testing.T) {
+// TestCommitRejectsCommitVersionNotAfterStartVersion preserves MVCC ordering.
+func TestCommitRejectsCommitVersionNotAfterStartVersion(t *testing.T) {
 	db := openTestDB(t)
 	latches := latch.NewManager(32)
 	key := []byte("mvcc-order")
 	startTs := uint64(20)
-	commitTs := uint64(10)
 	readTs := uint64(15)
 
 	prewrite := &kvrpcpb.PrewriteRequest{
@@ -351,13 +428,17 @@ func TestCommitRejectsCommitVersionEarlierThanStartVersion(t *testing.T) {
 	}
 	require.Empty(t, Prewrite(db, latches, prewrite))
 
-	keyErr := Commit(db, latches, &kvrpcpb.CommitRequest{
-		Keys:          [][]byte{key},
-		StartVersion:  startTs,
-		CommitVersion: commitTs,
-	})
-	if keyErr == nil {
-		t.Errorf("Commit accepted commitVersion=%d earlier than startVersion=%d", commitTs, startTs)
+	for _, commitTs := range []uint64{10, startTs} {
+		keyErr := Commit(db, latches, &kvrpcpb.CommitRequest{
+			Keys:          [][]byte{key},
+			StartVersion:  startTs,
+			CommitVersion: commitTs,
+		})
+		if keyErr == nil {
+			t.Errorf("Commit accepted commitVersion=%d with startVersion=%d", commitTs, startTs)
+			continue
+		}
+		require.Contains(t, keyErr.GetAbort(), "greater than start version")
 	}
 
 	reader := NewReader(db)
@@ -715,13 +796,12 @@ func TestResolveLockRollbackReturnsError(t *testing.T) {
 	require.Contains(t, keyErr.GetRetryable(), "apply failed")
 }
 
-// TestResolveLockRejectsCommitVersionEarlierThanStartVersion preserves MVCC ordering.
-func TestResolveLockRejectsCommitVersionEarlierThanStartVersion(t *testing.T) {
+// TestResolveLockRejectsCommitVersionNotAfterStartVersion preserves MVCC ordering.
+func TestResolveLockRejectsCommitVersionNotAfterStartVersion(t *testing.T) {
 	db := openTestDB(t)
 	latches := latch.NewManager(16)
 	key := []byte("res-order")
 	startTs := uint64(40)
-	commitTs := uint64(30)
 	readTs := uint64(35)
 
 	pre := &kvrpcpb.PrewriteRequest{
@@ -736,16 +816,20 @@ func TestResolveLockRejectsCommitVersionEarlierThanStartVersion(t *testing.T) {
 	}
 	require.Empty(t, Prewrite(db, latches, pre))
 
-	count, keyErr := ResolveLock(db, latches, &kvrpcpb.ResolveLockRequest{
-		Keys:          [][]byte{key},
-		StartVersion:  startTs,
-		CommitVersion: commitTs,
-	})
-	if keyErr == nil {
-		t.Errorf("ResolveLock accepted commitVersion=%d earlier than startVersion=%d", commitTs, startTs)
-	}
-	if count != 0 {
-		t.Errorf("ResolveLock resolved %d locks with invalid commitVersion=%d", count, commitTs)
+	for _, commitTs := range []uint64{30, startTs} {
+		count, keyErr := ResolveLock(db, latches, &kvrpcpb.ResolveLockRequest{
+			Keys:          [][]byte{key},
+			StartVersion:  startTs,
+			CommitVersion: commitTs,
+		})
+		if keyErr == nil {
+			t.Errorf("ResolveLock accepted commitVersion=%d with startVersion=%d", commitTs, startTs)
+			continue
+		}
+		if count != 0 {
+			t.Errorf("ResolveLock resolved %d locks with invalid commitVersion=%d", count, commitTs)
+		}
+		require.Contains(t, keyErr.GetAbort(), "greater than start version")
 	}
 
 	reader := NewReader(db)

--- a/percolator/txn_test.go
+++ b/percolator/txn_test.go
@@ -153,6 +153,8 @@ func TestPrewriteAndCommitPut(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, lock)
 	require.Equal(t, req.StartVersion, lock.Ts)
+	require.NotZero(t, lock.StartTime)
+	require.Equal(t, req.LockTtl, lock.TTL)
 
 	commitReq := &kvrpcpb.CommitRequest{
 		Keys:          [][]byte{[]byte("k1")},
@@ -986,17 +988,92 @@ func TestCheckTxnStatusTTLExpire(t *testing.T) {
 		LockTtl:      5,
 	}
 	require.Empty(t, Prewrite(db, latches, pre))
-	resp := CheckTxnStatus(db, latches, &kvrpcpb.CheckTxnStatusRequest{
-		PrimaryKey:         []byte("primary"),
-		LockTs:             startTs,
-		CurrentTs:          startTs + 10,
-		RollbackIfNotExist: true,
-	})
-	require.Equal(t, kvrpcpb.CheckTxnStatusAction_CheckTxnStatusTTLExpireRollback, resp.GetAction())
 	reader := NewReader(db)
 	lock, err := reader.GetLock([]byte("primary"))
 	require.NoError(t, err)
+	require.NotNil(t, lock)
+	resp := CheckTxnStatus(db, latches, &kvrpcpb.CheckTxnStatusRequest{
+		PrimaryKey:         []byte("primary"),
+		LockTs:             startTs,
+		CurrentTs:          startTs,
+		RollbackIfNotExist: true,
+		CurrentTime:        lock.StartTime + lock.TTL,
+	})
+	require.Equal(t, kvrpcpb.CheckTxnStatusAction_CheckTxnStatusTTLExpireRollback, resp.GetAction())
+	lock, err = reader.GetLock([]byte("primary"))
+	require.NoError(t, err)
 	require.Nil(t, lock)
+}
+
+func TestCheckTxnStatusDoesNotExpireFromLogicalTSODistance(t *testing.T) {
+	db := openTestDB(t)
+	latches := latch.NewManager(16)
+	key := []byte("logical-live")
+	startTs := uint64(100)
+	pre := &kvrpcpb.PrewriteRequest{
+		Mutations: []*kvrpcpb.Mutation{{
+			Op:    kvrpcpb.Mutation_Put,
+			Key:   key,
+			Value: []byte("value"),
+		}},
+		PrimaryLock:  key,
+		StartVersion: startTs,
+		LockTtl:      5000,
+	}
+	require.Empty(t, Prewrite(db, latches, pre))
+
+	reader := NewReader(db)
+	lock, err := reader.GetLock(key)
+	require.NoError(t, err)
+	require.NotNil(t, lock)
+
+	resp := CheckTxnStatus(db, latches, &kvrpcpb.CheckTxnStatusRequest{
+		PrimaryKey:         key,
+		LockTs:             startTs,
+		CurrentTs:          startTs + 1_000_000,
+		RollbackIfNotExist: true,
+		CurrentTime:        lock.StartTime + lock.TTL - 1,
+	})
+	require.Nil(t, resp.GetError())
+	require.Equal(t, kvrpcpb.CheckTxnStatusAction_CheckTxnStatusNoAction, resp.GetAction())
+	require.Equal(t, lock.TTL, resp.GetLockTtl())
+
+	lock, err = reader.GetLock(key)
+	require.NoError(t, err)
+	require.NotNil(t, lock)
+}
+
+func TestCheckTxnStatusExpiresFromPhysicalTimeWithoutLogicalTSODistance(t *testing.T) {
+	db := openTestDB(t)
+	latches := latch.NewManager(16)
+	key := []byte("physical-expired")
+	startTs := uint64(100)
+	pre := &kvrpcpb.PrewriteRequest{
+		Mutations: []*kvrpcpb.Mutation{{
+			Op:    kvrpcpb.Mutation_Put,
+			Key:   key,
+			Value: []byte("value"),
+		}},
+		PrimaryLock:  key,
+		StartVersion: startTs,
+		LockTtl:      5,
+	}
+	require.Empty(t, Prewrite(db, latches, pre))
+
+	reader := NewReader(db)
+	lock, err := reader.GetLock(key)
+	require.NoError(t, err)
+	require.NotNil(t, lock)
+
+	resp := CheckTxnStatus(db, latches, &kvrpcpb.CheckTxnStatusRequest{
+		PrimaryKey:         key,
+		LockTs:             startTs,
+		CurrentTs:          startTs,
+		RollbackIfNotExist: true,
+		CurrentTime:        lock.StartTime + lock.TTL,
+	})
+	require.Nil(t, resp.GetError())
+	require.Equal(t, kvrpcpb.CheckTxnStatusAction_CheckTxnStatusTTLExpireRollback, resp.GetAction())
 }
 
 func TestReaderGetValueFromShortValueWithExpiresAt(t *testing.T) {
@@ -1170,8 +1247,10 @@ func TestRollbackKeyReturnsRetryableWhenApplyFails(t *testing.T) {
 
 func TestIsLockExpired(t *testing.T) {
 	require.False(t, isLockExpired(nil, 10))
-	require.False(t, isLockExpired(&mvcc.Lock{Ts: 5, TTL: 0}, 10))
-	require.True(t, isLockExpired(&mvcc.Lock{Ts: 5, TTL: 5}, 10))
+	require.False(t, isLockExpired(&mvcc.Lock{Ts: 5, StartTime: 100, TTL: 0}, 110))
+	require.False(t, isLockExpired(&mvcc.Lock{Ts: 5, StartTime: 0, TTL: 5}, 110))
+	require.False(t, isLockExpired(&mvcc.Lock{Ts: 5, StartTime: 100, TTL: 5}, 104))
+	require.True(t, isLockExpired(&mvcc.Lock{Ts: 5, StartTime: 100, TTL: 5}, 105))
 }
 
 func TestCommitTsExpired(t *testing.T) {
@@ -1224,10 +1303,11 @@ func TestIdempotentCommitCleansUpLock(t *testing.T) {
 	key := []byte("k")
 
 	lockVal := mvcc.EncodeLock(mvcc.Lock{
-		Primary: key,
-		Ts:      11,
-		TTL:     3000,
-		Kind:    kvrpcpb.Mutation_Put,
+		Primary:   key,
+		Ts:        11,
+		StartTime: 1100,
+		TTL:       3000,
+		Kind:      kvrpcpb.Mutation_Put,
 	})
 	applyVersionedEntryForTxnTest(t, db, kv.CFLock, key, lockColumnTs, lockVal, 0)
 
@@ -1256,6 +1336,7 @@ func TestIdempotentCommitWithPushedMinCommitTs(t *testing.T) {
 	lockVal := mvcc.EncodeLock(mvcc.Lock{
 		Primary:     key,
 		Ts:          11,
+		StartTime:   1100,
 		TTL:         3000,
 		Kind:        kvrpcpb.Mutation_Put,
 		MinCommitTs: 30,

--- a/percolator/txn_test.go
+++ b/percolator/txn_test.go
@@ -646,6 +646,44 @@ func TestBatchRollbackDoesNotDeleteOtherTransactionLock(t *testing.T) {
 	require.Equal(t, []byte("value"), value)
 }
 
+func TestLateBatchRollbackAfterCommitPreservesCommittedWrite(t *testing.T) {
+	db := openTestDB(t)
+	latches := latch.NewManager(16)
+	key := []byte("late-rollback")
+	startTs := uint64(20)
+	commitTs := uint64(30)
+
+	require.Empty(t, Prewrite(db, latches, &kvrpcpb.PrewriteRequest{
+		Mutations: []*kvrpcpb.Mutation{{
+			Op:    kvrpcpb.Mutation_Put,
+			Key:   key,
+			Value: []byte("value"),
+		}},
+		PrimaryLock:  key,
+		StartVersion: startTs,
+		LockTtl:      1000,
+	}))
+	require.Nil(t, Commit(db, latches, &kvrpcpb.CommitRequest{
+		Keys:          [][]byte{key},
+		StartVersion:  startTs,
+		CommitVersion: commitTs,
+	}))
+	require.Nil(t, BatchRollback(db, latches, &kvrpcpb.BatchRollbackRequest{
+		Keys:         [][]byte{key},
+		StartVersion: startTs,
+	}))
+
+	reader := NewReader(db)
+	write, gotCommitTs, err := reader.GetWriteByStartTs(key, startTs)
+	require.NoError(t, err)
+	require.NotNil(t, write)
+	require.Equal(t, kvrpcpb.Mutation_Put, write.Kind)
+	require.Equal(t, commitTs, gotCommitTs)
+	value, _, err := reader.GetValue(key, commitTs+1)
+	require.NoError(t, err)
+	require.Equal(t, []byte("value"), value)
+}
+
 func TestResolveLockCommit(t *testing.T) {
 	db := openTestDB(t)
 	latches := latch.NewManager(16)
@@ -671,6 +709,54 @@ func TestResolveLockCommit(t *testing.T) {
 	val, _, err := reader.GetValue([]byte("res"), 60)
 	require.NoError(t, err)
 	require.Equal(t, []byte("val"), val)
+}
+
+func TestResolveLockCommitsSecondaryAfterPrimaryCommitCrashWindow(t *testing.T) {
+	db := openTestDB(t)
+	latches := latch.NewManager(16)
+	primary := []byte("crash-primary")
+	secondary := []byte("crash-secondary")
+	startTs := uint64(40)
+	commitTs := uint64(50)
+
+	require.Empty(t, Prewrite(db, latches, &kvrpcpb.PrewriteRequest{
+		Mutations: []*kvrpcpb.Mutation{
+			{Op: kvrpcpb.Mutation_Put, Key: primary, Value: []byte("primary-value")},
+			{Op: kvrpcpb.Mutation_Put, Key: secondary, Value: []byte("secondary-value")},
+		},
+		PrimaryLock:  primary,
+		StartVersion: startTs,
+		LockTtl:      1000,
+	}))
+	require.Nil(t, Commit(db, latches, &kvrpcpb.CommitRequest{
+		Keys:          [][]byte{primary},
+		StartVersion:  startTs,
+		CommitVersion: commitTs,
+	}))
+
+	count, keyErr := ResolveLock(db, latches, &kvrpcpb.ResolveLockRequest{
+		Keys:          [][]byte{secondary},
+		StartVersion:  startTs,
+		CommitVersion: commitTs,
+	})
+	require.Nil(t, keyErr)
+	require.Equal(t, uint64(1), count)
+
+	reader := NewReader(db)
+	value, _, err := reader.GetValue(secondary, commitTs+1)
+	require.NoError(t, err)
+	require.Equal(t, []byte("secondary-value"), value)
+	lock, err := reader.GetLock(secondary)
+	require.NoError(t, err)
+	require.Nil(t, lock)
+
+	count, keyErr = ResolveLock(db, latches, &kvrpcpb.ResolveLockRequest{
+		Keys:          [][]byte{secondary},
+		StartVersion:  startTs,
+		CommitVersion: commitTs,
+	})
+	require.Nil(t, keyErr)
+	require.Zero(t, count)
 }
 
 // TestResolveLockNilRequest verifies ResolveLock ignores nil requests.
@@ -1074,6 +1160,148 @@ func TestCheckTxnStatusExpiresFromPhysicalTimeWithoutLogicalTSODistance(t *testi
 	})
 	require.Nil(t, resp.GetError())
 	require.Equal(t, kvrpcpb.CheckTxnStatusAction_CheckTxnStatusTTLExpireRollback, resp.GetAction())
+}
+
+func TestTxnHeartBeatExtendsPrimaryLockTTL(t *testing.T) {
+	db := openTestDB(t)
+	latches := latch.NewManager(16)
+	key := []byte("hb-primary")
+	startTs := uint64(100)
+	require.Empty(t, Prewrite(db, latches, &kvrpcpb.PrewriteRequest{
+		Mutations: []*kvrpcpb.Mutation{{
+			Op:    kvrpcpb.Mutation_Put,
+			Key:   key,
+			Value: []byte("value"),
+		}},
+		PrimaryLock:  key,
+		StartVersion: startTs,
+		LockTtl:      100,
+	}))
+
+	reader := NewReader(db)
+	lock, err := reader.GetLock(key)
+	require.NoError(t, err)
+	require.NotNil(t, lock)
+	originalStart := lock.StartTime
+
+	hb := TxnHeartBeat(db, latches, &kvrpcpb.TxnHeartBeatRequest{
+		PrimaryKey:   key,
+		StartVersion: startTs,
+		TtlExtension: 200,
+		CurrentTime:  originalStart + 50,
+	})
+	require.Nil(t, hb.GetError())
+	require.Equal(t, kvrpcpb.TxnHeartBeatAction_TxnHeartBeatTTLExtended, hb.GetAction())
+	require.Equal(t, uint64(250), hb.GetLockTtl())
+	require.Equal(t, originalStart+250, hb.GetLockExpireTime())
+
+	status := CheckTxnStatus(db, latches, &kvrpcpb.CheckTxnStatusRequest{
+		PrimaryKey:         key,
+		LockTs:             startTs,
+		CurrentTs:          startTs + 1_000_000,
+		RollbackIfNotExist: true,
+		CurrentTime:        originalStart + 150,
+	})
+	require.Nil(t, status.GetError())
+	require.Equal(t, kvrpcpb.CheckTxnStatusAction_CheckTxnStatusNoAction, status.GetAction())
+
+	lock, err = reader.GetLock(key)
+	require.NoError(t, err)
+	require.NotNil(t, lock)
+	require.Equal(t, uint64(250), lock.TTL)
+}
+
+func TestTxnHeartBeatDoesNotResurrectExpiredPrimary(t *testing.T) {
+	db := openTestDB(t)
+	latches := latch.NewManager(16)
+	key := []byte("hb-expired")
+	startTs := uint64(100)
+	require.Empty(t, Prewrite(db, latches, &kvrpcpb.PrewriteRequest{
+		Mutations: []*kvrpcpb.Mutation{{
+			Op:    kvrpcpb.Mutation_Put,
+			Key:   key,
+			Value: []byte("value"),
+		}},
+		PrimaryLock:  key,
+		StartVersion: startTs,
+		LockTtl:      5,
+	}))
+
+	reader := NewReader(db)
+	lock, err := reader.GetLock(key)
+	require.NoError(t, err)
+	require.NotNil(t, lock)
+
+	hb := TxnHeartBeat(db, latches, &kvrpcpb.TxnHeartBeatRequest{
+		PrimaryKey:   key,
+		StartVersion: startTs,
+		TtlExtension: 100,
+		CurrentTime:  lock.StartTime + lock.TTL,
+	})
+	require.Nil(t, hb.GetError())
+	require.Equal(t, kvrpcpb.TxnHeartBeatAction_TxnHeartBeatTTLExpireRollback, hb.GetAction())
+
+	lock, err = reader.GetLock(key)
+	require.NoError(t, err)
+	require.Nil(t, lock)
+	write, _, err := reader.GetWriteByStartTs(key, startTs)
+	require.NoError(t, err)
+	require.NotNil(t, write)
+	require.Equal(t, kvrpcpb.Mutation_Rollback, write.Kind)
+}
+
+func TestTxnHeartBeatReportsCommittedPrimary(t *testing.T) {
+	db := openTestDB(t)
+	latches := latch.NewManager(16)
+	key := []byte("hb-committed")
+	startTs := uint64(100)
+	commitTs := uint64(120)
+	require.Empty(t, Prewrite(db, latches, &kvrpcpb.PrewriteRequest{
+		Mutations: []*kvrpcpb.Mutation{{
+			Op:    kvrpcpb.Mutation_Put,
+			Key:   key,
+			Value: []byte("value"),
+		}},
+		PrimaryLock:  key,
+		StartVersion: startTs,
+		LockTtl:      100,
+	}))
+	require.Nil(t, Commit(db, latches, &kvrpcpb.CommitRequest{
+		Keys:          [][]byte{key},
+		StartVersion:  startTs,
+		CommitVersion: commitTs,
+	}))
+
+	hb := TxnHeartBeat(db, latches, &kvrpcpb.TxnHeartBeatRequest{
+		PrimaryKey:   key,
+		StartVersion: startTs,
+		TtlExtension: 100,
+		CurrentTime:  1,
+	})
+	require.Nil(t, hb.GetError())
+	require.Equal(t, commitTs, hb.GetCommitVersion())
+}
+
+func TestTxnHeartBeatFencesMissingPrimaryWithRollback(t *testing.T) {
+	db := openTestDB(t)
+	latches := latch.NewManager(16)
+	key := []byte("hb-missing")
+	startTs := uint64(100)
+
+	hb := TxnHeartBeat(db, latches, &kvrpcpb.TxnHeartBeatRequest{
+		PrimaryKey:   key,
+		StartVersion: startTs,
+		TtlExtension: 100,
+		CurrentTime:  1,
+	})
+	require.Nil(t, hb.GetError())
+	require.Equal(t, kvrpcpb.TxnHeartBeatAction_TxnHeartBeatLockNotExistRollback, hb.GetAction())
+
+	reader := NewReader(db)
+	write, _, err := reader.GetWriteByStartTs(key, startTs)
+	require.NoError(t, err)
+	require.NotNil(t, write)
+	require.Equal(t, kvrpcpb.Mutation_Rollback, write.Kind)
 }
 
 func TestReaderGetValueFromShortValueWithExpiresAt(t *testing.T) {

--- a/raftstore/client/client.go
+++ b/raftstore/client/client.go
@@ -44,6 +44,7 @@ type RetryPolicy struct {
 	RouteUnavailableBackoff     time.Duration
 	TransportUnavailableBackoff time.Duration
 	RegionErrorBackoff          time.Duration
+	LockResolveBackoff          time.Duration
 }
 
 // Client provides Region-aware helpers for NoKV RPCs, including 2PC.
@@ -92,6 +93,7 @@ func New(cfg Config) (*Client, error) {
 	retry.RouteUnavailableBackoff = normalizeRetryBackoff(retry.RouteUnavailableBackoff, 20*time.Millisecond)
 	retry.TransportUnavailableBackoff = normalizeRetryBackoff(retry.TransportUnavailableBackoff, 10*time.Millisecond)
 	retry.RegionErrorBackoff = normalizeRetryBackoff(retry.RegionErrorBackoff, 0)
+	retry.LockResolveBackoff = normalizeRetryBackoff(retry.LockResolveBackoff, 10*time.Millisecond)
 	return &Client{
 		stores:             make(map[uint64]*storeConn),
 		regions:            make(map[uint64]*regionState),

--- a/raftstore/client/client_kv.go
+++ b/raftstore/client/client_kv.go
@@ -323,6 +323,10 @@ func readLockFingerprint(locked *kvrpcpb.Locked) string {
 	return string(locked.GetKey()) + "\x00" + fmt.Sprint(locked.GetLockVersion())
 }
 
+func currentPhysicalTimeMillis() uint64 {
+	return uint64(time.Now().UnixMilli())
+}
+
 func (c *Client) resolveReadLock(ctx context.Context, locked *kvrpcpb.Locked, readTs uint64) (bool, error) {
 	if locked == nil {
 		return false, nil
@@ -331,7 +335,7 @@ func (c *Client) resolveReadLock(ctx context.Context, locked *kvrpcpb.Locked, re
 	if len(lockKey) == 0 || len(locked.GetPrimaryLock()) == 0 || locked.GetLockVersion() == 0 {
 		return false, txnKeyError(&kvrpcpb.KeyError{Locked: locked})
 	}
-	statusResp, err := c.CheckTxnStatus(ctx, locked.GetPrimaryLock(), locked.GetLockVersion(), readTs)
+	statusResp, err := c.CheckTxnStatus(ctx, locked.GetPrimaryLock(), locked.GetLockVersion(), readTs, currentPhysicalTimeMillis())
 	if err != nil {
 		return false, err
 	}
@@ -772,7 +776,7 @@ func (c *Client) batchRollbackRegionOnce(ctx context.Context, region regionSnaps
 
 // CheckTxnStatus inspects the primary lock for a transaction and returns the
 // scheduler's decision (rollback, still alive, or already committed).
-func (c *Client) CheckTxnStatus(ctx context.Context, primary []byte, lockTs, currentTs uint64) (*kvrpcpb.CheckTxnStatusResponse, error) {
+func (c *Client) CheckTxnStatus(ctx context.Context, primary []byte, lockTs, currentTs, currentTime uint64) (*kvrpcpb.CheckTxnStatusResponse, error) {
 	var lastErr error
 	for attempt := 0; attempt < c.retry.MaxAttempts; attempt++ {
 		region, err := c.routeKeyWithRetry(ctx, primary)
@@ -802,7 +806,7 @@ func (c *Client) CheckTxnStatus(ctx context.Context, primary []byte, lockTs, cur
 				CurrentTs:          currentTs,
 				CallerStartTs:      currentTs,
 				RollbackIfNotExist: true,
-				CurrentTime:        uint64(time.Now().Unix()),
+				CurrentTime:        currentTime,
 			},
 		}
 		resp, err := cl.KvCheckTxnStatus(ctx, req)

--- a/raftstore/client/client_kv.go
+++ b/raftstore/client/client_kv.go
@@ -4,9 +4,9 @@ import (
 	"context"
 	"errors"
 	"fmt"
+
 	errorpb "github.com/feichai0017/NoKV/pb/error"
 	kvrpcpb "github.com/feichai0017/NoKV/pb/kv"
-	"time"
 
 	"google.golang.org/protobuf/proto"
 )
@@ -68,7 +68,7 @@ func (c *Client) Get(ctx context.Context, key []byte, version uint64) (*kvrpcpb.
 	if err := ctx.Err(); err != nil {
 		return nil, err
 	}
-	return nil, fmt.Errorf("client: kv get retries exhausted for key %q", key)
+	return nil, &RetryExhaustedError{Operation: "kv get", Key: append([]byte(nil), key...)}
 }
 
 // BatchGet fetches multiple keys using the same snapshot version. Keys are
@@ -177,7 +177,7 @@ func (c *Client) BatchGet(ctx context.Context, keys [][]byte, version uint64) (m
 		if err := ctx.Err(); err != nil {
 			return nil, err
 		}
-		return nil, fmt.Errorf("client: kv batch get retries exhausted")
+		return nil, &RetryExhaustedError{Operation: "kv batch get"}
 	}
 	return results, nil
 }
@@ -323,10 +323,6 @@ func readLockFingerprint(locked *kvrpcpb.Locked) string {
 	return string(locked.GetKey()) + "\x00" + fmt.Sprint(locked.GetLockVersion())
 }
 
-func currentPhysicalTimeMillis() uint64 {
-	return uint64(time.Now().UnixMilli())
-}
-
 func (c *Client) resolveReadLock(ctx context.Context, locked *kvrpcpb.Locked, readTs uint64) (bool, error) {
 	if locked == nil {
 		return false, nil
@@ -335,12 +331,12 @@ func (c *Client) resolveReadLock(ctx context.Context, locked *kvrpcpb.Locked, re
 	if len(lockKey) == 0 || len(locked.GetPrimaryLock()) == 0 || locked.GetLockVersion() == 0 {
 		return false, txnKeyError(&kvrpcpb.KeyError{Locked: locked})
 	}
-	statusResp, err := c.CheckTxnStatus(ctx, locked.GetPrimaryLock(), locked.GetLockVersion(), readTs, currentPhysicalTimeMillis())
+	statusResp, err := c.CheckTxnStatus(ctx, locked.GetPrimaryLock(), locked.GetLockVersion(), readTs, 0)
 	if err != nil {
 		return false, err
 	}
 	if statusResp == nil {
-		return false, fmt.Errorf("client: nil check txn status response for primary %q", locked.GetPrimaryLock())
+		return false, &ProtocolError{Operation: "resolve read lock", Detail: fmt.Sprintf("nil check txn status response for primary %q", locked.GetPrimaryLock())}
 	}
 	if keyErr := statusResp.GetError(); keyErr != nil {
 		return false, txnKeyError(keyErr)
@@ -387,7 +383,7 @@ func (c *Client) callScan(ctx context.Context, region regionSnapshot, startKey [
 // ensure the primary key is part of the mutation set.
 func (c *Client) Mutate(ctx context.Context, primary []byte, mutations []*kvrpcpb.Mutation, startVersion, commitVersion, lockTTL uint64) error {
 	if len(primary) == 0 {
-		return fmt.Errorf("client: primary key required")
+		return &ProtocolError{Operation: "mutate", Detail: "primary key required"}
 	}
 	cleaned := make([]*kvrpcpb.Mutation, 0, len(mutations))
 	for _, mut := range mutations {
@@ -400,7 +396,7 @@ func (c *Client) Mutate(ctx context.Context, primary []byte, mutations []*kvrpcp
 		return nil
 	}
 	if !mutationHasPrimary(cleaned, primary) {
-		return fmt.Errorf("client: primary key %q not present in mutations", primary)
+		return &ProtocolError{Operation: "mutate", Detail: fmt.Sprintf("primary key %q not present in mutations", primary)}
 	}
 	return c.TwoPhaseCommit(ctx, append([]byte(nil), primary...), cleaned, startVersion, commitVersion, lockTTL)
 }
@@ -442,7 +438,7 @@ func (c *Client) TwoPhaseCommit(ctx context.Context, primary []byte, mutations [
 		cleaned = append(cleaned, cloned)
 	}
 	if primaryMutation == nil {
-		return fmt.Errorf("client: primary key %q missing from mutations", primary)
+		return &ProtocolError{Operation: "two phase commit", Detail: fmt.Sprintf("primary key %q missing from mutations", primary)}
 	}
 	prewritten, err := c.prewriteMutationsByRoute(ctx, primary, startVersion, lockTTL, []*kvrpcpb.Mutation{primaryMutation})
 	if err != nil {
@@ -542,7 +538,7 @@ func (c *Client) prewriteMutationsByRoute(ctx context.Context, primary []byte, s
 	if err := ctx.Err(); err != nil {
 		return prewritten, err
 	}
-	return prewritten, fmt.Errorf("client: prewrite retries exhausted")
+	return prewritten, &RetryExhaustedError{Operation: "prewrite"}
 }
 
 func (c *Client) rollbackPrewrites(ctx context.Context, prewritten map[uint64][][]byte, startVersion uint64) error {
@@ -584,7 +580,7 @@ func (c *Client) commitRegion(ctx context.Context, regionID uint64, keys [][]byt
 	for attempt := 0; attempt < c.retry.MaxAttempts; attempt++ {
 		region, ok := c.regionSnapshot(regionID)
 		if !ok {
-			return fmt.Errorf("client: region %d missing for commit", regionID)
+			return &ProtocolError{Operation: "commit", Detail: fmt.Sprintf("region %d missing from cache", regionID)}
 		}
 		resp, regionErr, err := c.commitRegionOnce(ctx, region, keys, startVersion, commitVersion)
 		if err != nil {
@@ -618,7 +614,7 @@ func (c *Client) commitRegion(ctx context.Context, regionID uint64, keys [][]byt
 	if err := ctx.Err(); err != nil {
 		return err
 	}
-	return fmt.Errorf("client: commit retries exhausted for region %d", regionID)
+	return &RetryExhaustedError{Operation: "commit", RegionID: regionID}
 }
 
 func (c *Client) commitKeysByRoute(ctx context.Context, keys [][]byte, startVersion, commitVersion uint64) error {
@@ -671,7 +667,7 @@ func (c *Client) commitKeysByRoute(ctx context.Context, keys [][]byte, startVers
 	if err := ctx.Err(); err != nil {
 		return err
 	}
-	return fmt.Errorf("client: commit retries exhausted")
+	return &RetryExhaustedError{Operation: "commit"}
 }
 
 func (c *Client) commitRegionOnce(ctx context.Context, region regionSnapshot, keys [][]byte, startVersion, commitVersion uint64) (*kvrpcpb.CommitResponse, *errorpb.RegionError, error) {
@@ -748,7 +744,7 @@ func (c *Client) rollbackKeysByRoute(ctx context.Context, keys [][]byte, startVe
 	if err := ctx.Err(); err != nil {
 		return err
 	}
-	return fmt.Errorf("client: rollback retries exhausted")
+	return &RetryExhaustedError{Operation: "rollback"}
 }
 
 func (c *Client) batchRollbackRegionOnce(ctx context.Context, region regionSnapshot, keys [][]byte, startVersion uint64) (*kvrpcpb.BatchRollbackResponse, *errorpb.RegionError, error) {
@@ -831,7 +827,68 @@ func (c *Client) CheckTxnStatus(ctx context.Context, primary []byte, lockTs, cur
 	if err := ctx.Err(); err != nil {
 		return nil, err
 	}
-	return nil, fmt.Errorf("client: check txn status retries exhausted")
+	return nil, &RetryExhaustedError{Operation: "check txn status"}
+}
+
+// TxnHeartBeat extends the primary lock TTL for a live transaction.
+func (c *Client) TxnHeartBeat(ctx context.Context, primary []byte, startVersion, ttlExtension uint64) (*kvrpcpb.TxnHeartBeatResponse, error) {
+	return c.txnHeartBeatAt(ctx, primary, startVersion, ttlExtension, 0)
+}
+
+func (c *Client) txnHeartBeatAt(ctx context.Context, primary []byte, startVersion, ttlExtension, currentTime uint64) (*kvrpcpb.TxnHeartBeatResponse, error) {
+	var lastErr error
+	for attempt := 0; attempt < c.retry.MaxAttempts; attempt++ {
+		region, err := c.routeKeyWithRetry(ctx, primary)
+		if err != nil {
+			return nil, err
+		}
+		cl, err := c.storeClient(ctx, region.leader)
+		if err != nil {
+			if isTransportUnavailable(err) {
+				lastErr = err
+				if err := c.waitRetry(ctx, attempt, retryTransportUnavailable); err != nil {
+					return nil, err
+				}
+				continue
+			}
+			return nil, err
+		}
+		header, err := buildContext(region)
+		if err != nil {
+			return nil, err
+		}
+		req := &kvrpcpb.KvTxnHeartBeatRequest{
+			Context: header,
+			Request: &kvrpcpb.TxnHeartBeatRequest{
+				PrimaryKey:   append([]byte(nil), primary...),
+				StartVersion: startVersion,
+				TtlExtension: ttlExtension,
+				CurrentTime:  currentTime,
+			},
+		}
+		resp, err := cl.KvTxnHeartBeat(ctx, req)
+		if err != nil {
+			return nil, normalizeRPCError(err)
+		}
+		if regionErr := resp.GetRegionError(); regionErr != nil {
+			lastErr = c.handleRegionError(region.desc.RegionID, regionErr)
+			if lastErr != nil {
+				return nil, lastErr
+			}
+			if err := c.waitRetry(ctx, attempt, retryRegionError); err != nil {
+				return nil, err
+			}
+			continue
+		}
+		return resp.GetResponse(), nil
+	}
+	if lastErr != nil {
+		return nil, lastErr
+	}
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	return nil, &RetryExhaustedError{Operation: "txn heartbeat"}
 }
 
 // ResolveLocks attempts to resolve (commit or rollback) the provided keys for
@@ -894,7 +951,7 @@ func (c *Client) resolveLocksByRoute(ctx context.Context, startVersion, commitVe
 	if err := ctx.Err(); err != nil {
 		return resolved, err
 	}
-	return resolved, fmt.Errorf("client: resolve lock retries exhausted")
+	return resolved, &RetryExhaustedError{Operation: "resolve lock"}
 }
 
 func (c *Client) resolveRegionLocksOnce(ctx context.Context, region regionSnapshot, startVersion, commitVersion uint64, keys [][]byte) (*kvrpcpb.ResolveLockResponse, *errorpb.RegionError, error) {

--- a/raftstore/client/client_kv.go
+++ b/raftstore/client/client_kv.go
@@ -14,6 +14,7 @@ import (
 // Get issues a KvGet for the provided key/version. It retries on region errors.
 func (c *Client) Get(ctx context.Context, key []byte, version uint64) (*kvrpcpb.GetResponse, error) {
 	var lastErr error
+	var lastKeyErr *kvrpcpb.KeyError
 	for attempt := 0; attempt < c.retry.MaxAttempts; attempt++ {
 		region, err := c.routeKeyWithRetry(ctx, key)
 		if err != nil {
@@ -40,10 +41,29 @@ func (c *Client) Get(ctx context.Context, key []byte, version uint64) (*kvrpcpb.
 			}
 			continue
 		}
+		if keyErr := resp.GetError(); keyErr != nil {
+			if locked := keyErr.GetLocked(); locked != nil {
+				lastKeyErr = keyErr
+				resolved, err := c.resolveReadLock(ctx, locked, version)
+				if err != nil && !errors.Is(err, errReadLockStillLive) {
+					return nil, err
+				}
+				if !resolved {
+					if err := c.waitRetry(ctx, attempt, retryLockResolve); err != nil {
+						return nil, err
+					}
+				}
+				continue
+			}
+			return nil, txnKeyError(keyErr)
+		}
 		return resp, nil
 	}
 	if lastErr != nil {
 		return nil, lastErr
+	}
+	if lastKeyErr != nil {
+		return nil, txnKeyError(lastKeyErr)
 	}
 	if err := ctx.Err(); err != nil {
 		return nil, err
@@ -70,6 +90,7 @@ func (c *Client) BatchGet(ctx context.Context, keys [][]byte, version uint64) (m
 		ids    []string
 	}
 	var lastErr error
+	var lastKeyErr *kvrpcpb.KeyError
 	for attempt := 0; attempt < c.retry.MaxAttempts && len(pending) > 0; attempt++ {
 		groups := make(map[uint64]*regionBatch)
 		for keyID, key := range pending {
@@ -111,6 +132,20 @@ func (c *Client) BatchGet(ctx context.Context, keys [][]byte, version uint64) (m
 				} else {
 					getResp = &kvrpcpb.GetResponse{NotFound: true}
 				}
+				if keyErr := getResp.GetError(); keyErr != nil {
+					if locked := keyErr.GetLocked(); locked != nil {
+						lastKeyErr = keyErr
+						resolved, err := c.resolveReadLock(ctx, locked, version)
+						if err != nil && !errors.Is(err, errReadLockStillLive) {
+							return nil, err
+						}
+						if !resolved {
+							lastErr = txnKeyError(keyErr)
+						}
+						continue
+					}
+					return nil, txnKeyError(keyErr)
+				}
 				results[keyID] = getResp
 				completed = append(completed, keyID)
 			}
@@ -124,6 +159,8 @@ func (c *Client) BatchGet(ctx context.Context, keys [][]byte, version uint64) (m
 				kind = retryRouteUnavailable
 			} else if isTransportUnavailable(lastErr) {
 				kind = retryTransportUnavailable
+			} else if lastKeyErr != nil {
+				kind = retryLockResolve
 			}
 			if err := c.waitRetry(ctx, attempt, kind); err != nil {
 				return nil, err
@@ -133,6 +170,9 @@ func (c *Client) BatchGet(ctx context.Context, keys [][]byte, version uint64) (m
 	if len(pending) > 0 {
 		if lastErr != nil {
 			return nil, lastErr
+		}
+		if lastKeyErr != nil {
+			return nil, txnKeyError(lastKeyErr)
 		}
 		if err := ctx.Err(); err != nil {
 			return nil, err
@@ -202,6 +242,9 @@ func (c *Client) Scan(ctx context.Context, startKey []byte, limit uint32, versio
 	collected := make([]*kvrpcpb.KV, 0, limit)
 	currentKey := append([]byte(nil), startKey...)
 	remaining := limit
+	lockAttempts := 0
+	lastLock := ""
+	var lastKeyErr *kvrpcpb.KeyError
 	for remaining > 0 {
 		region, err := c.routeKeyWithRetry(ctx, currentKey)
 		if err != nil {
@@ -226,6 +269,31 @@ func (c *Client) Scan(ctx context.Context, startKey []byte, limit uint32, versio
 			}
 			continue
 		}
+		if keyErr := resp.GetError(); keyErr != nil {
+			if locked := keyErr.GetLocked(); locked != nil {
+				lastKeyErr = keyErr
+				lockID := readLockFingerprint(locked)
+				if lockID != lastLock {
+					lastLock = lockID
+					lockAttempts = 0
+				}
+				if lockAttempts >= c.retry.MaxAttempts {
+					return nil, txnKeyError(lastKeyErr)
+				}
+				resolved, err := c.resolveReadLock(ctx, locked, version)
+				if err != nil && !errors.Is(err, errReadLockStillLive) {
+					return nil, err
+				}
+				if !resolved {
+					if err := c.waitRetry(ctx, lockAttempts, retryLockResolve); err != nil {
+						return nil, err
+					}
+				}
+				lockAttempts++
+				continue
+			}
+			return nil, txnKeyError(keyErr)
+		}
 		kvs := resp.GetKvs()
 		collected = append(collected, kvs...)
 		if len(kvs) == 0 {
@@ -249,6 +317,42 @@ func (c *Client) Scan(ctx context.Context, startKey []byte, limit uint32, versio
 		currentKey = nextKey
 	}
 	return collected, nil
+}
+
+func readLockFingerprint(locked *kvrpcpb.Locked) string {
+	return string(locked.GetKey()) + "\x00" + fmt.Sprint(locked.GetLockVersion())
+}
+
+func (c *Client) resolveReadLock(ctx context.Context, locked *kvrpcpb.Locked, readTs uint64) (bool, error) {
+	if locked == nil {
+		return false, nil
+	}
+	lockKey := locked.GetKey()
+	if len(lockKey) == 0 || len(locked.GetPrimaryLock()) == 0 || locked.GetLockVersion() == 0 {
+		return false, txnKeyError(&kvrpcpb.KeyError{Locked: locked})
+	}
+	statusResp, err := c.CheckTxnStatus(ctx, locked.GetPrimaryLock(), locked.GetLockVersion(), readTs)
+	if err != nil {
+		return false, err
+	}
+	if statusResp == nil {
+		return false, fmt.Errorf("client: nil check txn status response for primary %q", locked.GetPrimaryLock())
+	}
+	if keyErr := statusResp.GetError(); keyErr != nil {
+		return false, txnKeyError(keyErr)
+	}
+	commitVersion := statusResp.GetCommitVersion()
+	switch {
+	case commitVersion > 0:
+		_, err = c.ResolveLocks(ctx, locked.GetLockVersion(), commitVersion, [][]byte{lockKey})
+		return err == nil, err
+	case statusResp.GetAction() == kvrpcpb.CheckTxnStatusAction_CheckTxnStatusTTLExpireRollback ||
+		statusResp.GetAction() == kvrpcpb.CheckTxnStatusAction_CheckTxnStatusLockNotExistRollback:
+		_, err = c.ResolveLocks(ctx, locked.GetLockVersion(), 0, [][]byte{lockKey})
+		return err == nil, err
+	default:
+		return false, errReadLockStillLive
+	}
 }
 
 func (c *Client) callScan(ctx context.Context, region regionSnapshot, startKey []byte, limit uint32, version uint64) (*kvrpcpb.ScanResponse, *errorpb.RegionError, error) {
@@ -414,7 +518,7 @@ func (c *Client) prewriteMutationsByRoute(ctx context.Context, primary []byte, s
 				break
 			}
 			if resp != nil && len(resp.GetErrors()) > 0 {
-				return prewritten, &KeyConflictError{Errors: resp.GetErrors()}
+				return prewritten, &TxnKeyError{Errors: resp.GetErrors()}
 			}
 			prewritten[group.region.desc.RegionID] = append(prewritten[group.region.desc.RegionID], collectKeys(group.mutations)...)
 			pending = removeMutationSet(pending, group.mutations)
@@ -499,8 +603,8 @@ func (c *Client) commitRegion(ctx context.Context, regionID uint64, keys [][]byt
 			}
 			continue
 		}
-		if resp != nil && resp.GetError() != nil {
-			return fmt.Errorf("client: commit key error: %v", resp.GetError())
+		if err := txnKeyError(resp.GetError()); err != nil {
+			return err
 		}
 		return nil
 	}
@@ -543,8 +647,8 @@ func (c *Client) commitKeysByRoute(ctx context.Context, keys [][]byte, startVers
 				shouldRetry = true
 				break
 			}
-			if resp != nil && resp.GetError() != nil {
-				return fmt.Errorf("client: commit key error: %v", resp.GetError())
+			if err := txnKeyError(resp.GetError()); err != nil {
+				return err
 			}
 			pending = removeKeySet(pending, group.keys)
 		}
@@ -620,8 +724,8 @@ func (c *Client) rollbackKeysByRoute(ctx context.Context, keys [][]byte, startVe
 				shouldRetry = true
 				break
 			}
-			if resp != nil && resp.GetError() != nil {
-				return fmt.Errorf("client: rollback key error: %v", resp.GetError())
+			if err := txnKeyError(resp.GetError()); err != nil {
+				return err
 			}
 			pending = removeKeySet(pending, group.keys)
 		}
@@ -765,7 +869,7 @@ func (c *Client) resolveLocksByRoute(ctx context.Context, startVersion, commitVe
 			}
 			if resp != nil {
 				if keyErr := resp.GetError(); keyErr != nil {
-					return resolved, fmt.Errorf("client: resolve lock key error: %v", keyErr)
+					return resolved, txnKeyError(keyErr)
 				}
 				resolved += resp.GetResolvedLocks()
 			}

--- a/raftstore/client/client_kv_test.go
+++ b/raftstore/client/client_kv_test.go
@@ -25,6 +25,7 @@ type scriptedKVService struct {
 	rollbackFn       func(context.Context, *kvrpcpb.KvBatchRollbackRequest) (*kvrpcpb.KvBatchRollbackResponse, error)
 	resolveLockFn    func(context.Context, *kvrpcpb.KvResolveLockRequest) (*kvrpcpb.KvResolveLockResponse, error)
 	checkTxnStatusFn func(context.Context, *kvrpcpb.KvCheckTxnStatusRequest) (*kvrpcpb.KvCheckTxnStatusResponse, error)
+	txnHeartBeatFn   func(context.Context, *kvrpcpb.KvTxnHeartBeatRequest) (*kvrpcpb.KvTxnHeartBeatResponse, error)
 }
 
 func (s *scriptedKVService) KvGet(ctx context.Context, req *kvrpcpb.KvGetRequest) (*kvrpcpb.KvGetResponse, error) {
@@ -81,6 +82,13 @@ func (s *scriptedKVService) KvCheckTxnStatus(ctx context.Context, req *kvrpcpb.K
 		return s.checkTxnStatusFn(ctx, req)
 	}
 	return s.mockService.KvCheckTxnStatus(ctx, req)
+}
+
+func (s *scriptedKVService) KvTxnHeartBeat(ctx context.Context, req *kvrpcpb.KvTxnHeartBeatRequest) (*kvrpcpb.KvTxnHeartBeatResponse, error) {
+	if s.txnHeartBeatFn != nil {
+		return s.txnHeartBeatFn(ctx, req)
+	}
+	return s.mockService.KvTxnHeartBeat(ctx, req)
 }
 
 func TestClientCommitRegionReturnsKeyError(t *testing.T) {
@@ -175,7 +183,7 @@ func TestClientGetResolvesCommittedLockAndRetries(t *testing.T) {
 			require.Equal(t, []byte("primary"), req.GetRequest().GetPrimaryKey())
 			require.Equal(t, uint64(10), req.GetRequest().GetLockTs())
 			require.Equal(t, uint64(20), req.GetRequest().GetCurrentTs())
-			require.NotZero(t, req.GetRequest().GetCurrentTime())
+			require.Zero(t, req.GetRequest().GetCurrentTime())
 			return &kvrpcpb.KvCheckTxnStatusResponse{
 				Response: &kvrpcpb.CheckTxnStatusResponse{CommitVersion: 30},
 			}, nil
@@ -619,6 +627,58 @@ func TestClientCheckTxnStatusRetriesOnNotLeader(t *testing.T) {
 	cli.mu.RUnlock()
 }
 
+func TestClientTxnHeartBeatRoutesPrimaryAndDelegatesPhysicalTime(t *testing.T) {
+	cluster := newMockCluster(clusterRegion{
+		meta: &metapb.RegionDescriptor{
+			RegionId: 1,
+			StartKey: []byte("a"),
+			EndKey:   []byte("z"),
+			Epoch:    &metapb.RegionEpoch{Version: 1, ConfVersion: 1},
+			Peers: []*metapb.RegionPeer{
+				{StoreId: 1, PeerId: 101},
+			},
+		},
+		leaderStore: 1,
+	})
+
+	var calls int
+	addr, stop := startBlockingStore(t, &scriptedKVService{
+		mockService: mockService{storeID: 1, cluster: cluster},
+		txnHeartBeatFn: func(_ context.Context, req *kvrpcpb.KvTxnHeartBeatRequest) (*kvrpcpb.KvTxnHeartBeatResponse, error) {
+			calls++
+			require.Equal(t, uint64(1), req.GetContext().GetRegionId())
+			require.Equal(t, []byte("primary"), req.GetRequest().GetPrimaryKey())
+			require.Equal(t, uint64(10), req.GetRequest().GetStartVersion())
+			require.Equal(t, uint64(3000), req.GetRequest().GetTtlExtension())
+			require.Zero(t, req.GetRequest().GetCurrentTime())
+			return &kvrpcpb.KvTxnHeartBeatResponse{
+				Response: &kvrpcpb.TxnHeartBeatResponse{
+					LockTtl:        5000,
+					LockExpireTime: 9000,
+					Action:         kvrpcpb.TxnHeartBeatAction_TxnHeartBeatTTLExtended,
+				},
+			}, nil
+		},
+	})
+	defer stop()
+
+	cli, err := New(Config{
+		StoreResolver:  staticStoreResolver{{StoreID: 1, Addr: addr}},
+		RegionResolver: resolverFromCluster(cluster),
+		DialOptions:    []grpc.DialOption{grpc.WithTransportCredentials(insecure.NewCredentials())},
+		Retry:          RetryPolicy{MaxAttempts: 2, RegionErrorBackoff: 0},
+	})
+	require.NoError(t, err)
+	defer func() { _ = cli.Close() }()
+
+	resp, err := cli.TxnHeartBeat(context.Background(), []byte("primary"), 10, 3000)
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	require.Equal(t, kvrpcpb.TxnHeartBeatAction_TxnHeartBeatTTLExtended, resp.GetAction())
+	require.Equal(t, uint64(5000), resp.GetLockTtl())
+	require.Equal(t, 1, calls)
+}
+
 func TestClientResolveLocksReturnsKeyError(t *testing.T) {
 	cluster := newMockCluster(clusterRegion{
 		meta: &metapb.RegionDescriptor{
@@ -702,7 +762,8 @@ func TestClientTwoPhaseCommitRejectsMissingPrimaryMutation(t *testing.T) {
 	err = cli.TwoPhaseCommit(context.Background(), []byte("omega"), []*kvrpcpb.Mutation{
 		{Op: kvrpcpb.Mutation_Put, Key: []byte("alfa"), Value: []byte("value")},
 	}, 1, 2, 3)
-	require.EqualError(t, err, fmt.Sprintf("client: primary key %q missing from mutations", []byte("omega")))
+	require.True(t, IsProtocolError(err))
+	require.ErrorContains(t, err, fmt.Sprintf("primary key %q missing from mutations", []byte("omega")))
 }
 
 func TestClientTwoPhaseCommitRollsBackPrewritesAfterSecondaryPrewriteFailure(t *testing.T) {

--- a/raftstore/client/client_kv_test.go
+++ b/raftstore/client/client_kv_test.go
@@ -17,11 +17,35 @@ import (
 
 type scriptedKVService struct {
 	mockService
+	getFn            func(context.Context, *kvrpcpb.KvGetRequest) (*kvrpcpb.KvGetResponse, error)
+	batchGetFn       func(context.Context, *kvrpcpb.KvBatchGetRequest) (*kvrpcpb.KvBatchGetResponse, error)
+	scanFn           func(context.Context, *kvrpcpb.KvScanRequest) (*kvrpcpb.KvScanResponse, error)
 	prewriteFn       func(context.Context, *kvrpcpb.KvPrewriteRequest) (*kvrpcpb.KvPrewriteResponse, error)
 	commitFn         func(context.Context, *kvrpcpb.KvCommitRequest) (*kvrpcpb.KvCommitResponse, error)
 	rollbackFn       func(context.Context, *kvrpcpb.KvBatchRollbackRequest) (*kvrpcpb.KvBatchRollbackResponse, error)
 	resolveLockFn    func(context.Context, *kvrpcpb.KvResolveLockRequest) (*kvrpcpb.KvResolveLockResponse, error)
 	checkTxnStatusFn func(context.Context, *kvrpcpb.KvCheckTxnStatusRequest) (*kvrpcpb.KvCheckTxnStatusResponse, error)
+}
+
+func (s *scriptedKVService) KvGet(ctx context.Context, req *kvrpcpb.KvGetRequest) (*kvrpcpb.KvGetResponse, error) {
+	if s.getFn != nil {
+		return s.getFn(ctx, req)
+	}
+	return s.mockService.KvGet(ctx, req)
+}
+
+func (s *scriptedKVService) KvBatchGet(ctx context.Context, req *kvrpcpb.KvBatchGetRequest) (*kvrpcpb.KvBatchGetResponse, error) {
+	if s.batchGetFn != nil {
+		return s.batchGetFn(ctx, req)
+	}
+	return s.mockService.KvBatchGet(ctx, req)
+}
+
+func (s *scriptedKVService) KvScan(ctx context.Context, req *kvrpcpb.KvScanRequest) (*kvrpcpb.KvScanResponse, error) {
+	if s.scanFn != nil {
+		return s.scanFn(ctx, req)
+	}
+	return s.mockService.KvScan(ctx, req)
 }
 
 func (s *scriptedKVService) KvPrewrite(ctx context.Context, req *kvrpcpb.KvPrewriteRequest) (*kvrpcpb.KvPrewriteResponse, error) {
@@ -78,7 +102,11 @@ func TestClientCommitRegionReturnsKeyError(t *testing.T) {
 		commitFn: func(context.Context, *kvrpcpb.KvCommitRequest) (*kvrpcpb.KvCommitResponse, error) {
 			return &kvrpcpb.KvCommitResponse{
 				Response: &kvrpcpb.CommitResponse{
-					Error: &kvrpcpb.KeyError{Abort: "commit failed"},
+					Error: &kvrpcpb.KeyError{CommitTsExpired: &kvrpcpb.CommitTsExpired{
+						Key:         []byte("alfa"),
+						CommitTs:    22,
+						MinCommitTs: 30,
+					}},
 				},
 			}, nil
 		},
@@ -99,7 +127,360 @@ func TestClientCommitRegionReturnsKeyError(t *testing.T) {
 	cli.mu.Unlock()
 
 	err = cli.commitRegion(context.Background(), 1, [][]byte{[]byte("alfa")}, 11, 22)
-	require.ErrorContains(t, err, "commit key error")
+	txnErr, ok := AsTxnKeyError(err)
+	require.True(t, ok)
+	require.Len(t, txnErr.Errors, 1)
+	require.NotNil(t, txnErr.Errors[0].GetCommitTsExpired())
+	require.Equal(t, uint64(30), txnErr.Errors[0].GetCommitTsExpired().GetMinCommitTs())
+}
+
+func TestClientGetResolvesCommittedLockAndRetries(t *testing.T) {
+	cluster := newMockCluster(clusterRegion{
+		meta: &metapb.RegionDescriptor{
+			RegionId: 1,
+			StartKey: []byte("a"),
+			EndKey:   []byte("z"),
+			Epoch:    &metapb.RegionEpoch{Version: 1, ConfVersion: 1},
+			Peers: []*metapb.RegionPeer{
+				{StoreId: 1, PeerId: 101},
+			},
+		},
+		leaderStore: 1,
+	})
+
+	var getCalls int
+	var checkCalls int
+	var resolveCalls int
+	addr, stop := startBlockingStore(t, &scriptedKVService{
+		mockService: mockService{storeID: 1, cluster: cluster},
+		getFn: func(context.Context, *kvrpcpb.KvGetRequest) (*kvrpcpb.KvGetResponse, error) {
+			getCalls++
+			if getCalls == 1 {
+				return &kvrpcpb.KvGetResponse{
+					Response: &kvrpcpb.GetResponse{
+						Error: &kvrpcpb.KeyError{Locked: &kvrpcpb.Locked{
+							PrimaryLock: []byte("primary"),
+							Key:         []byte("alfa"),
+							LockVersion: 10,
+						}},
+					},
+				}, nil
+			}
+			return &kvrpcpb.KvGetResponse{
+				Response: &kvrpcpb.GetResponse{Value: []byte("visible")},
+			}, nil
+		},
+		checkTxnStatusFn: func(_ context.Context, req *kvrpcpb.KvCheckTxnStatusRequest) (*kvrpcpb.KvCheckTxnStatusResponse, error) {
+			checkCalls++
+			require.Equal(t, []byte("primary"), req.GetRequest().GetPrimaryKey())
+			require.Equal(t, uint64(10), req.GetRequest().GetLockTs())
+			require.Equal(t, uint64(20), req.GetRequest().GetCurrentTs())
+			return &kvrpcpb.KvCheckTxnStatusResponse{
+				Response: &kvrpcpb.CheckTxnStatusResponse{CommitVersion: 30},
+			}, nil
+		},
+		resolveLockFn: func(_ context.Context, req *kvrpcpb.KvResolveLockRequest) (*kvrpcpb.KvResolveLockResponse, error) {
+			resolveCalls++
+			require.Equal(t, uint64(10), req.GetRequest().GetStartVersion())
+			require.Equal(t, uint64(30), req.GetRequest().GetCommitVersion())
+			require.Equal(t, [][]byte{[]byte("alfa")}, req.GetRequest().GetKeys())
+			return &kvrpcpb.KvResolveLockResponse{
+				Response: &kvrpcpb.ResolveLockResponse{ResolvedLocks: 1},
+			}, nil
+		},
+	})
+	defer stop()
+
+	cli, err := New(Config{
+		StoreResolver:  staticStoreResolver{{StoreID: 1, Addr: addr}},
+		RegionResolver: resolverFromCluster(cluster),
+		DialOptions:    []grpc.DialOption{grpc.WithTransportCredentials(insecure.NewCredentials())},
+		Retry:          RetryPolicy{MaxAttempts: 3, RegionErrorBackoff: 0},
+	})
+	require.NoError(t, err)
+	defer func() { _ = cli.Close() }()
+
+	resp, err := cli.Get(context.Background(), []byte("alfa"), 20)
+	require.NoError(t, err)
+	require.Equal(t, []byte("visible"), resp.GetValue())
+	require.Equal(t, 2, getCalls)
+	require.Equal(t, 1, checkCalls)
+	require.Equal(t, 1, resolveCalls)
+}
+
+func TestClientGetReturnsLiveLockAfterRetryBudget(t *testing.T) {
+	cluster := newMockCluster(clusterRegion{
+		meta: &metapb.RegionDescriptor{
+			RegionId: 1,
+			StartKey: []byte("a"),
+			EndKey:   []byte("z"),
+			Epoch:    &metapb.RegionEpoch{Version: 1, ConfVersion: 1},
+			Peers: []*metapb.RegionPeer{
+				{StoreId: 1, PeerId: 101},
+			},
+		},
+		leaderStore: 1,
+	})
+
+	var checkCalls int
+	var resolveCalls int
+	addr, stop := startBlockingStore(t, &scriptedKVService{
+		mockService: mockService{storeID: 1, cluster: cluster},
+		getFn: func(context.Context, *kvrpcpb.KvGetRequest) (*kvrpcpb.KvGetResponse, error) {
+			return &kvrpcpb.KvGetResponse{
+				Response: &kvrpcpb.GetResponse{
+					Error: &kvrpcpb.KeyError{Locked: &kvrpcpb.Locked{
+						PrimaryLock: []byte("primary"),
+						Key:         []byte("alfa"),
+						LockVersion: 10,
+					}},
+				},
+			}, nil
+		},
+		checkTxnStatusFn: func(context.Context, *kvrpcpb.KvCheckTxnStatusRequest) (*kvrpcpb.KvCheckTxnStatusResponse, error) {
+			checkCalls++
+			return &kvrpcpb.KvCheckTxnStatusResponse{
+				Response: &kvrpcpb.CheckTxnStatusResponse{
+					LockTtl: 100,
+					Action:  kvrpcpb.CheckTxnStatusAction_CheckTxnStatusMinCommitTsPushed,
+				},
+			}, nil
+		},
+		resolveLockFn: func(context.Context, *kvrpcpb.KvResolveLockRequest) (*kvrpcpb.KvResolveLockResponse, error) {
+			resolveCalls++
+			return &kvrpcpb.KvResolveLockResponse{}, nil
+		},
+	})
+	defer stop()
+
+	cli, err := New(Config{
+		StoreResolver:  staticStoreResolver{{StoreID: 1, Addr: addr}},
+		RegionResolver: resolverFromCluster(cluster),
+		DialOptions:    []grpc.DialOption{grpc.WithTransportCredentials(insecure.NewCredentials())},
+		Retry:          RetryPolicy{MaxAttempts: 1, LockResolveBackoff: -1},
+	})
+	require.NoError(t, err)
+	defer func() { _ = cli.Close() }()
+
+	resp, err := cli.Get(context.Background(), []byte("alfa"), 20)
+	require.Nil(t, resp)
+	txnErr, ok := AsTxnKeyError(err)
+	require.True(t, ok)
+	require.Len(t, txnErr.Errors, 1)
+	require.NotNil(t, txnErr.Errors[0].GetLocked())
+	require.Equal(t, 1, checkCalls)
+	require.Equal(t, 0, resolveCalls)
+}
+
+func TestClientBatchGetResolvesCommittedLockAndKeepsCompletedReads(t *testing.T) {
+	cluster := newMockCluster(clusterRegion{
+		meta: &metapb.RegionDescriptor{
+			RegionId: 1,
+			StartKey: []byte("a"),
+			EndKey:   []byte("z"),
+			Epoch:    &metapb.RegionEpoch{Version: 1, ConfVersion: 1},
+			Peers: []*metapb.RegionPeer{
+				{StoreId: 1, PeerId: 101},
+			},
+		},
+		leaderStore: 1,
+	})
+
+	var batchCalls int
+	var checkCalls int
+	var resolveCalls int
+	addr, stop := startBlockingStore(t, &scriptedKVService{
+		mockService: mockService{storeID: 1, cluster: cluster},
+		batchGetFn: func(_ context.Context, req *kvrpcpb.KvBatchGetRequest) (*kvrpcpb.KvBatchGetResponse, error) {
+			batchCalls++
+			responses := make([]*kvrpcpb.GetResponse, 0, len(req.GetRequest().GetRequests()))
+			for _, getReq := range req.GetRequest().GetRequests() {
+				switch string(getReq.GetKey()) {
+				case "alfa":
+					responses = append(responses, &kvrpcpb.GetResponse{Value: []byte("value-a")})
+				case "bravo":
+					if batchCalls == 1 {
+						responses = append(responses, &kvrpcpb.GetResponse{
+							Error: &kvrpcpb.KeyError{Locked: &kvrpcpb.Locked{
+								PrimaryLock: []byte("primary"),
+								Key:         []byte("bravo"),
+								LockVersion: 10,
+							}},
+						})
+						continue
+					}
+					responses = append(responses, &kvrpcpb.GetResponse{Value: []byte("value-b")})
+				default:
+					responses = append(responses, &kvrpcpb.GetResponse{NotFound: true})
+				}
+			}
+			return &kvrpcpb.KvBatchGetResponse{
+				Response: &kvrpcpb.BatchGetResponse{Responses: responses},
+			}, nil
+		},
+		checkTxnStatusFn: func(context.Context, *kvrpcpb.KvCheckTxnStatusRequest) (*kvrpcpb.KvCheckTxnStatusResponse, error) {
+			checkCalls++
+			return &kvrpcpb.KvCheckTxnStatusResponse{
+				Response: &kvrpcpb.CheckTxnStatusResponse{CommitVersion: 30},
+			}, nil
+		},
+		resolveLockFn: func(_ context.Context, req *kvrpcpb.KvResolveLockRequest) (*kvrpcpb.KvResolveLockResponse, error) {
+			resolveCalls++
+			require.Equal(t, uint64(10), req.GetRequest().GetStartVersion())
+			require.Equal(t, uint64(30), req.GetRequest().GetCommitVersion())
+			require.Equal(t, [][]byte{[]byte("bravo")}, req.GetRequest().GetKeys())
+			return &kvrpcpb.KvResolveLockResponse{
+				Response: &kvrpcpb.ResolveLockResponse{ResolvedLocks: 1},
+			}, nil
+		},
+	})
+	defer stop()
+
+	cli, err := New(Config{
+		StoreResolver:  staticStoreResolver{{StoreID: 1, Addr: addr}},
+		RegionResolver: resolverFromCluster(cluster),
+		DialOptions:    []grpc.DialOption{grpc.WithTransportCredentials(insecure.NewCredentials())},
+		Retry:          RetryPolicy{MaxAttempts: 3, RegionErrorBackoff: 0},
+	})
+	require.NoError(t, err)
+	defer func() { _ = cli.Close() }()
+
+	got, err := cli.BatchGet(context.Background(), [][]byte{[]byte("alfa"), []byte("bravo")}, 20)
+	require.NoError(t, err)
+	require.Equal(t, []byte("value-a"), got["alfa"].GetValue())
+	require.Equal(t, []byte("value-b"), got["bravo"].GetValue())
+	require.Equal(t, 2, batchCalls)
+	require.Equal(t, 1, checkCalls)
+	require.Equal(t, 1, resolveCalls)
+}
+
+func TestClientScanReturnsNonLockKeyError(t *testing.T) {
+	cluster := newMockCluster(clusterRegion{
+		meta: &metapb.RegionDescriptor{
+			RegionId: 1,
+			StartKey: []byte("a"),
+			EndKey:   []byte("z"),
+			Epoch:    &metapb.RegionEpoch{Version: 1, ConfVersion: 1},
+			Peers: []*metapb.RegionPeer{
+				{StoreId: 1, PeerId: 101},
+			},
+		},
+		leaderStore: 1,
+	})
+
+	addr, stop := startBlockingStore(t, &scriptedKVService{
+		mockService: mockService{storeID: 1, cluster: cluster},
+		scanFn: func(context.Context, *kvrpcpb.KvScanRequest) (*kvrpcpb.KvScanResponse, error) {
+			return &kvrpcpb.KvScanResponse{
+				Response: &kvrpcpb.ScanResponse{
+					Kvs: []*kvrpcpb.KV{{
+						Key:   []byte("alfa"),
+						Value: []byte("partial"),
+					}},
+					Error: &kvrpcpb.KeyError{Abort: "scan failed"},
+				},
+			}, nil
+		},
+	})
+	defer stop()
+
+	cli, err := New(Config{
+		StoreResolver:  staticStoreResolver{{StoreID: 1, Addr: addr}},
+		RegionResolver: resolverFromCluster(cluster),
+		DialOptions:    []grpc.DialOption{grpc.WithTransportCredentials(insecure.NewCredentials())},
+		Retry:          RetryPolicy{MaxAttempts: 2, RegionErrorBackoff: 0},
+	})
+	require.NoError(t, err)
+	defer func() { _ = cli.Close() }()
+
+	kvs, err := cli.Scan(context.Background(), []byte("alfa"), 1, 20)
+	require.Nil(t, kvs)
+	txnErr, ok := AsTxnKeyError(err)
+	require.True(t, ok)
+	require.Len(t, txnErr.Errors, 1)
+	require.Equal(t, "scan failed", txnErr.Errors[0].GetAbort())
+}
+
+func TestClientScanResolvesCommittedLockAndRetriesWithoutPartialResult(t *testing.T) {
+	cluster := newMockCluster(clusterRegion{
+		meta: &metapb.RegionDescriptor{
+			RegionId: 1,
+			StartKey: []byte("a"),
+			EndKey:   []byte("z"),
+			Epoch:    &metapb.RegionEpoch{Version: 1, ConfVersion: 1},
+			Peers: []*metapb.RegionPeer{
+				{StoreId: 1, PeerId: 101},
+			},
+		},
+		leaderStore: 1,
+	})
+
+	var scanCalls int
+	var checkCalls int
+	var resolveCalls int
+	addr, stop := startBlockingStore(t, &scriptedKVService{
+		mockService: mockService{storeID: 1, cluster: cluster},
+		scanFn: func(context.Context, *kvrpcpb.KvScanRequest) (*kvrpcpb.KvScanResponse, error) {
+			scanCalls++
+			if scanCalls == 1 {
+				return &kvrpcpb.KvScanResponse{
+					Response: &kvrpcpb.ScanResponse{
+						Kvs: []*kvrpcpb.KV{{
+							Key:   []byte("alfa"),
+							Value: []byte("partial"),
+						}},
+						Error: &kvrpcpb.KeyError{Locked: &kvrpcpb.Locked{
+							PrimaryLock: []byte("primary"),
+							Key:         []byte("bravo"),
+							LockVersion: 10,
+						}},
+					},
+				}, nil
+			}
+			return &kvrpcpb.KvScanResponse{
+				Response: &kvrpcpb.ScanResponse{
+					Kvs: []*kvrpcpb.KV{{
+						Key:   []byte("bravo"),
+						Value: []byte("visible"),
+					}},
+				},
+			}, nil
+		},
+		checkTxnStatusFn: func(context.Context, *kvrpcpb.KvCheckTxnStatusRequest) (*kvrpcpb.KvCheckTxnStatusResponse, error) {
+			checkCalls++
+			return &kvrpcpb.KvCheckTxnStatusResponse{
+				Response: &kvrpcpb.CheckTxnStatusResponse{CommitVersion: 30},
+			}, nil
+		},
+		resolveLockFn: func(_ context.Context, req *kvrpcpb.KvResolveLockRequest) (*kvrpcpb.KvResolveLockResponse, error) {
+			resolveCalls++
+			require.Equal(t, uint64(10), req.GetRequest().GetStartVersion())
+			require.Equal(t, uint64(30), req.GetRequest().GetCommitVersion())
+			require.Equal(t, [][]byte{[]byte("bravo")}, req.GetRequest().GetKeys())
+			return &kvrpcpb.KvResolveLockResponse{
+				Response: &kvrpcpb.ResolveLockResponse{ResolvedLocks: 1},
+			}, nil
+		},
+	})
+	defer stop()
+
+	cli, err := New(Config{
+		StoreResolver:  staticStoreResolver{{StoreID: 1, Addr: addr}},
+		RegionResolver: resolverFromCluster(cluster),
+		DialOptions:    []grpc.DialOption{grpc.WithTransportCredentials(insecure.NewCredentials())},
+		Retry:          RetryPolicy{MaxAttempts: 3, RegionErrorBackoff: 0},
+	})
+	require.NoError(t, err)
+	defer func() { _ = cli.Close() }()
+
+	kvs, err := cli.Scan(context.Background(), []byte("alfa"), 1, 20)
+	require.NoError(t, err)
+	require.Len(t, kvs, 1)
+	require.Equal(t, []byte("bravo"), kvs[0].GetKey())
+	require.Equal(t, []byte("visible"), kvs[0].GetValue())
+	require.Equal(t, 2, scanCalls)
+	require.Equal(t, 1, checkCalls)
+	require.Equal(t, 1, resolveCalls)
 }
 
 func TestClientResolveLocksRetriesOnNotLeader(t *testing.T) {
@@ -273,7 +654,10 @@ func TestClientResolveLocksReturnsKeyError(t *testing.T) {
 	defer func() { _ = cli.Close() }()
 
 	_, err = cli.ResolveLocks(context.Background(), 10, 11, [][]byte{[]byte("alfa")})
-	require.ErrorContains(t, err, "resolve lock key error")
+	txnErr, ok := AsTxnKeyError(err)
+	require.True(t, ok)
+	require.Len(t, txnErr.Errors, 1)
+	require.Equal(t, "resolve failed", txnErr.Errors[0].GetAbort())
 }
 
 func TestClientTwoPhaseCommitRejectsMissingPrimaryMutation(t *testing.T) {

--- a/raftstore/client/client_kv_test.go
+++ b/raftstore/client/client_kv_test.go
@@ -175,6 +175,7 @@ func TestClientGetResolvesCommittedLockAndRetries(t *testing.T) {
 			require.Equal(t, []byte("primary"), req.GetRequest().GetPrimaryKey())
 			require.Equal(t, uint64(10), req.GetRequest().GetLockTs())
 			require.Equal(t, uint64(20), req.GetRequest().GetCurrentTs())
+			require.NotZero(t, req.GetRequest().GetCurrentTime())
 			return &kvrpcpb.KvCheckTxnStatusResponse{
 				Response: &kvrpcpb.CheckTxnStatusResponse{CommitVersion: 30},
 			}, nil
@@ -606,7 +607,7 @@ func TestClientCheckTxnStatusRetriesOnNotLeader(t *testing.T) {
 	require.NoError(t, err)
 	defer func() { _ = cli.Close() }()
 
-	resp, err := cli.CheckTxnStatus(context.Background(), []byte("alfa"), 10, 20)
+	resp, err := cli.CheckTxnStatus(context.Background(), []byte("alfa"), 10, 20, 30)
 	require.NoError(t, err)
 	require.NotNil(t, resp)
 	require.Equal(t, uint64(77), resp.GetCommitVersion())

--- a/raftstore/client/client_route_cache.go
+++ b/raftstore/client/client_route_cache.go
@@ -71,7 +71,7 @@ func (c *Client) routeKeyWithRetry(ctx context.Context, key []byte) (regionSnaps
 	if err := ctx.Err(); err != nil {
 		return regionSnapshot{}, err
 	}
-	return regionSnapshot{}, fmt.Errorf("client: route retries exhausted for key %q", key)
+	return regionSnapshot{}, &RetryExhaustedError{Operation: "route", Key: append([]byte(nil), key...)}
 }
 
 // regionForKeyFromCache returns a cached Region snapshot when the key is
@@ -114,7 +114,12 @@ func (c *Client) regionForKeyFromResolver(ctx context.Context, key []byte) (regi
 		return regionSnapshot{}, errResolvedRegionIDMissing
 	}
 	if len(desc.Peers) == 0 {
-		return regionSnapshot{}, fmt.Errorf("client: resolved region %d missing peers", desc.RegionID)
+		return regionSnapshot{}, &RegionRoutingError{
+			Operation: "resolve region",
+			RegionID:  desc.RegionID,
+			Key:       append([]byte(nil), key...),
+			Detail:    "resolved region missing peers",
+		}
 	}
 	leader := defaultLeaderStoreID(desc)
 	if old, ok := c.regionSnapshot(desc.RegionID); ok && old.leader != 0 && regionHasStoreID(desc, old.leader) {
@@ -124,7 +129,12 @@ func (c *Client) regionForKeyFromResolver(ctx context.Context, key []byte) (regi
 	c.upsertRegionLocked(desc, leader)
 	c.mu.Unlock()
 	if !containsKey(desc, key) {
-		return regionSnapshot{}, fmt.Errorf("client: resolved region %d does not contain key %q", desc.RegionID, key)
+		return regionSnapshot{}, &RegionRoutingError{
+			Operation: "resolve region",
+			RegionID:  desc.RegionID,
+			Key:       append([]byte(nil), key...),
+			Detail:    "resolved region does not contain key",
+		}
 	}
 	return regionSnapshot{
 		desc:   desc,
@@ -171,14 +181,21 @@ func (c *Client) handleRegionError(regionID uint64, err *errorpb.RegionError) er
 		c.mu.Lock()
 		c.removeRegionLocked(regionID)
 		c.mu.Unlock()
-		return fmt.Errorf(
-			"client: region %d store mismatch: requested store %d, actual store %d",
-			regionID,
-			storeMismatch.GetRequestStoreId(),
-			storeMismatch.GetActualStoreId(),
-		)
+		return &RegionRoutingError{
+			Operation: "handle region error",
+			RegionID:  regionID,
+			Detail: fmt.Sprintf(
+				"store mismatch: requested store %d, actual store %d",
+				storeMismatch.GetRequestStoreId(),
+				storeMismatch.GetActualStoreId(),
+			),
+		}
 	}
-	return fmt.Errorf("client: region %d error: %v", regionID, err)
+	return &RegionRoutingError{
+		Operation: "handle region error",
+		RegionID:  regionID,
+		Detail:    fmt.Sprintf("protobuf region error: %v", err),
+	}
 }
 
 func (c *Client) upsertRegionLocked(desc descriptor.Descriptor, leader uint64) {
@@ -271,7 +288,11 @@ func buildContext(region regionSnapshot) (*kvrpcpb.Context, error) {
 		}
 	}
 	if peerMeta == nil {
-		return nil, fmt.Errorf("client: leader store %d not found in region %d peers", leaderStoreID, region.desc.RegionID)
+		return nil, &RegionRoutingError{
+			Operation: "build request context",
+			RegionID:  region.desc.RegionID,
+			Detail:    fmt.Sprintf("leader store %d not found in region peers", leaderStoreID),
+		}
 	}
 	return &kvrpcpb.Context{
 		RegionId: region.desc.RegionID,

--- a/raftstore/client/client_test.go
+++ b/raftstore/client/client_test.go
@@ -865,9 +865,9 @@ func TestClientBatchGetAndMutateHelpers(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, uint64(0), resolved)
 
-	errStr := (&KeyConflictError{Errors: []*kvrpcpb.KeyError{{Abort: "boom"}}}).Error()
-	require.Contains(t, errStr, "client: prewrite key errors")
-	conflict, ok := AsKeyConflict(&KeyConflictError{Errors: []*kvrpcpb.KeyError{{Abort: "boom"}}})
+	errStr := (&TxnKeyError{Errors: []*kvrpcpb.KeyError{{Abort: "boom"}}}).Error()
+	require.Contains(t, errStr, "client: transaction key errors")
+	conflict, ok := AsTxnKeyError(&TxnKeyError{Errors: []*kvrpcpb.KeyError{{Abort: "boom"}}})
 	require.True(t, ok)
 	require.Len(t, conflict.Errors, 1)
 }
@@ -880,6 +880,25 @@ func TestNewRequiresRegionResolver(t *testing.T) {
 	})
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "region resolver required")
+}
+
+func TestNewDefaultsLockResolveBackoff(t *testing.T) {
+	cli, err := New(Config{
+		StoreResolver:  staticStoreResolver{{StoreID: 1, Addr: "127.0.0.1:1"}},
+		RegionResolver: &mockRegionResolver{},
+	})
+	require.NoError(t, err)
+	require.Equal(t, 10*time.Millisecond, cli.retry.LockResolveBackoff)
+	require.NoError(t, cli.Close())
+
+	cli, err = New(Config{
+		StoreResolver:  staticStoreResolver{{StoreID: 1, Addr: "127.0.0.1:1"}},
+		RegionResolver: &mockRegionResolver{},
+		Retry:          RetryPolicy{LockResolveBackoff: -1},
+	})
+	require.NoError(t, err)
+	require.Zero(t, cli.retry.LockResolveBackoff)
+	require.NoError(t, cli.Close())
 }
 
 func TestClientRegionResolverLookupAndCache(t *testing.T) {

--- a/raftstore/client/client_test.go
+++ b/raftstore/client/client_test.go
@@ -857,7 +857,7 @@ func TestClientBatchGetAndMutateHelpers(t *testing.T) {
 		{Op: kvrpcpb.Mutation_Put, Key: []byte("bravo"), Value: []byte("v3")},
 	}, 80, 81, 3000))
 
-	resp, err := cli.CheckTxnStatus(ctx, []byte("alfa"), 1, 2)
+	resp, err := cli.CheckTxnStatus(ctx, []byte("alfa"), 1, 2, 3)
 	require.NoError(t, err)
 	require.Nil(t, resp)
 
@@ -1292,7 +1292,7 @@ func TestClientCheckTxnStatusRetriesRouteUnavailable(t *testing.T) {
 	require.NoError(t, err)
 	defer func() { _ = cli.Close() }()
 
-	_, err = cli.CheckTxnStatus(context.Background(), []byte("alfa"), 1, 2)
+	_, err = cli.CheckTxnStatus(context.Background(), []byte("alfa"), 1, 2, 3)
 	require.NoError(t, err)
 
 	resolver.mu.Lock()

--- a/raftstore/client/client_test.go
+++ b/raftstore/client/client_test.go
@@ -627,6 +627,10 @@ func (s *mockService) KvCheckTxnStatus(context.Context, *kvrpcpb.KvCheckTxnStatu
 	return &kvrpcpb.KvCheckTxnStatusResponse{}, nil
 }
 
+func (s *mockService) KvTxnHeartBeat(context.Context, *kvrpcpb.KvTxnHeartBeatRequest) (*kvrpcpb.KvTxnHeartBeatResponse, error) {
+	return &kvrpcpb.KvTxnHeartBeatResponse{}, nil
+}
+
 func (s *blockingService) KvGet(ctx context.Context, req *kvrpcpb.KvGetRequest) (*kvrpcpb.KvGetResponse, error) {
 	s.signal()
 	<-ctx.Done()

--- a/raftstore/client/client_transport.go
+++ b/raftstore/client/client_transport.go
@@ -32,6 +32,7 @@ const (
 	retryRouteUnavailable retryKind = iota
 	retryTransportUnavailable
 	retryRegionError
+	retryLockResolve
 )
 
 func dialStore(ctx context.Context, target string, opts ...grpc.DialOption) (*grpc.ClientConn, error) {
@@ -231,6 +232,8 @@ func (c *Client) waitRetry(ctx context.Context, attempt int, kind retryKind) err
 		backoff = c.retry.TransportUnavailableBackoff
 	case retryRegionError:
 		backoff = c.retry.RegionErrorBackoff
+	case retryLockResolve:
+		backoff = c.retry.LockResolveBackoff
 	default:
 		backoff = 0
 	}

--- a/raftstore/client/client_transport_test.go
+++ b/raftstore/client/client_transport_test.go
@@ -1,0 +1,23 @@
+package client
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestWaitRetryUsesLockResolveBackoff(t *testing.T) {
+	cli := &Client{
+		retry: RetryPolicy{
+			MaxAttempts:        2,
+			LockResolveBackoff: time.Hour,
+		},
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	err := cli.waitRetry(ctx, 0, retryLockResolve)
+	require.ErrorIs(t, err, context.Canceled)
+}

--- a/raftstore/client/errors.go
+++ b/raftstore/client/errors.go
@@ -24,6 +24,8 @@ var (
 	errLeaderUnknown = errors.New("client: leader unknown")
 	// errInvalidScanLimit indicates that scan was called with limit == 0.
 	errInvalidScanLimit = errors.New("client: scan limit must be > 0")
+	// errReadLockStillLive indicates that a read lock is valid and should be retried within the caller budget.
+	errReadLockStillLive = errors.New("client: read lock still live")
 )
 
 func IsMissingRegionResolver(err error) bool { return errors.Is(err, errMissingRegionResolver) }
@@ -42,32 +44,45 @@ func IsLeaderUnknown(err error) bool { return errors.Is(err, errLeaderUnknown) }
 
 func IsInvalidScanLimit(err error) bool { return errors.Is(err, errInvalidScanLimit) }
 
-// KeyConflictError represents prewrite-time key conflicts surfaced by the raft
-// service. Callers can inspect the KeyErrors to resolve locks before retrying.
-type KeyConflictError struct {
+// TxnKeyError represents transaction key errors surfaced by raftstore.
+// Callers can inspect KeyErrors to resolve locks or retry timestamp-expired commits.
+type TxnKeyError struct {
 	Errors []*kvrpcpb.KeyError
 }
 
-func (e *KeyConflictError) Error() string {
-	return fmt.Sprintf("client: prewrite key errors: %+v", e.Errors)
+func (e *TxnKeyError) Error() string {
+	return fmt.Sprintf("client: transaction key errors: %+v", e.Errors)
 }
 
-// KeyErrors exposes the raw per-key conflicts without forcing callers to
+// KeyErrors exposes the raw per-key errors without forcing callers to
 // depend on this package's concrete error type.
-func (e *KeyConflictError) KeyErrors() []*kvrpcpb.KeyError {
+func (e *TxnKeyError) KeyErrors() []*kvrpcpb.KeyError {
 	if e == nil {
 		return nil
 	}
 	return e.Errors
 }
 
-// AsKeyConflict extracts a KeyConflictError from err.
-func AsKeyConflict(err error) (*KeyConflictError, bool) {
-	var target *KeyConflictError
+// AsTxnKeyError extracts a TxnKeyError from err.
+func AsTxnKeyError(err error) (*TxnKeyError, bool) {
+	var target *TxnKeyError
 	if !errors.As(err, &target) {
 		return nil, false
 	}
 	return target, true
+}
+
+func txnKeyError(errs ...*kvrpcpb.KeyError) error {
+	filtered := make([]*kvrpcpb.KeyError, 0, len(errs))
+	for _, err := range errs {
+		if err != nil {
+			filtered = append(filtered, err)
+		}
+	}
+	if len(filtered) == 0 {
+		return nil
+	}
+	return &TxnKeyError{Errors: filtered}
 }
 
 // RouteUnavailableError indicates that the client could not resolve a route

--- a/raftstore/client/errors.go
+++ b/raftstore/client/errors.go
@@ -44,6 +44,97 @@ func IsLeaderUnknown(err error) bool { return errors.Is(err, errLeaderUnknown) }
 
 func IsInvalidScanLimit(err error) bool { return errors.Is(err, errInvalidScanLimit) }
 
+// RetryExhaustedError records a stable retry-budget failure for one client operation.
+type RetryExhaustedError struct {
+	Operation string
+	RegionID  uint64
+	Key       []byte
+}
+
+func (e *RetryExhaustedError) Error() string {
+	if e == nil {
+		return "client: retries exhausted"
+	}
+	switch {
+	case e.RegionID != 0:
+		return fmt.Sprintf("client: %s retries exhausted for region %d", e.Operation, e.RegionID)
+	case len(e.Key) > 0:
+		return fmt.Sprintf("client: %s retries exhausted for key %q", e.Operation, e.Key)
+	default:
+		return fmt.Sprintf("client: %s retries exhausted", e.Operation)
+	}
+}
+
+func IsRetryExhausted(err error) bool {
+	var target *RetryExhaustedError
+	return errors.As(err, &target)
+}
+
+// ProtocolError records local transaction/client contract violations.
+type ProtocolError struct {
+	Operation string
+	Detail    string
+}
+
+func (e *ProtocolError) Error() string {
+	if e == nil {
+		return "client: protocol error"
+	}
+	if e.Operation == "" {
+		return fmt.Sprintf("client: protocol error: %s", e.Detail)
+	}
+	return fmt.Sprintf("client: %s protocol error: %s", e.Operation, e.Detail)
+}
+
+func IsProtocolError(err error) bool {
+	var target *ProtocolError
+	return errors.As(err, &target)
+}
+
+// RegionRoutingError records stable region-cache and RegionError failures.
+type RegionRoutingError struct {
+	Operation string
+	RegionID  uint64
+	Key       []byte
+	Detail    string
+	Err       error
+}
+
+func (e *RegionRoutingError) Error() string {
+	if e == nil {
+		return "client: region routing error"
+	}
+	msg := "client: region routing error"
+	if e.Operation != "" {
+		msg += " during " + e.Operation
+	}
+	if e.RegionID != 0 {
+		msg += fmt.Sprintf(" for region %d", e.RegionID)
+	}
+	if len(e.Key) > 0 {
+		msg += fmt.Sprintf(" key %q", e.Key)
+	}
+	if e.Detail != "" {
+		msg += ": " + e.Detail
+	}
+	if e.Err != nil {
+		msg += ": " + e.Err.Error()
+	}
+	return msg
+}
+
+func (e *RegionRoutingError) Unwrap() error {
+	if e == nil {
+		return nil
+	}
+	return e.Err
+}
+
+func IsRegionRoutingError(err error) bool {
+	var target *RegionRoutingError
+	return errors.As(err, &target)
+}
+
 // TxnKeyError represents transaction key errors surfaced by raftstore.
 // Callers can inspect KeyErrors to resolve locks or retry timestamp-expired commits.
 type TxnKeyError struct {

--- a/raftstore/client/errors_test.go
+++ b/raftstore/client/errors_test.go
@@ -53,4 +53,27 @@ func TestClientTypedErrors(t *testing.T) {
 	require.Same(t, notFound, gotNotFound)
 	_, ok = AsRegionNotFound(errors.New("other"))
 	require.False(t, ok)
+
+	retry := &RetryExhaustedError{Operation: "commit", RegionID: 7}
+	require.Contains(t, retry.Error(), "commit retries exhausted")
+	require.True(t, IsRetryExhausted(retry))
+	require.False(t, IsRetryExhausted(errors.New("other")))
+
+	protocol := &ProtocolError{Operation: "mutate", Detail: "primary key required"}
+	require.Contains(t, protocol.Error(), "mutate protocol error")
+	require.True(t, IsProtocolError(protocol))
+	require.False(t, IsProtocolError(errors.New("other")))
+
+	routing := &RegionRoutingError{
+		Operation: "resolve region",
+		RegionID:  11,
+		Key:       []byte("key"),
+		Detail:    "missing peers",
+		Err:       errors.New("resolver failed"),
+	}
+	require.Contains(t, routing.Error(), "region routing error")
+	require.Contains(t, routing.Error(), "missing peers")
+	require.EqualError(t, routing.Unwrap(), "resolver failed")
+	require.True(t, IsRegionRoutingError(routing))
+	require.False(t, IsRegionRoutingError(errors.New("other")))
 }

--- a/raftstore/client/errors_test.go
+++ b/raftstore/client/errors_test.go
@@ -22,14 +22,14 @@ func TestClientSentinelHelpers(t *testing.T) {
 }
 
 func TestClientTypedErrors(t *testing.T) {
-	keyConflict := &KeyConflictError{
+	txnKeyErr := &TxnKeyError{
 		Errors: []*kvrpcpb.KeyError{{Locked: &kvrpcpb.Locked{PrimaryLock: []byte("pk")}}},
 	}
-	require.Contains(t, keyConflict.Error(), "prewrite key errors")
-	gotKeyConflict, ok := AsKeyConflict(keyConflict)
+	require.Contains(t, txnKeyErr.Error(), "transaction key errors")
+	gotTxnKeyErr, ok := AsTxnKeyError(txnKeyErr)
 	require.True(t, ok)
-	require.Same(t, keyConflict, gotKeyConflict)
-	_, ok = AsKeyConflict(errors.New("other"))
+	require.Same(t, txnKeyErr, gotTxnKeyErr)
+	_, ok = AsTxnKeyError(errors.New("other"))
 	require.False(t, ok)
 
 	routeErr := &RouteUnavailableError{Key: []byte("route-key"), Err: errors.New("dial failed")}

--- a/raftstore/kv/apply.go
+++ b/raftstore/kv/apply.go
@@ -333,6 +333,9 @@ func collectVisibleValue(db txnstore.Store, iter index.Iterator, key []byte, rea
 			return nil, 0, false, err
 		}
 		switch write.Kind {
+		case kvrpcpb.Mutation_Lock:
+			iter.Next()
+			continue
 		case kvrpcpb.Mutation_Delete, kvrpcpb.Mutation_Rollback:
 			advanceToNextUserKey(iter, key)
 			return nil, 0, false, nil

--- a/raftstore/kv/apply.go
+++ b/raftstore/kv/apply.go
@@ -59,6 +59,9 @@ func Apply(db txnstore.Store, latches *latch.Manager, req *raftcmdpb.RaftCmdRequ
 		case raftcmdpb.CmdType_CMD_CHECK_TXN_STATUS:
 			result := percolator.CheckTxnStatus(db, latches, r.GetCheckTxnStatus())
 			resp.Responses = append(resp.Responses, &raftcmdpb.Response{Cmd: &raftcmdpb.Response_CheckTxnStatus{CheckTxnStatus: result}})
+		case raftcmdpb.CmdType_CMD_TXN_HEART_BEAT:
+			result := percolator.TxnHeartBeat(db, latches, r.GetTxnHeartBeat())
+			resp.Responses = append(resp.Responses, &raftcmdpb.Response{Cmd: &raftcmdpb.Response_TxnHeartBeat{TxnHeartBeat: result}})
 		case raftcmdpb.CmdType_CMD_MVCC_MAINTENANCE:
 			result, err := applyMVCCMaintenance(db, r.GetMvccMaintenance())
 			if err != nil {

--- a/raftstore/kv/apply_test.go
+++ b/raftstore/kv/apply_test.go
@@ -235,6 +235,63 @@ func TestHandleScanShortValueCarriesExpiresAt(t *testing.T) {
 	require.Equal(t, expiresAt, resp.GetKvs()[0].GetExpiresAt())
 }
 
+func TestHandleScanCommittedLockDoesNotHideVisiblePut(t *testing.T) {
+	opt := NoKV.NewDefaultOptions()
+	opt.WorkDir = t.TempDir()
+	db, err := NoKV.Open(opt)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = db.Close() })
+
+	key := []byte("scan-lock-visible-put")
+	applyVersionedEntryForApplyTest(t, db, entrykv.CFDefault, key, 10, []byte("value1"), 0, 0)
+	applyVersionedEntryForApplyTest(t, db, entrykv.CFWrite, key, 20, mvcc.EncodeWrite(mvcc.Write{
+		Kind:    kvrpcpb.Mutation_Put,
+		StartTs: 10,
+	}), 0, 0)
+	applyVersionedEntryForApplyTest(t, db, entrykv.CFDefault, key, 30, nil, entrykv.BitDelete, 0)
+	applyVersionedEntryForApplyTest(t, db, entrykv.CFWrite, key, 40, mvcc.EncodeWrite(mvcc.Write{
+		Kind:    kvrpcpb.Mutation_Lock,
+		StartTs: 30,
+	}), 0, 0)
+
+	resp, err := handleScan(db, &kvrpcpb.ScanRequest{
+		StartKey:     key,
+		Limit:        1,
+		Version:      50,
+		IncludeStart: true,
+	})
+	require.NoError(t, err)
+	require.Nil(t, resp.GetError())
+	require.Len(t, resp.GetKvs(), 1)
+	require.Equal(t, key, resp.GetKvs()[0].GetKey())
+	require.Equal(t, []byte("value1"), resp.GetKvs()[0].GetValue())
+}
+
+func TestHandleScanCommittedLockDoesNotCreateVisibleKey(t *testing.T) {
+	opt := NoKV.NewDefaultOptions()
+	opt.WorkDir = t.TempDir()
+	db, err := NoKV.Open(opt)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = db.Close() })
+
+	key := []byte("scan-lock-only")
+	applyVersionedEntryForApplyTest(t, db, entrykv.CFDefault, key, 10, nil, entrykv.BitDelete, 0)
+	applyVersionedEntryForApplyTest(t, db, entrykv.CFWrite, key, 20, mvcc.EncodeWrite(mvcc.Write{
+		Kind:    kvrpcpb.Mutation_Lock,
+		StartTs: 10,
+	}), 0, 0)
+
+	resp, err := handleScan(db, &kvrpcpb.ScanRequest{
+		StartKey:     key,
+		Limit:        1,
+		Version:      30,
+		IncludeStart: true,
+	})
+	require.NoError(t, err)
+	require.Nil(t, resp.GetError())
+	require.Empty(t, resp.GetKvs())
+}
+
 func TestHandleScanSkipsExpiredShortValue(t *testing.T) {
 	opt := NoKV.NewDefaultOptions()
 	opt.WorkDir = t.TempDir()

--- a/raftstore/kv/apply_test.go
+++ b/raftstore/kv/apply_test.go
@@ -78,6 +78,7 @@ func TestLockedErrorMapping(t *testing.T) {
 	lock := &mvcc.Lock{
 		Primary:     []byte("primary"),
 		Ts:          42,
+		StartTime:   4200,
 		TTL:         9000,
 		Kind:        kvrpcpb.Mutation_Put,
 		MinCommitTs: 100,

--- a/raftstore/kv/service.go
+++ b/raftstore/kv/service.go
@@ -30,21 +30,31 @@ func servicePhysicalTimeMillis() uint64 {
 }
 
 func checkTxnStatusRequestWithServiceTime(req *kvrpcpb.CheckTxnStatusRequest) *kvrpcpb.CheckTxnStatusRequest {
-	cloned := *req
-	cloned.PrimaryKey = append([]byte(nil), req.GetPrimaryKey()...)
-	if cloned.CurrentTime == 0 {
-		cloned.CurrentTime = servicePhysicalTimeMillis()
+	currentTime := req.GetCurrentTime()
+	if currentTime == 0 {
+		currentTime = servicePhysicalTimeMillis()
 	}
-	return &cloned
+	return &kvrpcpb.CheckTxnStatusRequest{
+		PrimaryKey:         append([]byte(nil), req.GetPrimaryKey()...),
+		LockTs:             req.GetLockTs(),
+		CurrentTs:          req.GetCurrentTs(),
+		RollbackIfNotExist: req.GetRollbackIfNotExist(),
+		CallerStartTs:      req.GetCallerStartTs(),
+		CurrentTime:        currentTime,
+	}
 }
 
 func txnHeartBeatRequestWithServiceTime(req *kvrpcpb.TxnHeartBeatRequest) *kvrpcpb.TxnHeartBeatRequest {
-	cloned := *req
-	cloned.PrimaryKey = append([]byte(nil), req.GetPrimaryKey()...)
-	if cloned.CurrentTime == 0 {
-		cloned.CurrentTime = servicePhysicalTimeMillis()
+	currentTime := req.GetCurrentTime()
+	if currentTime == 0 {
+		currentTime = servicePhysicalTimeMillis()
 	}
-	return &cloned
+	return &kvrpcpb.TxnHeartBeatRequest{
+		PrimaryKey:   append([]byte(nil), req.GetPrimaryKey()...),
+		StartVersion: req.GetStartVersion(),
+		TtlExtension: req.GetTtlExtension(),
+		CurrentTime:  currentTime,
+	}
 }
 
 func (s *Service) KvGet(ctx context.Context, req *kvrpcpb.KvGetRequest) (*kvrpcpb.KvGetResponse, error) {

--- a/raftstore/kv/service.go
+++ b/raftstore/kv/service.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"time"
+
 	kvrpcpb "github.com/feichai0017/NoKV/pb/kv"
 	raftcmdpb "github.com/feichai0017/NoKV/pb/raft"
 
@@ -21,6 +23,28 @@ type Service struct {
 // NewService constructs a NoKV service bound to the provided store.
 func NewService(st *store.Store) *Service {
 	return &Service{store: st}
+}
+
+func servicePhysicalTimeMillis() uint64 {
+	return uint64(time.Now().UnixMilli())
+}
+
+func checkTxnStatusRequestWithServiceTime(req *kvrpcpb.CheckTxnStatusRequest) *kvrpcpb.CheckTxnStatusRequest {
+	cloned := *req
+	cloned.PrimaryKey = append([]byte(nil), req.GetPrimaryKey()...)
+	if cloned.CurrentTime == 0 {
+		cloned.CurrentTime = servicePhysicalTimeMillis()
+	}
+	return &cloned
+}
+
+func txnHeartBeatRequestWithServiceTime(req *kvrpcpb.TxnHeartBeatRequest) *kvrpcpb.TxnHeartBeatRequest {
+	cloned := *req
+	cloned.PrimaryKey = append([]byte(nil), req.GetPrimaryKey()...)
+	if cloned.CurrentTime == 0 {
+		cloned.CurrentTime = servicePhysicalTimeMillis()
+	}
+	return &cloned
 }
 
 func (s *Service) KvGet(ctx context.Context, req *kvrpcpb.KvGetRequest) (*kvrpcpb.KvGetResponse, error) {
@@ -243,11 +267,12 @@ func (s *Service) KvCheckTxnStatus(ctx context.Context, req *kvrpcpb.KvCheckTxnS
 	if req.GetRequest() == nil {
 		return nil, status.Error(codes.InvalidArgument, "check txn status request missing payload")
 	}
+	checkReq := checkTxnStatusRequestWithServiceTime(req.GetRequest())
 	resp, err := s.propose(ctx, &raftcmdpb.RaftCmdRequest{
 		Header: header,
 		Requests: []*raftcmdpb.Request{{
 			CmdType: raftcmdpb.CmdType_CMD_CHECK_TXN_STATUS,
-			Cmd:     &raftcmdpb.Request_CheckTxnStatus{CheckTxnStatus: req.GetRequest()},
+			Cmd:     &raftcmdpb.Request_CheckTxnStatus{CheckTxnStatus: checkReq},
 		}},
 	})
 	if err != nil {
@@ -256,6 +281,32 @@ func (s *Service) KvCheckTxnStatus(ctx context.Context, req *kvrpcpb.KvCheckTxnS
 	out := &kvrpcpb.KvCheckTxnStatusResponse{RegionError: resp.GetRegionError()}
 	if len(resp.GetResponses()) > 0 && resp.GetResponses()[0].GetCheckTxnStatus() != nil {
 		out.Response = resp.GetResponses()[0].GetCheckTxnStatus()
+	}
+	return out, nil
+}
+
+func (s *Service) KvTxnHeartBeat(ctx context.Context, req *kvrpcpb.KvTxnHeartBeatRequest) (*kvrpcpb.KvTxnHeartBeatResponse, error) {
+	header, err := buildHeader(req.GetContext())
+	if err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	if req.GetRequest() == nil {
+		return nil, status.Error(codes.InvalidArgument, "txn heartbeat request missing payload")
+	}
+	heartBeatReq := txnHeartBeatRequestWithServiceTime(req.GetRequest())
+	resp, err := s.propose(ctx, &raftcmdpb.RaftCmdRequest{
+		Header: header,
+		Requests: []*raftcmdpb.Request{{
+			CmdType: raftcmdpb.CmdType_CMD_TXN_HEART_BEAT,
+			Cmd:     &raftcmdpb.Request_TxnHeartBeat{TxnHeartBeat: heartBeatReq},
+		}},
+	})
+	if err != nil {
+		return nil, rpcStatus(err)
+	}
+	out := &kvrpcpb.KvTxnHeartBeatResponse{RegionError: resp.GetRegionError()}
+	if len(resp.GetResponses()) > 0 && resp.GetResponses()[0].GetTxnHeartBeat() != nil {
+		out.Response = resp.GetResponses()[0].GetTxnHeartBeat()
 	}
 	return out, nil
 }

--- a/raftstore/kv/service_test.go
+++ b/raftstore/kv/service_test.go
@@ -300,6 +300,20 @@ func TestServiceResolveAndCheckStatus(t *testing.T) {
 	key := []byte("lock-key")
 	prewriteKey(t, h.service, h.ctx, key, []byte("value"), 10)
 
+	heartBeatResp, err := h.service.KvTxnHeartBeat(context.Background(), &kvrpcpb.KvTxnHeartBeatRequest{
+		Context: h.ctx,
+		Request: &kvrpcpb.TxnHeartBeatRequest{
+			PrimaryKey:   key,
+			StartVersion: 10,
+			TtlExtension: 5000,
+			CurrentTime:  0,
+		},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, heartBeatResp)
+	require.Nil(t, heartBeatResp.GetRegionError())
+	require.Equal(t, kvrpcpb.TxnHeartBeatAction_TxnHeartBeatTTLExtended, heartBeatResp.GetResponse().GetAction())
+
 	resp, err := h.service.KvCheckTxnStatus(context.Background(), &kvrpcpb.KvCheckTxnStatusRequest{
 		Context: h.ctx,
 		Request: &kvrpcpb.CheckTxnStatusRequest{

--- a/raftstore/mvcc/errors.go
+++ b/raftstore/mvcc/errors.go
@@ -1,0 +1,21 @@
+package mvcc
+
+import (
+	"errors"
+	"fmt"
+)
+
+var (
+	errNilMVCCStore            = errors.New("raftstore/mvcc: nil MVCC store")
+	errNilMaintenanceProposer  = errors.New("raftstore/mvcc: nil maintenance proposer")
+	errNilLockResolver         = errors.New("raftstore/mvcc: nil lock resolver")
+	errNilCheckTxnStatusResult = errors.New("raftstore/mvcc: nil check txn status response")
+)
+
+func errDecodeCFLock(key []byte, err error) error {
+	return fmt.Errorf("raftstore/mvcc: decode CFLock %x: %w", key, err)
+}
+
+func errCheckTxnStatusKeyError(primary []byte, err any) error {
+	return fmt.Errorf("raftstore/mvcc: check txn status key error for primary %x: %v", primary, err)
+}

--- a/raftstore/mvcc/lock_resolver.go
+++ b/raftstore/mvcc/lock_resolver.go
@@ -121,7 +121,7 @@ type resolveLockBatch struct {
 func collectResolveLockBatch(ctx context.Context, db txnstore.Store, currentTime uint64, afterUserKey []byte, maxExpiredLocks int, maxLocks uint64) (resolveLockBatch, error) {
 	var batch resolveLockBatch
 	if db == nil {
-		return batch, fmt.Errorf("raftstore/mvcc: nil MVCC store")
+		return batch, errNilMVCCStore
 	}
 	iter := db.NewInternalIterator(&index.Options{IsAsc: true})
 	if iter == nil {
@@ -160,7 +160,7 @@ func collectResolveLockBatch(ctx context.Context, db txnstore.Store, currentTime
 		}
 		lock, err := txnmvcc.DecodeLock(entry.Value)
 		if err != nil {
-			return batch, fmt.Errorf("raftstore/mvcc: decode CFLock %x: %w", userKey, err)
+			return batch, errDecodeCFLock(userKey, err)
 		}
 		batch.scan.ScannedLocks++
 		if !lockExpired(lock, currentTime) {
@@ -253,10 +253,10 @@ func resolveOneLock(ctx context.Context, resolver LockResolver, currentTs, curre
 		return nil, err
 	}
 	if status == nil {
-		return nil, fmt.Errorf("raftstore/mvcc: nil check txn status response for primary %x", rec.lock.Primary)
+		return nil, fmt.Errorf("%w for primary %x", errNilCheckTxnStatusResult, rec.lock.Primary)
 	}
 	if keyErr := status.GetError(); keyErr != nil {
-		return nil, fmt.Errorf("raftstore/mvcc: check txn status key error for primary %x: %v", rec.lock.Primary, keyErr)
+		return nil, errCheckTxnStatusKeyError(rec.lock.Primary, keyErr)
 	}
 	if commitTs := status.GetCommitVersion(); commitTs > 0 {
 		return &resolveLockDecision{
@@ -298,7 +298,7 @@ func lockForKey(db txnstore.Store, key []byte) (*txnmvcc.Lock, error) {
 	}
 	lock, err := txnmvcc.DecodeLock(entry.Value)
 	if err != nil {
-		return nil, fmt.Errorf("raftstore/mvcc: decode primary lock %x: %w", key, err)
+		return nil, errDecodeCFLock(key, err)
 	}
 	return &lock, nil
 }

--- a/raftstore/mvcc/lock_resolver.go
+++ b/raftstore/mvcc/lock_resolver.go
@@ -46,10 +46,11 @@ type ResolveLocksStats struct {
 	RolledBackLocks    uint64
 }
 
-// ResolveExpiredLocksReplicated resolves expired locks through semantic raft
-// ResolveLock commands. Use this path for cluster-mode stores so apply
-// observers and watch streams see normal transaction-resolution events.
-func ResolveExpiredLocksReplicated(ctx context.Context, db txnstore.Store, proposer LockResolverProposer, opt ResolveLocksOptions) (ResolveLocksStats, error) {
+// ResolveExpiredLocksReplicated resolves expired locks through primary-authority
+// CheckTxnStatus and semantic ResolveLock commands. Use this path for
+// cluster-mode stores so apply observers and watch streams see normal
+// transaction-resolution events.
+func ResolveExpiredLocksReplicated(ctx context.Context, db txnstore.Store, resolver LockResolver, opt ResolveLocksOptions) (ResolveLocksStats, error) {
 	var stats ResolveLocksStats
 	if opt.CurrentTs == 0 {
 		return stats, nil
@@ -72,13 +73,13 @@ func ResolveExpiredLocksReplicated(ctx context.Context, db txnstore.Store, propo
 		}
 		stats.add(batch.scan)
 		if len(batch.locks) > 0 {
-			decisions, resolved, err := planResolveLocks(ctx, db, opt.CurrentTs, batch.locks)
+			decisions, resolved, err := planResolveLocks(ctx, resolver, opt.CurrentTs, batch.locks)
 			if err != nil {
 				return stats, err
 			}
 			commands := groupResolveLockCommands(decisions)
 			for _, cmd := range commands {
-				applied, err := proposeResolveLocks(ctx, proposer, cmd.startTs, cmd.commitTs, cmd.keys)
+				applied, err := proposeResolveLocks(ctx, resolver, cmd.startTs, cmd.commitTs, cmd.keys)
 				if err != nil {
 					return stats, err
 				}
@@ -198,10 +199,10 @@ func seekLockStart(iter index.Iterator, afterUserKey []byte) {
 }
 
 type resolveLockDecision struct {
-	key      []byte
-	startTs  uint64
-	commitTs uint64
-	kind     kvrpcpb.Mutation_Op
+	key             []byte
+	startTs         uint64
+	commitTs        uint64
+	alreadyResolved bool
 }
 
 type resolveLockCommand struct {
@@ -210,14 +211,14 @@ type resolveLockCommand struct {
 	keys     [][]byte
 }
 
-func planResolveLocks(ctx context.Context, db txnstore.Store, currentTs uint64, locks []lockRecord) ([]resolveLockDecision, ResolveLocksStats, error) {
+func planResolveLocks(ctx context.Context, resolver LockResolver, currentTs uint64, locks []lockRecord) ([]resolveLockDecision, ResolveLocksStats, error) {
 	var stats ResolveLocksStats
 	decisions := make([]resolveLockDecision, 0, len(locks))
 	for _, rec := range locks {
 		if err := ctx.Err(); err != nil {
 			return nil, stats, err
 		}
-		decision, err := resolveOneLock(ctx, db, currentTs, rec)
+		decision, err := resolveOneLock(ctx, resolver, currentTs, rec)
 		if err != nil {
 			return nil, stats, err
 		}
@@ -225,47 +226,55 @@ func planResolveLocks(ctx context.Context, db txnstore.Store, currentTs uint64, 
 			stats.RetainedLocks++
 			continue
 		}
+		if decision.alreadyResolved {
+			stats.ResolvedLocks++
+			if decision.commitTs == 0 {
+				stats.RolledBackLocks++
+			} else {
+				stats.CommittedLocks++
+			}
+			continue
+		}
 		decisions = append(decisions, *decision)
 	}
 	return decisions, stats, nil
 }
 
-func resolveOneLock(ctx context.Context, db txnstore.Store, currentTs uint64, rec lockRecord) (*resolveLockDecision, error) {
+func resolveOneLock(ctx context.Context, resolver LockResolver, currentTs uint64, rec lockRecord) (*resolveLockDecision, error) {
 	if err := ctx.Err(); err != nil {
 		return nil, err
 	}
-	if write, commitTs, ok, err := writeByStartTs(db, rec.lock.Primary, rec.lock.Ts); err != nil {
+	status, err := checkTxnStatus(ctx, resolver, rec.lock.Primary, rec.lock.Ts, currentTs)
+	if err != nil {
 		return nil, err
-	} else if ok {
-		if write.Kind == kvrpcpb.Mutation_Rollback {
-			return &resolveLockDecision{
-				key:     entrykv.SafeCopy(nil, rec.key),
-				startTs: rec.lock.Ts,
-				kind:    rec.lock.Kind,
-			}, nil
-		}
+	}
+	if status == nil {
+		return nil, fmt.Errorf("raftstore/mvcc: nil check txn status response for primary %x", rec.lock.Primary)
+	}
+	if keyErr := status.GetError(); keyErr != nil {
+		return nil, fmt.Errorf("raftstore/mvcc: check txn status key error for primary %x: %v", rec.lock.Primary, keyErr)
+	}
+	if commitTs := status.GetCommitVersion(); commitTs > 0 {
 		return &resolveLockDecision{
 			key:      entrykv.SafeCopy(nil, rec.key),
 			startTs:  rec.lock.Ts,
 			commitTs: commitTs,
-			kind:     rec.lock.Kind,
 		}, nil
 	}
-
-	if !bytes.Equal(rec.key, rec.lock.Primary) {
-		primary, err := lockForKey(db, rec.lock.Primary)
-		if err != nil {
-			return nil, err
+	switch status.GetAction() {
+	case kvrpcpb.CheckTxnStatusAction_CheckTxnStatusTTLExpireRollback,
+		kvrpcpb.CheckTxnStatusAction_CheckTxnStatusLockNotExistRollback:
+		decision := &resolveLockDecision{
+			key:     entrykv.SafeCopy(nil, rec.key),
+			startTs: rec.lock.Ts,
 		}
-		if primary != nil && primary.Ts == rec.lock.Ts && !lockExpired(*primary, currentTs) {
-			return nil, nil
+		if bytes.Equal(rec.key, rec.lock.Primary) {
+			decision.alreadyResolved = true
 		}
+		return decision, nil
+	default:
+		return nil, nil
 	}
-	return &resolveLockDecision{
-		key:     entrykv.SafeCopy(nil, rec.key),
-		startTs: rec.lock.Ts,
-		kind:    rec.lock.Kind,
-	}, nil
 }
 
 func lockForKey(db txnstore.Store, key []byte) (*txnmvcc.Lock, error) {

--- a/raftstore/mvcc/lock_resolver.go
+++ b/raftstore/mvcc/lock_resolver.go
@@ -18,8 +18,12 @@ const defaultResolveLockBatch = 4096
 
 // ResolveLocksOptions bounds one local expired-lock resolution pass.
 type ResolveLocksOptions struct {
-	// CurrentTs is the timestamp used for TTL checks. Zero disables resolution.
+	// CurrentTs is the logical timestamp used for CheckTxnStatus and
+	// min-commit-ts pushes. Zero disables resolution.
 	CurrentTs uint64
+	// CurrentTime is the physical Unix millisecond time used for TTL checks.
+	// Zero disables resolution.
+	CurrentTime uint64
 	// BatchLocks limits how many expired locks are resolved in one semantic
 	// ResolveLock proposal batch. A non-positive value uses the default.
 	BatchLocks int
@@ -52,7 +56,7 @@ type ResolveLocksStats struct {
 // transaction-resolution events.
 func ResolveExpiredLocksReplicated(ctx context.Context, db txnstore.Store, resolver LockResolver, opt ResolveLocksOptions) (ResolveLocksStats, error) {
 	var stats ResolveLocksStats
-	if opt.CurrentTs == 0 {
+	if opt.CurrentTs == 0 || opt.CurrentTime == 0 {
 		return stats, nil
 	}
 	var afterUserKey []byte
@@ -67,13 +71,13 @@ func ResolveExpiredLocksReplicated(ctx context.Context, db txnstore.Store, resol
 			}
 			maxLocks = opt.MaxLocks - stats.ScannedLocks
 		}
-		batch, err := collectResolveLockBatch(ctx, db, opt.CurrentTs, afterUserKey, opt.batchLocks(), maxLocks)
+		batch, err := collectResolveLockBatch(ctx, db, opt.CurrentTime, afterUserKey, opt.batchLocks(), maxLocks)
 		if err != nil {
 			return stats, err
 		}
 		stats.add(batch.scan)
 		if len(batch.locks) > 0 {
-			decisions, resolved, err := planResolveLocks(ctx, resolver, opt.CurrentTs, batch.locks)
+			decisions, resolved, err := planResolveLocks(ctx, resolver, opt.CurrentTs, opt.CurrentTime, batch.locks)
 			if err != nil {
 				return stats, err
 			}
@@ -114,7 +118,7 @@ type resolveLockBatch struct {
 	done        bool
 }
 
-func collectResolveLockBatch(ctx context.Context, db txnstore.Store, currentTs uint64, afterUserKey []byte, maxExpiredLocks int, maxLocks uint64) (resolveLockBatch, error) {
+func collectResolveLockBatch(ctx context.Context, db txnstore.Store, currentTime uint64, afterUserKey []byte, maxExpiredLocks int, maxLocks uint64) (resolveLockBatch, error) {
 	var batch resolveLockBatch
 	if db == nil {
 		return batch, fmt.Errorf("raftstore/mvcc: nil MVCC store")
@@ -159,7 +163,7 @@ func collectResolveLockBatch(ctx context.Context, db txnstore.Store, currentTs u
 			return batch, fmt.Errorf("raftstore/mvcc: decode CFLock %x: %w", userKey, err)
 		}
 		batch.scan.ScannedLocks++
-		if !lockExpired(lock, currentTs) {
+		if !lockExpired(lock, currentTime) {
 			batch.scan.RetainedLocks++
 			iter.Next()
 			continue
@@ -211,14 +215,14 @@ type resolveLockCommand struct {
 	keys     [][]byte
 }
 
-func planResolveLocks(ctx context.Context, resolver LockResolver, currentTs uint64, locks []lockRecord) ([]resolveLockDecision, ResolveLocksStats, error) {
+func planResolveLocks(ctx context.Context, resolver LockResolver, currentTs, currentTime uint64, locks []lockRecord) ([]resolveLockDecision, ResolveLocksStats, error) {
 	var stats ResolveLocksStats
 	decisions := make([]resolveLockDecision, 0, len(locks))
 	for _, rec := range locks {
 		if err := ctx.Err(); err != nil {
 			return nil, stats, err
 		}
-		decision, err := resolveOneLock(ctx, resolver, currentTs, rec)
+		decision, err := resolveOneLock(ctx, resolver, currentTs, currentTime, rec)
 		if err != nil {
 			return nil, stats, err
 		}
@@ -240,11 +244,11 @@ func planResolveLocks(ctx context.Context, resolver LockResolver, currentTs uint
 	return decisions, stats, nil
 }
 
-func resolveOneLock(ctx context.Context, resolver LockResolver, currentTs uint64, rec lockRecord) (*resolveLockDecision, error) {
+func resolveOneLock(ctx context.Context, resolver LockResolver, currentTs, currentTime uint64, rec lockRecord) (*resolveLockDecision, error) {
 	if err := ctx.Err(); err != nil {
 		return nil, err
 	}
-	status, err := checkTxnStatus(ctx, resolver, rec.lock.Primary, rec.lock.Ts, currentTs)
+	status, err := checkTxnStatus(ctx, resolver, rec.lock.Primary, rec.lock.Ts, currentTs, currentTime)
 	if err != nil {
 		return nil, err
 	}
@@ -340,11 +344,11 @@ func writeByStartTs(db txnstore.Store, key []byte, startTs uint64) (txnmvcc.Writ
 	return txnmvcc.Write{}, 0, false, nil
 }
 
-func lockExpired(lock txnmvcc.Lock, currentTs uint64) bool {
-	if lock.TTL == 0 || currentTs == 0 {
+func lockExpired(lock txnmvcc.Lock, currentTime uint64) bool {
+	if lock.TTL == 0 || lock.StartTime == 0 || currentTime == 0 {
 		return false
 	}
-	return currentTs >= lock.Ts && currentTs-lock.Ts >= lock.TTL
+	return currentTime >= lock.StartTime && currentTime-lock.StartTime >= lock.TTL
 }
 
 func groupResolveLockCommands(decisions []resolveLockDecision) []resolveLockCommand {

--- a/raftstore/mvcc/lock_resolver_test.go
+++ b/raftstore/mvcc/lock_resolver_test.go
@@ -18,10 +18,11 @@ import (
 func applyMVCCGCLockRecord(t *testing.T, db *NoKV.DB, key, primary []byte, startTs, ttl uint64, kind kvrpcpb.Mutation_Op) {
 	t.Helper()
 	lock := txnmvcc.EncodeLock(txnmvcc.Lock{
-		Primary: primary,
-		Ts:      startTs,
-		TTL:     ttl,
-		Kind:    kind,
+		Primary:   primary,
+		Ts:        startTs,
+		StartTime: startTs,
+		TTL:       ttl,
+		Kind:      kind,
 	})
 	applyVersionedEntryForApplyTest(t, db, entrykv.CFLock, key, entrykv.MaxVersion, lock, 0, 0)
 }
@@ -33,8 +34,9 @@ func TestResolveExpiredLocksRollsBackExpiredPrimaryLock(t *testing.T) {
 	applyMVCCGCLockRecord(t, db, key, key, 10, 5, kvrpcpb.Mutation_Put)
 
 	stats, err := storemvcc.ResolveExpiredLocksReplicated(context.Background(), db, &testLockResolver{db: db}, storemvcc.ResolveLocksOptions{
-		CurrentTs:  20,
-		BatchLocks: 1,
+		CurrentTs:   20,
+		CurrentTime: 20,
+		BatchLocks:  1,
 	})
 	require.NoError(t, err)
 	require.Equal(t, uint64(1), stats.ScannedLocks)
@@ -68,7 +70,7 @@ func TestResolveExpiredLocksCommitsSecondaryFromPrimaryWrite(t *testing.T) {
 	applyVersionedEntryForApplyTest(t, db, entrykv.CFDefault, secondary, 10, []byte("value"), 0, 0)
 	applyMVCCGCLockRecord(t, db, secondary, primary, 10, 5, kvrpcpb.Mutation_Put)
 
-	stats, err := storemvcc.ResolveExpiredLocksReplicated(context.Background(), db, &testLockResolver{db: db}, storemvcc.ResolveLocksOptions{CurrentTs: 20})
+	stats, err := storemvcc.ResolveExpiredLocksReplicated(context.Background(), db, &testLockResolver{db: db}, storemvcc.ResolveLocksOptions{CurrentTs: 20, CurrentTime: 20})
 	require.NoError(t, err)
 	require.Equal(t, uint64(1), stats.ResolvedLocks)
 	require.Equal(t, uint64(1), stats.CommittedLocks)
@@ -95,7 +97,7 @@ func TestResolveExpiredLocksRollsBackSecondaryAfterPrimaryAuthorityRollback(t *t
 	applyMVCCGCLockRecord(t, db, secondary, primary, 10, 5, kvrpcpb.Mutation_Put)
 
 	resolver := &testLockResolver{db: db}
-	stats, err := storemvcc.ResolveExpiredLocksReplicated(context.Background(), db, resolver, storemvcc.ResolveLocksOptions{CurrentTs: 20})
+	stats, err := storemvcc.ResolveExpiredLocksReplicated(context.Background(), db, resolver, storemvcc.ResolveLocksOptions{CurrentTs: 20, CurrentTime: 20})
 	require.NoError(t, err)
 	require.Equal(t, uint64(1), stats.ScannedLocks)
 	require.Equal(t, uint64(1), stats.ExpiredLocks)
@@ -123,7 +125,7 @@ func TestResolveExpiredLocksReplicatedUsesResolveLockCommand(t *testing.T) {
 	applyMVCCGCLockRecord(t, db, secondary, primary, 10, 5, kvrpcpb.Mutation_Put)
 
 	proposer := &testLockResolver{db: db}
-	stats, err := storemvcc.ResolveExpiredLocksReplicated(context.Background(), db, proposer, storemvcc.ResolveLocksOptions{CurrentTs: 20})
+	stats, err := storemvcc.ResolveExpiredLocksReplicated(context.Background(), db, proposer, storemvcc.ResolveLocksOptions{CurrentTs: 20, CurrentTime: 20})
 	require.NoError(t, err)
 	require.Equal(t, 1, proposer.calls)
 	require.Equal(t, uint64(1), stats.ResolvedLocks)
@@ -145,7 +147,7 @@ func TestResolveExpiredLocksReplicatedRollsBackExpiredPrimary(t *testing.T) {
 	applyMVCCGCLockRecord(t, db, key, key, 10, 5, kvrpcpb.Mutation_Put)
 
 	proposer := &testLockResolver{db: db}
-	stats, err := storemvcc.ResolveExpiredLocksReplicated(context.Background(), db, proposer, storemvcc.ResolveLocksOptions{CurrentTs: 20})
+	stats, err := storemvcc.ResolveExpiredLocksReplicated(context.Background(), db, proposer, storemvcc.ResolveLocksOptions{CurrentTs: 20, CurrentTime: 20})
 	require.NoError(t, err)
 	require.Equal(t, uint64(1), stats.ResolvedLocks)
 	require.Equal(t, uint64(1), stats.RolledBackLocks)
@@ -163,7 +165,7 @@ func TestResolveExpiredLocksRetainsLiveLock(t *testing.T) {
 	key := []byte("live")
 	applyMVCCGCLockRecord(t, db, key, key, 10, 100, kvrpcpb.Mutation_Put)
 
-	stats, err := storemvcc.ResolveExpiredLocksReplicated(context.Background(), db, &testLockResolver{db: db}, storemvcc.ResolveLocksOptions{CurrentTs: 20})
+	stats, err := storemvcc.ResolveExpiredLocksReplicated(context.Background(), db, &testLockResolver{db: db}, storemvcc.ResolveLocksOptions{CurrentTs: 20, CurrentTime: 20})
 	require.NoError(t, err)
 	require.Equal(t, uint64(1), stats.ScannedLocks)
 	require.Equal(t, uint64(1), stats.RetainedLocks)
@@ -175,6 +177,39 @@ func TestResolveExpiredLocksRetainsLiveLock(t *testing.T) {
 	require.Equal(t, uint64(10), floor.OldestStartTs)
 }
 
+func TestResolveExpiredLocksDoesNotExpireFromLogicalTSODistance(t *testing.T) {
+	db := openMVCCGCPlanTestDB(t)
+	key := []byte("logical-live")
+	applyMVCCGCLockRecord(t, db, key, key, 10, 5000, kvrpcpb.Mutation_Put)
+
+	stats, err := storemvcc.ResolveExpiredLocksReplicated(context.Background(), db, &testLockResolver{db: db}, storemvcc.ResolveLocksOptions{
+		CurrentTs:   1_000_000,
+		CurrentTime: 20,
+	})
+	require.NoError(t, err)
+	require.Equal(t, uint64(1), stats.ScannedLocks)
+	require.Equal(t, uint64(1), stats.RetainedLocks)
+	require.Zero(t, stats.ExpiredLocks)
+	require.Zero(t, stats.ResolvedLocks)
+}
+
+func TestResolveExpiredLocksExpiresFromPhysicalTimeWithoutLogicalTSODistance(t *testing.T) {
+	db := openMVCCGCPlanTestDB(t)
+	key := []byte("physical-expired")
+	applyVersionedEntryForApplyTest(t, db, entrykv.CFDefault, key, 10, []byte("value"), 0, 0)
+	applyMVCCGCLockRecord(t, db, key, key, 10, 5, kvrpcpb.Mutation_Put)
+
+	stats, err := storemvcc.ResolveExpiredLocksReplicated(context.Background(), db, &testLockResolver{db: db}, storemvcc.ResolveLocksOptions{
+		CurrentTs:   10,
+		CurrentTime: 20,
+	})
+	require.NoError(t, err)
+	require.Equal(t, uint64(1), stats.ScannedLocks)
+	require.Equal(t, uint64(1), stats.ExpiredLocks)
+	require.Equal(t, uint64(1), stats.ResolvedLocks)
+	require.Equal(t, uint64(1), stats.RolledBackLocks)
+}
+
 func TestResolveExpiredLocksRetainsTTLAcrossUint64Boundary(t *testing.T) {
 	db := openMVCCGCPlanTestDB(t)
 	key := []byte("overflow-live")
@@ -182,7 +217,7 @@ func TestResolveExpiredLocksRetainsTTLAcrossUint64Boundary(t *testing.T) {
 	applyVersionedEntryForApplyTest(t, db, entrykv.CFDefault, key, startTs, []byte("value"), 0, 0)
 	applyMVCCGCLockRecord(t, db, key, key, startTs, 10, kvrpcpb.Mutation_Put)
 
-	stats, err := storemvcc.ResolveExpiredLocksReplicated(context.Background(), db, &testLockResolver{db: db}, storemvcc.ResolveLocksOptions{CurrentTs: startTs + 4})
+	stats, err := storemvcc.ResolveExpiredLocksReplicated(context.Background(), db, &testLockResolver{db: db}, storemvcc.ResolveLocksOptions{CurrentTs: 20, CurrentTime: startTs + 4})
 	require.NoError(t, err)
 	require.Equal(t, uint64(1), stats.ScannedLocks)
 	require.Equal(t, uint64(1), stats.RetainedLocks)
@@ -199,7 +234,7 @@ func TestResolveExpiredLocksUnblocksTxnFloor(t *testing.T) {
 	key := []byte("old")
 	applyMVCCGCLockRecord(t, db, key, key, 10, 5, kvrpcpb.Mutation_Put)
 
-	_, err := storemvcc.ResolveExpiredLocksReplicated(context.Background(), db, &testLockResolver{db: db}, storemvcc.ResolveLocksOptions{CurrentTs: 20})
+	_, err := storemvcc.ResolveExpiredLocksReplicated(context.Background(), db, &testLockResolver{db: db}, storemvcc.ResolveLocksOptions{CurrentTs: 20, CurrentTime: 20})
 	require.NoError(t, err)
 
 	floor, err := storemvcc.PlanTxnFloor(context.Background(), db)
@@ -217,9 +252,10 @@ func TestResolveExpiredLocksStopsAtMaxLocks(t *testing.T) {
 	}
 
 	stats, err := storemvcc.ResolveExpiredLocksReplicated(context.Background(), db, &testLockResolver{db: db}, storemvcc.ResolveLocksOptions{
-		CurrentTs:  20,
-		BatchLocks: 10,
-		MaxLocks:   2,
+		CurrentTs:   20,
+		CurrentTime: 20,
+		BatchLocks:  10,
+		MaxLocks:    2,
 	})
 	require.NoError(t, err)
 	require.Equal(t, uint64(2), stats.ScannedLocks)
@@ -238,7 +274,7 @@ type testLockResolver struct {
 	statusCalls int
 }
 
-func (p *testLockResolver) CheckTxnStatus(_ context.Context, primary []byte, lockTs, currentTs uint64) (*kvrpcpb.CheckTxnStatusResponse, error) {
+func (p *testLockResolver) CheckTxnStatus(_ context.Context, primary []byte, lockTs, currentTs, currentTime uint64) (*kvrpcpb.CheckTxnStatusResponse, error) {
 	p.statusCalls++
 	if p.db == nil {
 		return &kvrpcpb.CheckTxnStatusResponse{}, nil
@@ -249,6 +285,7 @@ func (p *testLockResolver) CheckTxnStatus(_ context.Context, primary []byte, loc
 		CurrentTs:          currentTs,
 		CallerStartTs:      currentTs,
 		RollbackIfNotExist: true,
+		CurrentTime:        currentTime,
 	}), nil
 }
 

--- a/raftstore/mvcc/lock_resolver_test.go
+++ b/raftstore/mvcc/lock_resolver_test.go
@@ -32,7 +32,7 @@ func TestResolveExpiredLocksRollsBackExpiredPrimaryLock(t *testing.T) {
 	applyVersionedEntryForApplyTest(t, db, entrykv.CFDefault, key, 10, []byte("value"), 0, 0)
 	applyMVCCGCLockRecord(t, db, key, key, 10, 5, kvrpcpb.Mutation_Put)
 
-	stats, err := storemvcc.ResolveExpiredLocksReplicated(context.Background(), db, &testLockResolverProposer{db: db}, storemvcc.ResolveLocksOptions{
+	stats, err := storemvcc.ResolveExpiredLocksReplicated(context.Background(), db, &testLockResolver{db: db}, storemvcc.ResolveLocksOptions{
 		CurrentTs:  20,
 		BatchLocks: 1,
 	})
@@ -68,7 +68,7 @@ func TestResolveExpiredLocksCommitsSecondaryFromPrimaryWrite(t *testing.T) {
 	applyVersionedEntryForApplyTest(t, db, entrykv.CFDefault, secondary, 10, []byte("value"), 0, 0)
 	applyMVCCGCLockRecord(t, db, secondary, primary, 10, 5, kvrpcpb.Mutation_Put)
 
-	stats, err := storemvcc.ResolveExpiredLocksReplicated(context.Background(), db, &testLockResolverProposer{db: db}, storemvcc.ResolveLocksOptions{CurrentTs: 20})
+	stats, err := storemvcc.ResolveExpiredLocksReplicated(context.Background(), db, &testLockResolver{db: db}, storemvcc.ResolveLocksOptions{CurrentTs: 20})
 	require.NoError(t, err)
 	require.Equal(t, uint64(1), stats.ResolvedLocks)
 	require.Equal(t, uint64(1), stats.CommittedLocks)
@@ -87,6 +87,33 @@ func TestResolveExpiredLocksCommitsSecondaryFromPrimaryWrite(t *testing.T) {
 	require.NotZero(t, lock.Meta&entrykv.BitDelete)
 }
 
+func TestResolveExpiredLocksRollsBackSecondaryAfterPrimaryAuthorityRollback(t *testing.T) {
+	db := openMVCCGCPlanTestDB(t)
+	primary := []byte("primary")
+	secondary := []byte("secondary")
+	applyVersionedEntryForApplyTest(t, db, entrykv.CFDefault, secondary, 10, []byte("value"), 0, 0)
+	applyMVCCGCLockRecord(t, db, secondary, primary, 10, 5, kvrpcpb.Mutation_Put)
+
+	resolver := &testLockResolver{db: db}
+	stats, err := storemvcc.ResolveExpiredLocksReplicated(context.Background(), db, resolver, storemvcc.ResolveLocksOptions{CurrentTs: 20})
+	require.NoError(t, err)
+	require.Equal(t, uint64(1), stats.ScannedLocks)
+	require.Equal(t, uint64(1), stats.ExpiredLocks)
+	require.Zero(t, stats.RetainedLocks)
+	require.Equal(t, uint64(1), stats.ResolvedLocks)
+	require.Equal(t, uint64(1), stats.RolledBackLocks)
+	require.Equal(t, 1, resolver.statusCalls)
+	require.Equal(t, 1, resolver.calls)
+
+	lock, err := db.GetInternalEntry(entrykv.CFLock, secondary, entrykv.MaxVersion)
+	require.NoError(t, err)
+	defer lock.DecrRef()
+	require.NotZero(t, lock.Meta&entrykv.BitDelete)
+
+	_, err = db.GetInternalEntry(entrykv.CFWrite, secondary, 10)
+	require.NoError(t, err)
+}
+
 func TestResolveExpiredLocksReplicatedUsesResolveLockCommand(t *testing.T) {
 	db := openMVCCGCPlanTestDB(t)
 	primary := []byte("primary")
@@ -95,7 +122,7 @@ func TestResolveExpiredLocksReplicatedUsesResolveLockCommand(t *testing.T) {
 	applyVersionedEntryForApplyTest(t, db, entrykv.CFDefault, secondary, 10, []byte("value"), 0, 0)
 	applyMVCCGCLockRecord(t, db, secondary, primary, 10, 5, kvrpcpb.Mutation_Put)
 
-	proposer := &testLockResolverProposer{db: db}
+	proposer := &testLockResolver{db: db}
 	stats, err := storemvcc.ResolveExpiredLocksReplicated(context.Background(), db, proposer, storemvcc.ResolveLocksOptions{CurrentTs: 20})
 	require.NoError(t, err)
 	require.Equal(t, 1, proposer.calls)
@@ -117,7 +144,7 @@ func TestResolveExpiredLocksReplicatedRollsBackExpiredPrimary(t *testing.T) {
 	applyVersionedEntryForApplyTest(t, db, entrykv.CFDefault, key, 10, []byte("value"), 0, 0)
 	applyMVCCGCLockRecord(t, db, key, key, 10, 5, kvrpcpb.Mutation_Put)
 
-	proposer := &testLockResolverProposer{db: db}
+	proposer := &testLockResolver{db: db}
 	stats, err := storemvcc.ResolveExpiredLocksReplicated(context.Background(), db, proposer, storemvcc.ResolveLocksOptions{CurrentTs: 20})
 	require.NoError(t, err)
 	require.Equal(t, uint64(1), stats.ResolvedLocks)
@@ -136,7 +163,7 @@ func TestResolveExpiredLocksRetainsLiveLock(t *testing.T) {
 	key := []byte("live")
 	applyMVCCGCLockRecord(t, db, key, key, 10, 100, kvrpcpb.Mutation_Put)
 
-	stats, err := storemvcc.ResolveExpiredLocksReplicated(context.Background(), db, &testLockResolverProposer{db: db}, storemvcc.ResolveLocksOptions{CurrentTs: 20})
+	stats, err := storemvcc.ResolveExpiredLocksReplicated(context.Background(), db, &testLockResolver{db: db}, storemvcc.ResolveLocksOptions{CurrentTs: 20})
 	require.NoError(t, err)
 	require.Equal(t, uint64(1), stats.ScannedLocks)
 	require.Equal(t, uint64(1), stats.RetainedLocks)
@@ -155,7 +182,7 @@ func TestResolveExpiredLocksRetainsTTLAcrossUint64Boundary(t *testing.T) {
 	applyVersionedEntryForApplyTest(t, db, entrykv.CFDefault, key, startTs, []byte("value"), 0, 0)
 	applyMVCCGCLockRecord(t, db, key, key, startTs, 10, kvrpcpb.Mutation_Put)
 
-	stats, err := storemvcc.ResolveExpiredLocksReplicated(context.Background(), db, &testLockResolverProposer{db: db}, storemvcc.ResolveLocksOptions{CurrentTs: startTs + 4})
+	stats, err := storemvcc.ResolveExpiredLocksReplicated(context.Background(), db, &testLockResolver{db: db}, storemvcc.ResolveLocksOptions{CurrentTs: startTs + 4})
 	require.NoError(t, err)
 	require.Equal(t, uint64(1), stats.ScannedLocks)
 	require.Equal(t, uint64(1), stats.RetainedLocks)
@@ -172,7 +199,7 @@ func TestResolveExpiredLocksUnblocksTxnFloor(t *testing.T) {
 	key := []byte("old")
 	applyMVCCGCLockRecord(t, db, key, key, 10, 5, kvrpcpb.Mutation_Put)
 
-	_, err := storemvcc.ResolveExpiredLocksReplicated(context.Background(), db, &testLockResolverProposer{db: db}, storemvcc.ResolveLocksOptions{CurrentTs: 20})
+	_, err := storemvcc.ResolveExpiredLocksReplicated(context.Background(), db, &testLockResolver{db: db}, storemvcc.ResolveLocksOptions{CurrentTs: 20})
 	require.NoError(t, err)
 
 	floor, err := storemvcc.PlanTxnFloor(context.Background(), db)
@@ -189,7 +216,7 @@ func TestResolveExpiredLocksStopsAtMaxLocks(t *testing.T) {
 		applyMVCCGCLockRecord(t, db, key, key, startTs, 5, kvrpcpb.Mutation_Put)
 	}
 
-	stats, err := storemvcc.ResolveExpiredLocksReplicated(context.Background(), db, &testLockResolverProposer{db: db}, storemvcc.ResolveLocksOptions{
+	stats, err := storemvcc.ResolveExpiredLocksReplicated(context.Background(), db, &testLockResolver{db: db}, storemvcc.ResolveLocksOptions{
 		CurrentTs:  20,
 		BatchLocks: 10,
 		MaxLocks:   2,
@@ -205,12 +232,27 @@ func TestResolveExpiredLocksStopsAtMaxLocks(t *testing.T) {
 	require.Equal(t, uint64(12), floor.OldestStartTs)
 }
 
-type testLockResolverProposer struct {
-	db    *NoKV.DB
-	calls int
+type testLockResolver struct {
+	db          *NoKV.DB
+	calls       int
+	statusCalls int
 }
 
-func (p *testLockResolverProposer) ProposeResolveLocks(_ context.Context, startVersion, commitVersion uint64, keys [][]byte) (uint64, error) {
+func (p *testLockResolver) CheckTxnStatus(_ context.Context, primary []byte, lockTs, currentTs uint64) (*kvrpcpb.CheckTxnStatusResponse, error) {
+	p.statusCalls++
+	if p.db == nil {
+		return &kvrpcpb.CheckTxnStatusResponse{}, nil
+	}
+	return percolator.CheckTxnStatus(p.db, latch.NewManager(32), &kvrpcpb.CheckTxnStatusRequest{
+		PrimaryKey:         primary,
+		LockTs:             lockTs,
+		CurrentTs:          currentTs,
+		CallerStartTs:      currentTs,
+		RollbackIfNotExist: true,
+	}), nil
+}
+
+func (p *testLockResolver) ResolveLocks(_ context.Context, startVersion, commitVersion uint64, keys [][]byte) (uint64, error) {
 	p.calls++
 	if p.db == nil {
 		return uint64(len(keys)), nil

--- a/raftstore/mvcc/orphan_default.go
+++ b/raftstore/mvcc/orphan_default.go
@@ -83,7 +83,7 @@ type orphanDefaultBatch struct {
 func collectOrphanDefaultBatch(ctx context.Context, db txnstore.Store, afterUserKey []byte, afterVersion uint64, maxEntries int) (orphanDefaultBatch, error) {
 	var batch orphanDefaultBatch
 	if db == nil {
-		return batch, fmt.Errorf("raftstore/mvcc: nil MVCC store")
+		return batch, errNilMVCCStore
 	}
 	iter := db.NewInternalIterator(&index.Options{IsAsc: true})
 	if iter == nil {

--- a/raftstore/mvcc/plan.go
+++ b/raftstore/mvcc/plan.go
@@ -123,7 +123,7 @@ type walkResult struct {
 func walk(ctx context.Context, db txnstore.Store, policy SafePointPolicy, afterUserKey []byte, stats *PlanStats, fn groupFn) (walkResult, error) {
 	var result walkResult
 	if db == nil {
-		return result, fmt.Errorf("raftstore/mvcc: nil MVCC store")
+		return result, errNilMVCCStore
 	}
 	iter := db.NewInternalIterator(&index.Options{IsAsc: true})
 	if iter == nil {

--- a/raftstore/mvcc/proposer.go
+++ b/raftstore/mvcc/proposer.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	entrykv "github.com/feichai0017/NoKV/engine/kv"
+	kvrpcpb "github.com/feichai0017/NoKV/pb/kv"
 )
 
 // MaintenanceProposer submits MVCC maintenance entries through the replicated
@@ -18,11 +19,12 @@ type MaintenanceProposer interface {
 	ProposeMVCCMaintenance(context.Context, []*entrykv.Entry) (entries, writeDeletes, defaultDeletes uint64, err error)
 }
 
-// LockResolverProposer submits semantic ResolveLock commands through raft.
-// Implementations must preserve the normal Percolator apply path instead of
-// translating locks into raw tombstones.
-type LockResolverProposer interface {
-	ProposeResolveLocks(ctx context.Context, startVersion, commitVersion uint64, keys [][]byte) (uint64, error)
+// LockResolver submits semantic transaction-resolution commands through the
+// authoritative region for each key. Implementations must preserve the normal
+// Percolator apply path instead of translating locks into raw tombstones.
+type LockResolver interface {
+	CheckTxnStatus(ctx context.Context, primary []byte, lockTs, currentTs uint64) (*kvrpcpb.CheckTxnStatusResponse, error)
+	ResolveLocks(ctx context.Context, startVersion, commitVersion uint64, keys [][]byte) (uint64, error)
 }
 
 type maintenanceSubmitResult struct {
@@ -56,12 +58,19 @@ func proposeMaintenanceEntries(ctx context.Context, proposer MaintenanceProposer
 	return result, nil
 }
 
-func proposeResolveLocks(ctx context.Context, proposer LockResolverProposer, startVersion, commitVersion uint64, keys [][]byte) (uint64, error) {
+func checkTxnStatus(ctx context.Context, resolver LockResolver, primary []byte, lockTs, currentTs uint64) (*kvrpcpb.CheckTxnStatusResponse, error) {
+	if resolver == nil {
+		return nil, fmt.Errorf("raftstore/mvcc: nil lock resolver")
+	}
+	return resolver.CheckTxnStatus(ctx, primary, lockTs, currentTs)
+}
+
+func proposeResolveLocks(ctx context.Context, resolver LockResolver, startVersion, commitVersion uint64, keys [][]byte) (uint64, error) {
 	if len(keys) == 0 {
 		return 0, nil
 	}
-	if proposer == nil {
-		return 0, fmt.Errorf("raftstore/mvcc: nil lock resolver proposer")
+	if resolver == nil {
+		return 0, fmt.Errorf("raftstore/mvcc: nil lock resolver")
 	}
-	return proposer.ProposeResolveLocks(ctx, startVersion, commitVersion, keys)
+	return resolver.ResolveLocks(ctx, startVersion, commitVersion, keys)
 }

--- a/raftstore/mvcc/proposer.go
+++ b/raftstore/mvcc/proposer.go
@@ -23,7 +23,7 @@ type MaintenanceProposer interface {
 // authoritative region for each key. Implementations must preserve the normal
 // Percolator apply path instead of translating locks into raw tombstones.
 type LockResolver interface {
-	CheckTxnStatus(ctx context.Context, primary []byte, lockTs, currentTs uint64) (*kvrpcpb.CheckTxnStatusResponse, error)
+	CheckTxnStatus(ctx context.Context, primary []byte, lockTs, currentTs, currentTime uint64) (*kvrpcpb.CheckTxnStatusResponse, error)
 	ResolveLocks(ctx context.Context, startVersion, commitVersion uint64, keys [][]byte) (uint64, error)
 }
 
@@ -58,11 +58,11 @@ func proposeMaintenanceEntries(ctx context.Context, proposer MaintenanceProposer
 	return result, nil
 }
 
-func checkTxnStatus(ctx context.Context, resolver LockResolver, primary []byte, lockTs, currentTs uint64) (*kvrpcpb.CheckTxnStatusResponse, error) {
+func checkTxnStatus(ctx context.Context, resolver LockResolver, primary []byte, lockTs, currentTs, currentTime uint64) (*kvrpcpb.CheckTxnStatusResponse, error) {
 	if resolver == nil {
 		return nil, fmt.Errorf("raftstore/mvcc: nil lock resolver")
 	}
-	return resolver.CheckTxnStatus(ctx, primary, lockTs, currentTs)
+	return resolver.CheckTxnStatus(ctx, primary, lockTs, currentTs, currentTime)
 }
 
 func proposeResolveLocks(ctx context.Context, resolver LockResolver, startVersion, commitVersion uint64, keys [][]byte) (uint64, error) {

--- a/raftstore/mvcc/proposer.go
+++ b/raftstore/mvcc/proposer.go
@@ -38,7 +38,7 @@ func proposeMaintenanceEntries(ctx context.Context, proposer MaintenanceProposer
 		return maintenanceSubmitResult{}, nil
 	}
 	if proposer == nil {
-		return maintenanceSubmitResult{}, fmt.Errorf("raftstore/mvcc: nil maintenance proposer")
+		return maintenanceSubmitResult{}, errNilMaintenanceProposer
 	}
 	applied, writeDeletes, defaultDeletes, err := proposer.ProposeMVCCMaintenance(ctx, entries)
 	result := maintenanceSubmitResult{
@@ -60,7 +60,7 @@ func proposeMaintenanceEntries(ctx context.Context, proposer MaintenanceProposer
 
 func checkTxnStatus(ctx context.Context, resolver LockResolver, primary []byte, lockTs, currentTs, currentTime uint64) (*kvrpcpb.CheckTxnStatusResponse, error) {
 	if resolver == nil {
-		return nil, fmt.Errorf("raftstore/mvcc: nil lock resolver")
+		return nil, errNilLockResolver
 	}
 	return resolver.CheckTxnStatus(ctx, primary, lockTs, currentTs, currentTime)
 }
@@ -70,7 +70,7 @@ func proposeResolveLocks(ctx context.Context, resolver LockResolver, startVersio
 		return 0, nil
 	}
 	if resolver == nil {
-		return 0, fmt.Errorf("raftstore/mvcc: nil lock resolver")
+		return 0, errNilLockResolver
 	}
 	return resolver.ResolveLocks(ctx, startVersion, commitVersion, keys)
 }

--- a/raftstore/mvcc/txn_floor.go
+++ b/raftstore/mvcc/txn_floor.go
@@ -28,7 +28,7 @@ func (f TxnFloor) Active() bool {
 func PlanTxnFloor(ctx context.Context, db txnstore.Store) (TxnFloor, error) {
 	var floor TxnFloor
 	if db == nil {
-		return floor, fmt.Errorf("raftstore/mvcc: nil MVCC store")
+		return floor, errNilMVCCStore
 	}
 	iter := db.NewInternalIterator(&index.Options{IsAsc: true})
 	if iter == nil {
@@ -60,7 +60,7 @@ func PlanTxnFloor(ctx context.Context, db txnstore.Store) (TxnFloor, error) {
 		}
 		lock, err := txnmvcc.DecodeLock(entry.Value)
 		if err != nil {
-			return floor, fmt.Errorf("raftstore/mvcc: decode CFLock %x: %w", userKey, err)
+			return floor, errDecodeCFLock(userKey, err)
 		}
 		if lock.Ts == 0 {
 			iter.Next()

--- a/raftstore/mvcc/worker.go
+++ b/raftstore/mvcc/worker.go
@@ -17,9 +17,9 @@ const MaintenanceTaskName = "mvcc-maintenance"
 // raftstore node. The worker never writes through the local Store surface:
 // every destructive mutation must pass through the supplied raft proposers.
 type MaintenanceWorkerConfig struct {
-	MVCCStore            txnstore.Store
-	MaintenanceProposer  MaintenanceProposer
-	LockResolverProposer LockResolverProposer
+	MVCCStore           txnstore.Store
+	MaintenanceProposer MaintenanceProposer
+	LockResolver        LockResolver
 
 	Interval time.Duration
 	Timeout  time.Duration
@@ -69,7 +69,7 @@ func NewMaintenanceWorker(cfg MaintenanceWorkerConfig) (*MaintenanceWorker, bool
 		return nil, false
 	}
 	hasGCApply := cfg.SafePoint != nil && cfg.MaintenanceProposer != nil
-	hasLockResolution := cfg.CurrentTs != nil && cfg.LockResolverProposer != nil
+	hasLockResolution := cfg.CurrentTs != nil && cfg.LockResolver != nil
 	hasOrphanCleanup := cfg.RunOrphanDefaults && cfg.MaintenanceProposer != nil
 	if !hasGCApply && !hasLockResolution && !hasOrphanCleanup {
 		return nil, false
@@ -132,10 +132,10 @@ func (w *MaintenanceWorker) RunOnce(ctx context.Context) error {
 	if w.cfg.CurrentTs != nil {
 		currentTs = w.cfg.CurrentTs()
 	}
-	if currentTs != 0 && w.cfg.LockResolverProposer != nil {
+	if currentTs != 0 && w.cfg.LockResolver != nil {
 		resolveOpt := w.cfg.ResolveLocks
 		resolveOpt.CurrentTs = currentTs
-		resolveStats, resolveErr = ResolveExpiredLocksReplicated(runCtx, w.cfg.MVCCStore, w.cfg.LockResolverProposer, resolveOpt)
+		resolveStats, resolveErr = ResolveExpiredLocksReplicated(runCtx, w.cfg.MVCCStore, w.cfg.LockResolver, resolveOpt)
 	}
 	if w.cfg.SafePoint != nil && w.cfg.MaintenanceProposer != nil {
 		requestedSafePoint := w.cfg.SafePoint()

--- a/raftstore/mvcc/worker.go
+++ b/raftstore/mvcc/worker.go
@@ -24,10 +24,11 @@ type MaintenanceWorkerConfig struct {
 	Interval time.Duration
 	Timeout  time.Duration
 
-	SafePoint func() uint64
-	CurrentTs func() uint64
-	Retention func() rootstate.SnapshotRetentionIndex
-	Mount     MountResolver
+	SafePoint   func() uint64
+	CurrentTs   func() uint64
+	CurrentTime func() uint64
+	Retention   func() rootstate.SnapshotRetentionIndex
+	Mount       MountResolver
 
 	Apply        ApplyOptions
 	ResolveLocks ResolveLocksOptions
@@ -69,7 +70,7 @@ func NewMaintenanceWorker(cfg MaintenanceWorkerConfig) (*MaintenanceWorker, bool
 		return nil, false
 	}
 	hasGCApply := cfg.SafePoint != nil && cfg.MaintenanceProposer != nil
-	hasLockResolution := cfg.CurrentTs != nil && cfg.LockResolver != nil
+	hasLockResolution := cfg.CurrentTs != nil && cfg.CurrentTime != nil && cfg.LockResolver != nil
 	hasOrphanCleanup := cfg.RunOrphanDefaults && cfg.MaintenanceProposer != nil
 	if !hasGCApply && !hasLockResolution && !hasOrphanCleanup {
 		return nil, false
@@ -132,9 +133,14 @@ func (w *MaintenanceWorker) RunOnce(ctx context.Context) error {
 	if w.cfg.CurrentTs != nil {
 		currentTs = w.cfg.CurrentTs()
 	}
-	if currentTs != 0 && w.cfg.LockResolver != nil {
+	currentTime := uint64(0)
+	if w.cfg.CurrentTime != nil {
+		currentTime = w.cfg.CurrentTime()
+	}
+	if currentTs != 0 && currentTime != 0 && w.cfg.LockResolver != nil {
 		resolveOpt := w.cfg.ResolveLocks
 		resolveOpt.CurrentTs = currentTs
+		resolveOpt.CurrentTime = currentTime
 		resolveStats, resolveErr = ResolveExpiredLocksReplicated(runCtx, w.cfg.MVCCStore, w.cfg.LockResolver, resolveOpt)
 	}
 	if w.cfg.SafePoint != nil && w.cfg.MaintenanceProposer != nil {

--- a/raftstore/mvcc/worker_test.go
+++ b/raftstore/mvcc/worker_test.go
@@ -27,18 +27,18 @@ func TestMaintenanceWorkerRunOnceUsesReplicatedPaths(t *testing.T) {
 	applyVersionedEntryForApplyTest(t, db, entrykv.CFDefault, orphanKey, 7, []byte("orphan"), 0, 0)
 
 	maintenance := &testMaintenanceProposer{db: db}
-	locks := &testLockResolverProposer{db: db}
+	locks := &testLockResolver{db: db}
 	worker, ok := storemvcc.NewMaintenanceWorker(storemvcc.MaintenanceWorkerConfig{
-		MVCCStore:            db,
-		MaintenanceProposer:  maintenance,
-		LockResolverProposer: locks,
-		Interval:             time.Hour,
-		SafePoint:            func() uint64 { return 100 },
-		CurrentTs:            func() uint64 { return 20 },
-		Apply:                storemvcc.ApplyOptions{BatchEntries: 2},
-		ResolveLocks:         storemvcc.ResolveLocksOptions{BatchLocks: 1},
-		RunOrphanDefaults:    true,
-		OrphanDefaults:       storemvcc.OrphanDefaultOptions{BatchEntries: 1},
+		MVCCStore:           db,
+		MaintenanceProposer: maintenance,
+		LockResolver:        locks,
+		Interval:            time.Hour,
+		SafePoint:           func() uint64 { return 100 },
+		CurrentTs:           func() uint64 { return 20 },
+		Apply:               storemvcc.ApplyOptions{BatchEntries: 2},
+		ResolveLocks:        storemvcc.ResolveLocksOptions{BatchLocks: 1},
+		RunOrphanDefaults:   true,
+		OrphanDefaults:      storemvcc.OrphanDefaultOptions{BatchEntries: 1},
 	})
 	require.True(t, ok)
 
@@ -51,7 +51,8 @@ func TestMaintenanceWorkerRunOnceUsesReplicatedPaths(t *testing.T) {
 	require.Equal(t, uint64(1), snap.LastApply.AppliedDefaultDeletes)
 	require.Equal(t, uint64(1), snap.LastOrphanDefaults.AppliedDefaultDeletes)
 	require.GreaterOrEqual(t, maintenance.calls, 2)
-	require.Equal(t, 1, locks.calls)
+	require.Equal(t, 1, locks.statusCalls)
+	require.Zero(t, locks.calls)
 }
 
 func TestMaintenanceWorkerContinuesAfterResolveError(t *testing.T) {
@@ -65,14 +66,14 @@ func TestMaintenanceWorkerContinuesAfterResolveError(t *testing.T) {
 	applyMVCCGCLockRecord(t, db, lockKey, lockKey, 200, 5, kvrpcpb.Mutation_Put)
 
 	worker, ok := storemvcc.NewMaintenanceWorker(storemvcc.MaintenanceWorkerConfig{
-		MVCCStore:            db,
-		MaintenanceProposer:  &testMaintenanceProposer{db: db},
-		LockResolverProposer: &failingLockResolverProposer{err: errors.New("resolve failed")},
-		Interval:             time.Hour,
-		SafePoint:            func() uint64 { return 100 },
-		CurrentTs:            func() uint64 { return 300 },
-		Apply:                storemvcc.ApplyOptions{BatchEntries: 8},
-		ResolveLocks:         storemvcc.ResolveLocksOptions{BatchLocks: 1},
+		MVCCStore:           db,
+		MaintenanceProposer: &testMaintenanceProposer{db: db},
+		LockResolver:        &failingLockResolver{err: errors.New("resolve failed")},
+		Interval:            time.Hour,
+		SafePoint:           func() uint64 { return 100 },
+		CurrentTs:           func() uint64 { return 300 },
+		Apply:               storemvcc.ApplyOptions{BatchEntries: 8},
+		ResolveLocks:        storemvcc.ResolveLocksOptions{BatchLocks: 1},
 	})
 	require.True(t, ok)
 
@@ -151,11 +152,11 @@ func TestMaintenanceWorkerAllowsLockResolutionOnly(t *testing.T) {
 	applyMVCCGCLockRecord(t, db, key, key, 10, 5, kvrpcpb.Mutation_Put)
 
 	worker, ok := storemvcc.NewMaintenanceWorker(storemvcc.MaintenanceWorkerConfig{
-		MVCCStore:            db,
-		LockResolverProposer: &testLockResolverProposer{db: db},
-		Interval:             time.Hour,
-		CurrentTs:            func() uint64 { return 20 },
-		ResolveLocks:         storemvcc.ResolveLocksOptions{BatchLocks: 1},
+		MVCCStore:    db,
+		LockResolver: &testLockResolver{db: db},
+		Interval:     time.Hour,
+		CurrentTs:    func() uint64 { return 20 },
+		ResolveLocks: storemvcc.ResolveLocksOptions{BatchLocks: 1},
 	})
 	require.True(t, ok)
 	require.NoError(t, worker.RunOnce(context.Background()))
@@ -267,12 +268,16 @@ func (p *blockingMaintenanceProposer) ProposeMVCCMaintenance(ctx context.Context
 	return 0, 0, 0, ctx.Err()
 }
 
-type failingLockResolverProposer struct {
+type failingLockResolver struct {
 	err error
 }
 
-func (p *failingLockResolverProposer) ProposeResolveLocks(context.Context, uint64, uint64, [][]byte) (uint64, error) {
+func (p *failingLockResolver) ResolveLocks(context.Context, uint64, uint64, [][]byte) (uint64, error) {
 	return 0, p.err
+}
+
+func (p *failingLockResolver) CheckTxnStatus(context.Context, []byte, uint64, uint64) (*kvrpcpb.CheckTxnStatusResponse, error) {
+	return &kvrpcpb.CheckTxnStatusResponse{CommitVersion: 301}, nil
 }
 
 type sequencedMaintenanceProposer struct {

--- a/raftstore/mvcc/worker_test.go
+++ b/raftstore/mvcc/worker_test.go
@@ -35,6 +35,7 @@ func TestMaintenanceWorkerRunOnceUsesReplicatedPaths(t *testing.T) {
 		Interval:            time.Hour,
 		SafePoint:           func() uint64 { return 100 },
 		CurrentTs:           func() uint64 { return 20 },
+		CurrentTime:         func() uint64 { return 20 },
 		Apply:               storemvcc.ApplyOptions{BatchEntries: 2},
 		ResolveLocks:        storemvcc.ResolveLocksOptions{BatchLocks: 1},
 		RunOrphanDefaults:   true,
@@ -72,6 +73,7 @@ func TestMaintenanceWorkerContinuesAfterResolveError(t *testing.T) {
 		Interval:            time.Hour,
 		SafePoint:           func() uint64 { return 100 },
 		CurrentTs:           func() uint64 { return 300 },
+		CurrentTime:         func() uint64 { return 300 },
 		Apply:               storemvcc.ApplyOptions{BatchEntries: 8},
 		ResolveLocks:        storemvcc.ResolveLocksOptions{BatchLocks: 1},
 	})
@@ -156,6 +158,7 @@ func TestMaintenanceWorkerAllowsLockResolutionOnly(t *testing.T) {
 		LockResolver: &testLockResolver{db: db},
 		Interval:     time.Hour,
 		CurrentTs:    func() uint64 { return 20 },
+		CurrentTime:  func() uint64 { return 20 },
 		ResolveLocks: storemvcc.ResolveLocksOptions{BatchLocks: 1},
 	})
 	require.True(t, ok)
@@ -276,7 +279,7 @@ func (p *failingLockResolver) ResolveLocks(context.Context, uint64, uint64, [][]
 	return 0, p.err
 }
 
-func (p *failingLockResolver) CheckTxnStatus(context.Context, []byte, uint64, uint64) (*kvrpcpb.CheckTxnStatusResponse, error) {
+func (p *failingLockResolver) CheckTxnStatus(context.Context, []byte, uint64, uint64, uint64) (*kvrpcpb.CheckTxnStatusResponse, error) {
 	return &kvrpcpb.CheckTxnStatusResponse{CommitVersion: 301}, nil
 }
 

--- a/raftstore/server/config.go
+++ b/raftstore/server/config.go
@@ -45,10 +45,11 @@ type MVCCMaintenanceConfig struct {
 	Interval time.Duration
 	Timeout  time.Duration
 
-	SafePoint func() uint64
-	CurrentTs func() uint64
-	Retention func() rootstate.SnapshotRetentionIndex
-	Mount     storemvcc.MountResolver
+	SafePoint   func() uint64
+	CurrentTs   func() uint64
+	CurrentTime func() uint64
+	Retention   func() rootstate.SnapshotRetentionIndex
+	Mount       storemvcc.MountResolver
 
 	Apply        storemvcc.ApplyOptions
 	ResolveLocks storemvcc.ResolveLocksOptions

--- a/raftstore/server/config.go
+++ b/raftstore/server/config.go
@@ -52,6 +52,7 @@ type MVCCMaintenanceConfig struct {
 
 	Apply        storemvcc.ApplyOptions
 	ResolveLocks storemvcc.ResolveLocksOptions
+	LockResolver storemvcc.LockResolver
 
 	RunOrphanDefaults bool
 	OrphanDefaults    storemvcc.OrphanDefaultOptions

--- a/raftstore/server/mvcc_maintenance.go
+++ b/raftstore/server/mvcc_maintenance.go
@@ -11,18 +11,18 @@ func newMVCCMaintenanceWorker(cfg MVCCMaintenanceConfig, mvccStore txnstore.Stor
 		return nil, false
 	}
 	return storemvcc.NewMaintenanceWorker(storemvcc.MaintenanceWorkerConfig{
-		MVCCStore:            mvccStore,
-		MaintenanceProposer:  raftStore,
-		LockResolverProposer: raftStore,
-		Interval:             cfg.Interval,
-		Timeout:              cfg.Timeout,
-		SafePoint:            cfg.SafePoint,
-		CurrentTs:            cfg.CurrentTs,
-		Retention:            cfg.Retention,
-		Mount:                cfg.Mount,
-		Apply:                cfg.Apply,
-		ResolveLocks:         cfg.ResolveLocks,
-		RunOrphanDefaults:    cfg.RunOrphanDefaults,
-		OrphanDefaults:       cfg.OrphanDefaults,
+		MVCCStore:           mvccStore,
+		MaintenanceProposer: raftStore,
+		LockResolver:        cfg.LockResolver,
+		Interval:            cfg.Interval,
+		Timeout:             cfg.Timeout,
+		SafePoint:           cfg.SafePoint,
+		CurrentTs:           cfg.CurrentTs,
+		Retention:           cfg.Retention,
+		Mount:               cfg.Mount,
+		Apply:               cfg.Apply,
+		ResolveLocks:        cfg.ResolveLocks,
+		RunOrphanDefaults:   cfg.RunOrphanDefaults,
+		OrphanDefaults:      cfg.OrphanDefaults,
 	})
 }

--- a/raftstore/server/mvcc_maintenance.go
+++ b/raftstore/server/mvcc_maintenance.go
@@ -18,6 +18,7 @@ func newMVCCMaintenanceWorker(cfg MVCCMaintenanceConfig, mvccStore txnstore.Stor
 		Timeout:             cfg.Timeout,
 		SafePoint:           cfg.SafePoint,
 		CurrentTs:           cfg.CurrentTs,
+		CurrentTime:         cfg.CurrentTime,
 		Retention:           cfg.Retention,
 		Mount:               cfg.Mount,
 		Apply:               cfg.Apply,

--- a/raftstore/store/command_ops.go
+++ b/raftstore/store/command_ops.go
@@ -382,6 +382,11 @@ func validateRequestKeys(meta localmeta.RegionMeta, req *raftcmdpb.RaftCmdReques
 			if len(key) > 0 && !keyInRange(meta, key) {
 				return keyNotInRegionError(meta, key), AdmissionReasonKeyNotInRegion
 			}
+		case raftcmdpb.CmdType_CMD_TXN_HEART_BEAT:
+			key := r.GetTxnHeartBeat().GetPrimaryKey()
+			if len(key) > 0 && !keyInRange(meta, key) {
+				return keyNotInRegionError(meta, key), AdmissionReasonKeyNotInRegion
+			}
 		case raftcmdpb.CmdType_CMD_MVCC_MAINTENANCE:
 			for _, entry := range r.GetMvccMaintenance().GetTombstones() {
 				if entry == nil {

--- a/raftstore/store/command_ops_test.go
+++ b/raftstore/store/command_ops_test.go
@@ -347,7 +347,7 @@ func TestStoreProposeMVCCMaintenanceRoutesAfterSplit(t *testing.T) {
 	require.NotZero(t, gotRight.Meta&entrykv.BitDelete)
 }
 
-func TestStoreProposeResolveLocks(t *testing.T) {
+func TestStoreResolveLocks(t *testing.T) {
 	db, localMeta := openStoreDB(t)
 	coord := newTestSchedulerSink()
 	st := NewStore(Config{Scheduler: coord, StoreID: 1, CommandApplier: newTestMVCCApplier(db)})
@@ -401,7 +401,7 @@ func TestStoreProposeResolveLocks(t *testing.T) {
 	require.Nil(t, resp.GetRegionError())
 	require.Empty(t, resp.GetResponses()[0].GetPrewrite().GetErrors())
 
-	resolved, err := st.ProposeResolveLocks(context.Background(), 20, 40, [][]byte{[]byte("resolve-key")})
+	resolved, err := st.ResolveLocks(context.Background(), 20, 40, [][]byte{[]byte("resolve-key")})
 	require.NoError(t, err)
 	require.Equal(t, uint64(1), resolved)
 
@@ -411,7 +411,7 @@ func TestStoreProposeResolveLocks(t *testing.T) {
 	require.Equal(t, []byte("resolve-value"), val)
 }
 
-func TestStoreProposeResolveLocksConvergesAfterPartialRegionFailure(t *testing.T) {
+func TestStoreResolveLocksConvergesAfterPartialRegionFailure(t *testing.T) {
 	db, localMeta := openStoreDB(t)
 	coord := newTestSchedulerSink()
 	st := NewStore(Config{Scheduler: coord, StoreID: 1, CommandApplier: newTestMVCCApplier(db)})
@@ -455,7 +455,7 @@ func TestStoreProposeResolveLocksConvergesAfterPartialRegionFailure(t *testing.T
 	applyTestLockRecord(t, db, []byte("b-lock-key"), 20, 5)
 	applyTestLockRecord(t, db, []byte("t-lock-key"), 20, 5)
 
-	resolved, err := st.ProposeResolveLocks(context.Background(), 20, 0, [][]byte{
+	resolved, err := st.ResolveLocks(context.Background(), 20, 0, [][]byte{
 		[]byte("b-lock-key"),
 		[]byte("t-lock-key"),
 	})
@@ -488,7 +488,7 @@ func TestStoreProposeResolveLocksConvergesAfterPartialRegionFailure(t *testing.T
 	t.Cleanup(func() { st.StopPeer(rightPeer.ID()) })
 	require.NoError(t, rightPeer.Campaign())
 
-	resolved, err = st.ProposeResolveLocks(context.Background(), 20, 0, [][]byte{
+	resolved, err = st.ResolveLocks(context.Background(), 20, 0, [][]byte{
 		[]byte("b-lock-key"),
 		[]byte("t-lock-key"),
 	})

--- a/raftstore/store/command_ops_test.go
+++ b/raftstore/store/command_ops_test.go
@@ -502,10 +502,11 @@ func TestStoreResolveLocksConvergesAfterPartialRegionFailure(t *testing.T) {
 func applyTestLockRecord(t *testing.T, db txnstore.Store, key []byte, startTs, ttl uint64) {
 	t.Helper()
 	lock := txnmvcc.EncodeLock(txnmvcc.Lock{
-		Primary: key,
-		Ts:      startTs,
-		TTL:     ttl,
-		Kind:    kvrpcpb.Mutation_Put,
+		Primary:   key,
+		Ts:        startTs,
+		StartTime: startTs,
+		TTL:       ttl,
+		Kind:      kvrpcpb.Mutation_Put,
 	})
 	entry := entrykv.NewInternalEntry(entrykv.CFLock, key, entrykv.MaxVersion, lock, 0, 0)
 	defer entry.DecrRef()

--- a/raftstore/store/command_ops_test.go
+++ b/raftstore/store/command_ops_test.go
@@ -1012,6 +1012,14 @@ func TestValidateRequestKeysAcrossCommandKinds(t *testing.T) {
 			kind: func(err *errorpb.RegionError) any { return err.GetKeyNotInRegion() },
 		},
 		{
+			name: "txn heartbeat out of range",
+			req: &raftcmdpb.RaftCmdRequest{Requests: []*raftcmdpb.Request{{
+				CmdType: raftcmdpb.CmdType_CMD_TXN_HEART_BEAT,
+				Cmd:     &raftcmdpb.Request_TxnHeartBeat{TxnHeartBeat: &kvrpcpb.TxnHeartBeatRequest{PrimaryKey: []byte("a")}},
+			}}},
+			kind: func(err *errorpb.RegionError) any { return err.GetKeyNotInRegion() },
+		},
+		{
 			name: "mvcc maintenance out of range",
 			req: &raftcmdpb.RaftCmdRequest{Requests: []*raftcmdpb.Request{{
 				CmdType: raftcmdpb.CmdType_CMD_MVCC_MAINTENANCE,

--- a/raftstore/store/errors.go
+++ b/raftstore/store/errors.go
@@ -43,11 +43,112 @@ var (
 	errInstallRegionSSTRequiresPeerBuild      = errors.New("raftstore: install region sst snapshot requires peer builder")
 	errFailpointAfterSnapshotApply            = errors.New("raftstore: failpoint after snapshot apply before publish")
 	errRouterRegisterNilPeer                  = errors.New("raftstore: router cannot register nil peer")
+	errResolveLocksStartVersionRequired       = errors.New("raftstore: resolve locks start version is required")
+	errEmptyResolveLockKey                    = errors.New("raftstore: empty resolve-lock key")
+	errCheckTxnStatusPrimaryRequired          = errors.New("raftstore: primary key is required for check txn status")
+	errTxnHeartBeatPrimaryRequired            = errors.New("raftstore: primary key is required for txn heartbeat")
 )
 
 func IsNilStore(err error) bool     { return errors.Is(err, errNilStore) }
 func IsZeroRegionID(err error) bool { return errors.Is(err, errZeroRegionID) }
 func IsZeroPeerID(err error) bool   { return errors.Is(err, errZeroPeerID) }
+
+// RegionRoutingError records stable region routing failures for store-local
+// transaction maintenance commands.
+type RegionRoutingError struct {
+	Operation string
+	RegionID  uint64
+	Key       []byte
+	Detail    string
+	Err       error
+}
+
+func (e *RegionRoutingError) Error() string {
+	if e == nil {
+		return "raftstore: region routing error"
+	}
+	msg := "raftstore: region routing error"
+	if e.Operation != "" {
+		msg += " during " + e.Operation
+	}
+	if e.RegionID != 0 {
+		msg += fmt.Sprintf(" for region %d", e.RegionID)
+	}
+	if len(e.Key) > 0 {
+		msg += fmt.Sprintf(" key %x", e.Key)
+	}
+	if e.Detail != "" {
+		msg += ": " + e.Detail
+	}
+	if e.Err != nil {
+		msg += ": " + e.Err.Error()
+	}
+	return msg
+}
+
+func (e *RegionRoutingError) Unwrap() error {
+	if e == nil {
+		return nil
+	}
+	return e.Err
+}
+
+func IsRegionRoutingError(err error) bool {
+	var target *RegionRoutingError
+	return errors.As(err, &target)
+}
+
+// ProtocolError records invalid command responses and transaction protocol
+// violations that should not be retried as ordinary storage errors.
+type ProtocolError struct {
+	Operation string
+	Detail    string
+}
+
+func (e *ProtocolError) Error() string {
+	if e == nil {
+		return "raftstore: protocol error"
+	}
+	if e.Operation == "" {
+		return "raftstore: protocol error: " + e.Detail
+	}
+	return "raftstore: " + e.Operation + " protocol error: " + e.Detail
+}
+
+func IsProtocolError(err error) bool {
+	var target *ProtocolError
+	return errors.As(err, &target)
+}
+
+func errNoRegionForKey(operation string, key []byte) error {
+	return &RegionRoutingError{
+		Operation: operation,
+		Key:       append([]byte(nil), key...),
+		Detail:    "no region covers key",
+	}
+}
+
+func errRegionCommandFailed(operation string, regionID uint64, err any) error {
+	return &RegionRoutingError{
+		Operation: operation,
+		RegionID:  regionID,
+		Detail:    fmt.Sprintf("region command failed: %v", err),
+	}
+}
+
+func errInvalidRegionCommandResponse(operation string, regionID uint64) error {
+	return &ProtocolError{
+		Operation: operation,
+		Detail:    fmt.Sprintf("region %d returned invalid response", regionID),
+	}
+}
+
+func errRegionKeyError(operation string, regionID uint64, err any) error {
+	return &ProtocolError{
+		Operation: operation,
+		Detail:    fmt.Sprintf("region %d returned key error: %v", regionID, err),
+	}
+}
 
 func errPeerNotFound(id uint64) error { return fmt.Errorf("raftstore: peer %d not found", id) }
 func errPeerAlreadyRegistered(id uint64) error {

--- a/raftstore/store/errors_test.go
+++ b/raftstore/store/errors_test.go
@@ -1,0 +1,29 @@
+package store
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestStoreTypedErrors(t *testing.T) {
+	routing := &RegionRoutingError{
+		Operation: "txn heartbeat",
+		RegionID:  7,
+		Key:       []byte("primary"),
+		Detail:    "no region covers key",
+		Err:       errors.New("resolver failed"),
+	}
+	require.Contains(t, routing.Error(), "region routing error")
+	require.Contains(t, routing.Error(), "txn heartbeat")
+	require.Contains(t, routing.Error(), "no region covers key")
+	require.EqualError(t, routing.Unwrap(), "resolver failed")
+	require.True(t, IsRegionRoutingError(routing))
+	require.False(t, IsRegionRoutingError(errors.New("other")))
+
+	protocol := &ProtocolError{Operation: "resolve locks", Detail: "invalid response"}
+	require.Contains(t, protocol.Error(), "resolve locks protocol error")
+	require.True(t, IsProtocolError(protocol))
+	require.False(t, IsProtocolError(errors.New("other")))
+}

--- a/raftstore/store/lock_resolution.go
+++ b/raftstore/store/lock_resolution.go
@@ -3,7 +3,6 @@ package store
 import (
 	"context"
 	"fmt"
-	"time"
 
 	kvrpcpb "github.com/feichai0017/NoKV/pb/kv"
 	metapb "github.com/feichai0017/NoKV/pb/meta"
@@ -57,7 +56,7 @@ func (s *Store) ResolveLocks(ctx context.Context, startVersion, commitVersion ui
 
 // CheckTxnStatus routes the primary-key status check through the primary
 // region's normal raft apply path.
-func (s *Store) CheckTxnStatus(ctx context.Context, primary []byte, lockTs, currentTs uint64) (*kvrpcpb.CheckTxnStatusResponse, error) {
+func (s *Store) CheckTxnStatus(ctx context.Context, primary []byte, lockTs, currentTs, currentTime uint64) (*kvrpcpb.CheckTxnStatusResponse, error) {
 	if len(primary) == 0 {
 		return nil, fmt.Errorf("raftstore: primary key is required for check txn status")
 	}
@@ -81,7 +80,7 @@ func (s *Store) CheckTxnStatus(ctx context.Context, primary []byte, lockTs, curr
 				CurrentTs:          currentTs,
 				CallerStartTs:      currentTs,
 				RollbackIfNotExist: true,
-				CurrentTime:        uint64(time.Now().Unix()),
+				CurrentTime:        currentTime,
 			}},
 		}},
 	})

--- a/raftstore/store/lock_resolution.go
+++ b/raftstore/store/lock_resolution.go
@@ -2,13 +2,20 @@ package store
 
 import (
 	"context"
-	"fmt"
+	"time"
 
 	kvrpcpb "github.com/feichai0017/NoKV/pb/kv"
 	metapb "github.com/feichai0017/NoKV/pb/meta"
 	raftcmdpb "github.com/feichai0017/NoKV/pb/raft"
 	localmeta "github.com/feichai0017/NoKV/raftstore/localmeta"
 )
+
+func storePhysicalTimeMillis(currentTime uint64) uint64 {
+	if currentTime != 0 {
+		return currentTime
+	}
+	return uint64(time.Now().UnixMilli())
+}
 
 // ResolveLocks submits a semantic Percolator ResolveLock command through raft.
 // It is used by cluster-mode MVCC maintenance; direct lock tombstones would
@@ -19,7 +26,7 @@ import (
 // converge through idempotent lock resolution.
 func (s *Store) ResolveLocks(ctx context.Context, startVersion, commitVersion uint64, keys [][]byte) (uint64, error) {
 	if startVersion == 0 {
-		return 0, fmt.Errorf("raftstore: resolve locks start version is required")
+		return 0, errResolveLocksStartVersionRequired
 	}
 	if len(keys) == 0 {
 		return 0, nil
@@ -28,11 +35,11 @@ func (s *Store) ResolveLocks(ctx context.Context, startVersion, commitVersion ui
 	regionIndex := make(map[uint64]int)
 	for _, key := range keys {
 		if len(key) == 0 {
-			return 0, fmt.Errorf("raftstore: empty resolve-lock key")
+			return 0, errEmptyResolveLockKey
 		}
 		meta, ok := s.RegionMetaByKey(key)
 		if !ok {
-			return 0, fmt.Errorf("raftstore: no region for resolve-lock key %x", key)
+			return 0, errNoRegionForKey("resolve locks", key)
 		}
 		idx, ok := regionIndex[meta.ID]
 		if !ok {
@@ -58,11 +65,11 @@ func (s *Store) ResolveLocks(ctx context.Context, startVersion, commitVersion ui
 // region's normal raft apply path.
 func (s *Store) CheckTxnStatus(ctx context.Context, primary []byte, lockTs, currentTs, currentTime uint64) (*kvrpcpb.CheckTxnStatusResponse, error) {
 	if len(primary) == 0 {
-		return nil, fmt.Errorf("raftstore: primary key is required for check txn status")
+		return nil, errCheckTxnStatusPrimaryRequired
 	}
 	meta, ok := s.RegionMetaByKey(primary)
 	if !ok {
-		return nil, fmt.Errorf("raftstore: no region for check txn status primary %x", primary)
+		return nil, errNoRegionForKey("check txn status", primary)
 	}
 	resp, err := s.ProposeCommand(ctx, &raftcmdpb.RaftCmdRequest{
 		Header: &raftcmdpb.CmdHeader{
@@ -80,7 +87,7 @@ func (s *Store) CheckTxnStatus(ctx context.Context, primary []byte, lockTs, curr
 				CurrentTs:          currentTs,
 				CallerStartTs:      currentTs,
 				RollbackIfNotExist: true,
-				CurrentTime:        currentTime,
+				CurrentTime:        storePhysicalTimeMillis(currentTime),
 			}},
 		}},
 	})
@@ -88,13 +95,54 @@ func (s *Store) CheckTxnStatus(ctx context.Context, primary []byte, lockTs, curr
 		return nil, err
 	}
 	if regionErr := resp.GetRegionError(); regionErr != nil {
-		return nil, fmt.Errorf("raftstore: check txn status region %d failed: %v", meta.ID, regionErr)
+		return nil, errRegionCommandFailed("check txn status", meta.ID, regionErr)
 	}
 	responses := resp.GetResponses()
 	if len(responses) != 1 || responses[0].GetCheckTxnStatus() == nil {
-		return nil, fmt.Errorf("raftstore: check txn status region %d returned invalid response", meta.ID)
+		return nil, errInvalidRegionCommandResponse("check txn status", meta.ID)
 	}
 	return responses[0].GetCheckTxnStatus(), nil
+}
+
+// TxnHeartBeat extends a live transaction's primary-lock TTL through the
+// primary region's normal raft apply path.
+func (s *Store) TxnHeartBeat(ctx context.Context, primary []byte, startVersion, ttlExtension, currentTime uint64) (*kvrpcpb.TxnHeartBeatResponse, error) {
+	if len(primary) == 0 {
+		return nil, errTxnHeartBeatPrimaryRequired
+	}
+	meta, ok := s.RegionMetaByKey(primary)
+	if !ok {
+		return nil, errNoRegionForKey("txn heartbeat", primary)
+	}
+	resp, err := s.ProposeCommand(ctx, &raftcmdpb.RaftCmdRequest{
+		Header: &raftcmdpb.CmdHeader{
+			RegionId: meta.ID,
+			RegionEpoch: &metapb.RegionEpoch{
+				Version:     meta.Epoch.Version,
+				ConfVersion: meta.Epoch.ConfVersion,
+			},
+		},
+		Requests: []*raftcmdpb.Request{{
+			CmdType: raftcmdpb.CmdType_CMD_TXN_HEART_BEAT,
+			Cmd: &raftcmdpb.Request_TxnHeartBeat{TxnHeartBeat: &kvrpcpb.TxnHeartBeatRequest{
+				PrimaryKey:   append([]byte(nil), primary...),
+				StartVersion: startVersion,
+				TtlExtension: ttlExtension,
+				CurrentTime:  storePhysicalTimeMillis(currentTime),
+			}},
+		}},
+	})
+	if err != nil {
+		return nil, err
+	}
+	if regionErr := resp.GetRegionError(); regionErr != nil {
+		return nil, errRegionCommandFailed("txn heartbeat", meta.ID, regionErr)
+	}
+	responses := resp.GetResponses()
+	if len(responses) != 1 || responses[0].GetTxnHeartBeat() == nil {
+		return nil, errInvalidRegionCommandResponse("txn heartbeat", meta.ID)
+	}
+	return responses[0].GetTxnHeartBeat(), nil
 }
 
 type resolveLockRegionBatch struct {
@@ -124,15 +172,15 @@ func (s *Store) proposeResolveLockBatch(ctx context.Context, startVersion, commi
 		return 0, err
 	}
 	if regionErr := resp.GetRegionError(); regionErr != nil {
-		return 0, fmt.Errorf("raftstore: resolve locks region %d failed: %v", batch.meta.ID, regionErr)
+		return 0, errRegionCommandFailed("resolve locks", batch.meta.ID, regionErr)
 	}
 	responses := resp.GetResponses()
 	if len(responses) != 1 || responses[0].GetResolveLock() == nil {
-		return 0, fmt.Errorf("raftstore: resolve locks region %d returned invalid response", batch.meta.ID)
+		return 0, errInvalidRegionCommandResponse("resolve locks", batch.meta.ID)
 	}
 	out := responses[0].GetResolveLock()
 	if keyErr := out.GetError(); keyErr != nil {
-		return 0, fmt.Errorf("raftstore: resolve locks region %d key error: %v", batch.meta.ID, keyErr)
+		return 0, errRegionKeyError("resolve locks", batch.meta.ID, keyErr)
 	}
 	return out.GetResolvedLocks(), nil
 }

--- a/raftstore/store/lock_resolution.go
+++ b/raftstore/store/lock_resolution.go
@@ -3,6 +3,7 @@ package store
 import (
 	"context"
 	"fmt"
+	"time"
 
 	kvrpcpb "github.com/feichai0017/NoKV/pb/kv"
 	metapb "github.com/feichai0017/NoKV/pb/meta"
@@ -10,14 +11,14 @@ import (
 	localmeta "github.com/feichai0017/NoKV/raftstore/localmeta"
 )
 
-// ProposeResolveLocks submits a semantic Percolator ResolveLock command through
-// raft. It is used by cluster-mode MVCC maintenance; direct lock tombstones
-// would bypass apply observers and WatchSubtree notifications.
+// ResolveLocks submits a semantic Percolator ResolveLock command through raft.
+// It is used by cluster-mode MVCC maintenance; direct lock tombstones would
+// bypass apply observers and WatchSubtree notifications.
 //
 // The operation is atomic per region batch, not across regions. If one region
 // succeeds and a later region fails, the next maintenance pass must rescan and
 // converge through idempotent lock resolution.
-func (s *Store) ProposeResolveLocks(ctx context.Context, startVersion, commitVersion uint64, keys [][]byte) (uint64, error) {
+func (s *Store) ResolveLocks(ctx context.Context, startVersion, commitVersion uint64, keys [][]byte) (uint64, error) {
 	if startVersion == 0 {
 		return 0, fmt.Errorf("raftstore: resolve locks start version is required")
 	}
@@ -52,6 +53,49 @@ func (s *Store) ProposeResolveLocks(ctx context.Context, startVersion, commitVer
 		resolved += count
 	}
 	return resolved, nil
+}
+
+// CheckTxnStatus routes the primary-key status check through the primary
+// region's normal raft apply path.
+func (s *Store) CheckTxnStatus(ctx context.Context, primary []byte, lockTs, currentTs uint64) (*kvrpcpb.CheckTxnStatusResponse, error) {
+	if len(primary) == 0 {
+		return nil, fmt.Errorf("raftstore: primary key is required for check txn status")
+	}
+	meta, ok := s.RegionMetaByKey(primary)
+	if !ok {
+		return nil, fmt.Errorf("raftstore: no region for check txn status primary %x", primary)
+	}
+	resp, err := s.ProposeCommand(ctx, &raftcmdpb.RaftCmdRequest{
+		Header: &raftcmdpb.CmdHeader{
+			RegionId: meta.ID,
+			RegionEpoch: &metapb.RegionEpoch{
+				Version:     meta.Epoch.Version,
+				ConfVersion: meta.Epoch.ConfVersion,
+			},
+		},
+		Requests: []*raftcmdpb.Request{{
+			CmdType: raftcmdpb.CmdType_CMD_CHECK_TXN_STATUS,
+			Cmd: &raftcmdpb.Request_CheckTxnStatus{CheckTxnStatus: &kvrpcpb.CheckTxnStatusRequest{
+				PrimaryKey:         append([]byte(nil), primary...),
+				LockTs:             lockTs,
+				CurrentTs:          currentTs,
+				CallerStartTs:      currentTs,
+				RollbackIfNotExist: true,
+				CurrentTime:        uint64(time.Now().Unix()),
+			}},
+		}},
+	})
+	if err != nil {
+		return nil, err
+	}
+	if regionErr := resp.GetRegionError(); regionErr != nil {
+		return nil, fmt.Errorf("raftstore: check txn status region %d failed: %v", meta.ID, regionErr)
+	}
+	responses := resp.GetResponses()
+	if len(responses) != 1 || responses[0].GetCheckTxnStatus() == nil {
+		return nil, fmt.Errorf("raftstore: check txn status region %d returned invalid response", meta.ID)
+	}
+	return responses[0].GetCheckTxnStatus(), nil
 }
 
 type resolveLockRegionBatch struct {

--- a/raftstore/store/lock_resolution_test.go
+++ b/raftstore/store/lock_resolution_test.go
@@ -56,3 +56,43 @@ func TestStoreCheckTxnStatusRoutesThroughPrimaryRegion(t *testing.T) {
 	require.NoError(t, err)
 	require.Nil(t, lock)
 }
+
+func TestStoreTxnHeartBeatRoutesThroughPrimaryRegion(t *testing.T) {
+	db, localMeta := openStoreDB(t)
+	st := NewStore(Config{Scheduler: newTestSchedulerSink(), StoreID: 1, CommandApplier: newTestMVCCApplier(db)})
+	t.Cleanup(func() { st.Close() })
+
+	region := &localmeta.RegionMeta{
+		ID:       714,
+		StartKey: []byte("a"),
+		EndKey:   []byte("z"),
+		Epoch:    metaregion.Epoch{Version: 1, ConfVersion: 1},
+		Peers:    []metaregion.Peer{{StoreID: 1, PeerID: 72}},
+	}
+	cfg := &peer.Config{
+		RaftConfig: myraft.Config{
+			ID:              72,
+			ElectionTick:    5,
+			HeartbeatTick:   1,
+			MaxSizePerMsg:   1 << 20,
+			MaxInflightMsgs: 256,
+			PreVote:         true,
+		},
+		Transport: noopTransport{},
+		Storage:   mustPeerStorage(t, db, localMeta, region.ID),
+		GroupID:   region.ID,
+		Region:    region,
+	}
+	p, err := st.StartPeer(cfg, []myraft.Peer{{ID: 72}})
+	require.NoError(t, err)
+	t.Cleanup(func() { st.StopPeer(p.ID()) })
+	require.NoError(t, p.Campaign())
+
+	applyTestLockRecord(t, db, []byte("primary-key"), 20, 100)
+
+	resp, err := st.TxnHeartBeat(context.Background(), []byte("primary-key"), 20, 200, 30)
+	require.NoError(t, err)
+	require.Equal(t, kvrpcpb.TxnHeartBeatAction_TxnHeartBeatTTLExtended, resp.GetAction())
+	require.Equal(t, uint64(210), resp.GetLockTtl())
+	require.Nil(t, resp.GetError())
+}

--- a/raftstore/store/lock_resolution_test.go
+++ b/raftstore/store/lock_resolution_test.go
@@ -1,0 +1,58 @@
+package store
+
+import (
+	"context"
+	"testing"
+
+	metaregion "github.com/feichai0017/NoKV/meta/region"
+	kvrpcpb "github.com/feichai0017/NoKV/pb/kv"
+	"github.com/feichai0017/NoKV/percolator"
+	myraft "github.com/feichai0017/NoKV/raft"
+	localmeta "github.com/feichai0017/NoKV/raftstore/localmeta"
+	"github.com/feichai0017/NoKV/raftstore/peer"
+	"github.com/stretchr/testify/require"
+)
+
+func TestStoreCheckTxnStatusRoutesThroughPrimaryRegion(t *testing.T) {
+	db, localMeta := openStoreDB(t)
+	st := NewStore(Config{Scheduler: newTestSchedulerSink(), StoreID: 1, CommandApplier: newTestMVCCApplier(db)})
+	t.Cleanup(func() { st.Close() })
+
+	region := &localmeta.RegionMeta{
+		ID:       713,
+		StartKey: []byte("a"),
+		EndKey:   []byte("z"),
+		Epoch:    metaregion.Epoch{Version: 1, ConfVersion: 1},
+		Peers:    []metaregion.Peer{{StoreID: 1, PeerID: 71}},
+	}
+	cfg := &peer.Config{
+		RaftConfig: myraft.Config{
+			ID:              71,
+			ElectionTick:    5,
+			HeartbeatTick:   1,
+			MaxSizePerMsg:   1 << 20,
+			MaxInflightMsgs: 256,
+			PreVote:         true,
+		},
+		Transport: noopTransport{},
+		Storage:   mustPeerStorage(t, db, localMeta, region.ID),
+		GroupID:   region.ID,
+		Region:    region,
+	}
+	p, err := st.StartPeer(cfg, []myraft.Peer{{ID: 71}})
+	require.NoError(t, err)
+	t.Cleanup(func() { st.StopPeer(p.ID()) })
+	require.NoError(t, p.Campaign())
+
+	applyTestLockRecord(t, db, []byte("primary-key"), 20, 5)
+
+	resp, err := st.CheckTxnStatus(context.Background(), []byte("primary-key"), 20, 30)
+	require.NoError(t, err)
+	require.Equal(t, kvrpcpb.CheckTxnStatusAction_CheckTxnStatusTTLExpireRollback, resp.GetAction())
+	require.Nil(t, resp.GetError())
+
+	reader := percolator.NewReader(db)
+	lock, err := reader.GetLock([]byte("primary-key"))
+	require.NoError(t, err)
+	require.Nil(t, lock)
+}

--- a/raftstore/store/lock_resolution_test.go
+++ b/raftstore/store/lock_resolution_test.go
@@ -46,7 +46,7 @@ func TestStoreCheckTxnStatusRoutesThroughPrimaryRegion(t *testing.T) {
 
 	applyTestLockRecord(t, db, []byte("primary-key"), 20, 5)
 
-	resp, err := st.CheckTxnStatus(context.Background(), []byte("primary-key"), 20, 30)
+	resp, err := st.CheckTxnStatus(context.Background(), []byte("primary-key"), 20, 30, 30)
 	require.NoError(t, err)
 	require.Equal(t, kvrpcpb.CheckTxnStatusAction_CheckTxnStatusTTLExpireRollback, resp.GetAction())
 	require.Nil(t, resp.GetError())

--- a/raftstore/store/store_test.go
+++ b/raftstore/store/store_test.go
@@ -819,6 +819,9 @@ func newTestMVCCApplier(db txnstore.Store) func(*raftcmdpb.RaftCmdRequest) (*raf
 			case raftcmdpb.CmdType_CMD_CHECK_TXN_STATUS:
 				result := percolator.CheckTxnStatus(db, latches, r.GetCheckTxnStatus())
 				resp.Responses = append(resp.Responses, &raftcmdpb.Response{Cmd: &raftcmdpb.Response_CheckTxnStatus{CheckTxnStatus: result}})
+			case raftcmdpb.CmdType_CMD_TXN_HEART_BEAT:
+				result := percolator.TxnHeartBeat(db, latches, r.GetTxnHeartBeat())
+				resp.Responses = append(resp.Responses, &raftcmdpb.Response{Cmd: &raftcmdpb.Response_TxnHeartBeat{TxnHeartBeat: result}})
 			case raftcmdpb.CmdType_CMD_MVCC_MAINTENANCE:
 				count, keyErr, err := applyTestMVCCMaintenance(db, r.GetMvccMaintenance())
 				if err != nil {

--- a/raftstore/store/store_test.go
+++ b/raftstore/store/store_test.go
@@ -816,6 +816,9 @@ func newTestMVCCApplier(db txnstore.Store) func(*raftcmdpb.RaftCmdRequest) (*raf
 					Error:         err,
 					ResolvedLocks: count,
 				}}})
+			case raftcmdpb.CmdType_CMD_CHECK_TXN_STATUS:
+				result := percolator.CheckTxnStatus(db, latches, r.GetCheckTxnStatus())
+				resp.Responses = append(resp.Responses, &raftcmdpb.Response{Cmd: &raftcmdpb.Response_CheckTxnStatus{CheckTxnStatus: result}})
 			case raftcmdpb.CmdType_CMD_MVCC_MAINTENANCE:
 				count, keyErr, err := applyTestMVCCMaintenance(db, r.GetMvccMaintenance())
 				if err != nil {


### PR DESCRIPTION
## Summary

- harden Percolator transaction resolution across scan/read locks, commit-ts-expired retry propagation, and primary-authority lock resolution
- switch lock TTL expiry to physical time while keeping the destructive v1 lock codec format before production compatibility constraints apply
- add `TxnHeartBeat` through proto, raft command apply, kv service, store routing, and client APIs so long-running transactions can extend primary-lock TTL
- centralize transaction-path errors in package-local `errors.go` files and add typed client/store errors for retry exhaustion, protocol violations, and region routing failures
- expand crash-window and idempotency tests for late rollback after commit, primary committed/secondary unresolved, heartbeat expiry fencing, and route/service paths

## Tests

- `git diff --check`
- `go test ./percolator ./percolator/mvcc ./raftstore/client ./raftstore/kv ./raftstore/store ./raftstore/mvcc`
- `go test ./...`
