### PR TITLE
test: add fsmeta contract correctness smoke

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -43,5 +43,8 @@ jobs:
     - name: Build
       run: make build
 
+    - name: Correctness smoke
+      run: make test-correctness-smoke
+
     - name: Test
       run: make test

--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,13 @@
 # NoKV Makefile
 # Provides standardized commands for development workflow
 
-.PHONY: help build test test-short test-race test-coverage lint fmt clean docker-up docker-dev-up docker-down bench install-tools
+.PHONY: help build test test-short test-race test-coverage test-contract-smoke test-correctness-smoke lint fmt clean docker-up docker-dev-up docker-down bench install-tools
 .PHONY: proto proto-check proto-breaking-check
 
 GOLANGCI_LINT_VERSION ?= v2.9.0
 BUF_VERSION ?= 1.66.0
 PROJECT_GO_VERSION ?= 1.26.2
+GO_TEST_P ?= 1
 
 # Default target
 help:
@@ -17,6 +18,8 @@ help:
 	@echo "  make test-short         - Run tests in short mode"
 	@echo "  make test-race          - Run tests with race detector"
 	@echo "  make test-coverage      - Run tests with coverage report"
+	@echo "  make test-contract-smoke - Run seeded fsmeta contract model smoke tests"
+	@echo "  make test-correctness-smoke - Run distributed correctness smoke tests"
 	@echo "  make lint               - Run golangci-lint (requires installation)"
 	@echo "  make fmt                - Run go fix, format code with gofmt, and tidy modules"
 	@echo "  make proto              - Format .proto files and regenerate protobuf Go code"
@@ -42,24 +45,34 @@ build:
 # Run all tests
 test:
 	@echo "Running all tests..."
-	go test -v ./...
+	go test -p $(GO_TEST_P) -v ./...
 
 # Run tests in short mode (faster, skips some long-running tests)
 test-short:
 	@echo "Running tests in short mode..."
-	go test -short -v ./...
+	go test -p $(GO_TEST_P) -short -v ./...
 
 # Run tests with race detector
 test-race:
 	@echo "Running tests with race detector..."
-	go test -race -v ./...
+	go test -p $(GO_TEST_P) -race -v ./...
 
 # Run tests with coverage
 test-coverage:
 	@echo "Running tests with coverage..."
-	go test -v -coverprofile=coverage.out -covermode=atomic $$(go list ./... | grep -v '/integration$$')
+	go test -p $(GO_TEST_P) -v -coverprofile=coverage.out -covermode=atomic $$(go list ./... | grep -v '/integration$$')
 	@echo "✓ Coverage report generated: coverage.out"
 	@echo "  View with: go tool cover -html=coverage.out"
