### PR TITLE
test: add distributed correctness fault matrix

### DIFF
--- a/.github/workflows/docker-chaos.yml
+++ b/.github/workflows/docker-chaos.yml
@@ -1,0 +1,30 @@
+name: Docker Chaos
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "17 18 * * 1,4"
+
+permissions:
+  contents: read
+
+jobs:
+  fsmeta-history-chaos:
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version: "1.26.2"
+
+      - name: Docker fsmeta history chaos
+        env:
+          NOKV_DOCKER_CHAOS_DOWN: "1"
+          NOKV_DOCKER_CHAOS_SEEDS: "2"
+          NOKV_DOCKER_CHAOS_STEPS: "32"
+          NOKV_DOCKER_CHAOS_BATCH: "3"
+          NOKV_DOCKER_CHAOS_TIMEOUT: "60s"
+        run: ./scripts/chaos/docker_fsmeta_history.sh

--- a/.github/workflows/nightly-correctness.yml
+++ b/.github/workflows/nightly-correctness.yml
@@ -1,0 +1,29 @@
+name: Nightly Correctness
+
+on:
+  schedule:
+    - cron: "23 16 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  correctness:
+    runs-on: ubuntu-latest
+    timeout-minutes: 120
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version: "1.26.2"
+
+      - name: Install tools
+        run: make install-tools
+
+      - name: Nightly correctness matrix
+        run: make test-correctness-nightly

--- a/.github/workflows/soak-correctness.yml
+++ b/.github/workflows/soak-correctness.yml
@@ -1,0 +1,39 @@
+name: Soak Correctness
+
+on:
+  workflow_dispatch:
+    inputs:
+      duration:
+        description: "Soak duration, for example 30m, 24h, or 72h"
+        required: false
+        default: "30m"
+      rolling_restarts:
+        description: "Enable rolling Docker restarts during the soak"
+        required: false
+        default: "true"
+  schedule:
+    - cron: "41 15 * * 6"
+
+permissions:
+  contents: read
+
+jobs:
+  fsmeta-soak:
+    runs-on: ubuntu-latest
+    timeout-minutes: 180
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version: "1.26.2"
+
+      - name: Docker fsmeta soak
+        env:
+          NOKV_SOAK_DOWN: "1"
+          NOKV_SOAK_DURATION: ${{ github.event.inputs.duration || '45m' }}
+          NOKV_SOAK_ROLLING_RESTARTS: ${{ github.event.inputs.rolling_restarts == 'false' && '0' || '1' }}
+          NOKV_SOAK_STEPS: "64"
+          NOKV_SOAK_BATCH: "3"
+        run: ./scripts/soak/fsmeta_soak.sh

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # NoKV Makefile
 # Provides standardized commands for development workflow
 
-.PHONY: help build test test-short test-race test-coverage test-contract-smoke test-raftstore-contract-smoke test-correctness-smoke lint fmt clean docker-up docker-dev-up docker-down bench install-tools
+.PHONY: help build test test-short test-race test-coverage test-contract-smoke test-raftstore-contract-smoke test-history-smoke test-model-smoke test-crash-matrix-smoke test-deterministic-simulation-smoke test-correctness-smoke test-correctness-nightly test-docker-chaos test-soak-smoke lint fmt clean docker-up docker-dev-up docker-down bench install-tools
 .PHONY: proto proto-check proto-breaking-check
 
 GOLANGCI_LINT_VERSION ?= v2.9.0
@@ -20,7 +20,14 @@ help:
 	@echo "  make test-coverage      - Run tests with coverage report"
 	@echo "  make test-contract-smoke - Run seeded fsmeta contract model smoke tests"
 	@echo "  make test-raftstore-contract-smoke - Run seeded fsmeta contract tests on real raftstore"
+	@echo "  make test-history-smoke - Run bounded concurrent fsmeta history checks"
+	@echo "  make test-model-smoke   - Run bounded transaction/raftstore/root model smoke tests"
+	@echo "  make test-crash-matrix-smoke - Run crash-consistency matrix smoke tests"
+	@echo "  make test-deterministic-simulation-smoke - Run seeded deterministic fault simulation"
 	@echo "  make test-correctness-smoke - Run distributed correctness smoke tests"
+	@echo "  make test-correctness-nightly - Run longer seeded correctness and failpoint matrix"
+	@echo "  make test-docker-chaos  - Run Docker fsmeta history checker under process chaos"
+	@echo "  make test-soak-smoke    - Run short Docker fsmeta soak smoke"
 	@echo "  make lint               - Run golangci-lint (requires installation)"
 	@echo "  make fmt                - Run go fix, format code with gofmt, and tidy modules"
 	@echo "  make proto              - Format .proto files and regenerate protobuf Go code"
@@ -75,10 +82,67 @@ test-raftstore-contract-smoke:
 	@echo "Running raftstore-backed fsmeta contract smoke tests..."
 	NOKV_RAFTSTORE_CONTRACT_SEEDS=$${NOKV_RAFTSTORE_CONTRACT_SEEDS:-2} NOKV_RAFTSTORE_CONTRACT_STEPS=$${NOKV_RAFTSTORE_CONTRACT_STEPS:-40} go test ./fsmeta/integration -run TestRaftstoreRunnerFSMetaContractOnSplitCluster -count=1 -v
 
+# Run bounded concurrent fsmeta histories through the model runner and the real
+# split-region raftstore path.
+test-history-smoke:
+	@echo "Running concurrent fsmeta history smoke tests..."
+	NOKV_CONTRACT_HISTORY_SEEDS=$${NOKV_CONTRACT_HISTORY_SEEDS:-8} NOKV_CONTRACT_HISTORY_STEPS=$${NOKV_CONTRACT_HISTORY_STEPS:-48} NOKV_CONTRACT_HISTORY_BATCH=$${NOKV_CONTRACT_HISTORY_BATCH:-3} go test ./fsmeta/contract -run TestFSMetaExecutorConcurrentHistoryContract -count=1 -v
+	NOKV_RAFTSTORE_HISTORY_SEEDS=$${NOKV_RAFTSTORE_HISTORY_SEEDS:-1} NOKV_RAFTSTORE_HISTORY_STEPS=$${NOKV_RAFTSTORE_HISTORY_STEPS:-24} NOKV_RAFTSTORE_HISTORY_BATCH=$${NOKV_RAFTSTORE_HISTORY_BATCH:-3} go test ./fsmeta/integration -run TestRaftstoreRunnerFSMetaConcurrentHistoryOnSplitCluster -count=1 -v
+
+# Run bounded generated model/fault schedules across transaction, data-plane,
+# and rooted control-plane surfaces.
+test-model-smoke:
+	@echo "Running distributed model smoke tests..."
+	NOKV_PERCOLATOR_MODEL_SEEDS=$${NOKV_PERCOLATOR_MODEL_SEEDS:-8} NOKV_PERCOLATOR_MODEL_STEPS=$${NOKV_PERCOLATOR_MODEL_STEPS:-64} go test ./percolator -run TestTxnModelGeneratedScheduleIsSerializable -count=1 -v
+	NOKV_RAFTSTORE_FAULT_SEEDS=$${NOKV_RAFTSTORE_FAULT_SEEDS:-1} NOKV_RAFTSTORE_FAULT_STEPS=$${NOKV_RAFTSTORE_FAULT_STEPS:-6} go test ./raftstore/integration -run TestTwoPhaseCommitFaultScheduleAcrossSplitCluster -count=1 -v
+	NOKV_ROOT_MODEL_SEEDS=$${NOKV_ROOT_MODEL_SEEDS:-2} NOKV_ROOT_MODEL_STEPS=$${NOKV_ROOT_MODEL_STEPS:-24} go test ./coordinator/integration -run TestRootModelReplayAndWatchSchedule -count=1 -v
+
+# Run explicit crash-window tests around 2PC and raft Ready advance/send
+# boundaries.
+test-crash-matrix-smoke:
+	@echo "Running crash-consistency matrix smoke tests..."
+	go test ./percolator -run TestPercolatorCrashMatrix -count=1 -v
+	go test ./raftstore/peer -run TestPeerFailpointAfterReadyAdvanceBeforeSendRecoversOnLaterTicks -count=1 -v
+
+# Run a reproducible seed-driven fault schedule across real split-region
+# raftstore runtimes.
+test-deterministic-simulation-smoke:
+	@echo "Running deterministic fault simulation smoke tests..."
+	NOKV_SIMULATION_SEEDS=$${NOKV_SIMULATION_SEEDS:-1} NOKV_SIMULATION_STEPS=$${NOKV_SIMULATION_STEPS:-6} go test ./raftstore/integration -run TestDeterministicFaultSimulationAcrossSplitCluster -count=1 -v
+
 # Run the highest-signal distributed correctness suites before the full package sweep.
-test-correctness-smoke: test-contract-smoke test-raftstore-contract-smoke
+test-correctness-smoke: test-contract-smoke test-raftstore-contract-smoke test-history-smoke test-model-smoke test-crash-matrix-smoke test-deterministic-simulation-smoke
 	@echo "Running distributed correctness smoke tests..."
 	go test -p $(GO_TEST_P) ./percolator/... ./raftstore/client ./raftstore/mvcc ./raftstore/store ./raftstore/integration ./coordinator/integration ./meta/root/integration -count=1
+
+# Run longer seeded model/fault schedules plus failpoint-heavy suites. This is
+# intended for nightly CI and manual release hardening, not every PR edit loop.
+test-correctness-nightly:
+	@echo "Running nightly correctness matrix..."
+	NOKV_CONTRACT_SEEDS=$${NOKV_CONTRACT_SEEDS:-256} NOKV_CONTRACT_STEPS=$${NOKV_CONTRACT_STEPS:-500} go test ./fsmeta/contract -run TestFSMetaExecutorModelContract -count=1 -v
+	NOKV_RAFTSTORE_CONTRACT_SEEDS=$${NOKV_RAFTSTORE_CONTRACT_SEEDS:-8} NOKV_RAFTSTORE_CONTRACT_STEPS=$${NOKV_RAFTSTORE_CONTRACT_STEPS:-120} go test ./fsmeta/integration -run TestRaftstoreRunnerFSMetaContractOnSplitCluster -count=1 -v
+	NOKV_CONTRACT_HISTORY_SEEDS=$${NOKV_CONTRACT_HISTORY_SEEDS:-64} NOKV_CONTRACT_HISTORY_STEPS=$${NOKV_CONTRACT_HISTORY_STEPS:-240} NOKV_CONTRACT_HISTORY_BATCH=$${NOKV_CONTRACT_HISTORY_BATCH:-3} go test ./fsmeta/contract -run TestFSMetaExecutorConcurrentHistoryContract -count=1 -v
+	NOKV_RAFTSTORE_HISTORY_SEEDS=$${NOKV_RAFTSTORE_HISTORY_SEEDS:-4} NOKV_RAFTSTORE_HISTORY_STEPS=$${NOKV_RAFTSTORE_HISTORY_STEPS:-80} NOKV_RAFTSTORE_HISTORY_BATCH=$${NOKV_RAFTSTORE_HISTORY_BATCH:-3} go test ./fsmeta/integration -run TestRaftstoreRunnerFSMetaConcurrentHistoryOnSplitCluster -count=1 -v
+	NOKV_PERCOLATOR_MODEL_SEEDS=$${NOKV_PERCOLATOR_MODEL_SEEDS:-64} NOKV_PERCOLATOR_MODEL_STEPS=$${NOKV_PERCOLATOR_MODEL_STEPS:-256} go test ./percolator -run TestTxnModelGeneratedScheduleIsSerializable -count=1 -v
+	NOKV_RAFTSTORE_FAULT_SEEDS=$${NOKV_RAFTSTORE_FAULT_SEEDS:-4} NOKV_RAFTSTORE_FAULT_STEPS=$${NOKV_RAFTSTORE_FAULT_STEPS:-18} go test ./raftstore/integration -run TestTwoPhaseCommitFaultScheduleAcrossSplitCluster -count=1 -v
+	NOKV_ROOT_MODEL_SEEDS=$${NOKV_ROOT_MODEL_SEEDS:-16} NOKV_ROOT_MODEL_STEPS=$${NOKV_ROOT_MODEL_STEPS:-128} go test ./coordinator/integration -run TestRootModelReplayAndWatchSchedule -count=1 -v
+	go test ./percolator -run TestPercolatorCrashMatrix -count=3 -v
+	go test ./raftstore/peer -run TestPeerFailpointAfterReadyAdvanceBeforeSendRecoversOnLaterTicks -count=3 -v
+	NOKV_SIMULATION_SEEDS=$${NOKV_SIMULATION_SEEDS:-4} NOKV_SIMULATION_STEPS=$${NOKV_SIMULATION_STEPS:-18} go test ./raftstore/integration -run TestDeterministicFaultSimulationAcrossSplitCluster -count=1 -v
+	CHAOS_TRACE_METRICS=1 go test ./raftstore/transport ./raftstore/integration -run 'Test(GRPCTransport|PartitionedFollower|TransferLeader|RepeatedLinkFlap|ExpandSnapshotInstallInterruptedBeforePublish)' -count=1 -v
+	go test ./raftstore/migrate ./coordinator/integration ./meta/root/integration -run 'Test.*Failpoint|TestMetaRootPartialSealRecoversFromCommittedLog' -count=3 -v
+
+# Run the Docker fsmeta history checker while restarting or killing one
+# service at a time. This target is intentionally separate from PR smoke.
+test-docker-chaos:
+	@echo "Running Docker fsmeta chaos history checker..."
+	./scripts/chaos/docker_fsmeta_history.sh
+
+# Run a short Docker soak. Override NOKV_SOAK_DURATION=24h or 72h for real
+# release-hardening runs.
+test-soak-smoke:
+	@echo "Running short Docker fsmeta soak..."
+	NOKV_SOAK_DURATION=$${NOKV_SOAK_DURATION:-30s} NOKV_SOAK_ROLLING_RESTARTS=$${NOKV_SOAK_ROLLING_RESTARTS:-0} ./scripts/soak/fsmeta_soak.sh
 
 # Run linter (requires golangci-lint to be installed)
 lint:

--- a/cmd/nokv-config/main.go
+++ b/cmd/nokv-config/main.go
@@ -29,6 +29,8 @@ func main() {
 
 	var err error
 	switch subcmd {
+	case "meta-root":
+		err = runMetaRoot(args)
 	case "stores":
 		err = runStores(args)
 	case "regions":
@@ -45,6 +47,46 @@ func main() {
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "nokv-config %s: %v\n", subcmd, err)
 		exit(1)
+	}
+}
+
+func runMetaRoot(args []string) error {
+	fs := flag.NewFlagSet("meta-root", flag.ExitOnError)
+	configPath := fs.String("config", defaultConfigPath(), "path to raft configuration file")
+	format := fs.String("format", "simple", "output format: simple|json")
+	scope := fs.String("scope", "host", "address scope: host|docker")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+
+	scopeNorm := strings.ToLower(strings.TrimSpace(*scope))
+	if scopeNorm != "host" && scopeNorm != "docker" {
+		return fmt.Errorf("unknown scope %q (expected host|docker)", *scope)
+	}
+
+	cfg, err := loadConfig(*configPath)
+	if err != nil {
+		return err
+	}
+	if cfg.MetaRoot == nil {
+		return fmt.Errorf("meta_root block missing from configuration")
+	}
+
+	switch strings.ToLower(*format) {
+	case "json":
+		return json.NewEncoder(os.Stdout).Encode(cfg.MetaRootPeers())
+	case "simple":
+		for _, peer := range cfg.MetaRootPeers() {
+			fmt.Printf("%d %s %s %s\n",
+				peer.NodeID,
+				cfg.ResolveMetaRootServiceAddr(peer.NodeID, scopeNorm),
+				cfg.ResolveMetaRootTransportAddr(peer.NodeID, scopeNorm),
+				firstNonEmpty(cfg.ResolveMetaRootWorkDir(peer.NodeID, scopeNorm)),
+			)
+		}
+		return nil
+	default:
+		return fmt.Errorf("unknown format %q", *format)
 	}
 }
 
@@ -219,6 +261,7 @@ func printUsage() {
 	fmt.Println(`Usage: nokv-config <command> [flags]
 
 Commands:
+  meta-root Print meta-root endpoints from the raft configuration
   stores   Print store endpoints from the raft configuration
   regions  Print region metadata from the raft configuration
   coordinator Print coordinator endpoint from the raft configuration
@@ -227,6 +270,7 @@ Commands:
 Flags:
   --config <path>   Path to raft_config JSON (defaults to ./raft_config.example.json)
   --format <fmt>    Output format (simple|json) depending on the command
+  --scope <scope>   Address scope (host|docker) for meta-root/coordinator
   --field <name>    For "coordinator --format simple": addr|workdir`)
 }
 

--- a/cmd/nokv-config/main_test.go
+++ b/cmd/nokv-config/main_test.go
@@ -63,6 +63,39 @@ func TestRunRegionsJSONFormat(t *testing.T) {
 	require.Len(t, regions, 2)
 }
 
