### PR TITLE
Fix MVCC historical read correctness edges

### DIFF
--- a/.github/workflows/docker-chaos.yml
+++ b/.github/workflows/docker-chaos.yml
@@ -26,5 +26,6 @@ jobs:
           NOKV_DOCKER_CHAOS_SEEDS: "2"
           NOKV_DOCKER_CHAOS_STEPS: "32"
           NOKV_DOCKER_CHAOS_BATCH: "3"
-          NOKV_DOCKER_CHAOS_TIMEOUT: "60s"
+          NOKV_DOCKER_CHAOS_TIMEOUT: "120s"
+          NOKV_DOCKER_CHAOS_INTERVAL: "2"
         run: ./scripts/chaos/docker_fsmeta_history.sh

--- a/.github/workflows/release-soak.yml
+++ b/.github/workflows/release-soak.yml
@@ -1,0 +1,44 @@
+name: Release Soak
+
+on:
+  workflow_dispatch:
+    inputs:
+      duration:
+        description: "Release soak duration: 24h or 72h"
+        required: true
+        default: "24h"
+        type: choice
+        options:
+          - "24h"
+          - "72h"
+
+permissions:
+  contents: read
+
+jobs:
+  fsmeta-release-soak:
+    runs-on: [self-hosted, linux, x64]
+    timeout-minutes: 4380
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version: "1.26.2"
+
+      - name: 24h fsmeta soak
+        if: ${{ github.event.inputs.duration == '24h' }}
+        env:
+          NOKV_SOAK_DOWN: "1"
+          NOKV_SOAK_DUMP_LOGS: "1"
+          NOKV_SOAK_LOG_TAIL: "500"
+        run: make test-soak-24h
+
+      - name: 72h fsmeta soak
+        if: ${{ github.event.inputs.duration == '72h' }}
+        env:
+          NOKV_SOAK_DOWN: "1"
+          NOKV_SOAK_DUMP_LOGS: "1"
+          NOKV_SOAK_LOG_TAIL: "500"
+        run: make test-soak-72h

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 # Provides standardized commands for development workflow
 
 .PHONY: help build test test-short test-race test-coverage test-architecture lint fmt clean docker-up docker-dev-up docker-down bench
-.PHONY: test-contract-smoke test-raftstore-contract-smoke test-history-smoke test-model-smoke test-crash-matrix-smoke test-deterministic-simulation-smoke test-correctness-smoke test-correctness-nightly test-docker-chaos test-soak-smoke
+.PHONY: test-contract-smoke test-raftstore-contract-smoke test-history-smoke test-model-smoke test-crash-matrix-smoke test-deterministic-simulation-smoke test-correctness-smoke test-correctness-nightly test-docker-chaos test-soak-smoke test-soak-24h test-soak-72h
 .PHONY: install-tools install-tla-tools test-tla-smoke test-tla-nightly
 .PHONY: proto proto-check proto-breaking-check
 .PHONY: tlc-eunomia tlc-eunomiamultidim tlc-mountlifecycle tlc-subtreeauthority tlc-percolator2pc tlc-mvccgc tlc-raftstore-apply-publish tlc-root-replay-watch tlc-fsmeta-namespace
@@ -35,6 +35,8 @@ help:
 	@echo "  make test-correctness-nightly - Run longer seeded correctness and failpoint matrix"
 	@echo "  make test-docker-chaos  - Run Docker fsmeta history checker under process chaos"
 	@echo "  make test-soak-smoke    - Run short Docker fsmeta soak smoke"
+	@echo "  make test-soak-24h      - Run release-hardening fsmeta soak for 24 hours"
+	@echo "  make test-soak-72h      - Run release-hardening fsmeta soak for 72 hours"
 	@echo "  make lint               - Run golangci-lint (requires installation)"
 	@echo "  make fmt                - Run go fix, format code with gofmt, and tidy modules"
 	@echo "  make proto              - Format .proto files and regenerate protobuf Go code"
@@ -55,10 +57,12 @@ help:
 # Build all binaries
 build:
 	@echo "Building NoKV binaries..."
+	mkdir -p build
 	go build -v ./...
 	go build -o build/nokv ./cmd/nokv
 	go build -o build/nokv-config ./cmd/nokv-config
 	go build -o build/nokv-fsmeta ./cmd/nokv-fsmeta
+	go build -o build/nokv-fsmeta-scrub ./cmd/nokv-fsmeta-scrub
 	@echo "✓ Build complete: binaries in build/"
 
 # Run all tests
@@ -109,6 +113,7 @@ test-history-smoke:
 test-model-smoke:
 	@echo "Running distributed model smoke tests..."
 	NOKV_PERCOLATOR_MODEL_SEEDS=$${NOKV_PERCOLATOR_MODEL_SEEDS:-8} NOKV_PERCOLATOR_MODEL_STEPS=$${NOKV_PERCOLATOR_MODEL_STEPS:-64} go test ./percolator -run TestTxnModelGeneratedScheduleIsSerializable -count=1 -v
+	NOKV_PERCOLATOR_CONCURRENT_SEEDS=$${NOKV_PERCOLATOR_CONCURRENT_SEEDS:-2} NOKV_PERCOLATOR_CONCURRENT_WAVES=$${NOKV_PERCOLATOR_CONCURRENT_WAVES:-4} NOKV_PERCOLATOR_CONCURRENT_BATCH=$${NOKV_PERCOLATOR_CONCURRENT_BATCH:-4} go test ./percolator -run TestTxnModelConcurrentHistoryIsSerializable -count=1 -v
 	NOKV_RAFTSTORE_FAULT_SEEDS=$${NOKV_RAFTSTORE_FAULT_SEEDS:-1} NOKV_RAFTSTORE_FAULT_STEPS=$${NOKV_RAFTSTORE_FAULT_STEPS:-6} go test ./raftstore/integration -run TestTwoPhaseCommitFaultScheduleAcrossSplitCluster -count=1 -v
 	NOKV_ROOT_MODEL_SEEDS=$${NOKV_ROOT_MODEL_SEEDS:-2} NOKV_ROOT_MODEL_STEPS=$${NOKV_ROOT_MODEL_STEPS:-24} go test ./coordinator/integration -run TestRootModelReplayAndWatchSchedule -count=1 -v
 
@@ -123,7 +128,7 @@ test-crash-matrix-smoke:
 # raftstore runtimes.
 test-deterministic-simulation-smoke:
 	@echo "Running deterministic fault simulation smoke tests..."
-	NOKV_SIMULATION_SEEDS=$${NOKV_SIMULATION_SEEDS:-1} NOKV_SIMULATION_STEPS=$${NOKV_SIMULATION_STEPS:-6} go test ./raftstore/integration -run TestDeterministicFaultSimulationAcrossSplitCluster -count=1 -v
+	NOKV_SIMULATION_SEEDS=$${NOKV_SIMULATION_SEEDS:-1} NOKV_SIMULATION_STEPS=$${NOKV_SIMULATION_STEPS:-8} go test ./raftstore/integration -run TestDeterministicFaultSimulationAcrossSplitCluster -count=1 -v
 
 # Run the highest-signal distributed correctness suites before the full package sweep.
 test-correctness-smoke: test-contract-smoke test-raftstore-contract-smoke test-history-smoke test-model-smoke test-crash-matrix-smoke test-deterministic-simulation-smoke
@@ -139,6 +144,7 @@ test-correctness-nightly:
 	NOKV_CONTRACT_HISTORY_SEEDS=$${NOKV_CONTRACT_HISTORY_SEEDS:-64} NOKV_CONTRACT_HISTORY_STEPS=$${NOKV_CONTRACT_HISTORY_STEPS:-240} NOKV_CONTRACT_HISTORY_BATCH=$${NOKV_CONTRACT_HISTORY_BATCH:-3} go test ./fsmeta/contract -run TestFSMetaExecutorConcurrentHistoryContract -count=1 -v
 	NOKV_RAFTSTORE_HISTORY_SEEDS=$${NOKV_RAFTSTORE_HISTORY_SEEDS:-4} NOKV_RAFTSTORE_HISTORY_STEPS=$${NOKV_RAFTSTORE_HISTORY_STEPS:-80} NOKV_RAFTSTORE_HISTORY_BATCH=$${NOKV_RAFTSTORE_HISTORY_BATCH:-3} go test ./fsmeta/integration -run TestRaftstoreRuntimeFSMetaConcurrentHistoryOnSplitCluster -count=1 -v
 	NOKV_PERCOLATOR_MODEL_SEEDS=$${NOKV_PERCOLATOR_MODEL_SEEDS:-64} NOKV_PERCOLATOR_MODEL_STEPS=$${NOKV_PERCOLATOR_MODEL_STEPS:-256} go test ./percolator -run TestTxnModelGeneratedScheduleIsSerializable -count=1 -v