+
+# Run seeded contract tests against the fsmeta executor model.
+test-contract-smoke:
+	@echo "Running fsmeta contract smoke tests..."
+	NOKV_CONTRACT_SEEDS=$${NOKV_CONTRACT_SEEDS:-64} NOKV_CONTRACT_STEPS=$${NOKV_CONTRACT_STEPS:-120} go test ./fsmeta/contract -run TestFSMetaExecutorModelContract -count=1 -v
+
+# Run the highest-signal distributed correctness suites before the full package sweep.
+test-correctness-smoke: test-contract-smoke
+	@echo "Running distributed correctness smoke tests..."
+	go test -p $(GO_TEST_P) ./percolator/... ./raftstore/client ./raftstore/mvcc ./raftstore/store ./raftstore/integration ./coordinator/integration ./meta/root/integration -count=1
 
 # Run linter (requires golangci-lint to be installed)
 lint:

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -7,8 +7,11 @@ This document inventories NoKV's automated coverage and provides guidance for ex
 ## 1. Quick Commands
 
 ```bash
-# All unit + integration tests (uses local module caches)
-GOCACHE=$PWD/.gocache GOMODCACHE=$PWD/.gomodcache go test ./...
+# All unit + integration tests, matching CI's package-serial default
+make test
+
+# Same full sweep with local module caches
+GOCACHE=$PWD/.gocache GOMODCACHE=$PWD/.gomodcache go test -p 1 ./...
 
 # Focused distributed transaction suite
 go test ./percolator/... ./raftstore/client/... -run 'Test.*(Commit|Prewrite|TwoPhaseCommit)'
@@ -18,6 +21,12 @@ go test ./raftstore/integration -count=1
 
 # Core chaos gate for GC + raftstore + fsmeta runtime stability
 go test ./raftstore/mvcc ./raftstore/store ./raftstore/server ./raftstore/integration ./fsmeta/exec ./fsmeta/integration -count=1
+
+# Seeded fsmeta contract/model smoke
+make test-contract-smoke
+
+# Curated distributed correctness smoke used by CI before the full sweep
+make test-correctness-smoke
 
 # Crash recovery scenarios
 RECOVERY_TRACE_METRICS=1 \
@@ -69,6 +78,7 @@ NOKV_RUN_BENCHMARKS=1 YCSB_RECORDS=10000 YCSB_OPS=50000 YCSB_WARM_OPS=0 \
 | LSM / Flush / Compaction | `engine/lsm/lsm_test.go`, `engine/lsm/picker_test.go`, `engine/lsm/planner_test.go`, `engine/lsm/compaction_test.go`, `engine/lsm/flush_runtime_test.go` | Memtable correctness, iterator merging, flush pipeline metrics, compaction scheduling. | Extend backpressure assertions and workload-shape coverage. |
 | Manifest | `engine/manifest/manager_test.go`, `engine/lsm/manifest_test.go` | CURRENT swap safety, rewrite crash handling, SST metadata persistence. | Simulate partial edit corruption, column family extensions. |
 | Percolator / Distributed Txn | `percolator/*_test.go`, `raftstore/client/client_test.go`, `stats_test.go` | Prewrite/Commit/ResolveLock flows, 2PC retries, timestamp-driven MVCC behaviour, metrics accounting. | Mixed multi-region fuzzing with lock TTL and leader churn. |
+| FS Metadata Contract | `fsmeta/contract/*_test.go`, `fsmeta/exec/runner_test.go` | Seeded model-based coverage for create/update/lookup/readdir/snapshot/rename/link/unlink/session expiry against the executor API. | Extend the same contract harness to a real raftstore-backed runner and fault-injected retry schedule. |
 | DB Integration | `db_test.go`, `db_bench_test.go` | End-to-end writes, recovery, and throttle behaviour. | Combine compaction stress and multi-DB interference. |
 | CLI & Stats | `cmd/nokv/main_test.go`, `stats_test.go` | Golden JSON output, stats snapshot correctness, hot key ranking. | CLI error handling, expvar HTTP integration tests. |
 | Scripts & Tooling | `cmd/nokv-config/main_test.go`, `cmd/nokv/serve_test.go` | `nokv-config` JSON/simple formats, catalog bootstrap CLI, serve bootstrap behavior. | Add direct shell-script golden tests (currently not present) and failure-path diagnostics for `cluster.sh`. |
@@ -114,6 +124,7 @@ NOKV_RUN_BENCHMARKS=1 YCSB_RECORDS=10000 YCSB_OPS=50000 YCSB_WARM_OPS=0 \
 - **Node-local integration tests**: store/admin tests verify snapshot install, membership application, and region runtime publication without booting a full cluster.
 - **Multi-node deterministic data-plane integration tests**: `raftstore/integration` uses `raftstore/testcluster` to boot real stores, wire transports, and drive migration/member flows against live runtimes.
 - **Multi-node deterministic control-plane integration tests**: `coordinator/integration/*_test.go` uses `coordinator/testcluster` to boot `3 coordinator + replicated meta`, exercise rooted watch/reload propagation, follower write rejection, allocator-fence/remove-region propagation, and control-plane read staleness without mixing those cases into store/data-plane tests.
+- **Model/contract tests**: `fsmeta/contract` generates deterministic operation scripts and compares the fsmeta executor against a reference model before the suite reaches raftstore/coordinator/meta fault matrices.
 - **Restart and recovery suites**: `raftstore/integration/restart_recovery_test.go` covers restarted followers, removed-peer dehost persistence, and leader restart with subsequent membership changes.
 - **Control-plane degradation and publish-boundary tests**: `raftstore/integration/coordinator_degraded_test.go` and `raftstore/integration/snapshot_interruption_test.go` cover live Coordinator outage after startup and failpoint-driven snapshot interruption before peer publication.
 
@@ -159,6 +170,7 @@ without manual timing assumptions or known flaky behaviour.
 | fsmeta watch | slow subscriber, expired cursor, reconnect/reconcile | watch replay is bounded; expired cursors force full-state reconcile instead of pretending exactly-once delivery | `fsmeta/exec/watch/router_test.go`, `fsmeta/client/reconcile_test.go`, `fsmeta/integration/e2e_test.go` | Covered |
 | fsmeta snapshot retention | SnapshotSubtree publish/retire, read-version use, MVCC retention floor | active snapshot epochs retain required MVCC history until explicit retire | `fsmeta/exec/runner_test.go`, `fsmeta/server/service_test.go`, `fsmeta/integration/e2e_test.go`, `raftstore/mvcc/policy_test.go` | Covered |
 | fsmeta session lifecycle | writer crash / heartbeat expiry / directory rejection / cleaner errors | stale writer sessions are expired by server time; directories cannot take file writer leases | `fsmeta/exec/runner_test.go`, `fsmeta/exec/session_cleaner_test.go` | Covered |
+| fsmeta operation contract | mixed namespace mutations, snapshot reads, hardlinks, writer sessions, time advance | executor-visible results match the reference model and stale owner cleanup cannot delete a reused live session | `fsmeta/contract/*_test.go`, `fsmeta/exec/runner_test.go::TestExecutorExpireWriteSessionsDoesNotDeleteReusedLiveSession` | Covered |
 | fsmeta namespace chaos | gateway restart, mixed mutations, subtree rename handoff | namespace operations remain transactionally visible and rooted handoff state converges after restart | `fsmeta/integration/namespace_chaos_test.go`, `fsmeta/integration/raftstore_runner_test.go` | Covered |
 
 CI policy for this matrix:

--- a/fsmeta/contract/harness.go
+++ b/fsmeta/contract/harness.go
@@ -1,0 +1,225 @@
+package contract
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+	"strings"
+
+	"github.com/feichai0017/NoKV/fsmeta"
+)
+
+// Executor is the fsmeta API surface exercised by the contract harness.
+type Executor interface {
+	Create(context.Context, fsmeta.CreateRequest, fsmeta.InodeRecord) error
+	UpdateInode(context.Context, fsmeta.UpdateInodeRequest) (fsmeta.InodeRecord, error)
+	Lookup(context.Context, fsmeta.LookupRequest) (fsmeta.DentryRecord, error)
+	ReadDirPlus(context.Context, fsmeta.ReadDirRequest) ([]fsmeta.DentryAttrPair, error)
+	SnapshotSubtree(context.Context, fsmeta.SnapshotSubtreeRequest) (fsmeta.SnapshotSubtreeToken, error)
+	RenameSubtree(context.Context, fsmeta.RenameSubtreeRequest) error
+	Link(context.Context, fsmeta.LinkRequest) error
+	Unlink(context.Context, fsmeta.UnlinkRequest) error
+	OpenWriteSession(context.Context, fsmeta.OpenWriteSessionRequest) (fsmeta.SessionRecord, error)
+	HeartbeatWriteSession(context.Context, fsmeta.HeartbeatWriteSessionRequest) (fsmeta.SessionRecord, error)
+	CloseWriteSession(context.Context, fsmeta.CloseWriteSessionRequest) error
+	ExpireWriteSessions(context.Context, fsmeta.ExpireWriteSessionsRequest) (fsmeta.ExpireWriteSessionsResult, error)
+}
+
+// Run executes operations against the system under test and the reference
+// model, comparing every externally visible result.
+func Run(ctx context.Context, exec Executor, model *Model, ops []Operation) error {
+	if exec == nil {
+		return fmt.Errorf("fsmeta/contract: executor is required")
+	}
+	if model == nil {
+		return fmt.Errorf("fsmeta/contract: model is required")
+	}
+	history := make([]string, 0, len(ops))
+	for i, op := range ops {
+		got := execute(ctx, exec, model, op)
+		var want Result
+		if op.Kind == OpSnapshotSubtree {
+			if got.Err == nil {
+				want = model.ApplySnapshot(op, got.Token)
+			} else {
+				want = model.Apply(op)
+			}
+		} else {
+			want = model.Apply(op)
+		}
+		history = append(history, fmt.Sprintf("%03d %s -> got=%s want=%s", i, op, summarize(got), summarize(want)))
+		if err := compareResult(got, want); err != nil {
+			return fmt.Errorf("step %d failed: %w\nhistory:\n%s", i, err, strings.Join(history, "\n"))
+		}
+		if err := model.CheckInvariants(); err != nil {
+			return fmt.Errorf("step %d corrupted model invariants: %w\nhistory:\n%s", i, err, strings.Join(history, "\n"))
+		}
+	}
+	return nil
+}
+
+func execute(ctx context.Context, exec Executor, model *Model, op Operation) Result {
+	switch op.Kind {
+	case OpCreate:
+		err := exec.Create(ctx, fsmeta.CreateRequest{
+			Mount:  op.Mount,
+			Parent: op.Parent,
+			Name:   op.Name,
+			Inode:  op.Inode,
+		}, fsmeta.InodeRecord{
+			Type:      op.Type,
+			Size:      op.Size,
+			Mode:      op.Mode,
+			LinkCount: 1,
+		})
+		return Result{Err: err}
+	case OpUpdateInode:
+		inode, err := exec.UpdateInode(ctx, fsmeta.UpdateInodeRequest{
+			Mount:   op.Mount,
+			Parent:  op.Parent,
+			Inode:   op.Inode,
+			Name:    op.Name,
+			SetSize: true,
+			Size:    op.Size,
+			SetMode: true,
+			Mode:    op.Mode,
+		})
+		return Result{Err: err, Inode: inode}
+	case OpLookup:
+		dentry, err := exec.Lookup(ctx, fsmeta.LookupRequest{
+			Mount:  op.Mount,
+			Parent: op.Parent,
+			Name:   op.Name,
+		})
+		return Result{Err: err, Dentry: dentry}
+	case OpReadDirPlus:
+		pairs, err := exec.ReadDirPlus(ctx, fsmeta.ReadDirRequest{
+			Mount:           op.Mount,
+			Parent:          op.Parent,
+			StartAfter:      op.StartAfter,
+			Limit:           op.Limit,
+			SnapshotVersion: model.SnapshotVersion(op.SnapshotRef),
+		})
+		return Result{Err: err, Pairs: pairs}
+	case OpSnapshotSubtree:
+		token, err := exec.SnapshotSubtree(ctx, fsmeta.SnapshotSubtreeRequest{
+			Mount:     op.Mount,
+			RootInode: op.Parent,
+		})
+		return Result{Err: err, Token: token}
+	case OpRenameSubtree:
+		err := exec.RenameSubtree(ctx, fsmeta.RenameSubtreeRequest{
+			Mount:      op.Mount,
+			FromParent: op.FromParent,
+			FromName:   op.FromName,
+			ToParent:   op.ToParent,
+			ToName:     op.ToName,
+		})
+		return Result{Err: err}
+	case OpLink:
+		err := exec.Link(ctx, fsmeta.LinkRequest{
+			Mount:      op.Mount,
+			FromParent: op.FromParent,
+			FromName:   op.FromName,
+			ToParent:   op.ToParent,
+			ToName:     op.ToName,
+		})
+		return Result{Err: err}
+	case OpUnlink:
+		err := exec.Unlink(ctx, fsmeta.UnlinkRequest{
+			Mount:  op.Mount,
+			Parent: op.Parent,
+			Name:   op.Name,
+		})
+		return Result{Err: err}
+	case OpOpenWriteSession:
+		session, err := exec.OpenWriteSession(ctx, fsmeta.OpenWriteSessionRequest{
+			Mount:         op.Mount,
+			Inode:         op.Inode,
+			Session:       op.Session,
+			ExpiresUnixNs: op.ExpiresNs,
+		})
+		return Result{Err: err, Session: session}
+	case OpHeartbeatSession:
+		session, err := exec.HeartbeatWriteSession(ctx, fsmeta.HeartbeatWriteSessionRequest{
+			Mount:         op.Mount,
+			Inode:         op.Inode,
+			Session:       op.Session,
+			ExpiresUnixNs: op.ExpiresNs,
+		})
+		return Result{Err: err, Session: session}
+	case OpCloseSession:
+		err := exec.CloseWriteSession(ctx, fsmeta.CloseWriteSessionRequest{
+			Mount:   op.Mount,
+			Session: op.Session,
+		})
+		return Result{Err: err}
+	case OpExpireSessions:
+		result, err := exec.ExpireWriteSessions(ctx, fsmeta.ExpireWriteSessionsRequest{
+			Mount: op.Mount,
+			Limit: op.Limit,
+		})
+		return Result{Err: err, Expired: result.Expired}
+	case OpAdvanceTime:
+		return Result{}
+	default:
+		return Result{Err: fsmeta.ErrInvalidRequest}
+	}
+}
+
+func compareResult(got, want Result) error {
+	if !EquivalentError(got.Err, want.Err) {
+		return fmt.Errorf("error mismatch: got %v want %v", got.Err, want.Err)
+	}
+	if got.Err != nil || want.Err != nil {
+		return nil
+	}
+	if got.Token != want.Token {
+		return fmt.Errorf("token mismatch: got %+v want %+v", got.Token, want.Token)
+	}
+	if got.Dentry != want.Dentry {
+		return fmt.Errorf("dentry mismatch: got %+v want %+v", got.Dentry, want.Dentry)
+	}
+	if !reflect.DeepEqual(got.Pairs, want.Pairs) {
+		return fmt.Errorf("pairs mismatch: got %+v want %+v", got.Pairs, want.Pairs)
+	}
+	if !reflect.DeepEqual(got.Inode, want.Inode) {
+		return fmt.Errorf("inode mismatch: got %+v want %+v", got.Inode, want.Inode)
+	}
+	if got.Session != want.Session {
+		return fmt.Errorf("session mismatch: got %+v want %+v", got.Session, want.Session)
+	}
+	if got.Expired != want.Expired {
+		return fmt.Errorf("expired mismatch: got %d want %d", got.Expired, want.Expired)
+	}
+	return nil
+}
+
+func summarize(result Result) string {
+	if result.Err != nil {
+		return "err=" + result.Err.Error()
+	}
+	if result.Token.ReadVersion != 0 {
+		return fmt.Sprintf("token=%+v", result.Token)
+	}
+	if len(result.Pairs) != 0 {
+		names := make([]string, 0, len(result.Pairs))
+		for _, pair := range result.Pairs {
+			names = append(names, fmt.Sprintf("%s:%d/%d", pair.Dentry.Name, pair.Dentry.Inode, pair.Inode.LinkCount))
+		}
+		return "pairs=[" + strings.Join(names, ",") + "]"
+	}
+	if result.Dentry.Name != "" {
+		return fmt.Sprintf("dentry=%s:%d", result.Dentry.Name, result.Dentry.Inode)
+	}
+	if result.Inode.Inode != 0 {
+		return fmt.Sprintf("inode=%d size=%d links=%d", result.Inode.Inode, result.Inode.Size, result.Inode.LinkCount)
+	}
+	if result.Session.Session != "" {
+		return fmt.Sprintf("session=%s inode=%d expires=%d", result.Session.Session, result.Session.Inode, result.Session.ExpiresUnixNs)
+	}
+	if result.Expired != 0 {
+		return fmt.Sprintf("expired=%d", result.Expired)
+	}
+	return "ok"
+}

--- a/fsmeta/contract/harness_test.go
+++ b/fsmeta/contract/harness_test.go
@@ -1,0 +1,402 @@
+package contract
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"math/rand"
+	"os"
+	"sort"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/feichai0017/NoKV/fsmeta"
+	fsmetaexec "github.com/feichai0017/NoKV/fsmeta/exec"
+	kvrpcpb "github.com/feichai0017/NoKV/pb/kv"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFSMetaExecutorModelContract(t *testing.T) {
+	seeds := envInt("NOKV_CONTRACT_SEEDS", 16)
+	steps := envInt("NOKV_CONTRACT_STEPS", 80)
+	for seed := int64(1); seed <= int64(seeds); seed++ {
+		t.Run(fmt.Sprintf("seed_%03d", seed), func(t *testing.T) {
+			model := NewModel("vol")
+			runner := newVersionedRunner()
+			executor, err := fsmetaexec.New(runner, fsmetaexec.WithClock(func() time.Time {
+				return time.Unix(0, model.NowUnixNs)
+			}))
+			require.NoError(t, err)
+
+			ops := generateScript(seed, steps)
+			err = Run(context.Background(), executor, model, ops)
+			require.NoError(t, err, "seed=%d steps=%d", seed, steps)
+		})
+	}
+}
+
+func generateScript(seed int64, steps int) []Operation {
+	rng := rand.New(rand.NewSource(seed))
+	model := NewModel("vol")
+	names := []string{"alpha", "beta", "gamma", "delta", "epsilon", "zeta", "eta", "theta"}
+	sessions := []fsmeta.SessionID{"writer-a", "writer-b", "writer-c"}
+	nextInode := fsmeta.InodeID(10)
+	nextSnapshotRef := 0
+	syntheticSnapshotVersion := uint64(10_000)
+	ops := make([]Operation, 0, steps)
+	for range steps {
+		op := chooseOperation(rng, model, names, sessions, &nextInode, &nextSnapshotRef)
+		ops = append(ops, op)
+		if op.Kind == OpSnapshotSubtree {
+			_ = model.ApplySnapshot(op, fsmeta.SnapshotSubtreeToken{
+				Mount:       op.Mount,
+				RootInode:   op.Parent,
+				ReadVersion: syntheticSnapshotVersion,
+			})
+			syntheticSnapshotVersion++
+			continue
+		}
+		_ = model.Apply(op)
+	}
+	return ops
+}
+
+func chooseOperation(rng *rand.Rand, model *Model, names []string, sessions []fsmeta.SessionID, nextInode *fsmeta.InodeID, nextSnapshotRef *int) Operation {
+	existing := model.ExistingDentries()
+	files := model.ExistingFileDentries()
+	liveSessions := model.ExistingSessions()
+	if len(existing) < 2 && rng.Intn(100) < 60 {
+		return createOperation(rng, model, names, nextInode)
+	}
+	switch rng.Intn(100) {
+	case 0, 1, 2, 3, 4, 5, 6, 7, 8, 9:
+		return createOperation(rng, model, names, nextInode)
+	case 10, 11, 12, 13, 14, 15, 16, 17:
+		return lookupOperation(rng, model, names)
+	case 18, 19, 20, 21, 22, 23, 24, 25:
+		return readDirPlusOperation(rng, model, names)
+	case 26, 27, 28, 29, 30, 31, 32, 33:
+		return renameOperation(rng, model, names)
+	case 34, 35, 36, 37, 38, 39, 40:
+		return linkOperation(rng, model, names)
+	case 41, 42, 43, 44, 45, 46, 47:
+		return unlinkOperation(rng, model, names)
+	case 48, 49, 50, 51, 52, 53:
+		return updateOperation(rng, model, names)
+	case 54, 55, 56, 57, 58:
+		if len(files) == 0 {
+			return createOperation(rng, model, names, nextInode)
+		}
+		record := files[rng.Intn(len(files))]
+		return Operation{
+			Kind:      OpOpenWriteSession,
+			Mount:     model.Mount,
+			Inode:     record.Inode,
+			Session:   sessions[rng.Intn(len(sessions))],
+			ExpiresNs: model.NowUnixNs + int64(1+rng.Intn(10))*int64(time.Second),
+		}
+	case 59, 60, 61, 62:
+		if len(liveSessions) == 0 {
+			return readDirPlusOperation(rng, model, names)
+		}
+		session := liveSessions[rng.Intn(len(liveSessions))]
+		return Operation{
+			Kind:      OpHeartbeatSession,
+			Mount:     model.Mount,
+			Inode:     session.Inode,
+			Session:   session.Session,
+			ExpiresNs: model.NowUnixNs + int64(10+rng.Intn(10))*int64(time.Second),
+		}
+	case 63, 64, 65:
+		if len(liveSessions) == 0 {
+			return lookupOperation(rng, model, names)
+		}
+		session := liveSessions[rng.Intn(len(liveSessions))]
+		return Operation{Kind: OpCloseSession, Mount: model.Mount, Session: session.Session}
+	case 66, 67:
+		return Operation{
+			Kind:      OpAdvanceTime,
+			Mount:     model.Mount,
+			AdvanceNs: int64(1+rng.Intn(6)) * int64(time.Second),
+		}
+	case 68, 69:
+		return Operation{Kind: OpExpireSessions, Mount: model.Mount, Limit: 16}
+	case 70, 71, 72:
+		ref := *nextSnapshotRef
+		*nextSnapshotRef++
+		return Operation{Kind: OpSnapshotSubtree, Mount: model.Mount, Parent: model.Root, SnapshotRef: ref}
+	default:
+		return readDirPlusOperation(rng, model, names)
+	}
+}
+
+func createOperation(rng *rand.Rand, model *Model, names []string, nextInode *fsmeta.InodeID) Operation {
+	name := names[rng.Intn(len(names))]
+	if rng.Intn(100) < 70 {
+		if free := freeNames(model, names); len(free) > 0 {
+			name = free[rng.Intn(len(free))]
+		}
+	}
+	inode := *nextInode
+	*nextInode++
+	if rng.Intn(100) < 15 && len(model.inodes) > 1 {
+		for existing := range model.inodes {
+			if existing != model.Root {
+				inode = existing
+				break
+			}
+		}
+	}
+	typ := fsmeta.InodeTypeFile
+	if rng.Intn(100) < 20 {
+		typ = fsmeta.InodeTypeDirectory
+	}
+	return Operation{
+		Kind:   OpCreate,
+		Mount:  model.Mount,
+		Parent: model.Root,
+		Name:   name,
+		Inode:  inode,
+		Type:   typ,
+		Size:   uint64(1 + rng.Intn(4096)),
+		Mode:   0o600 + uint32(rng.Intn(0o177)),
+	}
+}
+
+func lookupOperation(rng *rand.Rand, model *Model, names []string) Operation {
+	name := names[rng.Intn(len(names))]
+	if existing := model.ExistingDentries(); len(existing) > 0 && rng.Intn(100) < 70 {
+		name = existing[rng.Intn(len(existing))].Name
+	}
+	return Operation{Kind: OpLookup, Mount: model.Mount, Parent: model.Root, Name: name}
+}
+
+func readDirPlusOperation(rng *rand.Rand, model *Model, names []string) Operation {
+	startAfter := ""
+	if rng.Intn(100) < 25 {
+		startAfter = names[rng.Intn(len(names))]
+	}
+	snapshotRef := -1
+	refs := model.KnownSnapshotRefs()
+	if len(refs) > 0 && rng.Intn(100) < 35 {
+		snapshotRef = refs[rng.Intn(len(refs))]
+	}
+	return Operation{
+		Kind:        OpReadDirPlus,
+		Mount:       model.Mount,
+		Parent:      model.Root,
+		StartAfter:  startAfter,
+		Limit:       uint32(1 + rng.Intn(6)),
+		SnapshotRef: snapshotRef,
+	}
+}
+
+func renameOperation(rng *rand.Rand, model *Model, names []string) Operation {
+	fromName := names[rng.Intn(len(names))]
+	if existing := model.ExistingDentries(); len(existing) > 0 && rng.Intn(100) < 80 {
+		fromName = existing[rng.Intn(len(existing))].Name
+	}
+	toName := names[rng.Intn(len(names))]
+	if rng.Intn(100) < 70 {
+		if free := freeNames(model, names); len(free) > 0 {
+			toName = free[rng.Intn(len(free))]
+		}
+	}
+	return Operation{
+		Kind:       OpRenameSubtree,
+		Mount:      model.Mount,
+		FromParent: model.Root,
+		FromName:   fromName,
+		ToParent:   model.Root,
+		ToName:     toName,
+	}
+}
+
+func linkOperation(rng *rand.Rand, model *Model, names []string) Operation {
+	fromName := names[rng.Intn(len(names))]
+	if files := model.ExistingFileDentries(); len(files) > 0 && rng.Intn(100) < 85 {
+		fromName = files[rng.Intn(len(files))].Name
+	} else if existing := model.ExistingDentries(); len(existing) > 0 {
+		fromName = existing[rng.Intn(len(existing))].Name
+	}
+	toName := names[rng.Intn(len(names))]
+	if rng.Intn(100) < 75 {
+		if free := freeNames(model, names); len(free) > 0 {
+			toName = free[rng.Intn(len(free))]
+		}
+	}
+	return Operation{
+		Kind:       OpLink,
+		Mount:      model.Mount,
+		FromParent: model.Root,
+		FromName:   fromName,
+		ToParent:   model.Root,
+		ToName:     toName,
+	}
+}
+
+func unlinkOperation(rng *rand.Rand, model *Model, names []string) Operation {
+	name := names[rng.Intn(len(names))]
+	if existing := model.ExistingDentries(); len(existing) > 0 && rng.Intn(100) < 80 {
+		name = existing[rng.Intn(len(existing))].Name
+	}
+	return Operation{Kind: OpUnlink, Mount: model.Mount, Parent: model.Root, Name: name}
+}
+
+func updateOperation(rng *rand.Rand, model *Model, names []string) Operation {
+	name := names[rng.Intn(len(names))]
+	inode := fsmeta.InodeID(9999)
+	if existing := model.ExistingDentries(); len(existing) > 0 && rng.Intn(100) < 85 {
+		record := existing[rng.Intn(len(existing))]
+		name = record.Name
+		inode = record.Inode
+	}
+	return Operation{
+		Kind:   OpUpdateInode,
+		Mount:  model.Mount,
+		Parent: model.Root,
+		Name:   name,
+		Inode:  inode,
+		Size:   uint64(1 + rng.Intn(8192)),
+		Mode:   0o600 + uint32(rng.Intn(0o177)),
+	}
+}
+
+func freeNames(model *Model, names []string) []string {
+	out := make([]string, 0, len(names))
+	used := make(map[string]struct{})
+	for _, record := range model.ExistingDentries() {
+		used[record.Name] = struct{}{}
+	}
+	for _, name := range names {
+		if _, ok := used[name]; !ok {
+			out = append(out, name)
+		}
+	}
+	return out
+}
+
+func envInt(name string, fallback int) int {
+	raw := os.Getenv(name)
+	if raw == "" {
+		return fallback
+	}
+	value, err := strconv.Atoi(raw)
+	if err != nil || value <= 0 {
+		return fallback
+	}
+	return value
+}
+
+type versionedRunner struct {
+	nextTS uint64
+	data   map[string][]versionedValue
+}
+
+type versionedValue struct {
+	version uint64
+	value   []byte
+	deleted bool
+}
+
+func newVersionedRunner() *versionedRunner {
+	return &versionedRunner{
+		nextTS: 1,
+		data:   make(map[string][]versionedValue),
+	}
+}
+
+func (r *versionedRunner) ReserveTimestamp(_ context.Context, count uint64) (uint64, error) {
+	if count == 0 {
+		return 0, errors.New("zero timestamp reservation")
+	}
+	first := r.nextTS
+	r.nextTS += count
+	return first, nil
+}
+
+func (r *versionedRunner) Get(_ context.Context, key []byte, version uint64) ([]byte, bool, error) {
+	value, ok := r.visible(key, version)
+	return value, ok, nil
+}
+
+func (r *versionedRunner) BatchGet(_ context.Context, keys [][]byte, version uint64) (map[string][]byte, error) {
+	out := make(map[string][]byte, len(keys))
+	for _, key := range keys {
+		if value, ok := r.visible(key, version); ok {
+			out[string(key)] = value
+		}
+	}
+	return out, nil
+}
+
+func (r *versionedRunner) Scan(_ context.Context, startKey []byte, limit uint32, version uint64) ([]fsmetaexec.KV, error) {
+	keys := make([][]byte, 0, len(r.data))
+	for key := range r.data {
+		raw := []byte(key)
+		if bytes.Compare(raw, startKey) < 0 {
+			continue
+		}
+		if _, ok := r.visible(raw, version); ok {
+			keys = append(keys, append([]byte(nil), raw...))
+		}
+	}
+	sort.Slice(keys, func(i, j int) bool { return bytes.Compare(keys[i], keys[j]) < 0 })
+	out := make([]fsmetaexec.KV, 0, limit)
+	for _, key := range keys {
+		if uint32(len(out)) >= limit {
+			break
+		}
+		value, _ := r.visible(key, version)
+		out = append(out, fsmetaexec.KV{
+			Key:   append([]byte(nil), key...),
+			Value: value,
+		})
+	}
+	return out, nil
+}
+
+func (r *versionedRunner) Mutate(_ context.Context, _ []byte, mutations []*kvrpcpb.Mutation, startVersion, commitVersion, _ uint64) error {
+	for _, mut := range mutations {
+		if mut.GetAssertionNotExist() {
+			if _, ok := r.visible(mut.GetKey(), startVersion); ok {
+				return fsmeta.ErrExists
+			}
+		}
+	}
+	for _, mut := range mutations {
+		key := string(mut.GetKey())
+		switch mut.GetOp() {
+		case kvrpcpb.Mutation_Put:
+			r.data[key] = append(r.data[key], versionedValue{
+				version: commitVersion,
+				value:   append([]byte(nil), mut.GetValue()...),
+			})
+		case kvrpcpb.Mutation_Delete:
+			r.data[key] = append(r.data[key], versionedValue{
+				version: commitVersion,
+				deleted: true,
+			})
+		default:
+			return fsmeta.ErrInvalidRequest
+		}
+	}
+	return nil
+}
+
+func (r *versionedRunner) visible(key []byte, version uint64) ([]byte, bool) {
+	versions := r.data[string(key)]
+	for i := len(versions) - 1; i >= 0; i-- {
+		candidate := versions[i]
+		if candidate.version > version {
+			continue
+		}
+		if candidate.deleted {
+			return nil, false
+		}
+		return append([]byte(nil), candidate.value...), true
+	}
+	return nil, false
+}

--- a/fsmeta/contract/model.go
+++ b/fsmeta/contract/model.go
@@ -1,0 +1,615 @@
+package contract
+
+import (
+	"errors"
+	"fmt"
+	"maps"
+	"sort"
+
+	"github.com/feichai0017/NoKV/fsmeta"
+)
+
+// OperationKind identifies one fsmeta contract operation used by the seeded
+// model harness. It intentionally mirrors the public fsmeta primitive names.
+type OperationKind string
+
+const (
+	OpCreate           OperationKind = "create"
+	OpUpdateInode      OperationKind = "update_inode"
+	OpLookup           OperationKind = "lookup"
+	OpReadDirPlus      OperationKind = "readdir_plus"
+	OpSnapshotSubtree  OperationKind = "snapshot_subtree"
+	OpRenameSubtree    OperationKind = "rename_subtree"
+	OpLink             OperationKind = "link"
+	OpUnlink           OperationKind = "unlink"
+	OpOpenWriteSession OperationKind = "open_write_session"
+	OpHeartbeatSession OperationKind = "heartbeat_write_session"
+	OpCloseSession     OperationKind = "close_write_session"
+	OpExpireSessions   OperationKind = "expire_write_sessions"
+	OpAdvanceTime      OperationKind = "advance_time"
+)
+
+// Operation is one generated fsmeta request. Unused fields are ignored by the
+// selected Kind.
+type Operation struct {
+	Kind        OperationKind
+	Mount       fsmeta.MountID
+	Parent      fsmeta.InodeID
+	Name        string
+	Inode       fsmeta.InodeID
+	Type        fsmeta.InodeType
+	Size        uint64
+	Mode        uint32
+	FromParent  fsmeta.InodeID
+	FromName    string
+	ToParent    fsmeta.InodeID
+	ToName      string
+	Session     fsmeta.SessionID
+	ExpiresNs   int64
+	AdvanceNs   int64
+	StartAfter  string
+	Limit       uint32
+	SnapshotRef int
+}
+
+func (op Operation) String() string {
+	return fmt.Sprintf("%s mount=%s parent=%d name=%q inode=%d from=(%d,%q) to=(%d,%q) session=%q advance_ns=%d snapshot=%d",
+		op.Kind, op.Mount, op.Parent, op.Name, op.Inode, op.FromParent, op.FromName, op.ToParent, op.ToName, op.Session, op.AdvanceNs, op.SnapshotRef)
+}
+
+// Result is the comparable response shape returned by both the reference model
+// and the system under test.
+type Result struct {
+	Err     error
+	Dentry  fsmeta.DentryRecord
+	Pairs   []fsmeta.DentryAttrPair
+	Token   fsmeta.SnapshotSubtreeToken
+	Inode   fsmeta.InodeRecord
+	Session fsmeta.SessionRecord
+	Expired uint64
+}
+
+type dentryKey struct {
+	parent fsmeta.InodeID
+	name   string
+}
+
+type snapshotState struct {
+	dentries map[dentryKey]fsmeta.DentryRecord
+	inodes   map[fsmeta.InodeID]fsmeta.InodeRecord
+}
+
+type sessionIndexEntry struct {
+	key     string
+	record  fsmeta.SessionRecord
+	session bool
+}
+
+// Model is a sequential oracle for fsmeta namespace semantics. It does not
+// model raftstore, routing, or Percolator internals; it models the user-visible
+// metadata contract those layers must preserve.
+type Model struct {
+	Mount       fsmeta.MountID
+	Root        fsmeta.InodeID
+	NowUnixNs   int64
+	dentries    map[dentryKey]fsmeta.DentryRecord
+	inodes      map[fsmeta.InodeID]fsmeta.InodeRecord
+	sessions    map[fsmeta.SessionID]fsmeta.SessionRecord
+	owners      map[fsmeta.InodeID]fsmeta.SessionRecord
+	snapshots   map[uint64]snapshotState
+	snapshotRef map[int]uint64
+}
+
+// NewModel returns a model with one mounted namespace and a root directory.
+func NewModel(mount fsmeta.MountID) *Model {
+	m := &Model{
+		Mount:       mount,
+		Root:        fsmeta.RootInode,
+		NowUnixNs:   1_000_000_000,
+		dentries:    make(map[dentryKey]fsmeta.DentryRecord),
+		inodes:      make(map[fsmeta.InodeID]fsmeta.InodeRecord),
+		sessions:    make(map[fsmeta.SessionID]fsmeta.SessionRecord),
+		owners:      make(map[fsmeta.InodeID]fsmeta.SessionRecord),
+		snapshots:   make(map[uint64]snapshotState),
+		snapshotRef: make(map[int]uint64),
+	}
+	m.inodes[m.Root] = fsmeta.InodeRecord{
+		Inode:     m.Root,
+		Type:      fsmeta.InodeTypeDirectory,
+		Mode:      0o755,
+		LinkCount: 1,
+	}
+	return m
+}
+
+// Apply applies one operation to the reference model. Snapshot operations must
+// use ApplySnapshot with the actual token returned by the system under test.
+func (m *Model) Apply(op Operation) Result {
+	switch op.Kind {
+	case OpCreate:
+		return m.create(op)
+	case OpUpdateInode:
+		return m.updateInode(op)
+	case OpLookup:
+		return m.lookup(op)
+	case OpReadDirPlus:
+		return m.readDirPlus(op)
+	case OpRenameSubtree:
+		return m.renameSubtree(op)
+	case OpLink:
+		return m.link(op)
+	case OpUnlink:
+		return m.unlink(op)
+	case OpOpenWriteSession:
+		return m.openWriteSession(op)
+	case OpHeartbeatSession:
+		return m.heartbeatSession(op)
+	case OpCloseSession:
+		return m.closeSession(op)
+	case OpExpireSessions:
+		return m.expireSessions(op)
+	case OpAdvanceTime:
+		return m.advanceTime(op)
+	default:
+		return Result{Err: fsmeta.ErrInvalidRequest}
+	}
+}
+
+// ApplySnapshot records the model view protected by an externally allocated
+// snapshot token.
+func (m *Model) ApplySnapshot(op Operation, token fsmeta.SnapshotSubtreeToken) Result {
+	if op.Mount == "" || op.Mount != m.Mount || op.Parent == 0 || token.ReadVersion == 0 {
+		return Result{Err: fsmeta.ErrInvalidRequest}
+	}
+	if token.Mount != op.Mount || token.RootInode != op.Parent {
+		return Result{Err: fsmeta.ErrInvalidRequest}
+	}
+	m.snapshots[token.ReadVersion] = snapshotState{
+		dentries: cloneDentries(m.dentries),
+		inodes:   cloneInodes(m.inodes),
+	}
+	if op.SnapshotRef >= 0 {
+		m.snapshotRef[op.SnapshotRef] = token.ReadVersion
+	}
+	return Result{Token: token}
+}
+
+func (m *Model) SnapshotVersion(ref int) uint64 {
+	if ref < 0 {
+		return 0
+	}
+	return m.snapshotRef[ref]
+}
+
+func (m *Model) ExistingDentries() []fsmeta.DentryRecord {
+	out := make([]fsmeta.DentryRecord, 0, len(m.dentries))
+	for _, record := range m.dentries {
+		out = append(out, record)
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].Parent != out[j].Parent {
+			return out[i].Parent < out[j].Parent
+		}
+		return out[i].Name < out[j].Name
+	})
+	return out
+}
+
+func (m *Model) ExistingFileDentries() []fsmeta.DentryRecord {
+	all := m.ExistingDentries()
+	out := all[:0]
+	for _, record := range all {
+		if record.Type == fsmeta.InodeTypeFile {
+			out = append(out, record)
+		}
+	}
+	return out
+}
+
+func (m *Model) ExistingSessions() []fsmeta.SessionRecord {
+	out := make([]fsmeta.SessionRecord, 0, len(m.sessions))
+	for _, record := range m.sessions {
+		out = append(out, record)
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].Session < out[j].Session })
+	return out
+}
+
+func (m *Model) KnownSnapshotRefs() []int {
+	out := make([]int, 0, len(m.snapshotRef))
+	for ref := range m.snapshotRef {
+		out = append(out, ref)
+	}
+	sort.Ints(out)
+	return out
+}
+
+func (m *Model) create(op Operation) Result {
+	key := dentryKey{parent: op.Parent, name: op.Name}
+	if _, ok := m.dentries[key]; ok {
+		return Result{Err: fsmeta.ErrExists}
+	}
+	if _, ok := m.inodes[op.Inode]; ok {
+		return Result{Err: fsmeta.ErrExists}
+	}
+	linkCount := uint32(1)
+	inode := fsmeta.InodeRecord{
+		Inode:     op.Inode,
+		Type:      op.Type,
+		Size:      op.Size,
+		Mode:      op.Mode,
+		LinkCount: linkCount,
+	}
+	dentry := fsmeta.DentryRecord{Parent: op.Parent, Name: op.Name, Inode: op.Inode, Type: op.Type}
+	m.inodes[op.Inode] = inode
+	m.dentries[key] = dentry
+	return Result{}
+}
+
+func (m *Model) updateInode(op Operation) Result {
+	key := dentryKey{parent: op.Parent, name: op.Name}
+	dentry, ok := m.dentries[key]
+	if !ok {
+		return Result{Err: fsmeta.ErrNotFound}
+	}
+	if dentry.Inode != op.Inode {
+		return Result{Err: fsmeta.ErrInvalidRequest}
+	}
+	inode, ok := m.inodes[op.Inode]
+	if !ok {
+		return Result{Err: fsmeta.ErrNotFound}
+	}
+	if dentry.Type != inode.Type {
+		return Result{Err: fsmeta.ErrInvalidValue}
+	}
+	if inode.LinkCount != 1 {
+		return Result{Err: fsmeta.ErrInvalidRequest}
+	}
+	inode.Size = op.Size
+	inode.Mode = op.Mode
+	m.inodes[op.Inode] = inode
+	return Result{Inode: inode}
+}
+
+func (m *Model) lookup(op Operation) Result {
+	record, ok := m.dentries[dentryKey{parent: op.Parent, name: op.Name}]
+	if !ok {
+		return Result{Err: fsmeta.ErrNotFound}
+	}
+	return Result{Dentry: record}
+}
+
+func (m *Model) readDirPlus(op Operation) Result {
+	state := snapshotState{dentries: m.dentries, inodes: m.inodes}
+	if version := m.SnapshotVersion(op.SnapshotRef); version != 0 {
+		snapshot, ok := m.snapshots[version]
+		if !ok {
+			return Result{Err: fsmeta.ErrInvalidRequest}
+		}
+		state = snapshot
+	}
+	limit := op.Limit
+	if limit == 0 {
+		limit = fsmeta.DefaultReadDirLimit
+	}
+	names := make([]string, 0)
+	for key := range state.dentries {
+		if key.parent == op.Parent && key.name > op.StartAfter {
+			names = append(names, key.name)
+		}
+	}
+	sort.Strings(names)
+	if uint32(len(names)) > limit {
+		names = names[:limit]
+	}
+	pairs := make([]fsmeta.DentryAttrPair, 0, len(names))
+	for _, name := range names {
+		dentry := state.dentries[dentryKey{parent: op.Parent, name: name}]
+		inode, ok := state.inodes[dentry.Inode]
+		if !ok {
+			return Result{Err: fsmeta.ErrNotFound}
+		}
+		pairs = append(pairs, fsmeta.DentryAttrPair{Dentry: dentry, Inode: inode})
+	}
+	return Result{Pairs: pairs}
+}
+
+func (m *Model) renameSubtree(op Operation) Result {
+	if op.FromParent == op.ToParent && op.FromName == op.ToName {
+		return Result{Err: fsmeta.ErrInvalidRequest}
+	}
+	from := dentryKey{parent: op.FromParent, name: op.FromName}
+	to := dentryKey{parent: op.ToParent, name: op.ToName}
+	record, ok := m.dentries[from]
+	if !ok {
+		return Result{Err: fsmeta.ErrNotFound}
+	}
+	if _, ok := m.dentries[to]; ok {
+		return Result{Err: fsmeta.ErrExists}
+	}
+	delete(m.dentries, from)
+	record.Parent = op.ToParent
+	record.Name = op.ToName
+	m.dentries[to] = record
+	return Result{}
+}
+
+func (m *Model) link(op Operation) Result {
+	if op.FromParent == op.ToParent && op.FromName == op.ToName {
+		return Result{Err: fsmeta.ErrInvalidRequest}
+	}
+	from := dentryKey{parent: op.FromParent, name: op.FromName}
+	to := dentryKey{parent: op.ToParent, name: op.ToName}
+	record, ok := m.dentries[from]
+	if !ok {
+		return Result{Err: fsmeta.ErrNotFound}
+	}
+	if record.Type == fsmeta.InodeTypeDirectory {
+		return Result{Err: fsmeta.ErrInvalidRequest}
+	}
+	if _, ok := m.dentries[to]; ok {
+		return Result{Err: fsmeta.ErrExists}
+	}
+	inode, ok := m.inodes[record.Inode]
+	if !ok {
+		return Result{Err: fsmeta.ErrNotFound}
+	}
+	if inode.Type == fsmeta.InodeTypeDirectory || inode.LinkCount == ^uint32(0) {
+		return Result{Err: fsmeta.ErrInvalidRequest}
+	}
+	if inode.LinkCount == 0 {
+		inode.LinkCount = 1
+	}
+	inode.LinkCount++
+	m.inodes[inode.Inode] = inode
+	m.dentries[to] = fsmeta.DentryRecord{Parent: op.ToParent, Name: op.ToName, Inode: record.Inode, Type: record.Type}
+	return Result{}
+}
+
+func (m *Model) unlink(op Operation) Result {
+	key := dentryKey{parent: op.Parent, name: op.Name}
+	record, ok := m.dentries[key]
+	if !ok {
+		return Result{Err: fsmeta.ErrNotFound}
+	}
+	delete(m.dentries, key)
+	if inode, ok := m.inodes[record.Inode]; ok {
+		if inode.LinkCount <= 1 {
+			delete(m.inodes, inode.Inode)
+		} else {
+			inode.LinkCount--
+			m.inodes[inode.Inode] = inode
+		}
+	}
+	return Result{}
+}
+
+func (m *Model) openWriteSession(op Operation) Result {
+	if op.ExpiresNs <= m.NowUnixNs {
+		return Result{Err: fsmeta.ErrInvalidRequest}
+	}
+	inode, ok := m.inodes[op.Inode]
+	if !ok {
+		return Result{Err: fsmeta.ErrNotFound}
+	}
+	if inode.Type != fsmeta.InodeTypeFile {
+		return Result{Err: fsmeta.ErrInvalidRequest}
+	}
+	if existing, ok := m.sessions[op.Session]; ok && sessionLive(existing, m.NowUnixNs) {
+		return Result{Err: fsmeta.ErrExists}
+	}
+	if owner, ok := m.owners[op.Inode]; ok {
+		if sessionLive(owner, m.NowUnixNs) {
+			return Result{Err: fsmeta.ErrExists}
+		}
+		if current, ok := m.sessions[owner.Session]; ok && current == owner {
+			delete(m.sessions, owner.Session)
+		}
+	}
+	record := fsmeta.SessionRecord{Session: op.Session, Inode: op.Inode, ExpiresUnixNs: op.ExpiresNs}
+	m.sessions[op.Session] = record
+	m.owners[op.Inode] = record
+	return Result{Session: record}
+}
+
+func (m *Model) heartbeatSession(op Operation) Result {
+	if op.ExpiresNs <= m.NowUnixNs {
+		return Result{Err: fsmeta.ErrInvalidRequest}
+	}
+	session, ok := m.sessions[op.Session]
+	if !ok || !sessionLive(session, m.NowUnixNs) || session.Inode != op.Inode {
+		return Result{Err: fsmeta.ErrNotFound}
+	}
+	owner, ok := m.owners[op.Inode]
+	if !ok || !sessionLive(owner, m.NowUnixNs) || owner.Session != op.Session || owner.Inode != op.Inode {
+		return Result{Err: fsmeta.ErrNotFound}
+	}
+	record := fsmeta.SessionRecord{Session: op.Session, Inode: op.Inode, ExpiresUnixNs: op.ExpiresNs}
+	m.sessions[op.Session] = record
+	m.owners[op.Inode] = record
+	return Result{Session: record}
+}
+
+func (m *Model) closeSession(op Operation) Result {
+	session, ok := m.sessions[op.Session]
+	if !ok {
+		return Result{Err: fsmeta.ErrNotFound}
+	}
+	delete(m.sessions, op.Session)
+	if owner, ok := m.owners[session.Inode]; ok && owner.Session == op.Session && owner.Inode == session.Inode {
+		delete(m.owners, session.Inode)
+	}
+	return Result{}
+}
+
+func (m *Model) expireSessions(op Operation) Result {
+	limit := op.Limit
+	if limit == 0 {
+		limit = fsmeta.DefaultSessionExpireLimit
+	}
+	entries := make([]sessionIndexEntry, 0, len(m.sessions)+len(m.owners))
+	for _, record := range m.sessions {
+		key, err := fsmeta.EncodeSessionKey(m.Mount, record.Session)
+		if err != nil {
+			return Result{Err: err}
+		}
+		entries = append(entries, sessionIndexEntry{key: string(key), record: record, session: true})
+	}
+	for _, record := range m.owners {
+		key, err := fsmeta.EncodeInodeSessionKey(m.Mount, record.Inode)
+		if err != nil {
+			return Result{Err: err}
+		}
+		entries = append(entries, sessionIndexEntry{key: string(key), record: record})
+	}
+	sort.Slice(entries, func(i, j int) bool { return entries[i].key < entries[j].key })
+	deleteSessions := make(map[fsmeta.SessionID]struct{})
+	deleteOwners := make(map[fsmeta.InodeID]struct{})
+	expiredSessions := make(map[fsmeta.SessionID]struct{})
+	visited := uint32(0)
+	for _, entry := range entries {
+		if visited >= limit {
+			break
+		}
+		visited++
+		if sessionLive(entry.record, m.NowUnixNs) {
+			continue
+		}
+		if entry.session {
+			deleteSessions[entry.record.Session] = struct{}{}
+		} else {
+			deleteOwners[entry.record.Inode] = struct{}{}
+		}
+		if current, ok := m.sessions[entry.record.Session]; ok && current == entry.record {
+			deleteSessions[entry.record.Session] = struct{}{}
+			expiredSessions[entry.record.Session] = struct{}{}
+		}
+		if owner, ok := m.owners[entry.record.Inode]; ok && owner == entry.record {
+			deleteOwners[entry.record.Inode] = struct{}{}
+		}
+	}
+	for session := range deleteSessions {
+		delete(m.sessions, session)
+	}
+	for inode := range deleteOwners {
+		delete(m.owners, inode)
+	}
+	return Result{Expired: uint64(len(expiredSessions))}
+}
+
+func (m *Model) advanceTime(op Operation) Result {
+	if op.AdvanceNs <= 0 {
+		return Result{Err: fsmeta.ErrInvalidRequest}
+	}
+	m.NowUnixNs += op.AdvanceNs
+	return Result{}
+}
+
+func sessionLive(record fsmeta.SessionRecord, nowUnixNs int64) bool {
+	return record.ExpiresUnixNs > nowUnixNs
+}
+
+// CheckInvariants validates global namespace consistency after every generated
+// operation. It catches model bugs and expected-state corruption before the
+// model is used as an oracle for later steps.
+func (m *Model) CheckInvariants() error {
+	refs := make(map[fsmeta.InodeID]uint32)
+	for key, dentry := range m.dentries {
+		if key.parent == 0 || key.name == "" {
+			return fmt.Errorf("invalid dentry key: %+v", key)
+		}
+		if dentry.Parent != key.parent || dentry.Name != key.name {
+			return fmt.Errorf("dentry/key mismatch key=%+v record=%+v", key, dentry)
+		}
+		inode, ok := m.inodes[dentry.Inode]
+		if !ok {
+			return fmt.Errorf("%w: dentry %s points to inode %d", fsmeta.ErrNotFound, dentry.Name, dentry.Inode)
+		}
+		if inode.Inode != dentry.Inode {
+			return fmt.Errorf("inode key/value mismatch key=%d record=%+v", dentry.Inode, inode)
+		}
+		if inode.Type != dentry.Type {
+			return fmt.Errorf("%w: dentry type=%s inode type=%s", fsmeta.ErrInvalidValue, dentry.Type, inode.Type)
+		}
+		refs[dentry.Inode]++
+	}
+	for inodeID, inode := range m.inodes {
+		if inodeID == m.Root {
+			continue
+		}
+		if refs[inodeID] == 0 {
+			return fmt.Errorf("inode %d has no dentry references", inodeID)
+		}
+		if refs[inodeID] != inode.LinkCount {
+			return fmt.Errorf("inode %d link_count=%d refs=%d", inodeID, inode.LinkCount, refs[inodeID])
+		}
+	}
+	for sessionID, session := range m.sessions {
+		if session.Session != sessionID {
+			return fmt.Errorf("session key/value mismatch key=%s record=%+v", sessionID, session)
+		}
+		if !sessionLive(session, m.NowUnixNs) {
+			continue
+		}
+		owner, ok := m.owners[session.Inode]
+		if !ok || owner.Session != session.Session {
+			return fmt.Errorf("session %s missing owner for inode %d", session.Session, session.Inode)
+		}
+	}
+	for inodeID, owner := range m.owners {
+		if owner.Inode != inodeID {
+			return fmt.Errorf("owner key/value mismatch key=%d record=%+v", inodeID, owner)
+		}
+		if !sessionLive(owner, m.NowUnixNs) {
+			continue
+		}
+		session, ok := m.sessions[owner.Session]
+		if !ok || session.Inode != inodeID {
+			return fmt.Errorf("owner for inode %d missing session %s", inodeID, owner.Session)
+		}
+	}
+	return nil
+}
+
+func EquivalentError(got, want error) bool {
+	if got == nil || want == nil {
+		return got == nil && want == nil
+	}
+	for _, sentinel := range []error{
+		fsmeta.ErrInvalidMountID,
+		fsmeta.ErrInvalidInodeID,
+		fsmeta.ErrInvalidName,
+		fsmeta.ErrInvalidSession,
+		fsmeta.ErrInvalidRequest,
+		fsmeta.ErrInvalidKey,
+		fsmeta.ErrInvalidKeyKind,
+		fsmeta.ErrInvalidValue,
+		fsmeta.ErrInvalidValueKind,
+		fsmeta.ErrInvalidPageSize,
+		fsmeta.ErrExists,
+		fsmeta.ErrNotFound,
+		fsmeta.ErrMountNotRegistered,
+		fsmeta.ErrMountRetired,
+		fsmeta.ErrQuotaExceeded,
+	} {
+		if errors.Is(got, sentinel) || errors.Is(want, sentinel) {
+			return errors.Is(got, sentinel) && errors.Is(want, sentinel)
+		}
+	}
+	return got.Error() == want.Error()
+}
+
+func cloneDentries(in map[dentryKey]fsmeta.DentryRecord) map[dentryKey]fsmeta.DentryRecord {
+	out := make(map[dentryKey]fsmeta.DentryRecord, len(in))
+	maps.Copy(out, in)
+	return out
+}
+
+func cloneInodes(in map[fsmeta.InodeID]fsmeta.InodeRecord) map[fsmeta.InodeID]fsmeta.InodeRecord {
+	out := make(map[fsmeta.InodeID]fsmeta.InodeRecord, len(in))
+	for key, value := range in {
+		value.OpaqueAttrs = append([]byte(nil), value.OpaqueAttrs...)
+		out[key] = value
+	}
+	return out
+}

--- a/fsmeta/contract/model_test.go
+++ b/fsmeta/contract/model_test.go
@@ -1,0 +1,180 @@
+package contract
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/feichai0017/NoKV/fsmeta"
+	"github.com/stretchr/testify/require"
+)
+
+func TestModelUnlinkKeepsSessionIndexesUntilSessionLifecycleRuns(t *testing.T) {
+	model := NewModel("vol")
+	require.NoError(t, model.Apply(Operation{
+		Kind:   OpCreate,
+		Mount:  "vol",
+		Parent: model.Root,
+		Name:   "file",
+		Inode:  10,
+		Type:   fsmeta.InodeTypeFile,
+		Mode:   0o600,
+	}).Err)
+	require.NoError(t, model.Apply(Operation{
+		Kind:      OpOpenWriteSession,
+		Mount:     "vol",
+		Inode:     10,
+		Session:   "writer-1",
+		ExpiresNs: model.NowUnixNs + int64(time.Minute),
+	}).Err)
+
+	require.NoError(t, model.Apply(Operation{
+		Kind:   OpUnlink,
+		Mount:  "vol",
+		Parent: model.Root,
+		Name:   "file",
+	}).Err)
+
+	require.NoError(t, model.CheckInvariants())
+	require.NotContains(t, model.inodes, fsmeta.InodeID(10))
+	require.Contains(t, model.sessions, fsmeta.SessionID("writer-1"))
+	require.Contains(t, model.owners, fsmeta.InodeID(10))
+
+	require.NoError(t, model.Apply(Operation{
+		Kind:    OpCloseSession,
+		Mount:   "vol",
+		Session: "writer-1",
+	}).Err)
+	require.NoError(t, model.CheckInvariants())
+	require.Empty(t, model.sessions)
+	require.Empty(t, model.owners)
+}
+
+func TestModelExpiresSessionsAfterTimeAdvance(t *testing.T) {
+	model := NewModel("vol")
+	require.NoError(t, model.Apply(Operation{
+		Kind:   OpCreate,
+		Mount:  "vol",
+		Parent: model.Root,
+		Name:   "file",
+		Inode:  10,
+		Type:   fsmeta.InodeTypeFile,
+		Mode:   0o600,
+	}).Err)
+	require.NoError(t, model.Apply(Operation{
+		Kind:      OpOpenWriteSession,
+		Mount:     "vol",
+		Inode:     10,
+		Session:   "writer-1",
+		ExpiresNs: model.NowUnixNs + int64(time.Second),
+	}).Err)
+
+	require.NoError(t, model.Apply(Operation{
+		Kind:      OpAdvanceTime,
+		Mount:     "vol",
+		AdvanceNs: int64(2 * time.Second),
+	}).Err)
+	result := model.Apply(Operation{Kind: OpExpireSessions, Mount: "vol", Limit: 16})
+
+	require.NoError(t, result.Err)
+	require.Equal(t, uint64(1), result.Expired)
+	require.Empty(t, model.sessions)
+	require.Empty(t, model.owners)
+	require.NoError(t, model.CheckInvariants())
+}
+
+func TestModelExpireStaleOwnerDoesNotRemoveReusedLiveSession(t *testing.T) {
+	model := NewModel("vol")
+	for _, inode := range []fsmeta.InodeID{10, 11} {
+		require.NoError(t, model.Apply(Operation{
+			Kind:   OpCreate,
+			Mount:  "vol",
+			Parent: model.Root,
+			Name:   fmt.Sprintf("file-%d", inode),
+			Inode:  inode,
+			Type:   fsmeta.InodeTypeFile,
+			Mode:   0o600,
+		}).Err)
+	}
+	require.NoError(t, model.Apply(Operation{
+		Kind:      OpOpenWriteSession,
+		Mount:     "vol",
+		Inode:     10,
+		Session:   "writer-1",
+		ExpiresNs: model.NowUnixNs + int64(time.Second),
+	}).Err)
+	require.NoError(t, model.Apply(Operation{
+		Kind:      OpAdvanceTime,
+		Mount:     "vol",
+		AdvanceNs: int64(2 * time.Second),
+	}).Err)
+	require.NoError(t, model.Apply(Operation{
+		Kind:      OpOpenWriteSession,
+		Mount:     "vol",
+		Inode:     11,
+		Session:   "writer-1",
+		ExpiresNs: model.NowUnixNs + int64(time.Minute),
+	}).Err)
+
+	result := model.Apply(Operation{Kind: OpExpireSessions, Mount: "vol", Limit: 16})
+
+	require.NoError(t, result.Err)
+	require.Equal(t, uint64(0), result.Expired)
+	require.Equal(t, fsmeta.InodeID(11), model.sessions["writer-1"].Inode)
+	require.NotContains(t, model.owners, fsmeta.InodeID(10))
+	require.Contains(t, model.owners, fsmeta.InodeID(11))
+	require.NoError(t, model.CheckInvariants())
+}
+
+func TestModelOpenWithStaleOwnerDoesNotRemoveReusedLiveSession(t *testing.T) {
+	model := NewModel("vol")
+	for _, inode := range []fsmeta.InodeID{10, 11} {
+		require.NoError(t, model.Apply(Operation{
+			Kind:   OpCreate,
+			Mount:  "vol",
+			Parent: model.Root,
+			Name:   fmt.Sprintf("file-%d", inode),
+			Inode:  inode,
+			Type:   fsmeta.InodeTypeFile,
+			Mode:   0o600,
+		}).Err)
+	}
+	require.NoError(t, model.Apply(Operation{
+		Kind:      OpOpenWriteSession,
+		Mount:     "vol",
+		Inode:     10,
+		Session:   "writer-1",
+		ExpiresNs: model.NowUnixNs + int64(time.Second),
+	}).Err)
+	require.NoError(t, model.Apply(Operation{
+		Kind:      OpAdvanceTime,
+		Mount:     "vol",
+		AdvanceNs: int64(2 * time.Second),
+	}).Err)
+	require.NoError(t, model.Apply(Operation{
+		Kind:      OpOpenWriteSession,
+		Mount:     "vol",
+		Inode:     11,
+		Session:   "writer-1",
+		ExpiresNs: model.NowUnixNs + int64(time.Minute),
+	}).Err)
+
+	require.NoError(t, model.Apply(Operation{
+		Kind:      OpOpenWriteSession,
+		Mount:     "vol",
+		Inode:     10,
+		Session:   "writer-2",
+		ExpiresNs: model.NowUnixNs + int64(time.Minute),
+	}).Err)
+
+	require.Equal(t, fsmeta.InodeID(11), model.sessions["writer-1"].Inode)
+	require.Equal(t, fsmeta.InodeID(10), model.sessions["writer-2"].Inode)
+	require.Equal(t, fsmeta.SessionID("writer-1"), model.owners[11].Session)
+	require.Equal(t, fsmeta.SessionID("writer-2"), model.owners[10].Session)
+	require.NoError(t, model.CheckInvariants())
+}
+
+func TestEquivalentErrorMatchesWrappedSentinel(t *testing.T) {
+	require.True(t, EquivalentError(fmt.Errorf("wrapped: %w", fsmeta.ErrNotFound), fsmeta.ErrNotFound))
+	require.False(t, EquivalentError(fmt.Errorf("wrapped: %w", fsmeta.ErrNotFound), fsmeta.ErrExists))
+}

--- a/fsmeta/exec/runner.go
+++ b/fsmeta/exec/runner.go
@@ -825,7 +825,15 @@ func (e *Executor) OpenWriteSession(ctx context.Context, req fsmeta.OpenWriteSes
 				return err
 			}
 			if string(staleSessionKey) != string(plan.ReadKeys[1]) {
-				mutations = append(mutations, &kvrpcpb.Mutation{Op: kvrpcpb.Mutation_Delete, Key: staleSessionKey})
+				ownerValue, err := fsmeta.EncodeSessionValue(owner)
+				if err != nil {
+					return err
+				}
+				if value, ok, err := e.runner.Get(ctx, staleSessionKey, startVersion); err != nil {
+					return err
+				} else if ok && bytes.Equal(value, ownerValue) {
+					mutations = append(mutations, &kvrpcpb.Mutation{Op: kvrpcpb.Mutation_Delete, Key: staleSessionKey})
+				}
 			}
 		}
 		value, err := fsmeta.EncodeSessionValue(record)
@@ -957,9 +965,17 @@ func (e *Executor) ExpireWriteSessions(ctx context.Context, req fsmeta.ExpireWri
 			if err != nil {
 				return err
 			}
-			deletes[string(sessionKey)] = sessionKey
-			deletes[string(ownerKey)] = ownerKey
-			expiredSessions[record.Session] = struct{}{}
+			if value, ok, err := e.runner.Get(ctx, sessionKey, startVersion); err != nil {
+				return err
+			} else if ok && bytes.Equal(value, kv.Value) {
+				deletes[string(sessionKey)] = sessionKey
+				expiredSessions[record.Session] = struct{}{}
+			}
+			if value, ok, err := e.runner.Get(ctx, ownerKey, startVersion); err != nil {
+				return err
+			} else if ok && bytes.Equal(value, kv.Value) {
+				deletes[string(ownerKey)] = ownerKey
+			}
 		}
 		if len(deletes) == 0 {
 			expired = 0

--- a/fsmeta/exec/runner_test.go
+++ b/fsmeta/exec/runner_test.go
@@ -545,6 +545,41 @@ func TestExecutorOpenWriteSessionReclaimsExpiredOwner(t *testing.T) {
 	require.Contains(t, runner.data, string(ownerKey))
 }
 
+func TestExecutorOpenWriteSessionDoesNotDeleteReusedLiveSession(t *testing.T) {
+	runner := newFakeRunner()
+	seedInode(t, runner, "vol", fsmeta.InodeRecord{Inode: 22, Type: fsmeta.InodeTypeFile, LinkCount: 1})
+	seedInode(t, runner, "vol", fsmeta.InodeRecord{Inode: 23, Type: fsmeta.InodeTypeFile, LinkCount: 1})
+	live := fsmeta.SessionRecord{Session: "writer-reused", Inode: 23, ExpiresUnixNs: 500}
+	seedSession(t, runner, "vol", live)
+	expired := fsmeta.SessionRecord{Session: "writer-reused", Inode: 22, ExpiresUnixNs: 50}
+	expiredValue, err := fsmeta.EncodeSessionValue(expired)
+	require.NoError(t, err)
+	expiredOwnerKey, err := fsmeta.EncodeInodeSessionKey("vol", expired.Inode)
+	require.NoError(t, err)
+	runner.data[string(expiredOwnerKey)] = expiredValue
+	liveSessionKey, err := fsmeta.EncodeSessionKey("vol", live.Session)
+	require.NoError(t, err)
+	liveOwnerKey, err := fsmeta.EncodeInodeSessionKey("vol", live.Inode)
+	require.NoError(t, err)
+	executor, err := New(runner, WithClock(func() time.Time { return time.Unix(0, 100) }))
+	require.NoError(t, err)
+
+	_, err = executor.OpenWriteSession(context.Background(), fsmeta.OpenWriteSessionRequest{
+		Mount:         "vol",
+		Inode:         22,
+		Session:       "writer-new",
+		ExpiresUnixNs: 200,
+	})
+
+	require.NoError(t, err)
+	require.Contains(t, runner.data, string(liveSessionKey))
+	require.Contains(t, runner.data, string(liveOwnerKey))
+	owner, ok, err := executor.readSessionByKey(context.Background(), expiredOwnerKey, 99)
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Equal(t, fsmeta.SessionID("writer-new"), owner.Session)
+}
+
 func TestExecutorOpenWriteSessionRejectsDirectory(t *testing.T) {
 	runner := newFakeRunner()
 	seedInode(t, runner, "vol", fsmeta.InodeRecord{Inode: 22, Type: fsmeta.InodeTypeDirectory, LinkCount: 1})
@@ -585,6 +620,34 @@ func TestExecutorExpireWriteSessionsDeletesBothIndexes(t *testing.T) {
 	require.NotContains(t, runner.data, string(expiredSessionKey))
 	require.NotContains(t, runner.data, string(expiredOwnerKey))
 	require.Contains(t, runner.data, string(liveSessionKey))
+	require.Contains(t, runner.data, string(liveOwnerKey))
+}
+
+func TestExecutorExpireWriteSessionsDoesNotDeleteReusedLiveSession(t *testing.T) {
+	runner := newFakeRunner()
+	expired := fsmeta.SessionRecord{Session: "writer-reused", Inode: 22, ExpiresUnixNs: 50}
+	live := fsmeta.SessionRecord{Session: "writer-reused", Inode: 23, ExpiresUnixNs: 500}
+	expiredValue, err := fsmeta.EncodeSessionValue(expired)
+	require.NoError(t, err)
+	liveValue, err := fsmeta.EncodeSessionValue(live)
+	require.NoError(t, err)
+	sessionKey, err := fsmeta.EncodeSessionKey("vol", live.Session)
+	require.NoError(t, err)
+	expiredOwnerKey, err := fsmeta.EncodeInodeSessionKey("vol", expired.Inode)
+	require.NoError(t, err)
+	liveOwnerKey, err := fsmeta.EncodeInodeSessionKey("vol", live.Inode)
+	require.NoError(t, err)
+	runner.data[string(expiredOwnerKey)] = expiredValue
+	runner.data[string(sessionKey)] = liveValue
+	runner.data[string(liveOwnerKey)] = liveValue
+	executor, err := New(runner, WithClock(func() time.Time { return time.Unix(0, 100) }))
+	require.NoError(t, err)
+
+	result, err := executor.ExpireWriteSessions(context.Background(), fsmeta.ExpireWriteSessionsRequest{Mount: "vol"})
+	require.NoError(t, err)
+	require.Equal(t, fsmeta.ExpireWriteSessionsResult{}, result)
+	require.NotContains(t, runner.data, string(expiredOwnerKey))
+	require.Contains(t, runner.data, string(sessionKey))
 	require.Contains(t, runner.data, string(liveOwnerKey))
 }
 


### PR DESCRIPTION
## Summary

- add a seeded fsmeta contract/model harness covering namespace mutations, snapshots, links, unlinks, and write-session lifecycle operations
- fix fsmeta write-session cleanup so stale owner records cannot delete a reused live session id
- add CI correctness smoke coverage and document the new testing entry points

## Testing

- `git diff --check`
- `make test-correctness-smoke`
- `make test`

## Next

The next correctness PR should reuse this generated fsmeta contract against a real raftstore-backed runner with retry/fault schedules.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added contract testing framework for filesystem metadata validation
  * Introduced smoke test targets for correctness validation
  * Parameterized test execution for improved parallelization support

* **Bug Fixes**
  * Fixed session reuse handling in write session management to prevent incorrect deletions during expiration

* **Tests**
  * Added comprehensive contract tests for metadata operations and session lifecycle

* **Documentation**
  * Updated testing documentation with new smoke test commands

* **Chores**
  * Enhanced CI workflow with correctness smoke test step

<!-- end of auto-generated comment: release notes by coderabbit.ai -->