### PR TITLE
Fix serve-meta-root empty extra args

### DIFF
--- a/scripts/ops/serve-meta-root.sh
+++ b/scripts/ops/serve-meta-root.sh
@@ -88,7 +88,10 @@ if [[ -n "$WORKDIR" ]]; then
   cmd+=(--workdir "$WORKDIR")
 fi
 
-cmd+=("${EXTRA_ARGS[@]}")
+if ((${#EXTRA_ARGS[@]})); then
+  cmd+=("${EXTRA_ARGS[@]}")
+fi
+
 
 child=""
 cleanup() {


### PR DESCRIPTION
## Summary

Fix `scripts/ops/serve-meta-root.sh` so it does not expand an empty `EXTRA_ARGS` array under `set -u`.

## Root Cause

On bash 3.2, empty array expansion with `set -u` can fail with `EXTRA_ARGS[@]: unbound variable`. This breaks `scripts/dev/cluster.sh` when it starts meta-root peers without passing extra arguments.

## Validation

- Built `build/nokv` with `go build -o build/nokv ./cmd/nokv`.
- Ran a no-`--extra` smoke test on GNU bash 3.2.57 by launching `scripts/ops/serve-meta-root.sh` with a temporary workdir and dynamic listen port.
- Confirmed the process reached `Metadata root service listening ...` and did not emit `unbound variable`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved command argument handling in operational infrastructure scripts for enhanced stability and configuration flexibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->