+	NOKV_PERCOLATOR_CONCURRENT_SEEDS=$${NOKV_PERCOLATOR_CONCURRENT_SEEDS:-16} NOKV_PERCOLATOR_CONCURRENT_WAVES=$${NOKV_PERCOLATOR_CONCURRENT_WAVES:-24} NOKV_PERCOLATOR_CONCURRENT_BATCH=$${NOKV_PERCOLATOR_CONCURRENT_BATCH:-4} go test ./percolator -run TestTxnModelConcurrentHistoryIsSerializable -count=1 -v
 	NOKV_RAFTSTORE_FAULT_SEEDS=$${NOKV_RAFTSTORE_FAULT_SEEDS:-4} NOKV_RAFTSTORE_FAULT_STEPS=$${NOKV_RAFTSTORE_FAULT_STEPS:-18} go test ./raftstore/integration -run TestTwoPhaseCommitFaultScheduleAcrossSplitCluster -count=1 -v
 	NOKV_ROOT_MODEL_SEEDS=$${NOKV_ROOT_MODEL_SEEDS:-16} NOKV_ROOT_MODEL_STEPS=$${NOKV_ROOT_MODEL_STEPS:-128} go test ./coordinator/integration -run TestRootModelReplayAndWatchSchedule -count=1 -v
 	go test ./percolator -run TestPercolatorCrashMatrix -count=3 -v
@@ -158,6 +164,14 @@ test-docker-chaos:
 test-soak-smoke:
 	@echo "Running short Docker fsmeta soak..."
 	NOKV_SOAK_DURATION=$${NOKV_SOAK_DURATION:-30s} NOKV_SOAK_ROLLING_RESTARTS=$${NOKV_SOAK_ROLLING_RESTARTS:-0} ./scripts/soak/fsmeta_soak.sh
+
+test-soak-24h:
+	@echo "Running 24h Docker fsmeta soak..."
+	NOKV_SOAK_DURATION=24h NOKV_SOAK_ROLLING_RESTARTS=1 NOKV_SOAK_STEPS=$${NOKV_SOAK_STEPS:-120} NOKV_SOAK_BATCH=$${NOKV_SOAK_BATCH:-4} ./scripts/soak/fsmeta_soak.sh
+
+test-soak-72h:
+	@echo "Running 72h Docker fsmeta soak..."
+	NOKV_SOAK_DURATION=72h NOKV_SOAK_ROLLING_RESTARTS=1 NOKV_SOAK_STEPS=$${NOKV_SOAK_STEPS:-160} NOKV_SOAK_BATCH=$${NOKV_SOAK_BATCH:-4} ./scripts/soak/fsmeta_soak.sh
 
 # Run linter (requires golangci-lint to be installed)
 lint:

