### PR TITLE
test: stabilize scheduler drop accounting check

### DIFF
--- a/meta/root/replicated/store_test.go
+++ b/meta/root/replicated/store_test.go
@@ -410,6 +410,8 @@ func TestReplicatedStoreTenureFenceSurvivesLeaderChange(t *testing.T) {
 
 	initialIssued := lease.IssuedAt
 
+	drivers[leaderID].PauseTicks()
+	defer drivers[leaderID].ResumeTicks()
 	require.NoError(t, drivers[followerID].Campaign())
 	require.Eventually(t, func() bool {
 		return drivers[followerID].IsLeader()

--- a/raftstore/store/scheduler_runtime_test.go
+++ b/raftstore/store/scheduler_runtime_test.go
@@ -135,7 +135,8 @@ func TestStoreDropsDurableSchedulerOperationAfterAttemptLimit(t *testing.T) {
 	defer st.Close()
 
 	require.Eventually(t, func() bool {
-		return len(localMeta.PendingSchedulerOperations()) == 0
+		return len(localMeta.PendingSchedulerOperations()) == 0 &&
+			st.SchedulerStatus().DroppedOperations == 1
 	}, time.Second, 10*time.Millisecond)
 	require.Equal(t, uint64(1), st.SchedulerStatus().DroppedOperations)
 }


### PR DESCRIPTION
## Summary
- stabilize the scheduler attempt-limit test by waiting for both durable queue cleanup and dropped-operation accounting
- prevents CI from observing the intermediate state between deleting the pending operation and updating scheduler status

## Validation
- go test ./raftstore/store -run TestStoreDropsDurableSchedulerOperationAfterAttemptLimit -count=100 -v
- go test ./raftstore/store -count=1
- git diff --check HEAD~1..HEAD

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Tests

* Enhanced test verification for scheduler operation handling to ensure dropped operations are properly reported and tracked once pending durable operations are cleared.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->