+func TestRunMetaRootSimpleFormat(t *testing.T) {
+	cfgPath := writeSampleConfig(t)
+
+	output, err := captureStdout(t, func() error {
+		return runMetaRoot([]string{"--config", cfgPath, "--format", "simple", "--scope", "host"})
+	})
+	require.NoError(t, err)
+	lines := strings.Split(strings.TrimSpace(output), "\n")
+	require.Len(t, lines, 3)
+	require.Equal(t, "1 127.0.0.1:2380 127.0.0.1:3380 ./artifacts/cluster/meta-root-1", lines[0])
+	require.Equal(t, "2 127.0.0.1:2381 127.0.0.1:3381 ./artifacts/cluster/meta-root-2", lines[1])
+	require.Equal(t, "3 127.0.0.1:2382 127.0.0.1:3382 ./artifacts/cluster/meta-root-3", lines[2])
+
+	output, err = captureStdout(t, func() error {
+		return runMetaRoot([]string{"--config", cfgPath, "--format", "simple", "--scope", "docker"})
+	})
+	require.NoError(t, err)
+	lines = strings.Split(strings.TrimSpace(output), "\n")
+	require.Equal(t, "1 nokv-meta-root-1:2380 nokv-meta-root-1:2480 /var/lib/nokv-meta-root-1", lines[0])
+}
+
+func TestRunMetaRootJSONFormat(t *testing.T) {
+	cfgPath := writeSampleConfig(t)
+	output, err := captureStdout(t, func() error {
+		return runMetaRoot([]string{"--config", cfgPath, "--format", "json"})
+	})
+	require.NoError(t, err)
+	var peers []config.MetaRootPeer
+	require.NoError(t, json.Unmarshal([]byte(output), &peers))
+	require.Len(t, peers, 3)
+	require.Equal(t, uint64(1), peers[0].NodeID)
+}
+
 func TestRunPDSimpleFormat(t *testing.T) {
 	cfgPath := writeSampleConfig(t)
 
@@ -219,6 +252,24 @@ func TestMainCoordinatorCommand(t *testing.T) {
 	require.Equal(t, 0, code)
 }
 
+func TestMainMetaRootCommand(t *testing.T) {
+	cfgPath := writeSampleConfig(t)
+	origArgs := os.Args
+	defer func() { os.Args = origArgs }()
+	os.Args = []string{
+		"nokv-config",
+		"meta-root",
+		"--config",
+		cfgPath,
+		"--format",
+		"simple",
+	}
+	code := captureExitCode(t, func() {
+		main()
+	})
+	require.Equal(t, 0, code)
+}
+
 func TestMainMissingArgs(t *testing.T) {
 	code := captureExitCode(t, func() {
 		origArgs := os.Args
@@ -361,6 +412,22 @@ func TestRunPDUnknownFormatAndScope(t *testing.T) {
 	require.Error(t, runCoordinator([]string{"--config", cfgPath, "--field", "bad"}))
 }
 
+func TestRunMetaRootUnknownFormatScopeAndMissingBlock(t *testing.T) {
+	cfgPath := writeSampleConfig(t)
+	require.Error(t, runMetaRoot([]string{"--config", cfgPath, "--format", "bad"}))
+	require.Error(t, runMetaRoot([]string{"--config", cfgPath, "--scope", "oops"}))
+
+	cfg := config.File{
+		Stores: []config.Store{{StoreID: 1, Addr: "127.0.0.1:1"}},
+	}
+	dir := t.TempDir()
+	raw, err := json.Marshal(cfg)
+	require.NoError(t, err)
+	path := filepath.Join(dir, "config.json")
+	require.NoError(t, os.WriteFile(path, raw, 0o600))
+	require.Error(t, runMetaRoot([]string{"--config", path}))
+}
+
 func TestLoadConfigMissingFile(t *testing.T) {
 	_, err := loadConfig(filepath.Join(t.TempDir(), "missing.json"))
 	require.Error(t, err)
@@ -491,6 +558,35 @@ func writeSampleConfig(t *testing.T) string {
 	t.Helper()
 	cfg := config.File{
 		MaxRetries: 3,
+		MetaRoot: &config.MetaRoot{Peers: []config.MetaRootPeer{
+			{
+				NodeID:              1,
+				Addr:                "127.0.0.1:2380",
+				DockerAddr:          "nokv-meta-root-1:2380",
+				TransportAddr:       "127.0.0.1:3380",
+				DockerTransportAddr: "nokv-meta-root-1:2480",
+				WorkDir:             "./artifacts/cluster/meta-root-1",
+				DockerWorkDir:       "/var/lib/nokv-meta-root-1",
+			},
+			{
+				NodeID:              2,
+				Addr:                "127.0.0.1:2381",
+				DockerAddr:          "nokv-meta-root-2:2380",
+				TransportAddr:       "127.0.0.1:3381",
+				DockerTransportAddr: "nokv-meta-root-2:2480",
+				WorkDir:             "./artifacts/cluster/meta-root-2",
+				DockerWorkDir:       "/var/lib/nokv-meta-root-2",
+			},
+			{
+				NodeID:              3,
+				Addr:                "127.0.0.1:2382",
+				DockerAddr:          "nokv-meta-root-3:2380",
+				TransportAddr:       "127.0.0.1:3382",
+				DockerTransportAddr: "nokv-meta-root-3:2480",
+				WorkDir:             "./artifacts/cluster/meta-root-3",
+				DockerWorkDir:       "/var/lib/nokv-meta-root-3",
+			},
+		}},
 		Coordinator: &config.Coordinator{
 			Addr:          "127.0.0.1:2379",
 			DockerAddr:    "nokv-pd:2379",

--- a/cmd/nokv-fsmeta-history/main.go
+++ b/cmd/nokv-fsmeta-history/main.go
@@ -1,0 +1,96 @@
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"log"
+	"os"
+	"time"
+
+	"github.com/feichai0017/NoKV/fsmeta"
+	fsmetaclient "github.com/feichai0017/NoKV/fsmeta/client"
+	fsmetacontract "github.com/feichai0017/NoKV/fsmeta/contract"
+)
+
+func main() {
+	var (
+		addr    = flag.String("addr", "127.0.0.1:8090", "FSMetadata gRPC address")
+		mount   = flag.String("mount", "default", "registered mount ID")
+		seeds   = flag.Int("seeds", 1, "number of deterministic seeds to run")
+		start   = flag.Int64("seed-start", 1, "first deterministic seed")
+		steps   = flag.Int("steps", 64, "generated operations per seed before external filtering")
+		batch   = flag.Int("batch", 3, "concurrent history batch size")
+		timeout = flag.Duration("timeout", 60*time.Second, "overall command timeout")
+		scope   = flag.String("scope-prefix", "history", "unique root directory prefix for isolating each generated history")
+	)
+	flag.Parse()
+	if *seeds <= 0 || *start <= 0 || *steps <= 0 {
+		log.Fatalf("seeds, seed-start, and steps must be positive")
+	}
+	if *batch <= 0 {
+		log.Fatalf("batch must be positive")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), *timeout)
+	defer cancel()
+
+	cli, err := fsmetaclient.NewGRPCClient(ctx, *addr)
+	if err != nil {
+		log.Fatalf("dial fsmeta %s: %v", *addr, err)
+	}
+	defer func() { _ = cli.Close() }()
+
+	mountID := fsmeta.MountID(*mount)
+	for seed := *start; seed < *start+int64(*seeds); seed++ {
+		model := fsmetacontract.NewModel(mountID)
+		unique := time.Now().UnixNano()
+		scopeName := fmt.Sprintf("%s-%06d-%d", *scope, seed, unique)
+		scopeInode := fsmeta.InodeID(9_000_000_000 + seed*1_000_000 + unique%1_000_000)
+		ops := externalHistoryOps(fsmetacontract.GenerateScript(seed, *steps), mountID, scopeName, scopeInode)
+		if len(ops) == 0 {
+			log.Fatalf("seed %d generated no external-safe operations", seed)
+		}
+		if err := fsmetacontract.RunConcurrentBatches(ctx, cli, model, ops, *batch); err != nil {
+			fmt.Fprintf(os.Stderr, "fsmeta history failed seed=%d steps=%d filtered_ops=%d\n", seed, *steps, len(ops))
+			log.Fatal(err)
+		}
+		log.Printf("fsmeta history passed seed=%d filtered_ops=%d", seed, len(ops))
+	}
+}
+
+func externalHistoryOps(in []fsmetacontract.Operation, mount fsmeta.MountID, scopeName string, scopeInode fsmeta.InodeID) []fsmetacontract.Operation {
+	out := make([]fsmetacontract.Operation, 0, len(in)+1)
+	out = append(out, fsmetacontract.Operation{
+		Kind:   fsmetacontract.OpCreate,
+		Mount:  mount,
+		Parent: fsmeta.RootInode,
+		Name:   scopeName,
+		Inode:  scopeInode,
+		Type:   fsmeta.InodeTypeDirectory,
+		Mode:   0o755,
+	})
+	for _, op := range in {
+		switch op.Kind {
+		case fsmetacontract.OpOpenWriteSession,
+			fsmetacontract.OpHeartbeatSession,
+			fsmetacontract.OpCloseSession,
+			fsmetacontract.OpExpireSessions,
+			fsmetacontract.OpAdvanceTime:
+			continue
+		default:
+			op.Mount = mount
+			if op.Parent == fsmeta.RootInode {
+				op.Parent = scopeInode
+			}
+			if op.FromParent == fsmeta.RootInode {
+				op.FromParent = scopeInode
+			}
+			if op.ToParent == fsmeta.RootInode {
+				op.ToParent = scopeInode
+			}
+			out = append(out, op)
+		}
+	}
+	return out
+}

--- a/cmd/nokv-fsmeta-soak/main.go
+++ b/cmd/nokv-fsmeta-soak/main.go
@@ -1,0 +1,224 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"flag"
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/feichai0017/NoKV/fsmeta"
+	fsmetaclient "github.com/feichai0017/NoKV/fsmeta/client"
+	fsmetacontract "github.com/feichai0017/NoKV/fsmeta/contract"
+)
+
+func main() {
+	var (
+		addr      = flag.String("addr", "127.0.0.1:8090", "FSMetadata gRPC address")
+		mount     = flag.String("mount", "default", "registered mount ID")
+		duration  = flag.Duration("duration", 24*time.Hour, "soak duration")
+		steps     = flag.Int("steps", 80, "generated namespace operations per round before external filtering")
+		batch     = flag.Int("batch", 3, "concurrent history batch size")
+		seedStart = flag.Int64("seed-start", 1, "first deterministic seed")
+	)
+	flag.Parse()
+	if *duration <= 0 || *steps <= 0 || *batch <= 0 || *seedStart <= 0 {
+		log.Fatalf("duration, steps, batch, and seed-start must be positive")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), *duration)
+	defer cancel()
+
+	mountID := fsmeta.MountID(*mount)
+	deadline := time.Now().Add(*duration)
+	for seed := *seedStart; time.Now().Before(deadline); seed++ {
+		if err := runRound(ctx, *addr, mountID, seed, *steps, *batch); err != nil {
+			log.Fatalf("soak round failed seed=%d: %v", seed, err)
+		}
+		log.Printf("soak round passed seed=%d remaining=%s", seed, time.Until(deadline).Round(time.Second))
+	}
+}
+
+func runRound(ctx context.Context, addr string, mount fsmeta.MountID, seed int64, steps, batch int) error {
+	roundCtx, cancel := context.WithTimeout(ctx, 90*time.Second)
+	defer cancel()
+
+	cli, err := fsmetaclient.NewGRPCClient(roundCtx, addr)
+	if err != nil {
+		return fmt.Errorf("dial fsmeta: %w", err)
+	}
+	defer func() { _ = cli.Close() }()
+
+	model := fsmetacontract.NewModel(mount)
+	unique := time.Now().UnixNano()
+	scopeName := fmt.Sprintf("soak-history-%06d-%d", seed, unique)
+	scopeInode := fsmeta.InodeID(8_000_000_000 + seed*1_000_000 + unique%1_000_000)
+	ops := soakHistoryOps(fsmetacontract.GenerateScript(seed, steps), mount, scopeName, scopeInode)
+	if len(ops) == 0 {
+		return fmt.Errorf("generated no namespace operations")
+	}
+	if err := fsmetacontract.RunConcurrentBatches(roundCtx, cli, model, ops, batch); err != nil {
+		return fmt.Errorf("namespace history: %w", err)
+	}
+	if err := runSessionProbe(roundCtx, cli, mount, seed); err != nil {
+		return fmt.Errorf("session probe: %w", err)
+	}
+	if err := runSnapshotProbe(roundCtx, cli, mount); err != nil {
+		return fmt.Errorf("snapshot probe: %w", err)
+	}
+	if err := runWatchProbe(roundCtx, cli, mount, seed); err != nil {
+		return fmt.Errorf("watch probe: %w", err)
+	}
+	return nil
+}
+
+func soakHistoryOps(in []fsmetacontract.Operation, mount fsmeta.MountID, scopeName string, scopeInode fsmeta.InodeID) []fsmetacontract.Operation {
+	out := make([]fsmetacontract.Operation, 0, len(in)+1)
+	out = append(out, fsmetacontract.Operation{
+		Kind:   fsmetacontract.OpCreate,
+		Mount:  mount,
+		Parent: fsmeta.RootInode,
+		Name:   scopeName,
+		Inode:  scopeInode,
+		Type:   fsmeta.InodeTypeDirectory,
+		Mode:   0o755,
+	})
+	for _, op := range in {
+		switch op.Kind {
+		case fsmetacontract.OpOpenWriteSession,
+			fsmetacontract.OpHeartbeatSession,
+			fsmetacontract.OpCloseSession,
+			fsmetacontract.OpExpireSessions,
+			fsmetacontract.OpAdvanceTime:
+			continue
+		default:
+			op.Mount = mount
+			if op.Parent == fsmeta.RootInode {
+				op.Parent = scopeInode
+			}
+			if op.FromParent == fsmeta.RootInode {
+				op.FromParent = scopeInode
+			}
+			if op.ToParent == fsmeta.RootInode {
+				op.ToParent = scopeInode
+			}
+			out = append(out, op)
+		}
+	}
+	return out
+}
+
+func runSessionProbe(ctx context.Context, cli *fsmetaclient.GRPCClient, mount fsmeta.MountID, seed int64) error {
+	unique := time.Now().UnixNano()
+	name := fmt.Sprintf("soak-session-%06d-%d", seed, unique)
+	inode := fsmeta.InodeID(1_000_000 + seed*1_000_000 + unique%1_000_000)
+	if err := cli.Create(ctx, fsmeta.CreateRequest{
+		Mount:  mount,
+		Parent: fsmeta.RootInode,
+		Name:   name,
+		Inode:  inode,
+	}, fsmeta.InodeRecord{
+		Type:      fsmeta.InodeTypeFile,
+		Size:      uint64(seed),
+		Mode:      0o644,
+		LinkCount: 1,
+	}); err != nil && !errors.Is(err, fsmeta.ErrExists) {
+		return err
+	}
+
+	session := fsmeta.SessionID(fmt.Sprintf("soak-writer-%06d-%d", seed, unique))
+	expires := time.Now().Add(2 * time.Minute).UnixNano()
+	if _, err := cli.OpenWriteSession(ctx, fsmeta.OpenWriteSessionRequest{
+		Mount:         mount,
+		Inode:         inode,
+		Session:       session,
+		ExpiresUnixNs: expires,
+	}); err != nil {
+		return err
+	}
+	if _, err := cli.HeartbeatWriteSession(ctx, fsmeta.HeartbeatWriteSessionRequest{
+		Mount:         mount,
+		Inode:         inode,
+		Session:       session,
+		ExpiresUnixNs: time.Now().Add(3 * time.Minute).UnixNano(),
+	}); err != nil {
+		return err
+	}
+	if err := cli.CloseWriteSession(ctx, fsmeta.CloseWriteSessionRequest{
+		Mount:   mount,
+		Session: session,
+	}); err != nil {
+		return err
+	}
+	_, err := cli.ExpireWriteSessions(ctx, fsmeta.ExpireWriteSessionsRequest{Mount: mount, Limit: 32})
+	return err
+}
+
+func runSnapshotProbe(ctx context.Context, cli *fsmetaclient.GRPCClient, mount fsmeta.MountID) error {
+	token, err := cli.SnapshotSubtree(ctx, fsmeta.SnapshotSubtreeRequest{
+		Mount:     mount,
+		RootInode: fsmeta.RootInode,
+	})
+	if err != nil {
+		return err
+	}
+	if _, err := cli.ReadDirPlus(ctx, fsmeta.ReadDirRequest{
+		Mount:           mount,
+		Parent:          fsmeta.RootInode,
+		Limit:           16,
+		SnapshotVersion: token.ReadVersion,
+	}); err != nil {
+		return err
+	}
+	return cli.RetireSnapshotSubtree(ctx, token)
+}
+
+func runWatchProbe(ctx context.Context, cli *fsmetaclient.GRPCClient, mount fsmeta.MountID, seed int64) error {
+	prefix, err := fsmeta.EncodeDentryPrefix(mount, fsmeta.RootInode)
+	if err != nil {
+		return err
+	}
+	watchCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+	stream, err := cli.WatchSubtree(watchCtx, fsmeta.WatchRequest{
+		KeyPrefix:          prefix,
+		BackPressureWindow: 8,
+	})
+	if err != nil {
+		return err
+	}
+	defer func() { _ = stream.Close() }()
+
+	unique := time.Now().UnixNano()
+	name := fmt.Sprintf("soak-watch-%06d-%d", seed, unique)
+	inode := fsmeta.InodeID(2_000_000 + seed*1_000_000 + unique%1_000_000)
+	if err := cli.Create(watchCtx, fsmeta.CreateRequest{
+		Mount:  mount,
+		Parent: fsmeta.RootInode,
+		Name:   name,
+		Inode:  inode,
+	}, fsmeta.InodeRecord{
+		Type:      fsmeta.InodeTypeFile,
+		Size:      1,
+		Mode:      0o644,
+		LinkCount: 1,
+	}); err != nil && !errors.Is(err, fsmeta.ErrExists) {
+		return err
+	}
+	wantKey, err := fsmeta.EncodeDentryKey(mount, fsmeta.RootInode, name)
+	if err != nil {
+		return err
+	}
+	for {
+		evt, err := stream.Recv()
+		if err != nil {
+			return err
+		}
+		if string(evt.Key) != string(wantKey) {
+			_ = stream.Ack(evt.Cursor)
+			continue
+		}
+		return stream.Ack(evt.Cursor)
+	}
+}

--- a/coordinator/integration/root_model_test.go
+++ b/coordinator/integration/root_model_test.go
@@ -1,0 +1,314 @@
+package integration_test
+
+import (
+	"context"
+	"fmt"
+	"math/rand"
+	"os"
+	"reflect"
+	"strconv"
+	"testing"
+	"time"
+
+	pdtestcluster "github.com/feichai0017/NoKV/coordinator/testcluster"
+	metaregion "github.com/feichai0017/NoKV/meta/region"
+	rootevent "github.com/feichai0017/NoKV/meta/root/event"
+	rootmaterialize "github.com/feichai0017/NoKV/meta/root/materialize"
+	rootstate "github.com/feichai0017/NoKV/meta/root/state"
+	rootstorage "github.com/feichai0017/NoKV/meta/root/storage"
+	metawire "github.com/feichai0017/NoKV/meta/wire"
+	coordpb "github.com/feichai0017/NoKV/pb/coordinator"
+	"github.com/feichai0017/NoKV/raftstore/descriptor"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRootModelReplayAndWatchSchedule(t *testing.T) {
+	seeds := rootModelEnvInt("NOKV_ROOT_MODEL_SEEDS", 2)
+	steps := rootModelEnvInt("NOKV_ROOT_MODEL_STEPS", 24)
+	for seed := int64(1); seed <= int64(seeds); seed++ {
+		t.Run(fmt.Sprintf("seed_%03d", seed), func(t *testing.T) {
+			cluster := pdtestcluster.OpenReplicated(t)
+			leaderID, leader := cluster.LeaderService()
+			followerID := cluster.FollowerIDs(leaderID)[0]
+			subscription := cluster.SubscribeTail(followerID, rootstorage.TailToken{})
+			require.NotNil(t, subscription)
+
+			model := newRootScheduleModel(seed)
+			for step := range steps {
+				event := model.nextEvent()
+				before, err := cluster.Roots[leaderID].Snapshot()
+				require.NoError(t, err)
+
+				resp, err := leader.PublishRootEvent(context.Background(), &coordpb.PublishRootEventRequest{
+					Event: metawire.RootEventToProto(event),
+				})
+				require.NoError(t, err, "step=%d event=%v", step, event.Kind)
+				require.True(t, resp.GetAccepted(), "step=%d event=%v", step, event.Kind)
+
+				after, err := cluster.Roots[leaderID].Snapshot()
+				require.NoError(t, err)
+				assertRootEpochDelta(t, before, after, event)
+				assertRootReplayMatchesSnapshot(t, cluster.Roots[leaderID])
+				waitFollowerRootMatchesLeader(t, cluster, followerID, leaderID, subscription)
+			}
+		})
+	}
+}
+
+type rootScheduleModel struct {
+	rng             *rand.Rand
+	nextStoreID     uint64
+	activeStores    []uint64
+	nextRegionID    uint64
+	activeRegions   []uint64
+	nextMountID     uint64
+	activeMounts    []string
+	snapshotVersion map[string]uint64
+	quotaEra        map[string]uint64
+}
+
+func newRootScheduleModel(seed int64) *rootScheduleModel {
+	return &rootScheduleModel{
+		rng:             rand.New(rand.NewSource(seed)),
+		nextStoreID:     10,
+		nextRegionID:    1000,
+		nextMountID:     1,
+		snapshotVersion: make(map[string]uint64),
+		quotaEra:        make(map[string]uint64),
+	}
+}
+
+func (m *rootScheduleModel) nextEvent() rootevent.Event {
+	if len(m.activeStores) == 0 {
+		return m.storeJoined()
+	}
+	if len(m.activeMounts) == 0 {
+		return m.mountRegistered()
+	}
+	switch m.rng.Intn(100) {
+	case 0, 1, 2, 3, 4, 5, 6, 7, 8, 9:
+		return m.storeJoined()
+	case 10, 11, 12, 13:
+		return m.storeRetired()
+	case 14, 15, 16, 17, 18, 19:
+		return m.mountRegistered()
+	case 20, 21, 22:
+		return m.mountRetired()
+	case 23, 24, 25, 26, 27, 28, 29:
+		return m.snapshotPublished()
+	case 30, 31, 32, 33:
+		return m.snapshotRetired()
+	case 34, 35, 36, 37, 38:
+		return m.quotaUpdated()
+	case 39, 40, 41, 42, 43, 44, 45, 46:
+		return m.regionTombstoned()
+	default:
+		return m.regionPublished()
+	}
+}
+
+func (m *rootScheduleModel) storeJoined() rootevent.Event {
+	storeID := m.nextStoreID
+	m.nextStoreID++
+	m.activeStores = append(m.activeStores, storeID)
+	return rootevent.StoreJoined(storeID)
+}
+
+func (m *rootScheduleModel) storeRetired() rootevent.Event {
+	if len(m.activeStores) == 0 {
+		return m.storeJoined()
+	}
+	idx := m.rng.Intn(len(m.activeStores))
+	storeID := m.activeStores[idx]
+	m.activeStores = append(m.activeStores[:idx], m.activeStores[idx+1:]...)
+	return rootevent.StoreRetired(storeID)
+}
+
+func (m *rootScheduleModel) mountRegistered() rootevent.Event {
+	mount := fmt.Sprintf("vol-%03d", m.nextMountID)
+	m.nextMountID++
+	m.activeMounts = append(m.activeMounts, mount)
+	return rootevent.MountRegistered(mount, 1, 1)
+}
+
+func (m *rootScheduleModel) mountRetired() rootevent.Event {
+	if len(m.activeMounts) == 0 {
+		return m.mountRegistered()
+	}
+	idx := m.rng.Intn(len(m.activeMounts))
+	mount := m.activeMounts[idx]
+	m.activeMounts = append(m.activeMounts[:idx], m.activeMounts[idx+1:]...)
+	return rootevent.MountRetired(mount)
+}
+
+func (m *rootScheduleModel) snapshotPublished() rootevent.Event {
+	mount := m.randomMount()
+	m.snapshotVersion[mount]++
+	return rootevent.SnapshotEpochPublished(mount, 1, m.snapshotVersion[mount])
+}
+
+func (m *rootScheduleModel) snapshotRetired() rootevent.Event {
+	mount := m.randomMount()
+	if m.snapshotVersion[mount] == 0 {
+		return m.snapshotPublished()
+	}
+	return rootevent.SnapshotEpochRetired(mount, 1, m.snapshotVersion[mount])
+}
+
+func (m *rootScheduleModel) quotaUpdated() rootevent.Event {
+	mount := m.randomMount()
+	m.quotaEra[mount]++
+	era := m.quotaEra[mount]
+	return rootevent.QuotaFenceUpdated(mount, 0, 1024*era, 100+era, era, era*10)
+}
+
+func (m *rootScheduleModel) regionPublished() rootevent.Event {
+	regionID := m.nextRegionID
+	m.nextRegionID++
+	m.activeRegions = append(m.activeRegions, regionID)
+	return rootevent.RegionDescriptorPublished(rootModelDescriptor(regionID))
+}
+
+func (m *rootScheduleModel) regionTombstoned() rootevent.Event {
+	if len(m.activeRegions) == 0 {
+		return m.regionPublished()
+	}
+	idx := m.rng.Intn(len(m.activeRegions))
+	regionID := m.activeRegions[idx]
+	m.activeRegions = append(m.activeRegions[:idx], m.activeRegions[idx+1:]...)
+	return rootevent.RegionTombstoned(regionID)
+}
+
+func (m *rootScheduleModel) randomMount() string {
+	if len(m.activeMounts) == 0 {
+		return "vol-000"
+	}
+	return m.activeMounts[m.rng.Intn(len(m.activeMounts))]
+}
+
+func rootModelDescriptor(regionID uint64) descriptor.Descriptor {
+	start := fmt.Appendf(nil, "rk%06d", regionID)
+	end := fmt.Appendf(nil, "rk%06d", regionID+1)
+	desc := descriptor.Descriptor{
+		RegionID: regionID,
+		StartKey: start,
+		EndKey:   end,
+		Epoch:    metaregion.Epoch{Version: 1, ConfVersion: 1},
+		State:    metaregion.ReplicaStateRunning,
+	}
+	desc.EnsureHash()
+	return desc
+}
+
+func assertRootEpochDelta(t *testing.T, before, after rootstate.Snapshot, event rootevent.Event) {
+	t.Helper()
+	wantCluster := before.State.ClusterEpoch
+	wantMembership := before.State.MembershipEpoch
+	switch event.Kind {
+	case rootevent.KindStoreJoined, rootevent.KindStoreRetired:
+		wantMembership++
+	case rootevent.KindRegionBootstrap,
+		rootevent.KindRegionDescriptorPublished,
+		rootevent.KindRegionTombstoned,
+		rootevent.KindRegionSplitPlanned,
+		rootevent.KindRegionSplitCommitted,
+		rootevent.KindRegionSplitCancelled,
+		rootevent.KindRegionMergePlanned,
+		rootevent.KindRegionMerged,
+		rootevent.KindRegionMergeCancelled,
+		rootevent.KindPeerAdditionPlanned,
+		rootevent.KindPeerRemovalPlanned,
+		rootevent.KindPeerAdded,
+		rootevent.KindPeerRemoved,
+		rootevent.KindPeerAdditionCancelled,
+		rootevent.KindPeerRemovalCancelled:
+		wantCluster++
+	}
+	require.Equal(t, wantCluster, after.State.ClusterEpoch, "event=%v", event.Kind)
+	require.Equal(t, wantMembership, after.State.MembershipEpoch, "event=%v", event.Kind)
+	require.True(t, rootstate.CursorAfter(after.State.LastCommitted, before.State.LastCommitted), "event=%v", event.Kind)
+}
+
+func assertRootReplayMatchesSnapshot(t *testing.T, root interface {
+	ObserveCommitted() (rootstorage.ObservedCommitted, error)
+	Snapshot() (rootstate.Snapshot, error)
+}) {
+	t.Helper()
+	observed, err := root.ObserveCommitted()
+	require.NoError(t, err)
+	bootstrap := rootmaterialize.BootstrapFromObserved(observed)
+	snapshot, err := root.Snapshot()
+	require.NoError(t, err)
+	require.True(t, reflect.DeepEqual(normalizeRootSnapshot(snapshot), normalizeRootSnapshot(bootstrap.Snapshot)), "root snapshot and replayed bootstrap diverged")
+}
+
+func waitFollowerRootMatchesLeader(t *testing.T, cluster *pdtestcluster.Cluster, followerID, leaderID uint64, sub *rootstorage.TailSubscription) {
+	t.Helper()
+	require.Eventually(t, func() bool {
+		advance, err := sub.Next(context.Background(), 500*time.Millisecond)
+		if err != nil {
+			return false
+		}
+		switch advance.CatchUpAction() {
+		case rootstorage.TailCatchUpRefreshState, rootstorage.TailCatchUpInstallBootstrap:
+			if err := cluster.RootStores[followerID].Refresh(); err != nil {
+				return false
+			}
+			sub.Acknowledge(advance)
+		case rootstorage.TailCatchUpAcknowledgeWindow:
+			sub.Acknowledge(advance)
+		default:
+			return false
+		}
+		leaderSnapshot, err := cluster.Roots[leaderID].Snapshot()
+		if err != nil {
+			return false
+		}
+		followerSnapshot, err := cluster.Roots[followerID].Snapshot()
+		if err != nil {
+			return false
+		}
+		return reflect.DeepEqual(normalizeRootSnapshot(leaderSnapshot), normalizeRootSnapshot(followerSnapshot))
+	}, 8*time.Second, 50*time.Millisecond)
+}
+
+func normalizeRootSnapshot(snapshot rootstate.Snapshot) rootstate.Snapshot {
+	out := rootstate.CloneSnapshot(snapshot)
+	if out.Stores == nil {
+		out.Stores = make(map[uint64]rootstate.StoreMembership)
+	}
+	if out.SnapshotEpochs == nil {
+		out.SnapshotEpochs = make(map[string]rootstate.SnapshotEpoch)
+	}
+	if out.Mounts == nil {
+		out.Mounts = make(map[string]rootstate.MountRecord)
+	}
+	if out.Subtrees == nil {
+		out.Subtrees = make(map[string]rootstate.SubtreeAuthority)
+	}
+	if out.Quotas == nil {
+		out.Quotas = make(map[string]rootstate.QuotaFence)
+	}
+	if out.Descriptors == nil {
+		out.Descriptors = make(map[uint64]descriptor.Descriptor)
+	}
+	if out.PendingPeerChanges == nil {
+		out.PendingPeerChanges = make(map[uint64]rootstate.PendingPeerChange)
+	}
+	if out.PendingRangeChanges == nil {
+		out.PendingRangeChanges = make(map[uint64]rootstate.PendingRangeChange)
+	}
+	return out
+}
+
+func rootModelEnvInt(name string, fallback int) int {
+	raw := os.Getenv(name)
+	if raw == "" {
+		return fallback
+	}
+	value, err := strconv.Atoi(raw)
+	if err != nil || value <= 0 {
+		return fallback
+	}
+	return value
+}

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -226,7 +226,7 @@ nokv meta-root \
 
 - `scripts/ops/serve-meta-root.sh`
   - Starts one replicated `meta-root` peer and forwards shutdown signals.
-  - Requires `--workdir`, `--node-id`, `--transport-addr`, and 3 `--peer` values.
+  - Requires `--config` and `--node-id`; `meta_root.peers` is the only peer-list source.
 - `scripts/ops/serve-coordinator.sh`
   - Starts one `nokv coordinator` against an external meta-root cluster.
   - Requires `--coordinator-id` and 3 `--root-peer` values (meta-root gRPC endpoints).

--- a/docs/scripts.md
+++ b/docs/scripts.md
@@ -85,19 +85,16 @@ This split is deliberate:
 - Example:
   ```bash
   ./scripts/ops/serve-meta-root.sh \
+    --config ./raft_config.example.json \
+    --scope host \
     --addr 127.0.0.1:2380 \
     --workdir ./artifacts/cluster/meta-root-1 \
-    --node-id 1 \
-    --transport-addr 127.0.0.1:3380 \
-    --peer 1=127.0.0.1:3380 \
-    --peer 2=127.0.0.1:3381 \
-    --peer 3=127.0.0.1:3382
+    --node-id 1
   ```
 - Notes:
-  - `--peer` values are metadata-root raft transport addresses, not gRPC
-    service addresses
-  - `--workdir`, `--node-id`, `--transport-addr`, and exactly 3 `--peer`
-    values are required; there is no single-process local mode
+  - `meta_root.peers` in the config is the only peer-list source
+  - `--workdir` is only a local directory override for the selected node
+  - `--config` and `--node-id` are required; there is no single-process local mode
   - forwards shutdown signals to `nokv meta-root`
 
 ### `scripts/ops/serve-coordinator.sh`

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -28,8 +28,29 @@ make test-contract-smoke
 # Same generated fsmeta contract scripts through raftstore/client/percolator
 make test-raftstore-contract-smoke
 
+# Bounded generated model/fault schedules for PR CI
+make test-model-smoke
+
+# Explicit crash-window matrix around 2PC and raft Ready apply/send
+make test-crash-matrix-smoke
+
+# Seeded deterministic fault simulation over a real split-region cluster
+make test-deterministic-simulation-smoke
+
+# Bounded concurrent fsmeta history checks for PR CI
+make test-history-smoke
+
 # Curated distributed correctness smoke used by CI before the full sweep
 make test-correctness-smoke
+
+# Longer seeded correctness/failpoint matrix for nightly CI
+make test-correctness-nightly
+
+# Docker-compose black-box history checker with service restarts / crashes
+make test-docker-chaos
+
+# Short soak smoke; use NOKV_SOAK_DURATION=24h or 72h for release hardening
+make test-soak-smoke
 
 # Crash recovery scenarios
 RECOVERY_TRACE_METRICS=1 \
@@ -80,12 +101,12 @@ NOKV_RUN_BENCHMARKS=1 YCSB_RECORDS=10000 YCSB_OPS=50000 YCSB_WARM_OPS=0 \
 | WAL | `engine/wal/manager_test.go` | Segment rotation, sync semantics, replay tolerance for truncation, directory bootstrap. | Add IO fault injection, concurrent append stress. |
 | LSM / Flush / Compaction | `engine/lsm/lsm_test.go`, `engine/lsm/picker_test.go`, `engine/lsm/planner_test.go`, `engine/lsm/compaction_test.go`, `engine/lsm/flush_runtime_test.go` | Memtable correctness, iterator merging, flush pipeline metrics, compaction scheduling. | Extend backpressure assertions and workload-shape coverage. |
 | Manifest | `engine/manifest/manager_test.go`, `engine/lsm/manifest_test.go` | CURRENT swap safety, rewrite crash handling, SST metadata persistence. | Simulate partial edit corruption, column family extensions. |
-| Percolator / Distributed Txn | `percolator/*_test.go`, `raftstore/client/client_test.go`, `stats_test.go` | Prewrite/Commit/ResolveLock flows, 2PC retries, timestamp-driven MVCC behaviour, metrics accounting. | Mixed multi-region fuzzing with lock TTL and leader churn. |
-| FS Metadata Contract | `fsmeta/contract/*_test.go`, `fsmeta/exec/runner_test.go`, `fsmeta/integration/contract_test.go` | Seeded model-based coverage for create/update/lookup/readdir/snapshot/rename/link/unlink/session expiry against both the executor API and a real split-region raftstore-backed runner. | Add fault-injected retry schedules around the raftstore-backed contract. |
+| Percolator / Distributed Txn | `percolator/*_test.go`, `raftstore/client/client_test.go`, `stats_test.go` | Prewrite/Commit/ResolveLock flows, 2PC retries, timestamp-driven MVCC behaviour, generated transaction-history serializability, rollback marker visibility, lock cleanup, explicit primary-committed / primary-rollback crash windows, restart idempotency, and metrics accounting. | Expand generated recovery schedules for long-transaction heartbeat churn. |
+| FS Metadata Contract | `fsmeta/contract/*_test.go`, `fsmeta/exec/runner_test.go`, `fsmeta/integration/contract_test.go`, `fsmeta/integration/history_contract_test.go` | Seeded model-based coverage for create/update/lookup/readdir/snapshot/rename/link/unlink/session expiry against both the executor API and a real split-region raftstore-backed runner. Bounded concurrent history checks linearize overlapped fsmeta operations against the same reference model. | Add fault-injected retry schedules around the raftstore-backed contract. |
 | DB Integration | `db_test.go`, `db_bench_test.go` | End-to-end writes, recovery, and throttle behaviour. | Combine compaction stress and multi-DB interference. |
 | CLI & Stats | `cmd/nokv/main_test.go`, `stats_test.go` | Golden JSON output, stats snapshot correctness, hot key ranking. | CLI error handling, expvar HTTP integration tests. |
 | Scripts & Tooling | `cmd/nokv-config/main_test.go`, `cmd/nokv/serve_test.go` | `nokv-config` JSON/simple formats, catalog bootstrap CLI, serve bootstrap behavior. | Add direct shell-script golden tests (currently not present) and failure-path diagnostics for `cluster.sh`. |
-| Distributed Migration & Membership | `raftstore/integration/*_test.go`, `raftstore/migrate/*_test.go`, `raftstore/admin/service_test.go` | Standalone -> seeded -> cluster flow, snapshot install, add/remove peer, leader transfer, restart/dehost recovery, Coordinator outage after startup, quorum-loss context propagation, multi-region 2PC deadline propagation, repeated link flap during membership changes, partitioned follower catch-up, and snapshot-install interruption before publish. | Keep expanding publish-boundary coverage and larger fault matrices around runtime/transport interleavings. |
+| Distributed Migration & Membership | `raftstore/integration/*_test.go`, `raftstore/migrate/*_test.go`, `raftstore/admin/service_test.go` | Standalone -> seeded -> cluster flow, snapshot install, add/remove peer, leader transfer, restart/dehost recovery, Coordinator outage after startup, quorum-loss context propagation, multi-region 2PC deadline propagation, repeated link flap during membership changes, partitioned follower catch-up, deterministic split-region simulation schedules, and snapshot-install interruption before publish. | Keep expanding publish-boundary coverage and larger fault matrices around runtime/transport interleavings. |
 | Benchmark | `benchmark/ycsb/ycsb_test.go`, `benchmark/ycsb/ycsb_runner.go` | YCSB throughput/latency comparisons across engines (A-F) with detailed percentile + operation mix reporting. | Automate multi-node deployments and add longer-running, multi-GB stability baselines. |
 
 ---
@@ -127,9 +148,15 @@ NOKV_RUN_BENCHMARKS=1 YCSB_RECORDS=10000 YCSB_OPS=50000 YCSB_WARM_OPS=0 \
 - **Node-local integration tests**: store/admin tests verify snapshot install, membership application, and region runtime publication without booting a full cluster.
 - **Multi-node deterministic data-plane integration tests**: `raftstore/integration` uses `raftstore/testcluster` to boot real stores, wire transports, and drive migration/member flows against live runtimes.
 - **Multi-node deterministic control-plane integration tests**: `coordinator/integration/*_test.go` uses `coordinator/testcluster` to boot `3 coordinator + replicated meta`, exercise rooted watch/reload propagation, follower write rejection, allocator-fence/remove-region propagation, and control-plane read staleness without mixing those cases into store/data-plane tests.
-- **Model/contract tests**: `fsmeta/contract` generates deterministic operation scripts and compares the fsmeta executor against a reference model before the suite reaches raftstore/coordinator/meta fault matrices. `fsmeta/integration/contract_test.go` reuses those scripts against the real raftstore/client/percolator path on a split-region test cluster.
+- **Model/contract tests**: `percolator/txn_model_test.go` generates transaction histories and checks timestamp-order serializability against the real protocol API. `fsmeta/contract` generates deterministic operation scripts and compares the fsmeta executor against a reference model before the suite reaches raftstore/coordinator/meta fault matrices. `fsmeta/contract/history_test.go` runs bounded concurrent batches and searches for a valid linearization of each observed history. `fsmeta/integration/contract_test.go` and `fsmeta/integration/history_contract_test.go` reuse those scripts against the real raftstore/client/percolator path on a split-region test cluster.
+- **Generated data-plane fault tests**: `raftstore/integration/twopc_fault_model_test.go` runs bounded generated 2PC schedules across split regions, leader transfer, partial quorum failure, client retry, and lock resolution.
+- **Generated control-plane model tests**: `coordinator/integration/root_model_test.go` runs rooted event schedules and verifies epoch deltas, snapshot replay/materialization, and follower watch catch-up.
+- **Crash-consistency matrix tests**: `percolator/crash_matrix_test.go` covers primary committed / secondary unresolved, primary rollback / secondary unresolved, and commit/rollback idempotency after restart. `raftstore/peer/peer_test.go::TestPeerFailpointAfterReadyAdvanceBeforeSendRecoversOnLaterTicks` covers the raft apply/advance/send boundary.
+- **Deterministic simulation smoke**: `raftstore/integration/deterministic_simulation_test.go` uses seeded schedules over a real split-region cluster to replay commit, leader-transfer, partial-quorum rollback, delayed transport recovery, target-store restart, and stale lock-resolution pressure.
 - **Restart and recovery suites**: `raftstore/integration/restart_recovery_test.go` covers restarted followers, removed-peer dehost persistence, and leader restart with subsequent membership changes.
 - **Control-plane degradation and publish-boundary tests**: `raftstore/integration/coordinator_degraded_test.go` and `raftstore/integration/snapshot_interruption_test.go` cover live Coordinator outage after startup and failpoint-driven snapshot interruption before peer publication.
+- **Black-box Docker chaos**: `scripts/chaos/docker_fsmeta_history.sh` boots the Docker HA stack and runs `cmd/nokv-fsmeta-history`, a bounded external fsmeta history checker, after coordinator/store/meta-root/fsmeta restarts or single-process kills.
+- **Long soak**: `scripts/soak/fsmeta_soak.sh` runs `cmd/nokv-fsmeta-soak`, which repeatedly mixes namespace history checking with session, snapshot, watch, and cleanup probes. Use `NOKV_SOAK_DURATION=24h` or `72h` for release hardening; PR CI should keep this as a short manual smoke.
 
 When adding new distributed tests:
 
@@ -173,8 +200,14 @@ without manual timing assumptions or known flaky behaviour.
 | fsmeta watch | slow subscriber, expired cursor, reconnect/reconcile | watch replay is bounded; expired cursors force full-state reconcile instead of pretending exactly-once delivery | `fsmeta/exec/watch/router_test.go`, `fsmeta/client/reconcile_test.go`, `fsmeta/integration/e2e_test.go` | Covered |
 | fsmeta snapshot retention | SnapshotSubtree publish/retire, read-version use, MVCC retention floor | active snapshot epochs retain required MVCC history until explicit retire | `fsmeta/exec/runner_test.go`, `fsmeta/server/service_test.go`, `fsmeta/integration/e2e_test.go`, `raftstore/mvcc/policy_test.go` | Covered |
 | fsmeta session lifecycle | writer crash / heartbeat expiry / directory rejection / cleaner errors | stale writer sessions are expired by server time; directories cannot take file writer leases | `fsmeta/exec/runner_test.go`, `fsmeta/exec/session_cleaner_test.go` | Covered |
-| fsmeta operation contract | mixed namespace mutations, snapshot reads, hardlinks, writer sessions, time advance, split-region raftstore routing | executor-visible results match the reference model and stale owner cleanup cannot delete a reused live session | `fsmeta/contract/*_test.go`, `fsmeta/integration/contract_test.go`, `fsmeta/exec/runner_test.go::TestExecutorExpireWriteSessionsDoesNotDeleteReusedLiveSession` | Covered |
+| fsmeta operation contract | mixed namespace mutations, snapshot reads, hardlinks, writer sessions, time advance, split-region raftstore routing, bounded concurrent histories | executor-visible results match the reference model; overlapped API calls admit a legal serial order; stale owner cleanup cannot delete a reused live session | `fsmeta/contract/*_test.go`, `fsmeta/integration/contract_test.go`, `fsmeta/integration/history_contract_test.go`, `fsmeta/exec/runner_test.go::TestExecutorExpireWriteSessionsDoesNotDeleteReusedLiveSession` | Covered |
 | fsmeta namespace chaos | gateway restart, mixed mutations, subtree rename handoff | namespace operations remain transactionally visible and rooted handoff state converges after restart | `fsmeta/integration/namespace_chaos_test.go`, `fsmeta/integration/raftstore_runner_test.go` | Covered |
+| Percolator history model | generated Put/Delete/rollback transaction histories | reads match a timestamp-ordered serial history; committed and rolled-back records do not leave visible stale locks or hide older values | `percolator/txn_model_test.go`, `percolator/txn_test.go` | Covered |
+| Percolator crash matrix | primary committed with secondary unresolved, primary rollback with secondary unresolved, restart between commit/rollback retries | secondary resolution follows primary authority; repeated commit/rollback after restart is idempotent and does not change visibility | `percolator/crash_matrix_test.go` | Covered |
+| Raft Ready advance/send boundary | fail after Ready has been handled and raft node advanced but before outbound messages are sent | the peer can process later Ready batches and still serve linearizable reads after the failpoint is cleared | `raftstore/peer/peer_test.go::TestPeerFailpointAfterReadyAdvanceBeforeSendRecoversOnLaterTicks` | Covered |
+| Raftstore 2PC generated fault schedule | split-region writes, leader transfer, partial child-region quorum failure, client retry, rollback resolution | committed cross-region transactions remain visible and failed partial-quorum attempts do not leak committed writes | `raftstore/integration/twopc_fault_model_test.go` | Covered |
+| Deterministic split-region simulation | generated commit, leader transfer, partial quorum, delayed link recovery, target-store restart, stale lock resolution | every seed is reproducible; committed model state remains visible after each injected transition | `raftstore/integration/deterministic_simulation_test.go` | Covered |
+| Rooted control-plane generated model | store/mount/snapshot/quota/region event schedule with follower watch catch-up | cluster/membership epochs advance only on authority-changing events; replayed state equals live snapshot; follower watch converges | `coordinator/integration/root_model_test.go` | Covered |
 
 CI policy for this matrix:
 
@@ -188,9 +221,38 @@ CI policy for this matrix:
    must not assert a fixed raft recovery latency unless latency is the feature
    being tested.
 
+Nightly policy:
+
+1. PR CI runs bounded smoke through `make test-correctness-smoke`, including
+   `make test-history-smoke` and `make test-model-smoke`.
+2. Nightly CI runs `make test-correctness-nightly`, which raises model seeds
+   and steps, replays raftstore/fsmeta contract/history schedules with longer
+   bounds, repeats crash-matrix boundaries, replays deterministic split-region
+   fault simulation, and repeats failpoint-heavy coordinator/meta/raftstore suites.
+3. A nightly-only failure should still be triaged as a correctness issue unless
+   the failure is clearly in the test harness.
+
+Black-box and soak policy:
+
+1. `make test-docker-chaos` is the Jepsen-style Docker smoke: it validates
+   external fsmeta histories against the reference model while one service at a
+   time is restarted or killed between histories.
+2. `.github/workflows/docker-chaos.yml` runs that Docker smoke on schedule and
+   on demand.
+3. `make test-soak-smoke` is intentionally short by default. Real release
+   hardening should run `NOKV_SOAK_DURATION=24h ./scripts/soak/fsmeta_soak.sh`
+   and a separate `72h` pass on a machine where Docker is allowed to keep state
+   for the whole run.
+4. `.github/workflows/soak-correctness.yml` provides a bounded hosted-runner
+   soak. It is not a replacement for a 24h/72h self-hosted soak.
+
 Next fault-matrix additions should focus on:
 
 - more publish-boundary failpoints around snapshot install and migration init
 - deeper transport/interleave chaos beyond partition + recovery, especially more concurrent membership combinations and repeated multi-link flaps
+- unknown-result aware history checking for operations interrupted by gateway
+  restart mid-RPC
+- fake-clock driven long-transaction simulation that can force heartbeat,
+  expiry, resolver, and GC interaction without wall-clock sleeps
 
 Keep this matrix updated when adding new modules or scenarios so documentation and automation remain aligned.

--- a/engine/lsm/level_handler.go
+++ b/engine/lsm/level_handler.go
@@ -254,7 +254,17 @@ func (lh *levelHandler) searchL0SST(key []byte) (*kv.Entry, error) {
 		version uint64
 		best    *kv.Entry
 	)
-	for _, table := range lh.selectTablesForKey(key, true) {
+	candidates := append([]*table(nil), lh.selectTablesForKey(key, true)...)
+	sort.Slice(candidates, func(i, j int) bool {
+		if candidates[i] == nil {
+			return false
+		}
+		if candidates[j] == nil {
+			return true
+		}
+		return candidates[i].fid > candidates[j].fid
+	})
+	for _, table := range candidates {
 		if table == nil {
 			continue
 		}

--- a/engine/lsm/lsm_test.go
+++ b/engine/lsm/lsm_test.go
@@ -1019,6 +1019,31 @@ func TestL0SearchPrefersLatestVersion(t *testing.T) {
 	got.DecrRef()
 }
 
+func TestL0SearchPrefersNewestTableForSameVersion(t *testing.T) {
+	clearDir()
+	lsm := buildLSM()
+	defer func() { _ = lsm.Close() }()
+
+	key := []byte("same-version")
+	oldLock := kv.NewInternalEntry(kv.CFLock, key, kv.MaxVersion, []byte("lock"), 0, 0)
+	newDelete := kv.NewInternalEntry(kv.CFLock, key, kv.MaxVersion, nil, kv.BitDelete, 0)
+	tblOld := buildTableWithEntries(t, lsm, 41, oldLock)
+	tblNew := buildTableWithEntries(t, lsm, 42, newDelete)
+	defer func() { _ = tblOld.DecrRef() }()
+	defer func() { _ = tblNew.DecrRef() }()
+
+	query := kv.InternalKey(kv.CFLock, key, kv.MaxVersion)
+	l0 := &levelHandler{levelNum: 0, tables: []*table{tblOld, tblNew}}
+	got, err := l0.searchL0SST(query)
+	if err != nil || got == nil {
+		t.Fatalf("l0 search err=%v entry=%v", err, got)
+	}
+	if got.Meta&kv.BitDelete == 0 {
+		t.Fatalf("expected newest same-version table tombstone, got meta=%d value=%q", got.Meta, got.Value)
+	}
+	got.DecrRef()
+}
+
 func TestLevelSearchRespectsMaxVersion(t *testing.T) {
 	clearDir()
 	lsm := buildLSM()

--- a/fsmeta/contract/harness_test.go
+++ b/fsmeta/contract/harness_test.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"sort"
 	"strconv"
+	"sync"
 	"testing"
 	"time"
 
@@ -49,6 +50,7 @@ func envInt(name string, fallback int) int {
 }
 
 type versionedRunner struct {
+	mu     sync.Mutex
 	nextTS uint64
 	data   map[string][]versionedValue
 }
@@ -70,20 +72,26 @@ func (r *versionedRunner) ReserveTimestamp(_ context.Context, count uint64) (uin
 	if count == 0 {
 		return 0, errors.New("zero timestamp reservation")
 	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
 	first := r.nextTS
 	r.nextTS += count
 	return first, nil
 }
 
 func (r *versionedRunner) Get(_ context.Context, key []byte, version uint64) ([]byte, bool, error) {
-	value, ok := r.visible(key, version)
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	value, ok := r.visibleLocked(key, version)
 	return value, ok, nil
 }
 
 func (r *versionedRunner) BatchGet(_ context.Context, keys [][]byte, version uint64) (map[string][]byte, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
 	out := make(map[string][]byte, len(keys))
 	for _, key := range keys {
-		if value, ok := r.visible(key, version); ok {
+		if value, ok := r.visibleLocked(key, version); ok {
 			out[string(key)] = value
 		}
 	}
@@ -91,13 +99,15 @@ func (r *versionedRunner) BatchGet(_ context.Context, keys [][]byte, version uin
 }
 
 func (r *versionedRunner) Scan(_ context.Context, startKey []byte, limit uint32, version uint64) ([]fsmetaexec.KV, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
 	keys := make([][]byte, 0, len(r.data))
 	for key := range r.data {
 		raw := []byte(key)
 		if bytes.Compare(raw, startKey) < 0 {
 			continue
 		}
-		if _, ok := r.visible(raw, version); ok {
+		if _, ok := r.visibleLocked(raw, version); ok {
 			keys = append(keys, append([]byte(nil), raw...))
 		}
 	}
@@ -107,7 +117,7 @@ func (r *versionedRunner) Scan(_ context.Context, startKey []byte, limit uint32,
 		if uint32(len(out)) >= limit {
 			break
 		}
-		value, _ := r.visible(key, version)
+		value, _ := r.visibleLocked(key, version)
 		out = append(out, fsmetaexec.KV{
 			Key:   append([]byte(nil), key...),
 			Value: value,
@@ -116,11 +126,21 @@ func (r *versionedRunner) Scan(_ context.Context, startKey []byte, limit uint32,
 	return out, nil
 }
 
-func (r *versionedRunner) Mutate(_ context.Context, _ []byte, mutations []*kvrpcpb.Mutation, startVersion, commitVersion, _ uint64) error {
+func (r *versionedRunner) Mutate(_ context.Context, primary []byte, mutations []*kvrpcpb.Mutation, startVersion, commitVersion, _ uint64) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
 	for _, mut := range mutations {
 		if mut.GetAssertionNotExist() {
-			if _, ok := r.visible(mut.GetKey(), startVersion); ok {
+			if _, ok := r.visibleLocked(mut.GetKey(), startVersion); ok {
 				return fsmeta.ErrExists
+			}
+			if _, ok := r.visibleLatestLocked(mut.GetKey()); ok {
+				return fsmeta.ErrExists
+			}
+		}
+		if bytes.Equal(mut.GetKey(), primary) && mut.GetOp() == kvrpcpb.Mutation_Delete {
+			if _, ok := r.visibleLatestLocked(mut.GetKey()); !ok {
+				return fsmeta.ErrNotFound
 			}
 		}
 	}
@@ -144,17 +164,27 @@ func (r *versionedRunner) Mutate(_ context.Context, _ []byte, mutations []*kvrpc
 	return nil
 }
 
-func (r *versionedRunner) visible(key []byte, version uint64) ([]byte, bool) {
+func (r *versionedRunner) visibleLatestLocked(key []byte) ([]byte, bool) {
+	return r.visibleLocked(key, ^uint64(0))
+}
+
+func (r *versionedRunner) visibleLocked(key []byte, version uint64) ([]byte, bool) {
 	versions := r.data[string(key)]
-	for i := len(versions) - 1; i >= 0; i-- {
-		candidate := versions[i]
+	var (
+		best      versionedValue
+		bestFound bool
+	)
+	for _, candidate := range versions {
 		if candidate.version > version {
 			continue
 		}
-		if candidate.deleted {
-			return nil, false
+		if !bestFound || candidate.version > best.version {
+			best = candidate
+			bestFound = true
 		}
-		return append([]byte(nil), candidate.value...), true
 	}
-	return nil, false
+	if !bestFound || best.deleted {
+		return nil, false
+	}
+	return append([]byte(nil), best.value...), true
 }

--- a/fsmeta/contract/history.go
+++ b/fsmeta/contract/history.go
@@ -1,0 +1,255 @@
+package contract
+
+import (
+	"context"
+	"fmt"
+	"maps"
+	"strings"
+	"sync"
+	"sync/atomic"
+
+	"github.com/feichai0017/NoKV/fsmeta"
+)
+
+const maxConcurrentHistoryBatch = 5
+
+type scheduledOperation struct {
+	index int
+	op    Operation
+}
+
+type observedOperation struct {
+	index    int
+	op       Operation
+	result   Result
+	started  int64
+	finished int64
+}
+
+// RunConcurrentBatches executes generated fsmeta operations in small
+// overlapping batches and checks every completed batch against a bounded
+// linearization oracle. It is deliberately factorial and bounded: the point is
+// to catch non-serializable metadata histories in nightly runs without turning
+// the regular PR path into a large model checker.
+func RunConcurrentBatches(ctx context.Context, exec Executor, model *Model, ops []Operation, batchSize int) error {
+	if exec == nil {
+		return fmt.Errorf("fsmeta/contract: executor is required")
+	}
+	if model == nil {
+		return fmt.Errorf("fsmeta/contract: model is required")
+	}
+	if batchSize <= 1 {
+		return Run(ctx, exec, model, ops)
+	}
+	if batchSize > maxConcurrentHistoryBatch {
+		return fmt.Errorf("fsmeta/contract: concurrent batch size %d exceeds max %d", batchSize, maxConcurrentHistoryBatch)
+	}
+
+	history := make([]string, 0, len(ops))
+	batch := make([]scheduledOperation, 0, batchSize)
+	batchID := 0
+	flush := func() error {
+		if len(batch) == 0 {
+			return nil
+		}
+		observed := executeConcurrentBatch(ctx, exec, model, batch)
+		next, order, err := linearizeBatch(model, observed)
+		for _, event := range observed {
+			history = append(history, fmt.Sprintf("%03d batch=%03d start=%d finish=%d %s -> got=%s",
+				event.index, batchID, event.started, event.finished, event.op, summarize(event.result)))
+		}
+		if err != nil {
+			return fmt.Errorf("batch %d failed: %w\nbatch:\n%s\nhistory:\n%s",
+				batchID, err, describeObserved(observed), strings.Join(history, "\n"))
+		}
+		history = append(history, fmt.Sprintf("batch %03d linearized_as=%s", batchID, describeOrder(observed, order)))
+		replaceModel(model, next)
+		if err := model.CheckInvariants(); err != nil {
+			return fmt.Errorf("batch %d corrupted model invariants: %w\nhistory:\n%s", batchID, err, strings.Join(history, "\n"))
+		}
+		batch = batch[:0]
+		batchID++
+		return nil
+	}
+
+	for i, op := range ops {
+		if historyBarrier(op) {
+			if err := flush(); err != nil {
+				return err
+			}
+			if err := runSequentialObserved(ctx, exec, model, i, op, &history); err != nil {
+				return err
+			}
+			continue
+		}
+		batch = append(batch, scheduledOperation{index: i, op: op})
+		if len(batch) >= batchSize {
+			if err := flush(); err != nil {
+				return err
+			}
+		}
+	}
+	return flush()
+}
+
+func historyBarrier(op Operation) bool {
+	switch op.Kind {
+	case OpAdvanceTime, OpSnapshotSubtree:
+		return true
+	default:
+		return false
+	}
+}
+
+func runSequentialObserved(ctx context.Context, exec Executor, model *Model, index int, op Operation, history *[]string) error {
+	got := execute(ctx, exec, model, op)
+	want := applyObserved(model, op, got)
+	*history = append(*history, fmt.Sprintf("%03d sequential %s -> got=%s want=%s", index, op, summarize(got), summarize(want)))
+	if err := compareResult(got, want); err != nil {
+		return fmt.Errorf("step %d failed: %w\nhistory:\n%s", index, err, strings.Join(*history, "\n"))
+	}
+	if err := model.CheckInvariants(); err != nil {
+		return fmt.Errorf("step %d corrupted model invariants: %w\nhistory:\n%s", index, err, strings.Join(*history, "\n"))
+	}
+	return nil
+}
+
+func executeConcurrentBatch(ctx context.Context, exec Executor, model *Model, batch []scheduledOperation) []observedOperation {
+	observed := make([]observedOperation, len(batch))
+	var seq atomic.Int64
+	var wg sync.WaitGroup
+	start := make(chan struct{})
+	for i, entry := range batch {
+		observed[i].index = entry.index
+		observed[i].op = entry.op
+		wg.Go(func() {
+			<-start
+			observed[i].started = seq.Add(1)
+			observed[i].result = execute(ctx, exec, model, entry.op)
+			observed[i].finished = seq.Add(1)
+		})
+	}
+	close(start)
+	wg.Wait()
+	return observed
+}
+
+func linearizeBatch(base *Model, observed []observedOperation) (*Model, []int, error) {
+	used := make([]bool, len(observed))
+	order := make([]int, 0, len(observed))
+	var firstMismatch error
+
+	var search func(*Model) (*Model, bool)
+	search = func(current *Model) (*Model, bool) {
+		if len(order) == len(observed) {
+			return current, true
+		}
+		for i := range observed {
+			if used[i] || !respectsRealTime(i, used, observed) {
+				continue
+			}
+			next := cloneModel(current)
+			want := applyObserved(next, observed[i].op, observed[i].result)
+			if err := compareResult(observed[i].result, want); err != nil {
+				if firstMismatch == nil {
+					firstMismatch = fmt.Errorf("op %03d %s: %w; got=%s want=%s",
+						observed[i].index, observed[i].op, err, summarize(observed[i].result), summarize(want))
+				}
+				continue
+			}
+			if err := next.CheckInvariants(); err != nil {
+				if firstMismatch == nil {
+					firstMismatch = fmt.Errorf("op %03d %s corrupts candidate invariants: %w", observed[i].index, observed[i].op, err)
+				}
+				continue
+			}
+			used[i] = true
+			order = append(order, i)
+			if final, ok := search(next); ok {
+				return final, true
+			}
+			order = order[:len(order)-1]
+			used[i] = false
+		}
+		return nil, false
+	}
+
+	next, ok := search(cloneModel(base))
+	if ok {
+		return next, append([]int(nil), order...), nil
+	}
+	if firstMismatch == nil {
+		firstMismatch = fmt.Errorf("no candidate operation respects real-time constraints")
+	}
+	return nil, nil, fmt.Errorf("no serial order matched observed concurrent results: %w", firstMismatch)
+}
+
+func respectsRealTime(candidate int, used []bool, observed []observedOperation) bool {
+	for i := range observed {
+		if i == candidate || used[i] {
+			continue
+		}
+		if observed[i].finished < observed[candidate].started {
+			return false
+		}
+	}
+	return true
+}
+
+func applyObserved(model *Model, op Operation, got Result) Result {
+	if op.Kind == OpSnapshotSubtree {
+		if got.Err == nil {
+			return model.ApplySnapshot(op, got.Token)
+		}
+		return model.Apply(op)
+	}
+	return model.Apply(op)
+}
+
+func cloneModel(in *Model) *Model {
+	if in == nil {
+		return nil
+	}
+	out := &Model{
+		Mount:       in.Mount,
+		Root:        in.Root,
+		NowUnixNs:   in.NowUnixNs,
+		dentries:    cloneDentries(in.dentries),
+		inodes:      cloneInodes(in.inodes),
+		sessions:    make(map[fsmeta.SessionID]fsmeta.SessionRecord, len(in.sessions)),
+		owners:      make(map[fsmeta.InodeID]fsmeta.SessionRecord, len(in.owners)),
+		snapshots:   make(map[uint64]snapshotState, len(in.snapshots)),
+		snapshotRef: make(map[int]uint64, len(in.snapshotRef)),
+	}
+	maps.Copy(out.sessions, in.sessions)
+	maps.Copy(out.owners, in.owners)
+	maps.Copy(out.snapshotRef, in.snapshotRef)
+	for version, snapshot := range in.snapshots {
+		out.snapshots[version] = snapshotState{
+			dentries: cloneDentries(snapshot.dentries),
+			inodes:   cloneInodes(snapshot.inodes),
+		}
+	}
+	return out
+}
+
+func replaceModel(dst *Model, src *Model) {
+	*dst = *src
+}
+
+func describeObserved(observed []observedOperation) string {
+	lines := make([]string, 0, len(observed))
+	for _, event := range observed {
+		lines = append(lines, fmt.Sprintf("%03d start=%d finish=%d %s -> %s",
+			event.index, event.started, event.finished, event.op, summarize(event.result)))
+	}
+	return strings.Join(lines, "\n")
+}
+
+func describeOrder(observed []observedOperation, order []int) string {
+	parts := make([]string, 0, len(order))
+	for _, index := range order {
+		parts = append(parts, fmt.Sprintf("%03d", observed[index].index))
+	}
+	return "[" + strings.Join(parts, ",") + "]"
+}

--- a/fsmeta/contract/history_test.go
+++ b/fsmeta/contract/history_test.go
@@ -1,0 +1,31 @@
+package contract
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	fsmetaexec "github.com/feichai0017/NoKV/fsmeta/exec"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFSMetaExecutorConcurrentHistoryContract(t *testing.T) {
+	seeds := envInt("NOKV_CONTRACT_HISTORY_SEEDS", 8)
+	steps := envInt("NOKV_CONTRACT_HISTORY_STEPS", 48)
+	batchSize := envInt("NOKV_CONTRACT_HISTORY_BATCH", 3)
+	for seed := int64(1); seed <= int64(seeds); seed++ {
+		t.Run(fmt.Sprintf("seed_%03d", seed), func(t *testing.T) {
+			model := NewModel("vol")
+			runner := newVersionedRunner()
+			executor, err := fsmetaexec.New(runner, fsmetaexec.WithClock(func() time.Time {
+				return time.Unix(0, model.NowUnixNs)
+			}))
+			require.NoError(t, err)
+
+			ops := GenerateScript(seed, steps)
+			err = RunConcurrentBatches(context.Background(), executor, model, ops, batchSize)
+			require.NoError(t, err, "seed=%d steps=%d batch=%d", seed, steps, batchSize)
+		})
+	}
+}

--- a/fsmeta/exec/runner.go
+++ b/fsmeta/exec/runner.go
@@ -17,7 +17,8 @@ import (
 )
 
 const defaultLockTTL uint64 = 3000
-const maxCommitTsExpiredRetries = 3
+const maxTxnContentionRetries = 3
+const txnContentionRetryBackoff = time.Millisecond
 
 // KV is the minimal key/value tuple the fsmeta executor consumes from scans.
 type KV struct {
@@ -1193,7 +1194,7 @@ func (e *Executor) reserveTxnVersions(ctx context.Context) (uint64, uint64, erro
 
 func (e *Executor) withTxnRetry(ctx context.Context, run func(startVersion, commitVersion uint64) error) error {
 	var last error
-	for attempt := 0; attempt <= maxCommitTsExpiredRetries; attempt++ {
+	for attempt := 0; attempt <= maxTxnContentionRetries; attempt++ {
 		startVersion, commitVersion, err := e.reserveTxnVersions(ctx)
 		if err != nil {
 			return err
@@ -1202,20 +1203,32 @@ func (e *Executor) withTxnRetry(ctx context.Context, run func(startVersion, comm
 		if err == nil {
 			return nil
 		}
-		if !isCommitTsExpired(err) {
+		if !isRetryableTxnContention(err) {
 			return translateMutateError(err)
 		}
 		last = err
-		if attempt == maxCommitTsExpiredRetries {
+		if attempt == maxTxnContentionRetries {
 			e.txnRetryExhaustedTotal.Add(1)
 			break
 		}
 		e.txnRetriesTotal.Add(1)
-		if ctxErr := ctx.Err(); ctxErr != nil {
-			return ctxErr
+		if err := waitTxnContentionRetry(ctx, attempt); err != nil {
+			return err
 		}
 	}
 	return translateMutateError(last)
+}
+
+func waitTxnContentionRetry(ctx context.Context, attempt int) error {
+	delay := txnContentionRetryBackoff << attempt
+	timer := time.NewTimer(delay)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-timer.C:
+		return nil
+	}
 }
 
 func cloneBytes(in []byte) []byte {
@@ -1315,15 +1328,21 @@ func translateMutateError(err error) error {
 	return err
 }
 
-func isCommitTsExpired(err error) bool {
+func isRetryableTxnContention(err error) bool {
 	var keyErrs keyErrorCarrier
 	if !errors.As(err, &keyErrs) {
 		return false
 	}
+	retryable := false
 	for _, keyErr := range keyErrs.KeyErrors() {
-		if keyErr != nil && keyErr.GetCommitTsExpired() != nil {
-			return true
+		if keyErr == nil {
+			continue
 		}
+		if keyErr.GetCommitTsExpired() != nil || keyErr.GetLocked() != nil {
+			retryable = true
+			continue
+		}
+		return false
 	}
-	return false
+	return retryable
 }

--- a/fsmeta/exec/runner_test.go
+++ b/fsmeta/exec/runner_test.go
@@ -755,6 +755,35 @@ func TestExecutorRetriesCommitTsExpired(t *testing.T) {
 	require.Equal(t, uint64(0), executor.Stats()["txn_retry_exhausted_total"])
 }
 
+func TestExecutorRetriesLockedTxnContention(t *testing.T) {
+	runner := newFakeRunner()
+	runner.mutateErrs = []error{
+		fakeTxnKeyError{errors: []*kvrpcpb.KeyError{{
+			Locked: &kvrpcpb.Locked{
+				PrimaryLock: []byte("dentry"),
+				Key:         []byte("dentry"),
+				LockVersion: 2,
+				LockTtl:     defaultLockTTL,
+			},
+		}}},
+		nil,
+	}
+	executor, err := New(runner)
+	require.NoError(t, err)
+
+	err = executor.Create(context.Background(), fsmeta.CreateRequest{
+		Mount:  "vol",
+		Parent: fsmeta.RootInode,
+		Name:   "file",
+		Inode:  22,
+	}, fsmeta.InodeRecord{Type: fsmeta.InodeTypeFile})
+	require.NoError(t, err)
+	require.Len(t, runner.mutations, 1)
+	require.Equal(t, uint64(5), runner.nextTS)
+	require.Equal(t, uint64(1), executor.Stats()["txn_retries_total"])
+	require.Equal(t, uint64(0), executor.Stats()["txn_retry_exhausted_total"])
+}
+
 func TestExecutorLookupReturnsNotFound(t *testing.T) {
 	executor, err := New(newFakeRunner())
 	require.NoError(t, err)

--- a/fsmeta/integration/history_contract_test.go
+++ b/fsmeta/integration/history_contract_test.go
@@ -1,0 +1,33 @@
+package integration
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	fsmetacontract "github.com/feichai0017/NoKV/fsmeta/contract"
+	fsmetaexec "github.com/feichai0017/NoKV/fsmeta/exec"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRaftstoreRunnerFSMetaConcurrentHistoryOnSplitCluster(t *testing.T) {
+	seeds := envInt("NOKV_RAFTSTORE_HISTORY_SEEDS", 1)
+	steps := envInt("NOKV_RAFTSTORE_HISTORY_STEPS", 24)
+	batchSize := envInt("NOKV_RAFTSTORE_HISTORY_BATCH", 3)
+	for seed := int64(1); seed <= int64(seeds); seed++ {
+		t.Run(fmt.Sprintf("seed_%03d", seed), func(t *testing.T) {
+			ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+			defer cancel()
+
+			model := fsmetacontract.NewModel("vol")
+			executor := openSplitRealClusterExecutorWithOptions(t, ctx, fsmetaexec.WithClock(func() time.Time {
+				return time.Unix(0, model.NowUnixNs)
+			}))
+			ops := fsmetacontract.GenerateScript(seed, steps)
+
+			err := fsmetacontract.RunConcurrentBatches(ctx, executor, model, ops, batchSize)
+			require.NoError(t, err, "seed=%d steps=%d batch=%d", seed, steps, batchSize)
+		})
+	}
+}

--- a/percolator/crash_matrix_test.go
+++ b/percolator/crash_matrix_test.go
@@ -1,0 +1,170 @@
+package percolator
+
+import (
+	"path/filepath"
+	"testing"
+
+	NoKV "github.com/feichai0017/NoKV"
+	kvrpcpb "github.com/feichai0017/NoKV/pb/kv"
+	"github.com/feichai0017/NoKV/percolator/latch"
+	"github.com/feichai0017/NoKV/utils"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPercolatorCrashMatrixPrimaryCommittedSecondaryRecovered(t *testing.T) {
+	db := openTestDB(t)
+	latches := latch.NewManager(32)
+	primary := []byte("crash-primary-commit")
+	secondary := []byte("crash-secondary-commit")
+	startTs := uint64(100)
+	commitTs := uint64(120)
+
+	require.Empty(t, Prewrite(db, latches, &kvrpcpb.PrewriteRequest{
+		PrimaryLock:  primary,
+		StartVersion: startTs,
+		LockTtl:      3000,
+		Mutations: []*kvrpcpb.Mutation{
+			{Op: kvrpcpb.Mutation_Put, Key: primary, Value: []byte("primary-value")},
+			{Op: kvrpcpb.Mutation_Put, Key: secondary, Value: []byte("secondary-value")},
+		},
+	}))
+	require.Nil(t, Commit(db, latches, &kvrpcpb.CommitRequest{
+		Keys:          [][]byte{primary},
+		StartVersion:  startTs,
+		CommitVersion: commitTs,
+	}))
+
+	status := CheckTxnStatus(db, latches, &kvrpcpb.CheckTxnStatusRequest{
+		PrimaryKey: primary,
+		LockTs:     startTs,
+	})
+	require.Nil(t, status.GetError())
+	require.Equal(t, commitTs, status.GetCommitVersion())
+
+	resolved, keyErr := ResolveLock(db, latches, &kvrpcpb.ResolveLockRequest{
+		StartVersion:  startTs,
+		CommitVersion: status.GetCommitVersion(),
+		Keys:          [][]byte{secondary},
+	})
+	require.Nil(t, keyErr)
+	require.Equal(t, uint64(1), resolved)
+
+	reader := NewReader(db)
+	value, _, err := reader.GetValue(primary, commitTs+10)
+	require.NoError(t, err)
+	require.Equal(t, []byte("primary-value"), value)
+	value, _, err = reader.GetValue(secondary, commitTs+10)
+	require.NoError(t, err)
+	require.Equal(t, []byte("secondary-value"), value)
+	lock, err := reader.GetLock(secondary)
+	require.NoError(t, err)
+	require.Nil(t, lock)
+}
+
+func TestPercolatorCrashMatrixPrimaryRollbackSecondaryRecovered(t *testing.T) {
+	db := openTestDB(t)
+	latches := latch.NewManager(32)
+	primary := []byte("crash-primary-rollback")
+	secondary := []byte("crash-secondary-rollback")
+	startTs := uint64(200)
+
+	require.Empty(t, Prewrite(db, latches, &kvrpcpb.PrewriteRequest{
+		PrimaryLock:  primary,
+		StartVersion: startTs,
+		LockTtl:      3000,
+		Mutations: []*kvrpcpb.Mutation{
+			{Op: kvrpcpb.Mutation_Put, Key: primary, Value: []byte("primary-value")},
+			{Op: kvrpcpb.Mutation_Put, Key: secondary, Value: []byte("secondary-value")},
+		},
+	}))
+	require.Nil(t, BatchRollback(db, latches, &kvrpcpb.BatchRollbackRequest{
+		Keys:         [][]byte{primary},
+		StartVersion: startTs,
+	}))
+
+	status := CheckTxnStatus(db, latches, &kvrpcpb.CheckTxnStatusRequest{
+		PrimaryKey:         primary,
+		LockTs:             startTs,
+		RollbackIfNotExist: true,
+	})
+	require.Nil(t, status.GetError())
+	require.Equal(t, kvrpcpb.CheckTxnStatusAction_CheckTxnStatusLockNotExistRollback, status.GetAction())
+
+	resolved, keyErr := ResolveLock(db, latches, &kvrpcpb.ResolveLockRequest{
+		StartVersion: startTs,
+		Keys:         [][]byte{secondary},
+	})
+	require.Nil(t, keyErr)
+	require.Equal(t, uint64(1), resolved)
+
+	reader := NewReader(db)
+	_, _, err := reader.GetValue(primary, startTs+100)
+	require.ErrorIs(t, err, utils.ErrKeyNotFound)
+	_, _, err = reader.GetValue(secondary, startTs+100)
+	require.ErrorIs(t, err, utils.ErrKeyNotFound)
+	lock, err := reader.GetLock(secondary)
+	require.NoError(t, err)
+	require.Nil(t, lock)
+}
+
+func TestPercolatorCrashMatrixCommitAndRollbackIdempotentAfterRestart(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "db")
+	db, err := NoKV.Open(testOptionsForDir(dir))
+	require.NoError(t, err)
+	latches := latch.NewManager(32)
+
+	committedKey := []byte("crash-restart-committed")
+	require.Empty(t, Prewrite(db, latches, &kvrpcpb.PrewriteRequest{
+		PrimaryLock:  committedKey,
+		StartVersion: 300,
+		LockTtl:      3000,
+		Mutations: []*kvrpcpb.Mutation{
+			{Op: kvrpcpb.Mutation_Put, Key: committedKey, Value: []byte("committed-value")},
+		},
+	}))
+	require.Nil(t, Commit(db, latches, &kvrpcpb.CommitRequest{
+		Keys:          [][]byte{committedKey},
+		StartVersion:  300,
+		CommitVersion: 320,
+	}))
+
+	rolledBackKey := []byte("crash-restart-rolled-back")
+	require.Empty(t, Prewrite(db, latches, &kvrpcpb.PrewriteRequest{
+		PrimaryLock:  rolledBackKey,
+		StartVersion: 400,
+		LockTtl:      3000,
+		Mutations: []*kvrpcpb.Mutation{
+			{Op: kvrpcpb.Mutation_Put, Key: rolledBackKey, Value: []byte("rolled-back-value")},
+		},
+	}))
+	require.Nil(t, BatchRollback(db, latches, &kvrpcpb.BatchRollbackRequest{
+		Keys:         [][]byte{rolledBackKey},
+		StartVersion: 400,
+	}))
+	require.NoError(t, db.Close())
+
+	db, err = NoKV.Open(testOptionsForDir(dir))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = db.Close() })
+
+	require.Nil(t, Commit(db, latches, &kvrpcpb.CommitRequest{
+		Keys:          [][]byte{committedKey},
+		StartVersion:  300,
+		CommitVersion: 320,
+	}))
+	require.Nil(t, BatchRollback(db, latches, &kvrpcpb.BatchRollbackRequest{
+		Keys:         [][]byte{committedKey},
+		StartVersion: 300,
+	}))
+	require.Nil(t, BatchRollback(db, latches, &kvrpcpb.BatchRollbackRequest{
+		Keys:         [][]byte{rolledBackKey},
+		StartVersion: 400,
+	}))
+
+	reader := NewReader(db)
+	value, _, err := reader.GetValue(committedKey, 500)
+	require.NoError(t, err)
+	require.Equal(t, []byte("committed-value"), value)
+	_, _, err = reader.GetValue(rolledBackKey, 500)
+	require.ErrorIs(t, err, utils.ErrKeyNotFound)
+}

--- a/percolator/reader.go
+++ b/percolator/reader.go
@@ -123,7 +123,7 @@ func (r *Reader) getWriteForRead(key []byte, readTs uint64) (*mvcc.Write, uint64
 	var result *mvcc.Write
 	var commitTs uint64
 	if err := r.scanWrites(key, func(w mvcc.Write, ts uint64) bool {
-		if ts <= readTs && w.Kind == kvrpcpb.Mutation_Lock {
+		if ts <= readTs && (w.Kind == kvrpcpb.Mutation_Lock || w.Kind == kvrpcpb.Mutation_Rollback) {
 			return true
 		}
 		if ts <= readTs && (result == nil || ts > commitTs) {

--- a/percolator/txn_model_test.go
+++ b/percolator/txn_model_test.go
@@ -1,0 +1,314 @@
+package percolator_test
+
+import (
+	"errors"
+	"fmt"
+	"math/rand"
+	"os"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"testing"
+
+	NoKV "github.com/feichai0017/NoKV"
+	kvrpcpb "github.com/feichai0017/NoKV/pb/kv"
+	"github.com/feichai0017/NoKV/percolator"
+	"github.com/feichai0017/NoKV/percolator/latch"
+	"github.com/feichai0017/NoKV/utils"
+	"github.com/stretchr/testify/require"
+)
+
+type txnModelRead struct {
+	key    string
+	readTs uint64
+	value  string
+	found  bool
+}
+
+type txnModelTxn struct {
+	id        int
+	startTs   uint64
+	commitTs  uint64
+	reads     []txnModelRead
+	writes    map[string]txnModelWrite
+	committed bool
+}
+
+type txnModelWrite struct {
+	value    string
+	deleted  bool
+	lockOnly bool
+}
+
+type txnModelVersion struct {
+	commitTs uint64
+	value    string
+	deleted  bool
+}
+
+type txnModel struct {
+	versions map[string][]txnModelVersion
+}
+
+func TestTxnModelGeneratedScheduleIsSerializable(t *testing.T) {
+	seeds := percolatorModelEnvInt("NOKV_PERCOLATOR_MODEL_SEEDS", 8)
+	steps := percolatorModelEnvInt("NOKV_PERCOLATOR_MODEL_STEPS", 64)
+	for seed := int64(1); seed <= int64(seeds); seed++ {
+		t.Run(fmt.Sprintf("seed_%03d", seed), func(t *testing.T) {
+			db := openPercolatorModelDB(t)
+			latches := latch.NewManager(64)
+			model := newTxnModel()
+			history := runGeneratedTxnSchedule(t, db, latches, model, seed, steps)
+
+			require.NoError(t, checkSerializableByTimestamp(history))
+			reader := percolator.NewReader(db)
+			for _, key := range txnModelKeys() {
+				assertReaderMatchesTxnModel(t, reader, model, key, uint64(steps*20+10_000))
+			}
+		})
+	}
+}
+
+func openPercolatorModelDB(t *testing.T) *NoKV.DB {
+	t.Helper()
+	opt := NoKV.NewDefaultOptions()
+	opt.WorkDir = filepath.Join(t.TempDir(), "db")
+	opt.MemTableSize = 1 << 12
+	opt.SSTableMaxSz = 1 << 20
+	db, err := NoKV.Open(opt)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = db.Close() })
+	return db
+}
+
+func runGeneratedTxnSchedule(t *testing.T, db *NoKV.DB, latches *latch.Manager, model *txnModel, seed int64, steps int) []txnModelTxn {
+	t.Helper()
+	rng := rand.New(rand.NewSource(seed))
+	reader := percolator.NewReader(db)
+	history := make([]txnModelTxn, 0, steps)
+	nextStartTs := uint64(10)
+	for step := range steps {
+		startTs := nextStartTs
+		commitTs := startTs + uint64(1+rng.Intn(3))
+		nextStartTs = commitTs + uint64(1+rng.Intn(3))
+
+		mutations := generatedTxnMutations(rng, step)
+		txn := txnModelTxn{
+			id:       step,
+			startTs:  startTs,
+			commitTs: commitTs,
+			reads:    readTxnSnapshot(t, reader, mutations, startTs),
+			writes:   writesFromMutations(mutations),
+		}
+		for _, read := range txn.reads {
+			assertReadMatchesTxnModel(t, model, read)
+		}
+
+		errs := percolator.Prewrite(db, latches, &kvrpcpb.PrewriteRequest{
+			Mutations:    mutations,
+			PrimaryLock:  mutations[0].GetKey(),
+			StartVersion: startTs,
+			LockTtl:      3000,
+		})
+		require.Empty(t, errs, "seed=%d step=%d startTs=%d commitTs=%d", seed, step, startTs, commitTs)
+
+		rollback := rng.Intn(100) < 25
+		if rollback {
+			require.Nil(t, percolator.BatchRollback(db, latches, &kvrpcpb.BatchRollbackRequest{
+				Keys:         mutationKeys(mutations),
+				StartVersion: startTs,
+			}))
+			history = append(history, txn)
+			assertAllKeysMatchTxnModel(t, reader, model, commitTs+1)
+			continue
+		}
+
+		require.Nil(t, percolator.Commit(db, latches, &kvrpcpb.CommitRequest{
+			Keys:          mutationKeys(mutations),
+			StartVersion:  startTs,
+			CommitVersion: commitTs,
+		}))
+		require.Nil(t, percolator.Commit(db, latches, &kvrpcpb.CommitRequest{
+			Keys:          mutationKeys(mutations),
+			StartVersion:  startTs,
+			CommitVersion: commitTs,
+		}))
+		txn.committed = true
+		model.apply(txn)
+		history = append(history, txn)
+		assertAllKeysMatchTxnModel(t, reader, model, commitTs+1)
+	}
+	return history
+}
+
+func generatedTxnMutations(rng *rand.Rand, step int) []*kvrpcpb.Mutation {
+	keys := txnModelKeys()
+	rng.Shuffle(len(keys), func(i, j int) { keys[i], keys[j] = keys[j], keys[i] })
+	count := 1 + rng.Intn(3)
+	mutations := make([]*kvrpcpb.Mutation, 0, count)
+	for i := range count {
+		key := []byte(keys[i])
+		switch roll := rng.Intn(100); {
+		case roll < 75:
+			mutations = append(mutations, &kvrpcpb.Mutation{
+				Op:    kvrpcpb.Mutation_Put,
+				Key:   key,
+				Value: fmt.Appendf(nil, "value-%03d-%s", step, keys[i]),
+			})
+		default:
+			mutations = append(mutations, &kvrpcpb.Mutation{Op: kvrpcpb.Mutation_Delete, Key: key})
+		}
+	}
+	return mutations
+}
+
+func readTxnSnapshot(t *testing.T, reader *percolator.Reader, mutations []*kvrpcpb.Mutation, readTs uint64) []txnModelRead {
+	t.Helper()
+	reads := make([]txnModelRead, 0, len(mutations))
+	seen := make(map[string]struct{})
+	for _, mutation := range mutations {
+		key := string(mutation.GetKey())
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
+		value, _, err := reader.GetValue(mutation.GetKey(), readTs)
+		read := txnModelRead{key: key, readTs: readTs}
+		if err == nil {
+			read.value = string(value)
+			read.found = true
+		} else {
+			require.True(t, errors.Is(err, utils.ErrKeyNotFound), "unexpected read error for key=%s ts=%d: %v", key, readTs, err)
+		}
+		reads = append(reads, read)
+	}
+	return reads
+}
+
+func writesFromMutations(mutations []*kvrpcpb.Mutation) map[string]txnModelWrite {
+	writes := make(map[string]txnModelWrite, len(mutations))
+	for _, mutation := range mutations {
+		key := string(mutation.GetKey())
+		switch mutation.GetOp() {
+		case kvrpcpb.Mutation_Put:
+			writes[key] = txnModelWrite{value: string(mutation.GetValue())}
+		case kvrpcpb.Mutation_Delete:
+			writes[key] = txnModelWrite{deleted: true}
+		case kvrpcpb.Mutation_Lock:
+			writes[key] = txnModelWrite{lockOnly: true}
+		}
+	}
+	return writes
+}
+
+func checkSerializableByTimestamp(history []txnModelTxn) error {
+	committed := append([]txnModelTxn(nil), history...)
+	sort.Slice(committed, func(i, j int) bool {
+		if committed[i].commitTs != committed[j].commitTs {
+			return committed[i].commitTs < committed[j].commitTs
+		}
+		return committed[i].id < committed[j].id
+	})
+	model := newTxnModel()
+	for _, txn := range committed {
+		if txn.committed {
+			model.apply(txn)
+		}
+	}
+	for _, txn := range history {
+		for _, read := range txn.reads {
+			value, found := model.visible(read.key, read.readTs)
+			if found != read.found || value != read.value {
+				return fmt.Errorf("txn %d read key=%s ts=%d got=(%v,%q) serial=(%v,%q)", txn.id, read.key, read.readTs, read.found, read.value, found, value)
+			}
+		}
+	}
+	return nil
+}
+
+func newTxnModel() *txnModel {
+	return &txnModel{versions: make(map[string][]txnModelVersion)}
+}
+
+func (m *txnModel) apply(txn txnModelTxn) {
+	for key, write := range txn.writes {
+		if write.lockOnly {
+			continue
+		}
+		m.versions[key] = append(m.versions[key], txnModelVersion{
+			commitTs: txn.commitTs,
+			value:    write.value,
+			deleted:  write.deleted,
+		})
+	}
+	for key := range txn.writes {
+		sort.Slice(m.versions[key], func(i, j int) bool {
+			return m.versions[key][i].commitTs < m.versions[key][j].commitTs
+		})
+	}
+}
+
+func (m *txnModel) visible(key string, readTs uint64) (string, bool) {
+	versions := m.versions[key]
+	for i := len(versions) - 1; i >= 0; i-- {
+		version := versions[i]
+		if version.commitTs > readTs {
+			continue
+		}
+		if version.deleted {
+			return "", false
+		}
+		return version.value, true
+	}
+	return "", false
+}
+
+func assertReaderMatchesTxnModel(t *testing.T, reader *percolator.Reader, model *txnModel, key string, readTs uint64) {
+	t.Helper()
+	got, _, err := reader.GetValue([]byte(key), readTs)
+	want, found := model.visible(key, readTs)
+	if !found {
+		require.ErrorIs(t, err, utils.ErrKeyNotFound, "key=%s ts=%d", key, readTs)
+		return
+	}
+	require.NoError(t, err, "key=%s ts=%d", key, readTs)
+	require.Equal(t, want, string(got), "key=%s ts=%d", key, readTs)
+}
+
+func assertAllKeysMatchTxnModel(t *testing.T, reader *percolator.Reader, model *txnModel, readTs uint64) {
+	t.Helper()
+	for _, key := range txnModelKeys() {
+		assertReaderMatchesTxnModel(t, reader, model, key, readTs)
+	}
+}
+
+func assertReadMatchesTxnModel(t *testing.T, model *txnModel, read txnModelRead) {
+	t.Helper()
+	want, found := model.visible(read.key, read.readTs)
+	require.Equal(t, found, read.found, "key=%s ts=%d", read.key, read.readTs)
+	require.Equal(t, want, read.value, "key=%s ts=%d", read.key, read.readTs)
+}
+
+func mutationKeys(mutations []*kvrpcpb.Mutation) [][]byte {
+	keys := make([][]byte, 0, len(mutations))
+	for _, mutation := range mutations {
+		keys = append(keys, append([]byte(nil), mutation.GetKey()...))
+	}
+	return keys
+}
+
+func txnModelKeys() []string {
+	return []string{"key-a", "key-b", "key-c", "key-d", "key-e"}
+}
+
+func percolatorModelEnvInt(name string, fallback int) int {
+	raw := os.Getenv(name)
+	if raw == "" {
+		return fallback
+	}
+	value, err := strconv.Atoi(raw)
+	if err != nil || value <= 0 {
+		return fallback
+	}
+	return value
+}

--- a/percolator/txn_test.go
+++ b/percolator/txn_test.go
@@ -255,6 +255,31 @@ func TestCommittedLockDoesNotCreateVisibleKey(t *testing.T) {
 	require.False(t, exists)
 }
 
+func TestRollbackMarkerDoesNotHideVisiblePut(t *testing.T) {
+	db := openTestDB(t)
+	key := []byte("rollback-visible-put")
+
+	applyVersionedEntryForTxnTest(t, db, kv.CFDefault, key, 10, []byte("value1"), 0)
+	applyVersionedEntryForTxnTest(t, db, kv.CFWrite, key, 20, mvcc.EncodeWrite(mvcc.Write{
+		Kind:    kvrpcpb.Mutation_Put,
+		StartTs: 10,
+	}), 0)
+	applyVersionedEntryForTxnTest(t, db, kv.CFDefault, key, 30, nil, kv.BitDelete)
+	applyVersionedEntryForTxnTest(t, db, kv.CFWrite, key, 30, mvcc.EncodeWrite(mvcc.Write{
+		Kind:    kvrpcpb.Mutation_Rollback,
+		StartTs: 30,
+	}), 0)
+
+	reader := NewReader(db)
+	val, _, err := reader.GetValue(key, 40)
+	require.NoError(t, err)
+	require.Equal(t, []byte("value1"), val)
+
+	exists, err := keyExistsAt(reader, key, 40)
+	require.NoError(t, err)
+	require.True(t, exists)
+}
+
 func TestPrewriteAssertionNotExistRejectsVisibleValue(t *testing.T) {
 	db := openTestDB(t)
 	latches := latch.NewManager(32)
@@ -531,6 +556,38 @@ func TestCommitMissingLockWithExistingWriteIsIdempotent(t *testing.T) {
 	require.Nil(t, err)
 }
 
+func TestCommitRemovesAllLocks(t *testing.T) {
+	db := openTestDB(t)
+	latches := latch.NewManager(16)
+	keys := [][]byte{[]byte("commit-a"), []byte("commit-b"), []byte("commit-c")}
+	require.Empty(t, Prewrite(db, latches, &kvrpcpb.PrewriteRequest{
+		Mutations: []*kvrpcpb.Mutation{
+			{Op: kvrpcpb.Mutation_Put, Key: keys[0], Value: []byte("va")},
+			{Op: kvrpcpb.Mutation_Delete, Key: keys[1]},
+			{Op: kvrpcpb.Mutation_Put, Key: keys[2], Value: []byte("vc")},
+		},
+		PrimaryLock:  keys[0],
+		StartVersion: 18,
+		LockTtl:      1000,
+	}))
+	require.Nil(t, Commit(db, latches, &kvrpcpb.CommitRequest{
+		Keys:          keys,
+		StartVersion:  18,
+		CommitVersion: 25,
+	}))
+
+	reader := NewReader(db)
+	for _, key := range keys {
+		lock, err := reader.GetLock(key)
+		require.NoError(t, err)
+		require.Nil(t, lock, "key=%s", key)
+		write, commitTs, err := reader.GetWriteByStartTs(key, 18)
+		require.NoError(t, err)
+		require.NotNil(t, write, "key=%s", key)
+		require.Equal(t, uint64(25), commitTs, "key=%s", key)
+	}
+}
+
 // TestCommitReturnsLockedOnDifferentTransactionLock rejects foreign locks.
 func TestCommitReturnsLockedOnDifferentTransactionLock(t *testing.T) {
 	db := openTestDB(t)
@@ -595,6 +652,39 @@ func TestBatchRollbackRemovesLock(t *testing.T) {
 	require.NotNil(t, write)
 	require.Equal(t, kvrpcpb.Mutation_Rollback, write.Kind)
 	require.Equal(t, uint64(8), commitTs)
+}
+
+func TestBatchRollbackRemovesAllLocks(t *testing.T) {
+	db := openTestDB(t)
+	latches := latch.NewManager(16)
+	keys := [][]byte{[]byte("rk-a"), []byte("rk-b"), []byte("rk-c")}
+	req := &kvrpcpb.PrewriteRequest{
+		Mutations: []*kvrpcpb.Mutation{
+			{Op: kvrpcpb.Mutation_Put, Key: keys[0], Value: []byte("va")},
+			{Op: kvrpcpb.Mutation_Delete, Key: keys[1]},
+			{Op: kvrpcpb.Mutation_Put, Key: keys[2], Value: []byte("vc")},
+		},
+		PrimaryLock:  keys[0],
+		StartVersion: 18,
+		LockTtl:      1000,
+	}
+	require.Empty(t, Prewrite(db, latches, req))
+	require.Nil(t, BatchRollback(db, latches, &kvrpcpb.BatchRollbackRequest{
+		Keys:         keys,
+		StartVersion: 18,
+	}))
+
+	reader := NewReader(db)
+	for _, key := range keys {
+		lock, err := reader.GetLock(key)
+		require.NoError(t, err)
+		require.Nil(t, lock, "key=%s", key)
+		write, commitTs, err := reader.GetWriteByStartTs(key, 18)
+		require.NoError(t, err)
+		require.NotNil(t, write, "key=%s", key)
+		require.Equal(t, kvrpcpb.Mutation_Rollback, write.Kind, "key=%s", key)
+		require.Equal(t, uint64(18), commitTs, "key=%s", key)
+	}
 }
 
 func TestBatchRollbackDoesNotDeleteOtherTransactionLock(t *testing.T) {

--- a/raftstore/client/client_kv.go
+++ b/raftstore/client/client_kv.go
@@ -464,6 +464,11 @@ func (c *Client) TwoPhaseCommit(ctx context.Context, primary []byte, mutations [
 		}
 	}
 	if err := c.commitKeysByRoute(ctx, [][]byte{append([]byte(nil), primary...)}, startVersion, commitVersion); err != nil {
+		if shouldRollbackAfterPrimaryCommitFailure(err) {
+			if rollbackErr := c.rollbackPrewrites(ctx, prewritten, startVersion); rollbackErr != nil {
+				return errors.Join(err, fmt.Errorf("client: rollback after primary commit failure: %w", rollbackErr))
+			}
+		}
 		return err
 	}
 	secondaryKeys := collectKeys(secondaryMutations)
@@ -548,6 +553,19 @@ func (c *Client) rollbackPrewrites(ctx context.Context, prewritten map[uint64][]
 func (c *Client) resolveCommittedSecondaries(ctx context.Context, keys [][]byte, startVersion, commitVersion uint64) error {
 	_, err := c.ResolveLocks(ctx, startVersion, commitVersion, keys)
 	return err
+}
+
+func shouldRollbackAfterPrimaryCommitFailure(err error) bool {
+	txnErr, ok := AsTxnKeyError(err)
+	if !ok {
+		return false
+	}
+	for _, keyErr := range txnErr.Errors {
+		if keyErr != nil && keyErr.GetCommitTsExpired() != nil {
+			return true
+		}
+	}
+	return false
 }
 
 func (c *Client) prewriteRegionOnce(ctx context.Context, region regionSnapshot, primary []byte, startVersion, ttl uint64, muts []*kvrpcpb.Mutation) (*kvrpcpb.PrewriteResponse, *errorpb.RegionError, error) {

--- a/raftstore/client/client_kv_test.go
+++ b/raftstore/client/client_kv_test.go
@@ -826,6 +826,58 @@ func TestClientTwoPhaseCommitRollsBackPrewritesAfterSecondaryPrewriteFailure(t *
 	require.Equal(t, 1, primaryRollbackHits)
 }
 
+func TestClientTwoPhaseCommitRollsBackPrewritesAfterPrimaryCommitTsExpired(t *testing.T) {
+	cluster := newMockCluster(clusterRegion{
+		meta: &metapb.RegionDescriptor{
+			RegionId: 1,
+			StartKey: []byte("a"),
+			EndKey:   []byte("z"),
+			Epoch:    &metapb.RegionEpoch{Version: 1, ConfVersion: 1},
+			Peers:    []*metapb.RegionPeer{{StoreId: 1, PeerId: 101}},
+		},
+		leaderStore: 1,
+	})
+	svc := &scriptedKVService{mockService: mockService{storeID: 1, cluster: cluster}}
+	svc.commitFn = func(context.Context, *kvrpcpb.KvCommitRequest) (*kvrpcpb.KvCommitResponse, error) {
+		return &kvrpcpb.KvCommitResponse{
+			Response: &kvrpcpb.CommitResponse{
+				Error: &kvrpcpb.KeyError{CommitTsExpired: &kvrpcpb.CommitTsExpired{
+					Key:         []byte("alfa"),
+					CommitTs:    51,
+					MinCommitTs: 55,
+				}},
+			},
+		}, nil
+	}
+	addr, stop := startBlockingStore(t, svc)
+	defer stop()
+
+	cli, err := New(Config{
+		StoreResolver:  staticStoreResolver{{StoreID: 1, Addr: addr}},
+		RegionResolver: resolverFromCluster(cluster),
+		DialOptions:    []grpc.DialOption{grpc.WithTransportCredentials(insecure.NewCredentials())},
+		Retry:          RetryPolicy{MaxAttempts: 2, RegionErrorBackoff: 0},
+	})
+	require.NoError(t, err)
+	defer func() { _ = cli.Close() }()
+
+	err = cli.TwoPhaseCommit(context.Background(), []byte("alfa"), []*kvrpcpb.Mutation{
+		{Op: kvrpcpb.Mutation_Put, Key: []byte("alfa"), Value: []byte("v1")},
+		{Op: kvrpcpb.Mutation_Put, Key: []byte("bravo"), Value: []byte("v2")},
+	}, 50, 51, 3000)
+	txnErr, ok := AsTxnKeyError(err)
+	require.True(t, ok)
+	require.Len(t, txnErr.Errors, 1)
+	require.NotNil(t, txnErr.Errors[0].GetCommitTsExpired())
+
+	cluster.mu.Lock()
+	_, pending := cluster.regions[1].pending[50]
+	rollbackHits := cluster.regions[1].rollbackHits
+	cluster.mu.Unlock()
+	require.False(t, pending, "prewrites must be rolled back after deterministic primary commit rejection")
+	require.Equal(t, 1, rollbackHits)
+}
+
 func TestClientTwoPhaseCommitResolvesSecondariesAfterSecondaryCommitFailure(t *testing.T) {
 	cluster := newMockCluster(
 		clusterRegion{

--- a/raftstore/integration/deterministic_simulation_test.go
+++ b/raftstore/integration/deterministic_simulation_test.go
@@ -1,0 +1,165 @@
+package integration
+
+import (
+	"context"
+	"fmt"
+	"math/rand"
+	"testing"
+	"time"
+
+	kvrpcpb "github.com/feichai0017/NoKV/pb/kv"
+	metapb "github.com/feichai0017/NoKV/pb/meta"
+	"github.com/feichai0017/NoKV/raftstore/client"
+	"github.com/feichai0017/NoKV/raftstore/testcluster"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+)
+
+type simulationAction uint8
+
+const (
+	simulationCommit simulationAction = iota
+	simulationTransferChildLeader
+	simulationPartialQuorumRollback
+	simulationDelayedChildLink
+	simulationRestartTargetStore
+	simulationResolveOldLocks
+)
+
+func TestDeterministicFaultSimulationAcrossSplitCluster(t *testing.T) {
+	seeds := raftstoreFaultEnvInt("NOKV_SIMULATION_SEEDS", 1)
+	steps := raftstoreFaultEnvInt("NOKV_SIMULATION_STEPS", 8)
+	for seed := int64(1); seed <= int64(seeds); seed++ {
+		t.Run(fmt.Sprintf("seed_%03d", seed), func(t *testing.T) {
+			ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+			defer cancel()
+
+			rt := openTwoStoreSplitRuntime(t, ctx)
+			model := make(map[string]string)
+			startTs := uint64(10_000 + seed*1_000)
+			for step, action := range generateSimulationSchedule(seed, steps) {
+				switch action {
+				case simulationCommit:
+					startTs = runSplit2PCCommit(t, ctx, rt.client, model, startTs, step)
+				case simulationTransferChildLeader:
+					transferRegionLeader(t, ctx, 502, 102, 202, rt.seed, rt.target)
+				case simulationPartialQuorumRollback:
+					startTs = runPartialChildQuorumRollback(t, ctx, rt, model, startTs, step)
+				case simulationDelayedChildLink:
+					startTs = runDelayedChildLinkCommit(t, ctx, rt, model, startTs, step)
+				case simulationRestartTargetStore:
+					restartTargetStore(t, ctx, rt)
+				case simulationResolveOldLocks:
+					_, err := rt.client.ResolveLocks(ctx, startTs-500, 0, [][]byte{
+						fmt.Appendf(nil, "missing-primary-%03d", step),
+						fmt.Appendf(nil, "missing-child-%03d", step),
+					})
+					require.NoError(t, err)
+				}
+				assertCommitted2PCModel(t, ctx, rt.client, model, startTs+100)
+			}
+		})
+	}
+}
+
+func generateSimulationSchedule(seed int64, steps int) []simulationAction {
+	if steps < 6 {
+		steps = 6
+	}
+	actions := []simulationAction{
+		simulationCommit,
+		simulationDelayedChildLink,
+		simulationTransferChildLeader,
+		simulationPartialQuorumRollback,
+		simulationRestartTargetStore,
+		simulationResolveOldLocks,
+	}
+	rng := rand.New(rand.NewSource(seed))
+	for len(actions) < steps {
+		switch rng.Intn(100) {
+		case 0, 1, 2, 3, 4, 5, 6, 7:
+			actions = append(actions, simulationPartialQuorumRollback)
+		case 8, 9, 10, 11, 12, 13, 14, 15:
+			actions = append(actions, simulationRestartTargetStore)
+		case 16, 17, 18, 19, 20, 21, 22, 23:
+			actions = append(actions, simulationDelayedChildLink)
+		case 24, 25, 26, 27, 28, 29:
+			actions = append(actions, simulationTransferChildLeader)
+		case 30, 31, 32, 33, 34:
+			actions = append(actions, simulationResolveOldLocks)
+		default:
+			actions = append(actions, simulationCommit)
+		}
+	}
+	return actions[:steps]
+}
+
+func runDelayedChildLinkCommit(t *testing.T, ctx context.Context, rt *twopcFaultRuntime, model map[string]string, startTs uint64, step int) uint64 {
+	t.Helper()
+	primaryKey := fmt.Sprintf("delay-alpha-%03d", step)
+	childKey := fmt.Sprintf("delay-tango-%03d", step)
+	primaryValue := fmt.Sprintf("delay-parent-value-%03d", step)
+	childValue := fmt.Sprintf("delay-child-value-%03d", step)
+
+	blockChildPeerLink(rt.seed, rt.target)
+	unblocked := make(chan struct{})
+	go func() {
+		defer close(unblocked)
+		time.Sleep(120 * time.Millisecond)
+		unblockChildPeerLink(rt.seed, rt.target)
+	}()
+	defer func() {
+		<-unblocked
+		unblockChildPeerLink(rt.seed, rt.target)
+	}()
+
+	commitCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+	require.NoError(t, rt.client.TwoPhaseCommit(commitCtx, []byte(primaryKey), []*kvrpcpb.Mutation{
+		{Op: kvrpcpb.Mutation_Put, Key: []byte(primaryKey), Value: []byte(primaryValue)},
+		{Op: kvrpcpb.Mutation_Put, Key: []byte(childKey), Value: []byte(childValue)},
+	}, startTs, startTs+1, 3000))
+	model[primaryKey] = primaryValue
+	model[childKey] = childValue
+	return startTs + 10
+}
+
+func restartTargetStore(t *testing.T, ctx context.Context, rt *twopcFaultRuntime) {
+	t.Helper()
+	rt.target.Restart(t, nil, true)
+	wireTwoStorePeers(rt.seed, rt.target)
+	testcluster.WaitForHostedPeer(t, ctx, rt.target.Addr(), 501, 201)
+	testcluster.WaitForHostedPeer(t, ctx, rt.target.Addr(), 502, 202)
+	testcluster.FindLeader(t, ctx, 501, rt.seed, rt.target)
+	testcluster.FindLeader(t, ctx, 502, rt.seed, rt.target)
+	reopenFaultClient(t, ctx, rt)
+}
+
+func reopenFaultClient(t *testing.T, ctx context.Context, rt *twopcFaultRuntime) {
+	t.Helper()
+	_ = rt.client.Close()
+
+	parentStatus := testcluster.FetchRuntimeStatus(t, ctx, rt.seed.Addr(), 501)
+	childSeedStatus := testcluster.FetchRuntimeStatus(t, ctx, rt.seed.Addr(), 502)
+	parentLeaderNode, _ := testcluster.FindLeader(t, ctx, 501, rt.seed, rt.target)
+	childLeaderNode, _ := testcluster.FindLeader(t, ctx, 502, rt.seed, rt.target)
+	cli, err := client.New(client.Config{
+		StoreResolver: liveTwoStoreResolver{seed: rt.seed, target: rt.target},
+		RegionResolver: &staticResolver{regions: []*metapb.RegionDescriptor{
+			regionMetaWithLeaderFirst(parentStatus.GetRegion(), parentLeaderNode.StoreID),
+			regionMetaWithLeaderFirst(childSeedStatus.GetRegion(), childLeaderNode.StoreID),
+		}},
+		DialOptions: []grpc.DialOption{grpc.WithTransportCredentials(insecure.NewCredentials())},
+		Retry: client.RetryPolicy{
+			MaxAttempts:                 8,
+			RouteUnavailableBackoff:     10 * time.Millisecond,
+			TransportUnavailableBackoff: 10 * time.Millisecond,
+			RegionErrorBackoff:          10 * time.Millisecond,
+			LockResolveBackoff:          10 * time.Millisecond,
+		},
+	})
+	require.NoError(t, err)
+	rt.client = cli
+	t.Cleanup(func() { _ = cli.Close() })
+}

--- a/raftstore/integration/twopc_fault_model_test.go
+++ b/raftstore/integration/twopc_fault_model_test.go
@@ -1,0 +1,282 @@
+package integration
+
+import (
+	"context"
+	"fmt"
+	"math/rand"
+	"os"
+	"strconv"
+	"testing"
+	"time"
+
+	metaregion "github.com/feichai0017/NoKV/meta/region"
+	coordpb "github.com/feichai0017/NoKV/pb/coordinator"
+	kvrpcpb "github.com/feichai0017/NoKV/pb/kv"
+	metapb "github.com/feichai0017/NoKV/pb/meta"
+	"github.com/feichai0017/NoKV/raftstore/client"
+	localmeta "github.com/feichai0017/NoKV/raftstore/localmeta"
+	"github.com/feichai0017/NoKV/raftstore/migrate"
+	raftmode "github.com/feichai0017/NoKV/raftstore/mode"
+	"github.com/feichai0017/NoKV/raftstore/testcluster"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+)
+
+type twopcFaultAction uint8
+
+const (
+	twopcFaultCommit twopcFaultAction = iota
+	twopcFaultTransferChildLeader
+	twopcFaultPartialChildQuorum
+)
+
+type twopcFaultRuntime struct {
+	seed   *testcluster.Node
+	target *testcluster.Node
+	client *client.Client
+}
+
+type liveTwoStoreResolver struct {
+	seed   *testcluster.Node
+	target *testcluster.Node
+}
+
+func (r liveTwoStoreResolver) GetStore(_ context.Context, req *coordpb.GetStoreRequest) (*coordpb.GetStoreResponse, error) {
+	var node *testcluster.Node
+	switch req.GetStoreId() {
+	case r.seed.StoreID:
+		node = r.seed
+	case r.target.StoreID:
+		node = r.target
+	default:
+		return &coordpb.GetStoreResponse{NotFound: true}, nil
+	}
+	return &coordpb.GetStoreResponse{Store: &coordpb.StoreInfo{
+		StoreId:    node.StoreID,
+		ClientAddr: node.Addr(),
+		State:      coordpb.StoreState_STORE_STATE_UP,
+	}}, nil
+}
+
+func TestTwoPhaseCommitFaultScheduleAcrossSplitCluster(t *testing.T) {
+	seeds := raftstoreFaultEnvInt("NOKV_RAFTSTORE_FAULT_SEEDS", 1)
+	steps := raftstoreFaultEnvInt("NOKV_RAFTSTORE_FAULT_STEPS", 6)
+	for seed := int64(1); seed <= int64(seeds); seed++ {
+		t.Run(fmt.Sprintf("seed_%03d", seed), func(t *testing.T) {
+			ctx, cancel := context.WithTimeout(context.Background(), 45*time.Second)
+			defer cancel()
+
+			rt := openTwoStoreSplitRuntime(t, ctx)
+			model := make(map[string]string)
+			startTs := uint64(1000 + seed*1000)
+			for step, action := range generate2PCFaultSchedule(seed, steps) {
+				switch action {
+				case twopcFaultCommit:
+					startTs = runSplit2PCCommit(t, ctx, rt.client, model, startTs, step)
+				case twopcFaultTransferChildLeader:
+					transferRegionLeader(t, ctx, 502, 102, 202, rt.seed, rt.target)
+				case twopcFaultPartialChildQuorum:
+					startTs = runPartialChildQuorumRollback(t, ctx, rt, model, startTs, step)
+				}
+				assertCommitted2PCModel(t, ctx, rt.client, model, startTs+10)
+			}
+		})
+	}
+}
+
+func openTwoStoreSplitRuntime(t *testing.T, ctx context.Context) *twopcFaultRuntime {
+	t.Helper()
+	seedDir := t.TempDir()
+	standalone := testcluster.OpenStandaloneDB(t, seedDir, nil)
+	require.NoError(t, standalone.Close())
+
+	require.NoError(t, func() error {
+		_, err := migrate.Init(migrate.InitConfig{WorkDir: seedDir, StoreID: 1, RegionID: 501, PeerID: 101})
+		return err
+	}())
+
+	seed := testcluster.StartNode(t, 1, seedDir, []raftmode.Mode{raftmode.ModeSeeded, raftmode.ModeCluster}, true)
+	target := testcluster.StartNode(t, 2, t.TempDir(), nil, false)
+	t.Cleanup(func() {
+		seed.Close(t)
+		target.Close(t)
+	})
+	wireTwoStorePeers(seed, target)
+	testcluster.WaitForLeaderPeer(t, ctx, seed.Addr(), 501, 101)
+
+	_, err := migrate.Expand(ctx, migrate.ExpandConfig{
+		Addr:         seed.Addr(),
+		RegionID:     501,
+		WaitTimeout:  5 * time.Second,
+		PollInterval: 20 * time.Millisecond,
+		Targets: []migrate.PeerTarget{
+			{StoreID: 2, PeerID: 201, TargetAdminAddr: target.Addr()},
+		},
+	})
+	require.NoError(t, err)
+
+	parentLeader, _ := testcluster.FindLeader(t, ctx, 501, seed, target)
+	childMeta := localmeta.RegionMeta{
+		ID:       502,
+		StartKey: []byte("m"),
+		EndKey:   nil,
+		Epoch: metaregion.Epoch{
+			Version:     1,
+			ConfVersion: 1,
+		},
+		Peers: []metaregion.Peer{
+			{StoreID: 1, PeerID: 102},
+			{StoreID: 2, PeerID: 202},
+		},
+	}
+	require.NoError(t, parentLeader.Server.Store().ProposeSplit(501, childMeta, childMeta.StartKey))
+	require.Eventually(t, func() bool {
+		a := testcluster.FetchRuntimeStatus(t, ctx, seed.Addr(), 502)
+		b := testcluster.FetchRuntimeStatus(t, ctx, target.Addr(), 502)
+		return a.GetKnown() && a.GetHosted() && b.GetKnown() && b.GetHosted()
+	}, 5*time.Second, 20*time.Millisecond, testcluster.DumpStatus(t, ctx, 502, seed, target))
+
+	parentStatus := testcluster.FetchRuntimeStatus(t, ctx, seed.Addr(), 501)
+	childSeedStatus := testcluster.FetchRuntimeStatus(t, ctx, seed.Addr(), 502)
+	parentLeaderNode, _ := testcluster.FindLeader(t, ctx, 501, seed, target)
+	childLeaderNode, _ := testcluster.FindLeader(t, ctx, 502, seed, target)
+	cli, err := client.New(client.Config{
+		StoreResolver: liveTwoStoreResolver{seed: seed, target: target},
+		RegionResolver: &staticResolver{regions: []*metapb.RegionDescriptor{
+			regionMetaWithLeaderFirst(parentStatus.GetRegion(), parentLeaderNode.StoreID),
+			regionMetaWithLeaderFirst(childSeedStatus.GetRegion(), childLeaderNode.StoreID),
+		}},
+		DialOptions: []grpc.DialOption{grpc.WithTransportCredentials(insecure.NewCredentials())},
+		Retry: client.RetryPolicy{
+			MaxAttempts:                 8,
+			RouteUnavailableBackoff:     10 * time.Millisecond,
+			TransportUnavailableBackoff: 10 * time.Millisecond,
+			RegionErrorBackoff:          10 * time.Millisecond,
+			LockResolveBackoff:          10 * time.Millisecond,
+		},
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = cli.Close() })
+	return &twopcFaultRuntime{seed: seed, target: target, client: cli}
+}
+
+func generate2PCFaultSchedule(seed int64, steps int) []twopcFaultAction {
+	if steps < 3 {
+		steps = 3
+	}
+	rng := rand.New(rand.NewSource(seed))
+	actions := []twopcFaultAction{twopcFaultCommit, twopcFaultTransferChildLeader, twopcFaultPartialChildQuorum}
+	for len(actions) < steps {
+		switch rng.Intn(100) {
+		case 0, 1, 2, 3, 4, 5, 6, 7, 8, 9:
+			actions = append(actions, twopcFaultPartialChildQuorum)
+		case 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24:
+			actions = append(actions, twopcFaultTransferChildLeader)
+		default:
+			actions = append(actions, twopcFaultCommit)
+		}
+	}
+	return actions[:steps]
+}
+
+func runSplit2PCCommit(t *testing.T, ctx context.Context, cli *client.Client, model map[string]string, startTs uint64, step int) uint64 {
+	t.Helper()
+	primaryKey := fmt.Sprintf("alpha-%03d", step)
+	childKey := fmt.Sprintf("tango-%03d", step)
+	primaryValue := fmt.Sprintf("parent-value-%03d", step)
+	childValue := fmt.Sprintf("child-value-%03d", step)
+	require.NoError(t, cli.TwoPhaseCommit(ctx, []byte(primaryKey), []*kvrpcpb.Mutation{
+		{Op: kvrpcpb.Mutation_Put, Key: []byte(primaryKey), Value: []byte(primaryValue)},
+		{Op: kvrpcpb.Mutation_Put, Key: []byte(childKey), Value: []byte(childValue)},
+	}, startTs, startTs+1, 3000))
+	model[primaryKey] = primaryValue
+	model[childKey] = childValue
+	return startTs + 10
+}
+
+func runPartialChildQuorumRollback(t *testing.T, ctx context.Context, rt *twopcFaultRuntime, model map[string]string, startTs uint64, step int) uint64 {
+	t.Helper()
+	primaryKey := fmt.Sprintf("bravo-failed-%03d", step)
+	childKey := fmt.Sprintf("zulu-failed-%03d", step)
+	blockChildPeerLink(rt.seed, rt.target)
+	failCtx, cancel := context.WithTimeout(ctx, 350*time.Millisecond)
+	err := rt.client.TwoPhaseCommit(failCtx, []byte(primaryKey), []*kvrpcpb.Mutation{
+		{Op: kvrpcpb.Mutation_Put, Key: []byte(primaryKey), Value: []byte("should-not-commit-parent")},
+		{Op: kvrpcpb.Mutation_Put, Key: []byte(childKey), Value: []byte("should-not-commit-child")},
+	}, startTs, startTs+1, 3000)
+	cancel()
+	require.Error(t, err)
+
+	unblockChildPeerLink(rt.seed, rt.target)
+	_, err = rt.client.ResolveLocks(ctx, startTs, 0, [][]byte{[]byte(primaryKey), []byte(childKey)})
+	require.NoError(t, err)
+	assertKeyNotCommitted(t, ctx, rt.client, primaryKey, startTs+100)
+	assertKeyNotCommitted(t, ctx, rt.client, childKey, startTs+100)
+	require.NotContains(t, model, primaryKey)
+	require.NotContains(t, model, childKey)
+	return startTs + 10
+}
+
+func transferRegionLeader(t *testing.T, ctx context.Context, regionID, seedPeerID, targetPeerID uint64, seed, target *testcluster.Node) {
+	t.Helper()
+	leader, status := testcluster.FindLeader(t, ctx, regionID, seed, target)
+	targetNode := target
+	targetPeer := targetPeerID
+	if leader.StoreID == target.StoreID {
+		targetNode = seed
+		targetPeer = seedPeerID
+	}
+	_, err := migrate.TransferLeader(ctx, migrate.TransferLeaderConfig{
+		Addr:            leader.Addr(),
+		TargetAdminAddr: targetNode.Addr(),
+		RegionID:        regionID,
+		PeerID:          targetPeer,
+		WaitTimeout:     3 * time.Second,
+		PollInterval:    20 * time.Millisecond,
+	})
+	require.NoError(t, err, "transfer leader for region=%d from peer=%d to peer=%d", regionID, status.GetLeaderPeerId(), targetPeer)
+}
+
+func assertCommitted2PCModel(t *testing.T, ctx context.Context, cli *client.Client, model map[string]string, readTs uint64) {
+	t.Helper()
+	for key, want := range model {
+		resp, err := cli.Get(ctx, []byte(key), readTs)
+		require.NoError(t, err, "key=%s", key)
+		require.Equal(t, want, string(resp.GetValue()), "key=%s", key)
+	}
+}
+
+func assertKeyNotCommitted(t *testing.T, ctx context.Context, cli *client.Client, key string, readTs uint64) {
+	t.Helper()
+	resp, err := cli.Get(ctx, []byte(key), readTs)
+	require.NoError(t, err, "key=%s", key)
+	require.True(t, resp.GetNotFound(), "key=%s unexpectedly visible as %q", key, resp.GetValue())
+}
+
+func wireTwoStorePeers(seed, target *testcluster.Node) {
+	seed.WirePeers(map[uint64]string{201: target.Addr(), 202: target.Addr()})
+	target.WirePeers(map[uint64]string{101: seed.Addr(), 102: seed.Addr()})
+}
+
+func blockChildPeerLink(seed, target *testcluster.Node) {
+	seed.BlockPeer(202)
+	target.BlockPeer(102)
+}
+
+func unblockChildPeerLink(seed, target *testcluster.Node) {
+	seed.UnblockPeer(202)
+	target.UnblockPeer(102)
+}
+
+func raftstoreFaultEnvInt(name string, fallback int) int {
+	raw := os.Getenv(name)
+	if raw == "" {
+		return fallback
+	}
+	value, err := strconv.Atoi(raw)
+	if err != nil || value <= 0 {
+		return fallback
+	}
+	return value
+}

--- a/raftstore/kv/apply.go
+++ b/raftstore/kv/apply.go
@@ -336,10 +336,10 @@ func collectVisibleValue(db txnstore.Store, iter index.Iterator, key []byte, rea
 			return nil, 0, false, err
 		}
 		switch write.Kind {
-		case kvrpcpb.Mutation_Lock:
+		case kvrpcpb.Mutation_Lock, kvrpcpb.Mutation_Rollback:
 			iter.Next()
 			continue
-		case kvrpcpb.Mutation_Delete, kvrpcpb.Mutation_Rollback:
+		case kvrpcpb.Mutation_Delete:
 			advanceToNextUserKey(iter, key)
 			return nil, 0, false, nil
 		default:

--- a/raftstore/kv/apply_test.go
+++ b/raftstore/kv/apply_test.go
@@ -293,6 +293,38 @@ func TestHandleScanCommittedLockDoesNotCreateVisibleKey(t *testing.T) {
 	require.Empty(t, resp.GetKvs())
 }
 
+func TestHandleScanRollbackMarkerDoesNotHideVisiblePut(t *testing.T) {
+	opt := NoKV.NewDefaultOptions()
+	opt.WorkDir = t.TempDir()
+	db, err := NoKV.Open(opt)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = db.Close() })
+
+	key := []byte("scan-rollback-visible-put")
+	applyVersionedEntryForApplyTest(t, db, entrykv.CFDefault, key, 10, []byte("value1"), 0, 0)
+	applyVersionedEntryForApplyTest(t, db, entrykv.CFWrite, key, 20, mvcc.EncodeWrite(mvcc.Write{
+		Kind:    kvrpcpb.Mutation_Put,
+		StartTs: 10,
+	}), 0, 0)
+	applyVersionedEntryForApplyTest(t, db, entrykv.CFDefault, key, 30, nil, entrykv.BitDelete, 0)
+	applyVersionedEntryForApplyTest(t, db, entrykv.CFWrite, key, 30, mvcc.EncodeWrite(mvcc.Write{
+		Kind:    kvrpcpb.Mutation_Rollback,
+		StartTs: 30,
+	}), 0, 0)
+
+	resp, err := handleScan(db, &kvrpcpb.ScanRequest{
+		StartKey:     key,
+		Limit:        1,
+		Version:      40,
+		IncludeStart: true,
+	})
+	require.NoError(t, err)
+	require.Nil(t, resp.GetError())
+	require.Len(t, resp.GetKvs(), 1)
+	require.Equal(t, key, resp.GetKvs()[0].GetKey())
+	require.Equal(t, []byte("value1"), resp.GetKvs()[0].GetValue())
+}
+
 func TestHandleScanSkipsExpiredShortValue(t *testing.T) {
 	opt := NoKV.NewDefaultOptions()
 	opt.WorkDir = t.TempDir()

--- a/raftstore/peer/peer_test.go
+++ b/raftstore/peer/peer_test.go
@@ -2,11 +2,12 @@ package peer
 
 import (
 	"context"
-	metaregion "github.com/feichai0017/NoKV/meta/region"
 	"testing"
 	"time"
 
+	metaregion "github.com/feichai0017/NoKV/meta/region"
 	myraft "github.com/feichai0017/NoKV/raft"
+	"github.com/feichai0017/NoKV/raftstore/failpoints"
 	localmeta "github.com/feichai0017/NoKV/raftstore/localmeta"
 	"github.com/feichai0017/NoKV/raftstore/raftlog"
 	"github.com/stretchr/testify/require"
@@ -123,6 +124,39 @@ func TestLinearizableReadCanceledClearsPending(t *testing.T) {
 	p.readMu.Lock()
 	defer p.readMu.Unlock()
 	require.Empty(t, p.pendingReads)
+}
+
+func TestPeerFailpointAfterReadyAdvanceBeforeSendRecoversOnLaterTicks(t *testing.T) {
+	var applied []string
+	p := newTestPeer(t, newPayloadTestStorage(), func(entries []myraft.Entry) error {
+		for _, entry := range entries {
+			if len(entry.Data) > 0 {
+				applied = append(applied, string(entry.Data))
+			}
+		}
+		return nil
+	})
+	require.NoError(t, p.Bootstrap([]myraft.Peer{{ID: 11}}))
+	require.NoError(t, p.Campaign())
+	require.NoError(t, p.Flush())
+
+	failpoints.Set(failpoints.AfterReadyAdvanceBeforeSend)
+	t.Cleanup(func() { failpoints.Set(failpoints.None) })
+	err := p.Propose([]byte("first-after-advance"))
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "after ready advance before send")
+
+	failpoints.Set(failpoints.None)
+	require.NoError(t, p.Flush())
+	require.NoError(t, p.Propose([]byte("second-after-recovery")))
+	require.NoError(t, p.Flush())
+	require.Contains(t, applied, "second-after-recovery")
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	index, err := p.LinearizableRead(ctx)
+	require.NoError(t, err)
+	require.NoError(t, p.WaitApplied(ctx, index))
 }
 
 func TestReadIndexHelpersDeliverAndCancel(t *testing.T) {

--- a/scripts/chaos/docker_fsmeta_history.sh
+++ b/scripts/chaos/docker_fsmeta_history.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT_DIR"
+source "$ROOT_DIR/scripts/lib/common.sh"
+
+ADDR="${NOKV_FSMETA_ADDR:-127.0.0.1:8090}"
+MOUNT="${NOKV_FSMETA_MOUNT:-default}"
+SEEDS="${NOKV_DOCKER_CHAOS_SEEDS:-3}"
+STEPS="${NOKV_DOCKER_CHAOS_STEPS:-48}"
+BATCH="${NOKV_DOCKER_CHAOS_BATCH:-3}"
+TIMEOUT="${NOKV_DOCKER_CHAOS_TIMEOUT:-60s}"
+READY_TIMEOUT="${NOKV_DOCKER_CHAOS_READY_TIMEOUT:-180}"
+TOOLS_DIR="$(mktemp -d "${TMPDIR:-/tmp}/nokv-fsmeta-chaos.XXXXXX")"
+
+cleanup() {
+  rm -rf "$TOOLS_DIR"
+  if [[ "${NOKV_DOCKER_CHAOS_DOWN:-0}" == "1" ]]; then
+    docker compose down -v
+  fi
+}
+trap cleanup EXIT
+trap 'trap - EXIT; cleanup; exit 130' INT TERM
+
+go build -o "$TOOLS_DIR/nokv-fsmeta-history" ./cmd/nokv-fsmeta-history
+
+if [[ "${NOKV_DOCKER_CHAOS_BUILD:-1}" == "1" ]]; then
+  docker compose up -d --build
+else
+  docker compose up -d
+fi
+
+wait_fsmeta() {
+  nokv_wait_for_tcp "$ADDR" "$READY_TIMEOUT"
+}
+
+inject_fault() {
+  local seed="$1"
+  case $((seed % 6)) in
+    0)
+      docker compose restart fsmeta
+      ;;
+    1)
+      docker compose restart coordinator-1
+      ;;
+    2)
+      docker compose kill -s SIGKILL store-2
+      docker compose up -d store-2
+      ;;
+    3)
+      docker compose restart meta-root-3
+      ;;
+    4)
+      docker compose kill -s SIGKILL coordinator-2
+      docker compose up -d coordinator-2
+      ;;
+    *)
+      docker compose restart store-3
+      ;;
+  esac
+}
+
+wait_fsmeta
+for seed in $(seq 1 "$SEEDS"); do
+  inject_fault "$seed"
+  wait_fsmeta
+  "$TOOLS_DIR/nokv-fsmeta-history" \
+    --addr "$ADDR" \
+    --mount "$MOUNT" \
+    --seed-start "$seed" \
+    --seeds 1 \
+    --steps "$STEPS" \
+    --batch "$BATCH" \
+    --timeout "$TIMEOUT"
+done

--- a/scripts/debug.sh
+++ b/scripts/debug.sh
@@ -1,3 +1,9 @@
-#!/bin/bash
+#!/usr/bin/env bash
+set -euo pipefail
 
-dlv test -test.run=$1
+if [[ $# -ne 1 ]]; then
+  echo "Usage: scripts/debug.sh <go-test-regexp>" >&2
+  exit 2
+fi
+
+exec dlv test -- -test.run="$1"

--- a/scripts/dev/cluster.sh
+++ b/scripts/dev/cluster.sh
@@ -30,7 +30,7 @@ Notes:
   - cluster.sh is a bootstrap/dev launcher, not a restart workflow.
   - Fresh store workdirs are seeded from config.regions; existing runtime workdirs are reused as-is.
   - For production-style restarts, run the ops scripts directly against the same durable workdirs:
-      scripts/ops/serve-meta-root.sh --workdir ... --node-id ... --peer ...
+      scripts/ops/serve-meta-root.sh --config ... --node-id ...
       scripts/ops/serve-coordinator.sh --coordinator-id ... --root-peer ...
       scripts/ops/serve-store.sh --config ... --store-id ...
 USAGE
@@ -216,29 +216,29 @@ for idx in "${!STORE_IDS[@]}"; do
   done
 done
 
-ROOT_NODE_IDS=(1 2 3)
-ROOT_GRPC_ADDRS=("127.0.0.1:2380" "127.0.0.1:2381" "127.0.0.1:2382")
-ROOT_TRANSPORT_ADDRS=("127.0.0.1:3380" "127.0.0.1:3381" "127.0.0.1:3382")
-ROOT_PEER_FLAGS=(
-  "--peer" "1=${ROOT_TRANSPORT_ADDRS[0]}"
-  "--peer" "2=${ROOT_TRANSPORT_ADDRS[1]}"
-  "--peer" "3=${ROOT_TRANSPORT_ADDRS[2]}"
-)
+ROOT_NODE_IDS=()
+ROOT_GRPC_ADDRS=()
+while read -r node_id grpc_addr _transport_addr _root_workdir; do
+  ROOT_NODE_IDS+=("$node_id")
+  ROOT_GRPC_ADDRS+=("$grpc_addr")
+done < <(nokv_config_meta_root_lines "$CONFIG_PATH" host)
+if [[ "${#ROOT_NODE_IDS[@]}" -ne 3 ]]; then
+  nokv_die "cluster.sh: meta_root.peers must contain exactly 3 peers"
+fi
 
 for idx in "${!ROOT_NODE_IDS[@]}"; do
   node_id="${ROOT_NODE_IDS[$idx]}"
   grpc_addr="${ROOT_GRPC_ADDRS[$idx]}"
-  transport_addr="${ROOT_TRANSPORT_ADDRS[$idx]}"
   root_workdir="$WORKDIR/meta-root-$node_id"
   mkdir -p "$root_workdir"
-  echo "Starting metadata root ${node_id} (grpc=${grpc_addr} raft=${transport_addr})"
+  echo "Starting metadata root ${node_id} (grpc=${grpc_addr})"
   start_with_logs root_pid "meta-root-${node_id}" "$root_workdir/root.log" \
     "$ROOT_DIR/scripts/ops/serve-meta-root.sh" \
+      --config "$CONFIG_PATH" \
+      --scope host \
       --addr "$grpc_addr" \
       --workdir "$root_workdir" \
-      --node-id "$node_id" \
-      --transport-addr "$transport_addr" \
-      "${ROOT_PEER_FLAGS[@]}"
+      --node-id "$node_id"
   ROOT_PIDS+=("$root_pid")
 done
 

--- a/scripts/lib/config.sh
+++ b/scripts/lib/config.sh
@@ -23,6 +23,12 @@ nokv_config_coordinator_workdir() {
   nokv-config coordinator --config "$config_path" --scope host --format simple --field workdir 2>/dev/null | tr -d '\r' | sed -n '1p'
 }
 
+nokv_config_meta_root_lines() {
+  local config_path=$1
+  local scope=${2:-host}
+  nokv-config meta-root --config "$config_path" --scope "$scope" --format simple
+}
+
 nokv_config_store_lines() {
   local config_path=$1
   nokv-config stores --config "$config_path" --format simple

--- a/scripts/ops/serve-meta-root.sh
+++ b/scripts/ops/serve-meta-root.sh
@@ -6,28 +6,17 @@ source "$SCRIPT_DIR/../lib/common.sh"
 
 usage() {
   cat <<'USAGE'
-Usage: scripts/ops/serve-meta-root.sh [options]
+Usage: scripts/ops/serve-meta-root.sh --config <file> --node-id <id> [options]
 
-Launches one meta-root peer. NoKV only ships the replicated 3-peer topology.
-
-There are two ways to describe the cluster:
-
-  1. --config <file> + --node-id <id>:
-     The meta_root.peers section of the config file provides the peer list,
-     transport address, and workdir. This is the recommended path since it
-     keeps topology in one place.
-
-  2. Explicit flags (--workdir, --transport-addr, --peer x3):
-     Use when no config file is available.
+Launches one meta-root peer. The raft configuration is the only topology
+source; the script does not accept an alternate peer-list mode.
 
 Options:
   --config <file>            Raft config file (meta_root.peers drives peer list)
   --scope <host|docker>      Address scope for config resolution (default: host)
   --addr <addr>              Metadata root gRPC listen address (default: 127.0.0.1:2380)
-  --workdir <dir>            Metadata root workdir (required unless in --config)
+  --workdir <dir>            Optional metadata root workdir override
   --node-id <id>             Local node id (required, must be > 0)
-  --transport-addr <addr>    Raft transport address (required unless in --config)
-  --peer <id=addr>           Peer mapping; repeatable (exactly 3 unless in --config)
   --extra <args...>          Additional arguments passed to "nokv meta-root"
 USAGE
 }
@@ -37,8 +26,6 @@ SCOPE="host"
 ADDR="127.0.0.1:2380"
 WORKDIR=""
 NODE_ID=""
-TRANSPORT_ADDR=""
-PEERS=()
 EXTRA_ARGS=()
 
 while [[ $# -gt 0 ]]; do
@@ -63,14 +50,6 @@ while [[ $# -gt 0 ]]; do
       NODE_ID=$2
       shift 2
       ;;
-    --transport-addr)
-      TRANSPORT_ADDR=$2
-      shift 2
-      ;;
-    --peer)
-      PEERS+=("$2")
-      shift 2
-      ;;
     --help|-h)
       usage
       exit 0
@@ -92,48 +71,21 @@ while [[ $# -gt 0 ]]; do
   esac
 done
 
+if [[ -z "$CONFIG" ]]; then
+  nokv_die "serve-meta-root.sh: --config is required"
+fi
 if [[ -z "$NODE_ID" ]]; then
   nokv_die "serve-meta-root.sh: --node-id is required"
 fi
 
-# When --config is given, let `nokv meta-root` itself resolve peer/transport/
-# workdir from the config file. Only pass the explicitly-set flags through.
-if [[ -n "$CONFIG" ]]; then
-  cmd=(nokv meta-root
-    --config "$CONFIG"
-    --scope "$SCOPE"
-    --node-id "$NODE_ID"
-    --addr "$ADDR"
-  )
-  if [[ -n "$WORKDIR" ]]; then
-    cmd+=(--workdir "$WORKDIR")
-  fi
-  if [[ -n "$TRANSPORT_ADDR" ]]; then
-    cmd+=(--transport-addr "$TRANSPORT_ADDR")
-  fi
-  for peer in "${PEERS[@]}"; do
-    cmd+=(--peer "$peer")
-  done
-else
-  # Legacy path: all addresses via flags.
-  if [[ -z "$WORKDIR" ]]; then
-    nokv_die "serve-meta-root.sh: --workdir is required (or use --config)"
-  fi
-  if [[ -z "$TRANSPORT_ADDR" ]]; then
-    nokv_die "serve-meta-root.sh: --transport-addr is required (or use --config)"
-  fi
-  if [[ "${#PEERS[@]}" -ne 3 ]]; then
-    nokv_die "serve-meta-root.sh: requires exactly 3 --peer values (or use --config)"
-  fi
-  cmd=(nokv meta-root
-    --addr "$ADDR"
-    --workdir "$WORKDIR"
-    --node-id "$NODE_ID"
-    --transport-addr "$TRANSPORT_ADDR"
-  )
-  for peer in "${PEERS[@]}"; do
-    cmd+=(--peer "$peer")
-  done
+cmd=(nokv meta-root
+  --config "$CONFIG"
+  --scope "$SCOPE"
+  --node-id "$NODE_ID"
+  --addr "$ADDR"
+)
+if [[ -n "$WORKDIR" ]]; then
+  cmd+=(--workdir "$WORKDIR")
 fi
 
 cmd+=("${EXTRA_ARGS[@]}")

--- a/scripts/soak/fsmeta_soak.sh
+++ b/scripts/soak/fsmeta_soak.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT_DIR"
+source "$ROOT_DIR/scripts/lib/common.sh"
+
+ADDR="${NOKV_FSMETA_ADDR:-127.0.0.1:8090}"
+MOUNT="${NOKV_FSMETA_MOUNT:-default}"
+DURATION="${NOKV_SOAK_DURATION:-24h}"
+STEPS="${NOKV_SOAK_STEPS:-80}"
+BATCH="${NOKV_SOAK_BATCH:-3}"
+SEED_START="${NOKV_SOAK_SEED_START:-1}"
+RESTART_INTERVAL="${NOKV_SOAK_RESTART_INTERVAL:-10m}"
+READY_TIMEOUT="${NOKV_SOAK_READY_TIMEOUT:-180}"
+TOOLS_DIR="$(mktemp -d "${TMPDIR:-/tmp}/nokv-fsmeta-soak.XXXXXX")"
+chaos_pid=""
+
+cleanup() {
+  if [[ -n "$chaos_pid" ]] && kill -0 "$chaos_pid" 2>/dev/null; then
+    kill "$chaos_pid" 2>/dev/null || true
+    wait "$chaos_pid" 2>/dev/null || true
+  fi
+  rm -rf "$TOOLS_DIR"
+  if [[ "${NOKV_SOAK_DOWN:-0}" == "1" ]]; then
+    docker compose down -v
+  fi
+}
+trap cleanup EXIT
+trap 'trap - EXIT; cleanup; exit 130' INT TERM
+
+go build -o "$TOOLS_DIR/nokv-fsmeta-history" ./cmd/nokv-fsmeta-history
+go build -o "$TOOLS_DIR/nokv-fsmeta-soak" ./cmd/nokv-fsmeta-soak
+
+if [[ "${NOKV_SOAK_BUILD:-1}" == "1" ]]; then
+  docker compose up -d --build
+else
+  docker compose up -d
+fi
+
+wait_fsmeta() {
+  nokv_wait_for_tcp "$ADDR" "$READY_TIMEOUT"
+}
+
+rolling_restart_loop() {
+  local services=(coordinator-1 coordinator-2 coordinator-3 store-1 store-2 store-3 meta-root-1 meta-root-2 meta-root-3 fsmeta)
+  local i=0
+  while true; do
+    sleep "$RESTART_INTERVAL"
+    local svc="${services[$((i % ${#services[@]}))]}"
+    docker compose restart "$svc"
+    wait_fsmeta
+    i=$((i + 1))
+  done
+}
+
+wait_fsmeta
+if [[ "${NOKV_SOAK_ROLLING_RESTARTS:-1}" == "1" ]]; then
+  rolling_restart_loop &
+  chaos_pid="$!"
+fi
+
+"$TOOLS_DIR/nokv-fsmeta-soak" \
+  --addr "$ADDR" \
+  --mount "$MOUNT" \
+  --duration "$DURATION" \
+  --steps "$STEPS" \
+  --batch "$BATCH" \
+  --seed-start "$SEED_START"


### PR DESCRIPTION
## Summary
- Add fsmeta history checking, raftstore-backed history tests, and external `nokv-fsmeta-history` / `nokv-fsmeta-soak` commands.
- Add percolator serializability model tests, 2PC crash-window tests, raftstore deterministic fault simulation, and coordinator root replay/watch model checks.
- Add nightly correctness, Docker chaos, and soak workflows, plus Linux-style shell scripts and config-only meta-root script flow.
- Tighten MVCC/LSM visibility regressions covered by the new correctness matrix.

## Validation
- `find scripts -type f -name '*.sh' -print0 | xargs -0 bash -n`
- `git diff --check`
- `go test ./cmd/nokv-config ./cmd/nokv-fsmeta-history ./cmd/nokv-fsmeta-soak -count=1`
- `make test-correctness-smoke`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added GitHub Actions workflows for automated chaos testing, nightly correctness validation, and load/soak testing
  * Introduced new CLI tools for filesystem metadata history operations and soak testing
  * Extended testing infrastructure with new make targets for smoke tests, correctness validation, docker chaos, and soak scenarios

* **Bug Fixes**
  * Fixed rollback marker visibility to properly preserve earlier committed values
  * Improved L0 table search to correctly prioritize newest tables for concurrent versions

* **Documentation**
  * Updated CLI and testing documentation with new validation guidelines and test execution commands

* **Tests**
  * Added comprehensive test coverage for concurrent history operations, crash recovery, fault injection, and deterministic simulation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->