--- a/cmd/nokv-fsmeta-scrub/main.go
+++ b/cmd/nokv-fsmeta-scrub/main.go
@@ -1,0 +1,271 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"log"
+	"os"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/feichai0017/NoKV/fsmeta"
+	fsmetaclient "github.com/feichai0017/NoKV/fsmeta/client"
+)
+
+const defaultPageLimit uint32 = 256
+
+type scrubClient interface {
+	ReadDirPlus(context.Context, fsmeta.ReadDirRequest) ([]fsmeta.DentryAttrPair, error)
+	Close() error
+}
+
+type scrubIssueKind string
+
+const (
+	issueInvalidDentryName    scrubIssueKind = "invalid_dentry_name"
+	issueDentryParentMismatch scrubIssueKind = "dentry_parent_mismatch"
+	issueDentryInodeMismatch  scrubIssueKind = "dentry_inode_mismatch"
+	issueDentryTypeMismatch   scrubIssueKind = "dentry_type_mismatch"
+	issueDirectoryHardlink    scrubIssueKind = "directory_hardlink"
+	issueLinkCountMismatch    scrubIssueKind = "link_count_mismatch"
+	issuePaginationRegression scrubIssueKind = "pagination_regression"
+	issueIssueLimitExhausted  scrubIssueKind = "issue_limit_exhausted"
+)
+
+type scrubIssue struct {
+	Kind   scrubIssueKind `json:"kind"`
+	Parent fsmeta.InodeID `json:"parent,omitempty"`
+	Name   string         `json:"name,omitempty"`
+	Inode  fsmeta.InodeID `json:"inode,omitempty"`
+	Detail string         `json:"detail,omitempty"`
+}
+
+type scrubReport struct {
+	Mount       fsmeta.MountID `json:"mount"`
+	Root        fsmeta.InodeID `json:"root"`
+	Directories uint64         `json:"directories"`
+	Dentries    uint64         `json:"dentries"`
+	Inodes      uint64         `json:"inodes"`
+	Issues      []scrubIssue   `json:"issues,omitempty"`
+}
+
+func (r scrubReport) OK() bool {
+	return len(r.Issues) == 0
+}
+
+func main() {
+	var (
+		addr      = flag.String("addr", "127.0.0.1:8090", "FSMetadata gRPC address")
+		mount     = flag.String("mount", "default", "registered mount ID")
+		root      = flag.Uint64("root", uint64(fsmeta.RootInode), "root inode to scrub")
+		pageLimit = flag.Uint("page-limit", uint(defaultPageLimit), "ReadDirPlus page size")
+		maxIssues = flag.Int("max-issues", 32, "maximum issues to record before failing fast")
+		timeout   = flag.Duration("timeout", 60*time.Second, "overall scrub timeout")
+		jsonOut   = flag.Bool("json", false, "emit JSON report")
+	)
+	flag.Parse()
+	if *addr == "" || *mount == "" || *root == 0 || *pageLimit == 0 || *pageLimit > uint(fsmeta.MaxReadDirLimit) || *timeout <= 0 {
+		log.Fatalf("addr, mount, root, page-limit, and timeout must be valid")
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), *timeout)
+	defer cancel()
+
+	cli, err := fsmetaclient.NewGRPCClient(ctx, *addr)
+	if err != nil {
+		log.Fatalf("dial fsmeta %s: %v", *addr, err)
+	}
+	defer func() { _ = cli.Close() }()
+
+	report, err := scrubMount(ctx, cli, fsmeta.MountID(*mount), fsmeta.InodeID(*root), uint32(*pageLimit), *maxIssues)
+	if err != nil {
+		log.Fatalf("scrub failed: %v", err)
+	}
+	if *jsonOut {
+		enc := json.NewEncoder(os.Stdout)
+		enc.SetIndent("", "  ")
+		if err := enc.Encode(report); err != nil {
+			log.Fatalf("encode report: %v", err)
+		}
+	} else {
+		fmt.Printf("fsmeta scrub mount=%s root=%d directories=%d dentries=%d inodes=%d issues=%d\n",
+			report.Mount, report.Root, report.Directories, report.Dentries, report.Inodes, len(report.Issues))
+		for _, issue := range report.Issues {
+			fmt.Printf("issue kind=%s parent=%d name=%q inode=%d detail=%s\n",
+				issue.Kind, issue.Parent, issue.Name, issue.Inode, issue.Detail)
+		}
+	}
+	if !report.OK() {
+		os.Exit(1)
+	}
+}
+
+func scrubMount(ctx context.Context, cli scrubClient, mount fsmeta.MountID, root fsmeta.InodeID, pageLimit uint32, maxIssues int) (scrubReport, error) {
+	if cli == nil {
+		return scrubReport{}, fmt.Errorf("scrub client is required")
+	}
+	if mount == "" || root == 0 {
+		return scrubReport{}, fsmeta.ErrInvalidRequest
+	}
+	if pageLimit == 0 {
+		pageLimit = defaultPageLimit
+	}
+	report := scrubReport{Mount: mount, Root: root}
+	refs := make(map[fsmeta.InodeID]uint32)
+	inodes := make(map[fsmeta.InodeID]fsmeta.InodeRecord)
+	visitedDirs := make(map[fsmeta.InodeID]struct{})
+	queue := []fsmeta.InodeID{root}
+
+	addIssue := func(issue scrubIssue) bool {
+		if maxIssues > 0 && len(report.Issues) >= maxIssues {
+			report.Issues = append(report.Issues, scrubIssue{Kind: issueIssueLimitExhausted, Detail: "issue limit reached"})
+			return false
+		}
+		report.Issues = append(report.Issues, issue)
+		return true
+	}
+
+	for len(queue) > 0 {
+		if err := ctx.Err(); err != nil {
+			return report, err
+		}
+		parent := queue[0]
+		queue = queue[1:]
+		if _, ok := visitedDirs[parent]; ok {
+			continue
+		}
+		visitedDirs[parent] = struct{}{}
+		report.Directories++
+		entries, err := readDirPlusAll(ctx, cli, fsmeta.ReadDirRequest{
+			Mount:  mount,
+			Parent: parent,
+			Limit:  pageLimit,
+		})
+		if err != nil {
+			return report, err
+		}
+		for _, pair := range entries {
+			if !scrubDentryPair(pair, parent, refs, inodes, &queue, addIssue) {
+				return report, nil
+			}
+			report.Dentries++
+		}
+	}
+
+	report.Inodes = uint64(len(inodes))
+	for inodeID, refCount := range refs {
+		inode := inodes[inodeID]
+		if inode.LinkCount != refCount {
+			if !addIssue(scrubIssue{
+				Kind:   issueLinkCountMismatch,
+				Inode:  inodeID,
+				Detail: fmt.Sprintf("link_count=%d refs=%d", inode.LinkCount, refCount),
+			}) {
+				return report, nil
+			}
+		}
+	}
+	sortScrubIssues(report.Issues)
+	return report, nil
+}
+
+func readDirPlusAll(ctx context.Context, cli scrubClient, req fsmeta.ReadDirRequest) ([]fsmeta.DentryAttrPair, error) {
+	limit := req.Limit
+	if limit == 0 {
+		limit = defaultPageLimit
+	}
+	var out []fsmeta.DentryAttrPair
+	lastName := ""
+	haveLast := false
+	for {
+		req.Limit = limit
+		page, err := cli.ReadDirPlus(ctx, req)
+		if err != nil {
+			return nil, err
+		}
+		if len(page) == 0 {
+			return out, nil
+		}
+		for _, pair := range page {
+			name := pair.Dentry.Name
+			if haveLast && name <= lastName {
+				return out, fmt.Errorf("%s: parent=%d previous=%q current=%q", issuePaginationRegression, req.Parent, lastName, name)
+			}
+			lastName = name
+			haveLast = true
+		}
+		out = append(out, page...)
+		if uint32(len(page)) < limit {
+			return out, nil
+		}
+		req.StartAfter = page[len(page)-1].Dentry.Name
+	}
+}
+
+func scrubDentryPair(
+	pair fsmeta.DentryAttrPair,
+	parent fsmeta.InodeID,
+	refs map[fsmeta.InodeID]uint32,
+	inodes map[fsmeta.InodeID]fsmeta.InodeRecord,
+	queue *[]fsmeta.InodeID,
+	addIssue func(scrubIssue) bool,
+) bool {
+	dentry := pair.Dentry
+	inode := pair.Inode
+	if !validScrubName(dentry.Name) {
+		if !addIssue(scrubIssue{Kind: issueInvalidDentryName, Parent: parent, Name: dentry.Name, Inode: dentry.Inode}) {
+			return false
+		}
+	}
+	if dentry.Parent != parent {
+		if !addIssue(scrubIssue{Kind: issueDentryParentMismatch, Parent: parent, Name: dentry.Name, Inode: dentry.Inode, Detail: fmt.Sprintf("dentry_parent=%d", dentry.Parent)}) {
+			return false
+		}
+	}
+	if dentry.Inode != inode.Inode {
+		if !addIssue(scrubIssue{Kind: issueDentryInodeMismatch, Parent: parent, Name: dentry.Name, Inode: dentry.Inode, Detail: fmt.Sprintf("inode_record=%d", inode.Inode)}) {
+			return false
+		}
+	}
+	if dentry.Type != inode.Type {
+		if !addIssue(scrubIssue{Kind: issueDentryTypeMismatch, Parent: parent, Name: dentry.Name, Inode: dentry.Inode, Detail: fmt.Sprintf("dentry_type=%s inode_type=%s", dentry.Type, inode.Type)}) {
+			return false
+		}
+	}
+	if existing, ok := inodes[inode.Inode]; ok && existing.Type == fsmeta.InodeTypeDirectory && dentry.Type == fsmeta.InodeTypeDirectory {
+		if !addIssue(scrubIssue{Kind: issueDirectoryHardlink, Parent: parent, Name: dentry.Name, Inode: inode.Inode}) {
+			return false
+		}
+	}
+	refs[inode.Inode]++
+	inodes[inode.Inode] = inode
+	if inode.Type == fsmeta.InodeTypeDirectory {
+		*queue = append(*queue, inode.Inode)
+	}
+	return true
+}
+
+func validScrubName(name string) bool {
+	if name == "" || name == "." || name == ".." {
+		return false
+	}
+	return !strings.ContainsAny(name, "/\x00")
+}
+
+func sortScrubIssues(issues []scrubIssue) {
+	sort.SliceStable(issues, func(i, j int) bool {
+		if issues[i].Kind != issues[j].Kind {
+			return issues[i].Kind < issues[j].Kind
+		}
+		if issues[i].Parent != issues[j].Parent {
+			return issues[i].Parent < issues[j].Parent
+		}
+		if issues[i].Name != issues[j].Name {
+			return issues[i].Name < issues[j].Name
+		}
+		return issues[i].Inode < issues[j].Inode
+	})
+}

--- a/cmd/nokv-fsmeta-scrub/main_test.go
+++ b/cmd/nokv-fsmeta-scrub/main_test.go
@@ -1,0 +1,109 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/feichai0017/NoKV/fsmeta"
+	"github.com/stretchr/testify/require"
+)
+
+type fakeScrubClient struct {
+	dirs map[fsmeta.InodeID][]fsmeta.DentryAttrPair
+	err  error
+}
+
+func (c *fakeScrubClient) ReadDirPlus(_ context.Context, req fsmeta.ReadDirRequest) ([]fsmeta.DentryAttrPair, error) {
+	if c.err != nil {
+		return nil, c.err
+	}
+	entries := c.dirs[req.Parent]
+	start := 0
+	for start < len(entries) && entries[start].Dentry.Name <= req.StartAfter {
+		start++
+	}
+	limit := int(req.Limit)
+	if limit == 0 || limit > len(entries)-start {
+		limit = len(entries) - start
+	}
+	return append([]fsmeta.DentryAttrPair(nil), entries[start:start+limit]...), nil
+}
+
+func (c *fakeScrubClient) Close() error {
+	return nil
+}
+
+func TestScrubMountReportsHealthyNamespace(t *testing.T) {
+	cli := &fakeScrubClient{dirs: map[fsmeta.InodeID][]fsmeta.DentryAttrPair{
+		fsmeta.RootInode: {
+			scrubPair(fsmeta.RootInode, "dir", 10, fsmeta.InodeTypeDirectory, 1),
+			scrubPair(fsmeta.RootInode, "file", 11, fsmeta.InodeTypeFile, 2),
+			scrubPair(fsmeta.RootInode, "hardlink", 11, fsmeta.InodeTypeFile, 2),
+		},
+		10: {
+			scrubPair(10, "child", 12, fsmeta.InodeTypeFile, 1),
+		},
+	}}
+
+	report, err := scrubMount(context.Background(), cli, "vol", fsmeta.RootInode, 2, 8)
+	require.NoError(t, err)
+	require.True(t, report.OK())
+	require.Equal(t, uint64(2), report.Directories)
+	require.Equal(t, uint64(4), report.Dentries)
+	require.Equal(t, uint64(3), report.Inodes)
+}
+
+func TestScrubMountReportsInvariantIssues(t *testing.T) {
+	cli := &fakeScrubClient{dirs: map[fsmeta.InodeID][]fsmeta.DentryAttrPair{
+		fsmeta.RootInode: {
+			{
+				Dentry: fsmeta.DentryRecord{Parent: fsmeta.RootInode, Name: "bad-type", Inode: 20, Type: fsmeta.InodeTypeFile},
+				Inode:  fsmeta.InodeRecord{Inode: 20, Type: fsmeta.InodeTypeDirectory, LinkCount: 1},
+			},
+			scrubPair(fsmeta.RootInode, "link-a", 21, fsmeta.InodeTypeFile, 1),
+			scrubPair(fsmeta.RootInode, "link-b", 21, fsmeta.InodeTypeFile, 1),
+		},
+	}}
+
+	report, err := scrubMount(context.Background(), cli, "vol", fsmeta.RootInode, 8, 8)
+	require.NoError(t, err)
+	require.False(t, report.OK())
+	require.Contains(t, scrubIssueKinds(report.Issues), issueDentryTypeMismatch)
+	require.Contains(t, scrubIssueKinds(report.Issues), issueLinkCountMismatch)
+}
+
+func TestScrubMountLimitsIssues(t *testing.T) {
+	cli := &fakeScrubClient{dirs: map[fsmeta.InodeID][]fsmeta.DentryAttrPair{
+		fsmeta.RootInode: {
+			scrubPair(fsmeta.RootInode, "", 10, fsmeta.InodeTypeFile, 2),
+			scrubPair(99, "wrong-parent", 11, fsmeta.InodeTypeFile, 2),
+		},
+	}}
+
+	report, err := scrubMount(context.Background(), cli, "vol", fsmeta.RootInode, 8, 1)
+	require.NoError(t, err)
+	require.Len(t, report.Issues, 2)
+	require.Equal(t, issueIssueLimitExhausted, report.Issues[1].Kind)
+}
+
+func TestScrubMountPropagatesReadDirError(t *testing.T) {
+	want := errors.New("read failed")
+	_, err := scrubMount(context.Background(), &fakeScrubClient{err: want}, "vol", fsmeta.RootInode, 8, 8)
+	require.ErrorIs(t, err, want)
+}
+
+func scrubPair(parent fsmeta.InodeID, name string, inode fsmeta.InodeID, typ fsmeta.InodeType, links uint32) fsmeta.DentryAttrPair {
+	return fsmeta.DentryAttrPair{
+		Dentry: fsmeta.DentryRecord{Parent: parent, Name: name, Inode: inode, Type: typ},
+		Inode:  fsmeta.InodeRecord{Inode: inode, Type: typ, LinkCount: links},
+	}
+}
+
+func scrubIssueKinds(issues []scrubIssue) []scrubIssueKind {
+	kinds := make([]scrubIssueKind, 0, len(issues))
+	for _, issue := range issues {
+		kinds = append(kinds, issue.Kind)
+	}
+	return kinds
+}

--- a/engine/lsm/level_manager.go
+++ b/engine/lsm/level_manager.go
@@ -136,24 +136,33 @@ func (lm *levelManager) iterators(opt *index.Options) []index.Iterator {
 	return itrs
 }
 
-// Get searches levels from L0 to Ln and returns the newest visible entry for key.
+// Get searches every level and returns the highest visible version for key.
 func (lm *levelManager) Get(key []byte) (*kv.Entry, error) {
-	var (
-		entry *kv.Entry
-		err   error
-	)
-	// L0 layer query
-	if entry, err = lm.levels[0].Get(key); entry != nil {
-		return entry, err
-	}
-	// L1-7 layer query
-	for level := 1; level < lm.opt.MaxLevelNum; level++ {
-		ld := lm.levels[level]
-		if entry, err = ld.Get(key); entry != nil {
-			return entry, err
+	var best *kv.Entry
+	for level := 0; level < lm.opt.MaxLevelNum; level++ {
+		entry, err := lm.levels[level].Get(key)
+		if err != nil && err != utils.ErrKeyNotFound {
+			if best != nil {
+				best.DecrRef()
+			}
+			return nil, err
 		}
+		if entry == nil {
+			continue
+		}
+		if best == nil || entry.Version > best.Version {
+			if best != nil {
+				best.DecrRef()
+			}
+			best = entry
+			continue
+		}
+		entry.DecrRef()
 	}
-	return entry, utils.ErrKeyNotFound
+	if best != nil {
+		return best, nil
+	}
+	return nil, utils.ErrKeyNotFound
 }
 
 func (lm *levelManager) loadManifest() (err error) {

--- a/engine/lsm/level_manager_test.go
+++ b/engine/lsm/level_manager_test.go
@@ -34,6 +34,34 @@ func TestL0ReplaceTablesOrdering(t *testing.T) {
 	require.NoError(t, t4.DecrRef())
 }
 
+func TestLevelManagerGetChoosesHighestVisibleVersionAcrossLevels(t *testing.T) {
+	clearDir()
+	lsm := buildLSM()
+	defer func() {
+		require.NoError(t, lsm.Close())
+		require.NoError(t, os.RemoveAll(lsm.option.WorkDir))
+	}()
+
+	key := []byte("mvcc-cross-level")
+	l0Delete := kv.NewInternalEntry(kv.CFDefault, key, 393, nil, kv.BitDelete, 0)
+	l1Put := kv.NewInternalEntry(kv.CFDefault, key, 396, []byte("v396"), 0, 0)
+	t0 := buildTableWithEntries(t, lsm, 11, l0Delete)
+	t1 := buildTableWithEntries(t, lsm, 12, l1Put)
+	lsm.levels.levels[0].tables = []*table{t0}
+	lsm.levels.levels[0].Sort()
+	lsm.levels.levels[1].tables = []*table{t1}
+	lsm.levels.levels[1].Sort()
+
+	got, err := lsm.levels.Get(kv.InternalKey(kv.CFDefault, key, 396))
+	require.NoError(t, err)
+	require.Equal(t, uint64(396), got.Version)
+	require.Equal(t, []byte("v396"), got.Value)
+	got.DecrRef()
+
+	require.NoError(t, t0.DecrRef())
+	require.NoError(t, t1.DecrRef())
+}
+
 func TestLevelHandlerRangeFilterPrunesPointAndBounds(t *testing.T) {
 	clearDir()
 	lsm := buildLSM()

--- a/engine/lsm/lsm.go
+++ b/engine/lsm/lsm.go
@@ -616,14 +616,16 @@ func (lsm *LSM) Get(key []byte) (*kv.Entry, error) {
 		return nil, utils.ErrKeyNotFound
 	}
 
-	if shardID, ok := lsm.lookupShardHint(key); ok && !hasRangeTombstones {
-		tables, release := lsm.getMemTablesForShard(shardID)
-		best := bestMemtableEntry(key, tables)
-		if release != nil {
-			release()
-		}
-		if best != nil {
-			return best, nil
+	if kv.Timestamp(key) == kv.MaxVersion {
+		if shardID, ok := lsm.lookupShardHint(key); ok && !hasRangeTombstones {
+			tables, release := lsm.getMemTablesForShard(shardID)
+			best := bestMemtableEntry(key, tables)
+			if release != nil {
+				release()
+			}
+			if best != nil {
+				return best, nil
+			}
 		}
 	}
 
@@ -650,29 +652,37 @@ func (lsm *LSM) Get(key []byte) (*kv.Entry, error) {
 	// Walk every memtable and keep the highest-version hit so MVCC reads
 	// see the most recent write regardless of which shard accepted it.
 	best := bestMemtableEntry(key, tables)
-	if best != nil {
-		if isCovered(best) {
-			best.DecrRef()
-			return nil, utils.ErrKeyNotFound
-		}
-		return best, nil
+	if best != nil && isCovered(best) {
+		best.DecrRef()
+		best = nil
 	}
 	// query from the levels runtime
 	entry, err := lsm.levels.Get(key)
-	if err != nil || entry == nil {
-		if !hasRangeTombstones && (err == utils.ErrKeyNotFound || (err == nil && entry == nil)) {
-			lsm.rememberNegative(key)
+	if err != nil && err != utils.ErrKeyNotFound {
+		if best != nil {
+			best.DecrRef()
 		}
-		return entry, err
+		return nil, err
 	}
-	if isCovered(entry) {
-		entry.DecrRef()
+	if entry != nil {
+		if isCovered(entry) {
+			entry.DecrRef()
+		} else if best == nil || entry.Version > best.Version {
+			if best != nil {
+				best.DecrRef()
+			}
+			best = entry
+		} else {
+			entry.DecrRef()
+		}
+	}
+	if best == nil {
 		if !hasRangeTombstones {
 			lsm.rememberNegative(key)
 		}
 		return nil, utils.ErrKeyNotFound
 	}
-	return entry, nil
+	return best, nil
 }
 
 func (lsm *LSM) negativeHit(key []byte) bool {

--- a/engine/lsm/shard_hint_test.go
+++ b/engine/lsm/shard_hint_test.go
@@ -80,6 +80,51 @@ func TestShardHintFallsBackWhenHintMissesMemtable(t *testing.T) {
 	got.DecrRef()
 }
 
+func TestShardHintDoesNotShortCircuitHistoricalRead(t *testing.T) {
+	lsm, wals := openShardHintTestLSM(t, 4)
+	defer closeShardHintTestLSM(t, lsm, wals)
+
+	userKey := []byte("historical-key")
+	v20 := kv.NewInternalEntry(kv.CFDefault, userKey, 20, []byte("v20"), 0, 0)
+	v10 := kv.NewInternalEntry(kv.CFDefault, userKey, 10, []byte("v10"), 0, 0)
+	v30 := kv.NewInternalEntry(kv.CFDefault, userKey, 30, []byte("v30"), 0, 0)
+	_, err := lsm.SetBatchGroup(1, [][]*kv.Entry{{v20}})
+	require.NoError(t, err)
+	_, err = lsm.SetBatchGroup(2, [][]*kv.Entry{{v10}})
+	require.NoError(t, err)
+	_, err = lsm.SetBatchGroup(2, [][]*kv.Entry{{v30}})
+	require.NoError(t, err)
+
+	query := kv.InternalKey(kv.CFDefault, userKey, 25)
+	got, err := lsm.Get(query)
+	require.NoError(t, err)
+	require.Equal(t, uint64(20), got.Version)
+	require.Equal(t, []byte("v20"), got.Value)
+	got.DecrRef()
+}
+
+func TestGetChoosesHighestVisibleVersionAcrossMemtablesAndLevels(t *testing.T) {
+	lsm, wals := openShardHintTestLSM(t, 4)
+	defer closeShardHintTestLSM(t, lsm, wals)
+
+	userKey := []byte("mem-level-history")
+	levelPut := kv.NewInternalEntry(kv.CFDefault, userKey, 396, []byte("v396"), 0, 0)
+	memDelete := kv.NewInternalEntry(kv.CFDefault, userKey, 393, nil, kv.BitDelete, 0)
+	t1 := buildTableWithEntries(t, lsm, 91, levelPut)
+	lsm.levels.levels[1].tables = []*table{t1}
+	lsm.levels.levels[1].Sort()
+	_, err := lsm.SetBatchGroup(0, [][]*kv.Entry{{memDelete}})
+	require.NoError(t, err)
+
+	got, err := lsm.Get(kv.InternalKey(kv.CFDefault, userKey, 396))
+	require.NoError(t, err)
+	require.Equal(t, uint64(396), got.Version)
+	require.Equal(t, []byte("v396"), got.Value)
+	got.DecrRef()
+
+	require.NoError(t, t1.DecrRef())
+}
+
 func TestShardHintDoesNotBypassRangeTombstones(t *testing.T) {
 	lsm, wals := openShardHintTestLSM(t, 4)
 	defer closeShardHintTestLSM(t, lsm, wals)

--- a/fsmeta/exec/runner.go
+++ b/fsmeta/exec/runner.go
@@ -999,7 +999,8 @@ func (e *Executor) ExpireWriteSessions(ctx context.Context, req fsmeta.ExpireWri
 		for _, key := range keys {
 			mutations = append(mutations, &kvrpcpb.Mutation{Op: kvrpcpb.Mutation_Delete, Key: deletes[key]})
 		}
-		if err := e.runner.Mutate(ctx, plan.PrimaryKey, mutations, startVersion, commitVersion, e.lockTTL); err != nil {
+		primary := deletes[keys[0]]
+		if err := e.runner.Mutate(ctx, primary, mutations, startVersion, commitVersion, e.lockTTL); err != nil {
 			return err
 		}
 		expired = uint64(len(expiredSessions))

--- a/fsmeta/exec/runner_test.go
+++ b/fsmeta/exec/runner_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"fmt"
 	"sort"
 	"testing"
 	"time"
@@ -207,7 +208,7 @@ func TestExecutorGetQuotaUsageReturnsZeroForMissingCounter(t *testing.T) {
 	require.Equal(t, fsmeta.UsageRecord{}, usage)
 }
 
-func (r *fakeRunner) Mutate(_ context.Context, _ []byte, mutations []*kvrpcpb.Mutation, _, _, _ uint64) error {
+func (r *fakeRunner) Mutate(_ context.Context, primary []byte, mutations []*kvrpcpb.Mutation, _, _, _ uint64) error {
 	if len(r.mutateErrs) > 0 {
 		err := r.mutateErrs[0]
 		r.mutateErrs = r.mutateErrs[1:]
@@ -219,13 +220,20 @@ func (r *fakeRunner) Mutate(_ context.Context, _ []byte, mutations []*kvrpcpb.Mu
 		return r.mutateErr
 	}
 	cloned := make([]*kvrpcpb.Mutation, 0, len(mutations))
+	hasPrimary := len(mutations) == 0
 	for _, mut := range mutations {
 		if mut.GetAssertionNotExist() {
 			if _, ok := r.data[string(mut.GetKey())]; ok {
 				return fsmeta.ErrExists
 			}
 		}
+		if bytes.Equal(mut.GetKey(), primary) {
+			hasPrimary = true
+		}
 		cloned = append(cloned, cloneMutation(mut))
+	}
+	if !hasPrimary {
+		return fmt.Errorf("primary key %q not present in mutations", primary)
 	}
 	for _, mut := range cloned {
 		switch mut.GetOp() {

--- a/percolator/reader.go
+++ b/percolator/reader.go
@@ -42,6 +42,13 @@ func (r *Reader) GetLock(key []byte) (*mvcc.Lock, error) {
 	if err != nil {
 		return nil, err
 	}
+	write, _, err := r.GetWriteByStartTs(key, lock.Ts)
+	if err != nil {
+		return nil, err
+	}
+	if write != nil {
+		return nil, nil
+	}
 	return &lock, nil
 }
 

--- a/percolator/reader_test.go
+++ b/percolator/reader_test.go
@@ -1,0 +1,70 @@
+package percolator
+
+import (
+	"testing"
+
+	"github.com/feichai0017/NoKV/engine/kv"
+	kvrpcpb "github.com/feichai0017/NoKV/pb/kv"
+	"github.com/feichai0017/NoKV/percolator/mvcc"
+	"github.com/stretchr/testify/require"
+)
+
+func TestReaderGetLockReturnsLiveLockWithoutWriteRecord(t *testing.T) {
+	db := openTestDB(t)
+	key := []byte("live-lock")
+
+	applyVersionedEntryForTxnTest(t, db, kv.CFLock, key, lockColumnTs, mvcc.EncodeLock(mvcc.Lock{
+		Primary:   key,
+		Ts:        10,
+		StartTime: 1000,
+		TTL:       3000,
+		Kind:      kvrpcpb.Mutation_Put,
+	}), 0)
+
+	lock, err := NewReader(db).GetLock(key)
+	require.NoError(t, err)
+	require.NotNil(t, lock)
+	require.Equal(t, uint64(10), lock.Ts)
+}
+
+func TestReaderGetLockIgnoresCommittedStaleLock(t *testing.T) {
+	db := openTestDB(t)
+	key := []byte("committed-stale-lock")
+
+	applyVersionedEntryForTxnTest(t, db, kv.CFLock, key, lockColumnTs, mvcc.EncodeLock(mvcc.Lock{
+		Primary:   key,
+		Ts:        10,
+		StartTime: 1000,
+		TTL:       3000,
+		Kind:      kvrpcpb.Mutation_Put,
+	}), 0)
+	applyVersionedEntryForTxnTest(t, db, kv.CFWrite, key, 11, mvcc.EncodeWrite(mvcc.Write{
+		Kind:    kvrpcpb.Mutation_Put,
+		StartTs: 10,
+	}), 0)
+
+	lock, err := NewReader(db).GetLock(key)
+	require.NoError(t, err)
+	require.Nil(t, lock)
+}
+
+func TestReaderGetLockIgnoresRolledBackStaleLock(t *testing.T) {
+	db := openTestDB(t)
+	key := []byte("rolled-back-stale-lock")
+
+	applyVersionedEntryForTxnTest(t, db, kv.CFLock, key, lockColumnTs, mvcc.EncodeLock(mvcc.Lock{
+		Primary:   key,
+		Ts:        10,
+		StartTime: 1000,
+		TTL:       3000,
+		Kind:      kvrpcpb.Mutation_Delete,
+	}), 0)
+	applyVersionedEntryForTxnTest(t, db, kv.CFWrite, key, 10, mvcc.EncodeWrite(mvcc.Write{
+		Kind:    kvrpcpb.Mutation_Rollback,
+		StartTs: 10,
+	}), 0)
+
+	lock, err := NewReader(db).GetLock(key)
+	require.NoError(t, err)
+	require.Nil(t, lock)
+}

--- a/percolator/txn_model_test.go
+++ b/percolator/txn_model_test.go
@@ -8,6 +8,8 @@ import (
 	"path/filepath"
 	"sort"
 	"strconv"
+	"sync"
+	"sync/atomic"
 	"testing"
 
 	NoKV "github.com/feichai0017/NoKV"
@@ -65,6 +67,35 @@ func TestTxnModelGeneratedScheduleIsSerializable(t *testing.T) {
 			for _, key := range txnModelKeys() {
 				assertReaderMatchesTxnModel(t, reader, model, key, uint64(steps*20+10_000))
 			}
+		})
+	}
+}
+
+func TestTxnModelConcurrentHistoryIsSerializable(t *testing.T) {
+	seeds := percolatorModelEnvInt("NOKV_PERCOLATOR_CONCURRENT_SEEDS", 4)
+	waves := percolatorModelEnvInt("NOKV_PERCOLATOR_CONCURRENT_WAVES", 8)
+	batch := percolatorModelEnvInt("NOKV_PERCOLATOR_CONCURRENT_BATCH", 4)
+	for seed := int64(1); seed <= int64(seeds); seed++ {
+		t.Run(fmt.Sprintf("seed_%03d", seed), func(t *testing.T) {
+			db := openPercolatorModelDB(t)
+			latches := latch.NewManager(64)
+			history := runConcurrentTxnHistory(t, db, latches, seed, waves, batch)
+			require.NoError(t, checkSerializableByTimestamp(history))
+
+			model := newTxnModel()
+			committed := append([]txnModelTxn(nil), history...)
+			sort.Slice(committed, func(i, j int) bool {
+				if committed[i].commitTs != committed[j].commitTs {
+					return committed[i].commitTs < committed[j].commitTs
+				}
+				return committed[i].id < committed[j].id
+			})
+			for _, txn := range committed {
+				if txn.committed {
+					model.apply(txn)
+				}
+			}
+			assertAllKeysMatchTxnModel(t, percolator.NewReader(db), model, uint64(1<<62))
 		})
 	}
 }
@@ -139,6 +170,103 @@ func runGeneratedTxnSchedule(t *testing.T, db *NoKV.DB, latches *latch.Manager, 
 		assertAllKeysMatchTxnModel(t, reader, model, commitTs+1)
 	}
 	return history
+}
+
+func runConcurrentTxnHistory(t *testing.T, db *NoKV.DB, latches *latch.Manager, seed int64, waves, batch int) []txnModelTxn {
+	t.Helper()
+	if batch < 2 {
+		batch = 2
+	}
+	rng := rand.New(rand.NewSource(seed))
+	var ts atomic.Uint64
+	ts.Store(10)
+	history := make([]txnModelTxn, 0, waves*batch)
+	for wave := range waves {
+		results := make([]txnModelTxn, batch)
+		var wg sync.WaitGroup
+		start := make(chan struct{})
+		prewriteDone := make(chan struct{}, batch)
+		commitStart := make(chan struct{})
+		for slot := range batch {
+			step := wave*batch + slot
+			mutations := generatedTxnMutations(rng, step)
+			rollback := rng.Intn(100) < 25
+			wg.Add(1)
+			go func(slot int, step int, mutations []*kvrpcpb.Mutation, rollback bool) {
+				defer wg.Done()
+				<-start
+				results[slot] = runConcurrentTxnAttempt(t, db, latches, &ts, step, mutations, rollback, prewriteDone, commitStart)
+			}(slot, step, mutations, rollback)
+		}
+		close(start)
+		for range batch {
+			<-prewriteDone
+		}
+		close(commitStart)
+		wg.Wait()
+		history = append(history, results...)
+	}
+	return history
+}
+
+func runConcurrentTxnAttempt(
+	t *testing.T,
+	db *NoKV.DB,
+	latches *latch.Manager,
+	ts *atomic.Uint64,
+	step int,
+	mutations []*kvrpcpb.Mutation,
+	rollback bool,
+	prewriteDone chan<- struct{},
+	commitStart <-chan struct{},
+) txnModelTxn {
+	t.Helper()
+	startTs := ts.Add(2)
+	txn := txnModelTxn{
+		id:      step,
+		startTs: startTs,
+		reads:   readTxnSnapshot(t, percolator.NewReader(db), mutations, startTs),
+		writes:  writesFromMutations(mutations),
+	}
+	errs := percolator.Prewrite(db, latches, &kvrpcpb.PrewriteRequest{
+		Mutations:    mutations,
+		PrimaryLock:  mutations[0].GetKey(),
+		StartVersion: startTs,
+		LockTtl:      3000,
+	})
+	prewriteDone <- struct{}{}
+	if len(errs) != 0 {
+		<-commitStart
+		require.Nil(t, percolator.BatchRollback(db, latches, &kvrpcpb.BatchRollbackRequest{
+			Keys:         mutationKeys(mutations),
+			StartVersion: startTs,
+		}))
+		return txn
+	}
+	<-commitStart
+	if rollback {
+		require.Nil(t, percolator.BatchRollback(db, latches, &kvrpcpb.BatchRollbackRequest{
+			Keys:         mutationKeys(mutations),
+			StartVersion: startTs,
+		}))
+		return txn
+	}
+	commitTs := ts.Add(2)
+	txn.commitTs = commitTs
+	keyErr := percolator.Commit(db, latches, &kvrpcpb.CommitRequest{
+		Keys:          mutationKeys(mutations),
+		StartVersion:  startTs,
+		CommitVersion: commitTs,
+	})
+	if keyErr != nil {
+		require.Nil(t, percolator.BatchRollback(db, latches, &kvrpcpb.BatchRollbackRequest{
+			Keys:         mutationKeys(mutations),
+			StartVersion: startTs,
+		}))
+		return txn
+	}
+	txn.committed = true
+	return txn
 }
 
 func generatedTxnMutations(rng *rand.Rand, step int) []*kvrpcpb.Mutation {

--- a/raftstore/integration/deterministic_simulation_test.go
+++ b/raftstore/integration/deterministic_simulation_test.go
@@ -4,9 +4,12 @@ import (
 	"context"
 	"fmt"
 	"math/rand"
+	"sort"
+	"strings"
 	"testing"
 	"time"
 
+	workdirmode "github.com/feichai0017/NoKV/dbcore/mode"
 	kvrpcpb "github.com/feichai0017/NoKV/pb/kv"
 	metapb "github.com/feichai0017/NoKV/pb/meta"
 	"github.com/feichai0017/NoKV/raftstore/client"
@@ -24,7 +27,10 @@ const (
 	simulationPartialQuorumRollback
 	simulationDelayedChildLink
 	simulationRestartTargetStore
+	simulationRestartSeedStore
 	simulationResolveOldLocks
+	simulationTransferParentLeader
+	simulationScanModel
 )
 
 func TestDeterministicFaultSimulationAcrossSplitCluster(t *testing.T) {
@@ -50,12 +56,18 @@ func TestDeterministicFaultSimulationAcrossSplitCluster(t *testing.T) {
 					startTs = runDelayedChildLinkCommit(t, ctx, rt, model, startTs, step)
 				case simulationRestartTargetStore:
 					restartTargetStore(t, ctx, rt)
+				case simulationRestartSeedStore:
+					restartSeedStore(t, ctx, rt)
 				case simulationResolveOldLocks:
 					_, err := rt.client.ResolveLocks(ctx, startTs-500, 0, [][]byte{
 						fmt.Appendf(nil, "missing-primary-%03d", step),
 						fmt.Appendf(nil, "missing-child-%03d", step),
 					})
 					require.NoError(t, err)
+				case simulationTransferParentLeader:
+					transferRegionLeader(t, ctx, 501, 101, 201, rt.seed, rt.target)
+				case simulationScanModel:
+					assertScanMatches2PCModel(t, ctx, rt.client, model, startTs+100)
 				}
 				assertCommitted2PCModel(t, ctx, rt.client, model, startTs+100)
 			}
@@ -64,16 +76,19 @@ func TestDeterministicFaultSimulationAcrossSplitCluster(t *testing.T) {
 }
 
 func generateSimulationSchedule(seed int64, steps int) []simulationAction {
-	if steps < 6 {
-		steps = 6
-	}
 	actions := []simulationAction{
 		simulationCommit,
 		simulationDelayedChildLink,
 		simulationTransferChildLeader,
 		simulationPartialQuorumRollback,
 		simulationRestartTargetStore,
+		simulationRestartSeedStore,
 		simulationResolveOldLocks,
+		simulationTransferParentLeader,
+		simulationScanModel,
+	}
+	if steps < len(actions) {
+		steps = len(actions)
 	}
 	rng := rand.New(rand.NewSource(seed))
 	for len(actions) < steps {
@@ -82,12 +97,18 @@ func generateSimulationSchedule(seed int64, steps int) []simulationAction {
 			actions = append(actions, simulationPartialQuorumRollback)
 		case 8, 9, 10, 11, 12, 13, 14, 15:
 			actions = append(actions, simulationRestartTargetStore)
-		case 16, 17, 18, 19, 20, 21, 22, 23:
+		case 16, 17, 18, 19:
+			actions = append(actions, simulationRestartSeedStore)
+		case 20, 21, 22, 23, 24, 25, 26, 27:
 			actions = append(actions, simulationDelayedChildLink)
-		case 24, 25, 26, 27, 28, 29:
+		case 28, 29, 30, 31, 32, 33:
 			actions = append(actions, simulationTransferChildLeader)
-		case 30, 31, 32, 33, 34:
+		case 34, 35, 36, 37:
+			actions = append(actions, simulationTransferParentLeader)
+		case 38, 39, 40, 41, 42:
 			actions = append(actions, simulationResolveOldLocks)
+		case 43, 44, 45, 46, 47, 48, 49:
+			actions = append(actions, simulationScanModel)
 		default:
 			actions = append(actions, simulationCommit)
 		}
@@ -128,9 +149,22 @@ func runDelayedChildLinkCommit(t *testing.T, ctx context.Context, rt *twopcFault
 func restartTargetStore(t *testing.T, ctx context.Context, rt *twopcFaultRuntime) {
 	t.Helper()
 	rt.target.Restart(t, nil, true)
+	recoverRestartedTwoStoreRuntime(t, ctx, rt)
+}
+
+func restartSeedStore(t *testing.T, ctx context.Context, rt *twopcFaultRuntime) {
+	t.Helper()
+	rt.seed.Restart(t, []workdirmode.Mode{workdirmode.ModeSeeded, workdirmode.ModeCluster}, true)
+	recoverRestartedTwoStoreRuntime(t, ctx, rt)
+}
+
+func recoverRestartedTwoStoreRuntime(t *testing.T, ctx context.Context, rt *twopcFaultRuntime) {
+	t.Helper()
 	wireTwoStorePeers(rt.seed, rt.target)
 	testcluster.WaitForHostedPeer(t, ctx, rt.target.Addr(), 501, 201)
 	testcluster.WaitForHostedPeer(t, ctx, rt.target.Addr(), 502, 202)
+	testcluster.WaitForHostedPeer(t, ctx, rt.seed.Addr(), 501, 101)
+	testcluster.WaitForHostedPeer(t, ctx, rt.seed.Addr(), 502, 102)
 	testcluster.FindLeader(t, ctx, 501, rt.seed, rt.target)
 	testcluster.FindLeader(t, ctx, 502, rt.seed, rt.target)
 	reopenFaultClient(t, ctx, rt)
@@ -162,4 +196,30 @@ func reopenFaultClient(t *testing.T, ctx context.Context, rt *twopcFaultRuntime)
 	require.NoError(t, err)
 	rt.client = cli
 	t.Cleanup(func() { _ = cli.Close() })
+}
+
+func assertScanMatches2PCModel(t *testing.T, ctx context.Context, cli *client.Client, model map[string]string, readTs uint64) {
+	t.Helper()
+	kvs, err := cli.Scan(ctx, []byte(""), 256, readTs)
+	require.NoError(t, err)
+	visible := make(map[string]string, len(kvs))
+	for _, kv := range kvs {
+		key := string(kv.GetKey())
+		if strings.Contains(key, "failed") {
+			t.Fatalf("rolled-back key %q is visible in scan at ts=%d", key, readTs)
+		}
+		visible[key] = string(kv.GetValue())
+	}
+	for key, want := range model {
+		require.Equal(t, want, visible[key], "scan missing or mismatched key=%s ts=%d all=%v", key, readTs, sortedVisibleKeys(visible))
+	}
+}
+
+func sortedVisibleKeys(visible map[string]string) []string {
+	keys := make([]string, 0, len(visible))
+	for key := range visible {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	return keys
 }

--- a/scripts/chaos/docker_fsmeta_history.sh
+++ b/scripts/chaos/docker_fsmeta_history.sh
@@ -12,18 +12,44 @@ STEPS="${NOKV_DOCKER_CHAOS_STEPS:-48}"
 BATCH="${NOKV_DOCKER_CHAOS_BATCH:-3}"
 TIMEOUT="${NOKV_DOCKER_CHAOS_TIMEOUT:-60s}"
 READY_TIMEOUT="${NOKV_DOCKER_CHAOS_READY_TIMEOUT:-180}"
+CHAOS_INTERVAL="${NOKV_DOCKER_CHAOS_INTERVAL:-5}"
 TOOLS_DIR="$(mktemp -d "${TMPDIR:-/tmp}/nokv-fsmeta-chaos.XXXXXX")"
+chaos_pid=""
+
+dump_cluster_state() {
+  if [[ "${NOKV_DOCKER_CHAOS_DUMP_LOGS:-1}" != "1" ]]; then
+    return
+  fi
+  docker compose ps || true
+  docker compose logs --no-color --tail="${NOKV_DOCKER_CHAOS_LOG_TAIL:-200}" || true
+}
+
+stop_chaos() {
+  if [[ -n "$chaos_pid" ]] && kill -0 "$chaos_pid" 2>/dev/null; then
+    kill "$chaos_pid" 2>/dev/null || true
+    wait "$chaos_pid" 2>/dev/null || true
+  fi
+  chaos_pid=""
+  docker compose unpause coordinator-1 coordinator-2 coordinator-3 store-1 store-2 store-3 meta-root-1 meta-root-2 meta-root-3 fsmeta >/dev/null 2>&1 || true
+  docker compose up -d coordinator-1 coordinator-2 coordinator-3 store-1 store-2 store-3 meta-root-1 meta-root-2 meta-root-3 fsmeta >/dev/null 2>&1 || true
+}
 
 cleanup() {
+  local status="${1:-0}"
+  if [[ "$status" != "0" ]]; then
+    dump_cluster_state
+  fi
+  stop_chaos
   rm -rf "$TOOLS_DIR"
   if [[ "${NOKV_DOCKER_CHAOS_DOWN:-0}" == "1" ]]; then
     docker compose down -v
   fi
 }
-trap cleanup EXIT
-trap 'trap - EXIT; cleanup; exit 130' INT TERM
+trap 'status=$?; cleanup "$status"; exit "$status"' EXIT
+trap 'trap - EXIT; cleanup 130; exit 130' INT TERM
 
 go build -o "$TOOLS_DIR/nokv-fsmeta-history" ./cmd/nokv-fsmeta-history
+go build -o "$TOOLS_DIR/nokv-fsmeta-scrub" ./cmd/nokv-fsmeta-scrub
 
 if [[ "${NOKV_DOCKER_CHAOS_BUILD:-1}" == "1" ]]; then
   docker compose up -d --build
@@ -37,7 +63,7 @@ wait_fsmeta() {
 
 inject_fault() {
   local seed="$1"
-  case $((seed % 6)) in
+  case $((seed % 14)) in
     0)
       docker compose restart fsmeta
       ;;
@@ -55,22 +81,112 @@ inject_fault() {
       docker compose kill -s SIGKILL coordinator-2
       docker compose up -d coordinator-2
       ;;
-    *)
+    5)
       docker compose restart store-3
+      ;;
+    6)
+      docker compose pause store-1
+      sleep 2
+      docker compose unpause store-1
+      ;;
+    7)
+      docker compose pause coordinator-3
+      sleep 2
+      docker compose unpause coordinator-3
+      ;;
+    8)
+      docker compose restart meta-root-1
+      docker compose restart meta-root-2
+      ;;
+    9)
+      docker compose kill -s SIGKILL store-1
+      docker compose up -d store-1
+      ;;
+    10)
+      isolate_service store-2 2
+      ;;
+    11)
+      isolate_service coordinator-1 2
+      ;;
+    12)
+      isolate_service meta-root-2 2
+      ;;
+    *)
+      isolate_service fsmeta 2
       ;;
   esac
 }
 
+isolate_service() {
+  local service="$1"
+  local seconds="$2"
+  local container
+  container="$(docker compose ps -q "$service")"
+  if [[ -z "$container" ]]; then
+    return
+  fi
+  local network
+  network="$(docker inspect -f '{{range $name, $network := .NetworkSettings.Networks}}{{println $name}}{{end}}' "$container" | head -n 1)"
+  if [[ -z "$network" ]]; then
+    return
+  fi
+  docker network disconnect "$network" "$container" || true
+  sleep "$seconds"
+  docker network connect "$network" "$container" || true
+}
+
+inject_recovery_fault() {
+  local seed="$1"
+  case $((seed % 4)) in
+    0)
+      docker compose kill -s SIGKILL store-1
+      docker compose up -d store-1
+      ;;
+    1)
+      docker compose restart store-2
+      ;;
+    2)
+      docker compose restart coordinator-2
+      ;;
+    *)
+      docker compose restart meta-root-3
+      ;;
+  esac
+}
+
+chaos_loop() {
+  local seed=1
+  while true; do
+    sleep "$CHAOS_INTERVAL"
+    inject_fault "$seed" || true
+    wait_fsmeta || true
+    seed=$((seed + 1))
+  done
+}
+
 wait_fsmeta
-for seed in $(seq 1 "$SEEDS"); do
-  inject_fault "$seed"
+if [[ "${NOKV_DOCKER_CHAOS_NEMESIS:-1}" == "1" ]]; then
+  inject_recovery_fault 1
   wait_fsmeta
-  "$TOOLS_DIR/nokv-fsmeta-history" \
+  chaos_loop &
+  chaos_pid="$!"
+fi
+
+"$TOOLS_DIR/nokv-fsmeta-history" \
+  --addr "$ADDR" \
+  --mount "$MOUNT" \
+  --seed-start 1 \
+  --seeds "$SEEDS" \
+  --steps "$STEPS" \
+  --batch "$BATCH" \
+  --timeout "$TIMEOUT"
+
+stop_chaos
+wait_fsmeta
+if [[ "${NOKV_DOCKER_CHAOS_SCRUB:-1}" == "1" ]]; then
+  "$TOOLS_DIR/nokv-fsmeta-scrub" \
     --addr "$ADDR" \
     --mount "$MOUNT" \
-    --seed-start "$seed" \
-    --seeds 1 \
-    --steps "$STEPS" \
-    --batch "$BATCH" \
-    --timeout "$TIMEOUT"
-done
+    --timeout "${NOKV_DOCKER_CHAOS_SCRUB_TIMEOUT:-60s}" \
+    --max-issues "${NOKV_DOCKER_CHAOS_SCRUB_MAX_ISSUES:-32}"
+fi

--- a/scripts/soak/fsmeta_soak.sh
+++ b/scripts/soak/fsmeta_soak.sh
@@ -16,21 +16,39 @@ READY_TIMEOUT="${NOKV_SOAK_READY_TIMEOUT:-180}"
 TOOLS_DIR="$(mktemp -d "${TMPDIR:-/tmp}/nokv-fsmeta-soak.XXXXXX")"
 chaos_pid=""
 
-cleanup() {
+dump_cluster_state() {
+  if [[ "${NOKV_SOAK_DUMP_LOGS:-1}" != "1" ]]; then
+    return
+  fi
+  docker compose ps || true
+  docker compose logs --no-color --tail="${NOKV_SOAK_LOG_TAIL:-200}" || true
+}
+
+stop_chaos() {
   if [[ -n "$chaos_pid" ]] && kill -0 "$chaos_pid" 2>/dev/null; then
     kill "$chaos_pid" 2>/dev/null || true
     wait "$chaos_pid" 2>/dev/null || true
   fi
+  chaos_pid=""
+}
+
+cleanup() {
+  local status="${1:-0}"
+  if [[ "$status" != "0" ]]; then
+    dump_cluster_state
+  fi
+  stop_chaos
   rm -rf "$TOOLS_DIR"
   if [[ "${NOKV_SOAK_DOWN:-0}" == "1" ]]; then
     docker compose down -v
   fi
 }
-trap cleanup EXIT
-trap 'trap - EXIT; cleanup; exit 130' INT TERM
+trap 'status=$?; cleanup "$status"; exit "$status"' EXIT
+trap 'trap - EXIT; cleanup 130; exit 130' INT TERM
 
 go build -o "$TOOLS_DIR/nokv-fsmeta-history" ./cmd/nokv-fsmeta-history
 go build -o "$TOOLS_DIR/nokv-fsmeta-soak" ./cmd/nokv-fsmeta-soak
+go build -o "$TOOLS_DIR/nokv-fsmeta-scrub" ./cmd/nokv-fsmeta-scrub
 
 if [[ "${NOKV_SOAK_BUILD:-1}" == "1" ]]; then
   docker compose up -d --build
@@ -67,3 +85,13 @@ fi
   --steps "$STEPS" \
   --batch "$BATCH" \
   --seed-start "$SEED_START"
+
+stop_chaos
+wait_fsmeta
+if [[ "${NOKV_SOAK_SCRUB:-1}" == "1" ]]; then
+  "$TOOLS_DIR/nokv-fsmeta-scrub" \
+    --addr "$ADDR" \
+    --mount "$MOUNT" \
+    --timeout "${NOKV_SOAK_SCRUB_TIMEOUT:-60s}" \
+    --max-issues "${NOKV_SOAK_SCRUB_MAX_ISSUES:-64}"
+fi


### PR DESCRIPTION
## Summary
- make LSM reads choose the highest visible version across memtables and levels instead of stopping on a lower-version tombstone or shard-hint result
- make Percolator lock reads ignore stale lock records that already have a committed or rollback write record
- make fsmeta write-session expiration choose a primary key that is actually part of the delete mutation set

## Tests
- git diff --cached --check
- go test ./engine/lsm ./fsmeta/exec ./percolator -count=1