### PR TITLE
Fix coordinator tenure renewal and raft polling tests

### DIFF
--- a/coordinator/client/client.go
+++ b/coordinator/client/client.go
@@ -394,6 +394,9 @@ func invokeRPCValidated[T any](c *GRPCClient, retryable func(error) bool, call f
 		if len(endpoints) == 0 {
 			return zero, errNoReachableAddress
 		}
+		// Not-leader / lease-not-held replies mean the client reached a coordinator,
+		// but not the current authority. If every endpoint misses authority, retry
+		// the whole set briefly so rooted leadership and tenure can converge.
 		allAuthorityMiss := true
 		for i, endpoint := range endpoints {
 			resp, err := call(endpoint.coord)

--- a/coordinator/client/client.go
+++ b/coordinator/client/client.go
@@ -58,6 +58,8 @@ type grpcEndpoint struct {
 	coord coordpb.CoordinatorClient
 }
 
+const maxAuthorityMissRetryRounds = 3
+
 // NewGRPCClient dials a Coordinator endpoint and returns a ready client.
 func NewGRPCClient(ctx context.Context, addr string, dialOpts ...grpc.DialOption) (*GRPCClient, error) {
 	addrs, err := splitAddresses(addr)
@@ -165,37 +167,37 @@ func (c *GRPCClient) StoreHeartbeat(ctx context.Context, req *coordpb.StoreHeart
 
 // RegionLiveness forwards region liveness heartbeat RPC.
 func (c *GRPCClient) RegionLiveness(ctx context.Context, req *coordpb.RegionLivenessRequest) (*coordpb.RegionLivenessResponse, error) {
-	return invokeRPC(c, retryableRead, func(coord coordpb.CoordinatorClient) (*coordpb.RegionLivenessResponse, error) {
+	return invokeRPCValidated(c, retryableRead, func(coord coordpb.CoordinatorClient) (*coordpb.RegionLivenessResponse, error) {
 		return coord.RegionLiveness(ctx, req)
-	})
+	}, nil)
 }
 
 // PublishRootEvent forwards explicit rooted event RPC.
 func (c *GRPCClient) PublishRootEvent(ctx context.Context, req *coordpb.PublishRootEventRequest) (*coordpb.PublishRootEventResponse, error) {
-	return invokeRPC(c, retryableWrite, func(coord coordpb.CoordinatorClient) (*coordpb.PublishRootEventResponse, error) {
+	return invokeRPCValidated(c, retryableWrite, func(coord coordpb.CoordinatorClient) (*coordpb.PublishRootEventResponse, error) {
 		return coord.PublishRootEvent(ctx, req)
-	})
+	}, nil)
 }
 
 // ListTransitions returns the rooted pending transition view.
 func (c *GRPCClient) ListTransitions(ctx context.Context, req *coordpb.ListTransitionsRequest) (*coordpb.ListTransitionsResponse, error) {
-	return invokeRPC(c, retryableRead, func(coord coordpb.CoordinatorClient) (*coordpb.ListTransitionsResponse, error) {
+	return invokeRPCValidated(c, retryableRead, func(coord coordpb.CoordinatorClient) (*coordpb.ListTransitionsResponse, error) {
 		return coord.ListTransitions(ctx, req)
-	})
+	}, nil)
 }
 
 // AssessRootEvent evaluates one rooted transition event without mutating truth.
 func (c *GRPCClient) AssessRootEvent(ctx context.Context, req *coordpb.AssessRootEventRequest) (*coordpb.AssessRootEventResponse, error) {
-	return invokeRPC(c, retryableRead, func(coord coordpb.CoordinatorClient) (*coordpb.AssessRootEventResponse, error) {
+	return invokeRPCValidated(c, retryableRead, func(coord coordpb.CoordinatorClient) (*coordpb.AssessRootEventResponse, error) {
 		return coord.AssessRootEvent(ctx, req)
-	})
+	}, nil)
 }
 
 // RemoveRegion forwards region removal RPC.
 func (c *GRPCClient) RemoveRegion(ctx context.Context, req *coordpb.RemoveRegionRequest) (*coordpb.RemoveRegionResponse, error) {
-	return invokeRPC(c, retryableWrite, func(coord coordpb.CoordinatorClient) (*coordpb.RemoveRegionResponse, error) {
+	return invokeRPCValidated(c, retryableWrite, func(coord coordpb.CoordinatorClient) (*coordpb.RemoveRegionResponse, error) {
 		return coord.RemoveRegion(ctx, req)
-	})
+	}, nil)
 }
 
 // GetRegionByKey forwards region lookup RPC.
@@ -381,32 +383,40 @@ func (c *GRPCClient) markPreferred(addr string) {
 	}
 }
 
-func invokeRPC[T any](c *GRPCClient, retryable func(error) bool, call func(coord coordpb.CoordinatorClient) (T, error)) (T, error) {
-	return invokeRPCValidated(c, retryable, call, nil)
-}
-
 func invokeRPCValidated[T any](c *GRPCClient, retryable func(error) bool, call func(coord coordpb.CoordinatorClient) (T, error), validate func(T) error) (T, error) {
 	var zero T
 	if c == nil {
 		return zero, errNoReachableAddress
 	}
-	endpoints := c.orderedEndpoints()
-	if len(endpoints) == 0 {
-		return zero, errNoReachableAddress
-	}
 	var lastErr error
-	for i, endpoint := range endpoints {
-		resp, err := call(endpoint.coord)
-		if err == nil && validate != nil {
-			err = validate(resp)
+	for round := 0; round < maxAuthorityMissRetryRounds; round++ {
+		endpoints := c.orderedEndpoints()
+		if len(endpoints) == 0 {
+			return zero, errNoReachableAddress
 		}
-		if err == nil {
-			c.markPreferred(endpoint.addr)
-			return resp, nil
+		allAuthorityMiss := true
+		for i, endpoint := range endpoints {
+			resp, err := call(endpoint.coord)
+			if err == nil && validate != nil {
+				err = validate(resp)
+			}
+			if err == nil {
+				c.markPreferred(endpoint.addr)
+				return resp, nil
+			}
+			lastErr = err
+			if !isAuthorityMiss(err) {
+				allAuthorityMiss = false
+			}
+			if i == len(endpoints)-1 || !retryable(err) {
+				if allAuthorityMiss && retryable(err) && round+1 < maxAuthorityMissRetryRounds {
+					break
+				}
+				return zero, err
+			}
 		}
-		lastErr = err
-		if i == len(endpoints)-1 || !retryable(err) {
-			return zero, err
+		if !allAuthorityMiss {
+			return zero, lastErr
 		}
 	}
 	if lastErr == nil {
@@ -432,6 +442,10 @@ func retryableWrite(err error) bool {
 	if retryableRead(err) {
 		return true
 	}
+	return nokverrors.IsKind(err, nokverrors.KindNotLeader)
+}
+
+func isAuthorityMiss(err error) bool {
 	return nokverrors.IsKind(err, nokverrors.KindNotLeader)
 }
 

--- a/coordinator/client/client.go
+++ b/coordinator/client/client.go
@@ -389,7 +389,7 @@ func invokeRPCValidated[T any](c *GRPCClient, retryable func(error) bool, call f
 		return zero, errNoReachableAddress
 	}
 	var lastErr error
-	for round := 0; round < maxAuthorityMissRetryRounds; round++ {
+	for round := range maxAuthorityMissRetryRounds {
 		endpoints := c.orderedEndpoints()
 		if len(endpoints) == 0 {
 			return zero, errNoReachableAddress

--- a/coordinator/client/client_test.go
+++ b/coordinator/client/client_test.go
@@ -259,6 +259,84 @@ func TestGRPCClientRetriesWriteOnLeaseNotHeld(t *testing.T) {
 	require.False(t, IsNotLeader(err))
 }
 
+func TestGRPCClientRetriesTSOAcrossLeaseNotHeldEndpoint(t *testing.T) {
+	leaseErr := status.Error(codes.FailedPrecondition, errLeaseNotHeldPrefix+": "+rootstate.ErrPrimacy.Error())
+	servers := map[string]*scriptedCoordinatorServer{
+		"standby": {
+			tsoErrors: []error{leaseErr},
+		},
+		"holder": {
+			tsoResponses: []*coordpb.TsoResponse{{
+				Timestamp:        100,
+				Count:            2,
+				Era:              1,
+				ConsumedFrontier: 101,
+			}},
+		},
+	}
+	cli := newScriptedCoordinatorClient(t, []string{"standby", "holder"}, servers)
+
+	resp, err := cli.Tso(context.Background(), &coordpb.TsoRequest{Count: 2})
+	require.NoError(t, err)
+	require.Equal(t, uint64(100), resp.GetTimestamp())
+	require.Equal(t, uint64(2), resp.GetCount())
+	require.Equal(t, 1, servers["standby"].tsoCalls)
+	require.Equal(t, 1, servers["holder"].tsoCalls)
+	require.Equal(t, "passthrough:///holder", cli.orderedEndpoints()[0].addr)
+}
+
+func TestGRPCClientRetriesAllocIDAcrossLeaseNotHeldEndpoint(t *testing.T) {
+	leaseErr := status.Error(codes.FailedPrecondition, errLeaseNotHeldPrefix+": "+rootstate.ErrPrimacy.Error())
+	servers := map[string]*scriptedCoordinatorServer{
+		"standby": {
+			allocErrors: []error{leaseErr},
+		},
+		"holder": {
+			allocResponses: []*coordpb.AllocIDResponse{{
+				FirstId:          200,
+				Count:            3,
+				Era:              1,
+				ConsumedFrontier: 202,
+			}},
+		},
+	}
+	cli := newScriptedCoordinatorClient(t, []string{"standby", "holder"}, servers)
+
+	resp, err := cli.AllocID(context.Background(), &coordpb.AllocIDRequest{Count: 3})
+	require.NoError(t, err)
+	require.Equal(t, uint64(200), resp.GetFirstId())
+	require.Equal(t, uint64(3), resp.GetCount())
+	require.Equal(t, 1, servers["standby"].allocCalls)
+	require.Equal(t, 1, servers["holder"].allocCalls)
+	require.Equal(t, "passthrough:///holder", cli.orderedEndpoints()[0].addr)
+}
+
+func TestGRPCClientRetriesTSOAfterFullLeaseMissRound(t *testing.T) {
+	leaseErr := status.Error(codes.FailedPrecondition, errLeaseNotHeldPrefix+": "+rootstate.ErrPrimacy.Error())
+	servers := map[string]*scriptedCoordinatorServer{
+		"standby": {
+			tsoErrors: []error{leaseErr, leaseErr},
+		},
+		"holder": {
+			tsoErrors: []error{leaseErr},
+			tsoResponses: []*coordpb.TsoResponse{{
+				Timestamp:        300,
+				Count:            1,
+				Era:              2,
+				ConsumedFrontier: 300,
+			}},
+		},
+	}
+	cli := newScriptedCoordinatorClient(t, []string{"standby", "holder"}, servers)
+
+	resp, err := cli.Tso(context.Background(), &coordpb.TsoRequest{Count: 1})
+	require.NoError(t, err)
+	require.Equal(t, uint64(300), resp.GetTimestamp())
+	require.Equal(t, 2, servers["standby"].tsoCalls)
+	require.Equal(t, 2, servers["holder"].tsoCalls)
+	require.Equal(t, "passthrough:///holder", cli.orderedEndpoints()[0].addr)
+}
+
 func TestGRPCClientRejectsInvalidAllocWitness(t *testing.T) {
 	cli := newScriptedCoordinatorClient(t, []string{"alloc-invalid"}, map[string]*scriptedCoordinatorServer{
 		"alloc-invalid": {
@@ -808,12 +886,15 @@ func (s *scriptedCoordinatorServer) AllocID(_ context.Context, _ *coordpb.AllocI
 		err = s.allocErrors[0]
 		s.allocErrors = s.allocErrors[1:]
 	}
-	if len(s.allocResponses) == 0 {
+	if err != nil {
 		return nil, err
+	}
+	if len(s.allocResponses) == 0 {
+		return nil, nil
 	}
 	resp := s.allocResponses[0]
 	s.allocResponses = s.allocResponses[1:]
-	return resp, err
+	return resp, nil
 }
 
 func (s *scriptedCoordinatorServer) Tso(_ context.Context, _ *coordpb.TsoRequest) (*coordpb.TsoResponse, error) {
@@ -825,12 +906,15 @@ func (s *scriptedCoordinatorServer) Tso(_ context.Context, _ *coordpb.TsoRequest
 		err = s.tsoErrors[0]
 		s.tsoErrors = s.tsoErrors[1:]
 	}
-	if len(s.tsoResponses) == 0 {
+	if err != nil {
 		return nil, err
+	}
+	if len(s.tsoResponses) == 0 {
+		return nil, nil
 	}
 	resp := s.tsoResponses[0]
 	s.tsoResponses = s.tsoResponses[1:]
-	return resp, err
+	return resp, nil
 }
 
 func (s *scriptedCoordinatorServer) GetRegionByKey(_ context.Context, _ *coordpb.GetRegionByKeyRequest) (*coordpb.GetRegionByKeyResponse, error) {

--- a/coordinator/client/client_test.go
+++ b/coordinator/client/client_test.go
@@ -890,7 +890,7 @@ func (s *scriptedCoordinatorServer) AllocID(_ context.Context, _ *coordpb.AllocI
 		return nil, err
 	}
 	if len(s.allocResponses) == 0 {
-		return nil, nil
+		return nil, status.Error(codes.Internal, "scripted coordinator AllocID response queue is empty")
 	}
 	resp := s.allocResponses[0]
 	s.allocResponses = s.allocResponses[1:]
@@ -910,7 +910,7 @@ func (s *scriptedCoordinatorServer) Tso(_ context.Context, _ *coordpb.TsoRequest
 		return nil, err
 	}
 	if len(s.tsoResponses) == 0 {
-		return nil, nil
+		return nil, status.Error(codes.Internal, "scripted coordinator Tso response queue is empty")
 	}
 	resp := s.tsoResponses[0]
 	s.tsoResponses = s.tsoResponses[1:]

--- a/coordinator/client/errors_test.go
+++ b/coordinator/client/errors_test.go
@@ -25,4 +25,8 @@ func TestCoordinatorClientErrorsExposeStableKinds(t *testing.T) {
 	leaseNotHeld := status.Error(codes.FailedPrecondition, errLeaseNotHeldPrefix)
 	require.Equal(t, nokverrors.KindNotLeader, nokverrors.KindOf(leaseNotHeld))
 	require.True(t, nokverrors.Retryable(leaseNotHeld))
+
+	leaseExpired := status.Error(codes.FailedPrecondition, errLeaseNotHeldPrefix+": "+nokverrors.New(nokverrors.KindInvalidArgument, "meta/root/state: invalid tenure: rooted lease expired era=7").Error())
+	require.Equal(t, nokverrors.KindNotLeader, nokverrors.KindOf(leaseExpired))
+	require.True(t, nokverrors.Retryable(leaseExpired))
 }

--- a/coordinator/server/service_lease.go
+++ b/coordinator/server/service_lease.go
@@ -265,6 +265,7 @@ func (s *Service) ensureTenure(ctx context.Context) error {
 
 	s.writeMu.Lock()
 	defer s.writeMu.Unlock()
+	nowUnixNano, expiresUnixNano, holderID, renewIn, clockSkew = s.leaseCampaignBounds()
 	if s.coordinatorLeaseStillValid(holderID, nowUnixNano, renewIn, clockSkew) {
 		return nil
 	}
@@ -272,6 +273,10 @@ func (s *Service) ensureTenure(ctx context.Context) error {
 	s.allocMu.Lock()
 	inheritedFrontiers := eunomia.Frontiers(rootstate.State{IDFence: s.currentIDFenceLocked(), TSOFence: s.currentTSOFenceLocked()}, s.currentDescriptorRevision())
 	s.allocMu.Unlock()
+	nowUnixNano, expiresUnixNano, holderID, renewIn, clockSkew = s.leaseCampaignBounds()
+	if s.coordinatorLeaseStillValid(holderID, nowUnixNano, renewIn, clockSkew) {
+		return nil
+	}
 	current, seal := s.currentTenureView()
 	lineageDigest := rootstate.ResolveLineageDigest(current, seal, holderID, nowUnixNano)
 
@@ -408,7 +413,7 @@ func translateTenureError(err error) error {
 	if err == nil {
 		return nil
 	}
-	if errors.Is(err, rootstate.ErrPrimacy) || errors.Is(err, rootstate.ErrInheritance) || errors.Is(err, rootstate.ErrInheritance) {
+	if errors.Is(err, rootstate.ErrPrimacy) || errors.Is(err, rootstate.ErrInheritance) {
 		return statusTenure(err)
 	}
 	return status.Error(codes.Internal, "campaign coordinator lease: "+err.Error())

--- a/coordinator/server/service_lease.go
+++ b/coordinator/server/service_lease.go
@@ -258,6 +258,8 @@ func (s *Service) ensureTenure(ctx context.Context) error {
 	if s == nil || !s.coordinatorLeaseEnabled() || s.storage == nil {
 		return nil
 	}
+	// Fast path: avoid serializing read traffic behind the campaign lock while
+	// the current tenure is still outside the renew and clock-skew windows.
 	nowUnixNano, _, holderID, renewIn, clockSkew := s.leaseCampaignBounds()
 	if s.coordinatorLeaseStillValid(holderID, nowUnixNano, renewIn, clockSkew) {
 		return nil
@@ -265,6 +267,8 @@ func (s *Service) ensureTenure(ctx context.Context) error {
 
 	s.writeMu.Lock()
 	defer s.writeMu.Unlock()
+	// Another request or the background renew loop may have refreshed tenure
+	// while this caller waited for writeMu.
 	nowUnixNano, _, holderID, renewIn, clockSkew = s.leaseCampaignBounds()
 	if s.coordinatorLeaseStillValid(holderID, nowUnixNano, renewIn, clockSkew) {
 		return nil
@@ -273,6 +277,8 @@ func (s *Service) ensureTenure(ctx context.Context) error {
 	s.allocMu.Lock()
 	inheritedFrontiers := eunomia.Frontiers(rootstate.State{IDFence: s.currentIDFenceLocked(), TSOFence: s.currentTSOFenceLocked()}, s.currentDescriptorRevision())
 	s.allocMu.Unlock()
+	// Recompute time and expiry after sampling allocator fences so the tenure
+	// command carries fresh bounds and does not campaign unnecessarily.
 	nowUnixNano, expiresUnixNano, holderID, renewIn, clockSkew := s.leaseCampaignBounds()
 	if s.coordinatorLeaseStillValid(holderID, nowUnixNano, renewIn, clockSkew) {
 		return nil

--- a/coordinator/server/service_lease.go
+++ b/coordinator/server/service_lease.go
@@ -258,14 +258,14 @@ func (s *Service) ensureTenure(ctx context.Context) error {
 	if s == nil || !s.coordinatorLeaseEnabled() || s.storage == nil {
 		return nil
 	}
-	nowUnixNano, expiresUnixNano, holderID, renewIn, clockSkew := s.leaseCampaignBounds()
+	nowUnixNano, _, holderID, renewIn, clockSkew := s.leaseCampaignBounds()
 	if s.coordinatorLeaseStillValid(holderID, nowUnixNano, renewIn, clockSkew) {
 		return nil
 	}
 
 	s.writeMu.Lock()
 	defer s.writeMu.Unlock()
-	nowUnixNano, expiresUnixNano, holderID, renewIn, clockSkew = s.leaseCampaignBounds()
+	nowUnixNano, _, holderID, renewIn, clockSkew = s.leaseCampaignBounds()
 	if s.coordinatorLeaseStillValid(holderID, nowUnixNano, renewIn, clockSkew) {
 		return nil
 	}
@@ -273,7 +273,7 @@ func (s *Service) ensureTenure(ctx context.Context) error {
 	s.allocMu.Lock()
 	inheritedFrontiers := eunomia.Frontiers(rootstate.State{IDFence: s.currentIDFenceLocked(), TSOFence: s.currentTSOFenceLocked()}, s.currentDescriptorRevision())
 	s.allocMu.Unlock()
-	nowUnixNano, expiresUnixNano, holderID, renewIn, clockSkew = s.leaseCampaignBounds()
+	nowUnixNano, expiresUnixNano, holderID, renewIn, clockSkew := s.leaseCampaignBounds()
 	if s.coordinatorLeaseStillValid(holderID, nowUnixNano, renewIn, clockSkew) {
 		return nil
 	}
@@ -412,6 +412,12 @@ func (s *Service) leaseCampaignBounds() (nowUnixNano, expiresUnixNano int64, hol
 func translateTenureError(err error) error {
 	if err == nil {
 		return nil
+	}
+	if errors.Is(err, context.Canceled) {
+		return status.Error(codes.Canceled, err.Error())
+	}
+	if errors.Is(err, context.DeadlineExceeded) {
+		return status.Error(codes.DeadlineExceeded, err.Error())
 	}
 	if errors.Is(err, rootstate.ErrPrimacy) || errors.Is(err, rootstate.ErrInheritance) {
 		return statusTenure(err)

--- a/coordinator/server/service_metadata.go
+++ b/coordinator/server/service_metadata.go
@@ -27,6 +27,9 @@ func (s *Service) GetRegionByKey(ctx context.Context, req *coordpb.GetRegionByKe
 		return nil, status.Error(codes.InvalidArgument, "get region by key request is nil")
 	}
 	state, err := s.currentReadState()
+	// Region lookup is an authority-bearing metadata read. A coordinator that
+	// already owns the tenure should renew it before rejecting clients with a
+	// stale local read-state view.
 	renewed, renewErr := s.renewMetadataTenureIfNeeded(ctx, state, err)
 	if renewErr != nil {
 		return nil, renewErr
@@ -230,6 +233,9 @@ func (s *Service) currentReadState() (readState, error) {
 	return state, nil
 }
 
+// renewMetadataTenureIfNeeded only refreshes tenure already held by this
+// coordinator. It must not campaign over another holder just because a metadata
+// read arrived during that holder's active tenure.
 func (s *Service) renewMetadataTenureIfNeeded(ctx context.Context, state readState, loadErr error) (bool, error) {
 	if loadErr != nil || s == nil || !s.coordinatorLeaseEnabled() || !state.leasePresent {
 		return false, nil

--- a/coordinator/server/service_metadata.go
+++ b/coordinator/server/service_metadata.go
@@ -27,6 +27,13 @@ func (s *Service) GetRegionByKey(ctx context.Context, req *coordpb.GetRegionByKe
 		return nil, status.Error(codes.InvalidArgument, "get region by key request is nil")
 	}
 	state, err := s.currentReadState()
+	renewed, renewErr := s.renewMetadataTenureIfNeeded(ctx, state, err)
+	if renewErr != nil {
+		return nil, renewErr
+	}
+	if renewed {
+		state, err = s.currentReadState()
+	}
 	admission, err := s.admitMetadataAnswerability(req, state, err)
 	if err != nil {
 		return nil, err
@@ -73,6 +80,8 @@ type readState struct {
 	leaseActive    bool
 	leaseSealed    bool
 	leaseMandate   uint32
+	leaseHolderID  string
+	leaseExpiresAt int64
 }
 
 type metadataAnswerability struct {
@@ -191,6 +200,8 @@ func (s *Service) currentReadState() (readState, error) {
 		state.leaseActive = snapshot.Tenure.ActiveAt(nowUnixNano)
 		state.leaseSealed = rootstate.TenureSealed(snapshot.Tenure, snapshot.Legacy)
 		state.leaseMandate = snapshot.Tenure.Mandate
+		state.leaseHolderID = snapshot.Tenure.HolderID
+		state.leaseExpiresAt = snapshot.Tenure.ExpiresUnixNano
 	}
 	if snapshot.Legacy.Present() {
 		state.legacyEra = snapshot.Legacy.Era
@@ -217,6 +228,33 @@ func (s *Service) currentReadState() (readState, error) {
 		state.degraded = coordpb.DegradedMode_DEGRADED_MODE_ROOT_LAGGING
 	}
 	return state, nil
+}
+
+func (s *Service) renewMetadataTenureIfNeeded(ctx context.Context, state readState, loadErr error) (bool, error) {
+	if loadErr != nil || s == nil || !s.coordinatorLeaseEnabled() || !state.leasePresent {
+		return false, nil
+	}
+	s.leaseMu.RLock()
+	holderID := strings.TrimSpace(s.coordinatorID)
+	renewIn := s.leaseRenewIn
+	clockSkew := s.leaseClockSkew
+	s.leaseMu.RUnlock()
+	if holderID == "" || strings.TrimSpace(state.leaseHolderID) != holderID {
+		return false, nil
+	}
+	nowFn := s.now
+	if nowFn == nil {
+		nowFn = time.Now
+	}
+	nowUnixNano := nowFn().UnixNano()
+	if state.leaseExpiresAt > nowUnixNano+renewIn.Nanoseconds() &&
+		state.leaseExpiresAt > nowUnixNano+clockSkew.Nanoseconds() {
+		return false, nil
+	}
+	if err := s.ensureTenure(ctx); err != nil {
+		return false, translateTenureError(err)
+	}
+	return true, nil
 }
 
 func (s *Service) notLeaderError() error {

--- a/coordinator/server/service_test.go
+++ b/coordinator/server/service_test.go
@@ -3,6 +3,7 @@ package server
 import (
 	"context"
 	"errors"
+	"fmt"
 	"strings"
 	"sync/atomic"
 	"testing"
@@ -53,6 +54,33 @@ type fakeStorage struct {
 	leaderID      uint64
 	lastEvent     rootevent.Event
 	snapshot      rootview.Snapshot
+}
+
+func TestTranslateTenureErrorsAsLeaseNotHeld(t *testing.T) {
+	cases := []struct {
+		name     string
+		err      error
+		contains string
+	}{
+		{
+			name:     "primacy",
+			err:      translateTenureError(rootstate.ErrPrimacy),
+			contains: rootstate.ErrPrimacy.Error(),
+		},
+		{
+			name:     "expired",
+			err:      statusTenure(fmt.Errorf("%w: rooted lease expired era=7", rootstate.ErrInvalidTenure)),
+			contains: "rooted lease expired era=7",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, codes.FailedPrecondition, status.Code(tc.err))
+			message := status.Convert(tc.err).Message()
+			require.Contains(t, message, errTenurePrefix)
+			require.Contains(t, message, tc.contains)
+		})
+	}
 }
 
 func (f *fakeStorage) protocolState() rootstate.EunomiaState {
@@ -609,6 +637,77 @@ func TestServiceGetRegionByKeyStrongReadRejectsFollower(t *testing.T) {
 	require.Error(t, err)
 	require.Equal(t, codes.FailedPrecondition, status.Code(err))
 	require.Contains(t, err.Error(), errNotLeaderPrefix)
+}
+
+func TestServiceGetRegionByKeyRenewsSelfHeldExpiredTenure(t *testing.T) {
+	cluster := catalog.NewCluster()
+	desc := testDescriptor(11, []byte(""), []byte("m"), metaregion.Epoch{Version: 1, ConfVersion: 1}, nil)
+	desc.RootEpoch = 5
+	token := rootstorage.TailToken{Cursor: rootstate.Cursor{Term: 1, Index: 3}, Revision: 5}
+	cluster.ReplaceRootSnapshot(rootstate.Snapshot{
+		Descriptors: map[uint64]topology.Descriptor{desc.RegionID: desc},
+	}, token)
+	storage := &fakeStorage{
+		leader: true,
+		snapshot: rootview.Snapshot{
+			RootToken:   token,
+			Descriptors: map[uint64]topology.Descriptor{desc.RegionID: desc},
+			Tenure: rootstate.Tenure{
+				HolderID:        "c1",
+				ExpiresUnixNano: 100,
+				Era:             1,
+				Mandate:         rootproto.MandateDefault,
+			},
+		},
+	}
+	svc := NewService(cluster, idalloc.NewIDAllocator(1), tso.NewAllocator(1), storage)
+	svc.ConfigureTenure("c1", time.Second, 300*time.Millisecond)
+	svc.now = func() time.Time { return time.Unix(0, 200) }
+	require.NoError(t, svc.ReloadFromStorage())
+
+	resp, err := svc.GetRegionByKey(context.Background(), &coordpb.GetRegionByKeyRequest{Key: []byte("a")})
+	require.NoError(t, err)
+	require.False(t, resp.GetNotFound())
+	require.Equal(t, uint64(11), resp.GetRegionDescriptor().GetRegionId())
+	require.Equal(t, 1, storage.campaignCalls)
+	require.Equal(t, "c1", storage.snapshot.Tenure.HolderID)
+	require.Equal(t, uint64(2), storage.snapshot.Tenure.Era)
+	require.Equal(t, uint64(2), resp.GetEra())
+	require.True(t, storage.snapshot.Tenure.ActiveAt(200))
+}
+
+func TestServiceGetRegionByKeyDoesNotStealOtherActiveTenure(t *testing.T) {
+	cluster := catalog.NewCluster()
+	desc := testDescriptor(11, []byte(""), []byte("m"), metaregion.Epoch{Version: 1, ConfVersion: 1}, nil)
+	desc.RootEpoch = 5
+	token := rootstorage.TailToken{Cursor: rootstate.Cursor{Term: 1, Index: 3}, Revision: 5}
+	cluster.ReplaceRootSnapshot(rootstate.Snapshot{
+		Descriptors: map[uint64]topology.Descriptor{desc.RegionID: desc},
+	}, token)
+	storage := &fakeStorage{
+		leader: true,
+		snapshot: rootview.Snapshot{
+			RootToken:   token,
+			Descriptors: map[uint64]topology.Descriptor{desc.RegionID: desc},
+			Tenure: rootstate.Tenure{
+				HolderID:        "c2",
+				ExpiresUnixNano: 10_000,
+				Era:             4,
+				Mandate:         rootproto.MandateDefault,
+			},
+		},
+	}
+	svc := NewService(cluster, idalloc.NewIDAllocator(1), tso.NewAllocator(1), storage)
+	svc.ConfigureTenure("c1", time.Second, 300*time.Millisecond)
+	svc.now = func() time.Time { return time.Unix(0, 200) }
+	require.NoError(t, svc.ReloadFromStorage())
+
+	resp, err := svc.GetRegionByKey(context.Background(), &coordpb.GetRegionByKeyRequest{Key: []byte("a")})
+	require.NoError(t, err)
+	require.False(t, resp.GetNotFound())
+	require.Equal(t, 0, storage.campaignCalls)
+	require.Equal(t, "c2", storage.snapshot.Tenure.HolderID)
+	require.Equal(t, uint64(4), resp.GetEra())
 }
 
 func TestServiceGetRegionByKeyRequiredRootToken(t *testing.T) {

--- a/coordinator/server/service_test.go
+++ b/coordinator/server/service_test.go
@@ -83,6 +83,22 @@ func TestTranslateTenureErrorsAsLeaseNotHeld(t *testing.T) {
 	}
 }
 
+func TestTranslateTenureContextErrors(t *testing.T) {
+	cases := []struct {
+		name string
+		err  error
+		code codes.Code
+	}{
+		{name: "canceled", err: translateTenureError(context.Canceled), code: codes.Canceled},
+		{name: "deadline", err: translateTenureError(context.DeadlineExceeded), code: codes.DeadlineExceeded},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.code, status.Code(tc.err))
+		})
+	}
+}
+
 func (f *fakeStorage) protocolState() rootstate.EunomiaState {
 	return rootstate.EunomiaState{
 		Tenure:   f.snapshot.Tenure,

--- a/raftstore/integration/context_propagation_test.go
+++ b/raftstore/integration/context_propagation_test.go
@@ -287,8 +287,11 @@ func TestClientTwoPhaseCommitHonorsContextAcrossSplitRegionsUnderPartialQuorumLo
 	}
 	require.NoError(t, parentLeader.Server.Store().ProposeSplit(91, childMeta, childMeta.StartKey))
 	require.Eventually(t, func() bool {
-		a := testcluster.FetchRuntimeStatus(t, ctx, seed.Addr(), 92)
-		b := testcluster.FetchRuntimeStatus(t, ctx, target.Addr(), 92)
+		a, errA := testcluster.TryPollRuntimeStatus(ctx, seed.Addr(), 92)
+		b, errB := testcluster.TryPollRuntimeStatus(ctx, target.Addr(), 92)
+		if errA != nil || errB != nil {
+			return false
+		}
 		return a.GetKnown() && a.GetHosted() && b.GetKnown() && b.GetHosted()
 	}, 5*time.Second, 20*time.Millisecond, testcluster.DumpStatus(t, ctx, 92, seed, target))
 
@@ -341,10 +344,14 @@ func TestClientTwoPhaseCommitHonorsContextAcrossSplitRegionsUnderPartialQuorumLo
 
 	var lastRecoveryErr error
 	require.Eventuallyf(t, func() bool {
-		parentA := testcluster.FetchRuntimeStatus(t, ctx, seed.Addr(), 91)
-		parentB := testcluster.FetchRuntimeStatus(t, ctx, target.Addr(), 91)
-		childA := testcluster.FetchRuntimeStatus(t, ctx, seed.Addr(), 92)
-		childB := testcluster.FetchRuntimeStatus(t, ctx, target.Addr(), 92)
+		parentA, errParentA := testcluster.TryPollRuntimeStatus(ctx, seed.Addr(), 91)
+		parentB, errParentB := testcluster.TryPollRuntimeStatus(ctx, target.Addr(), 91)
+		childA, errChildA := testcluster.TryPollRuntimeStatus(ctx, seed.Addr(), 92)
+		childB, errChildB := testcluster.TryPollRuntimeStatus(ctx, target.Addr(), 92)
+		if errParentA != nil || errParentB != nil || errChildA != nil || errChildB != nil {
+			lastRecoveryErr = errors.Join(errParentA, errParentB, errChildA, errChildB)
+			return false
+		}
 		parentMeta, parentLeaderStoreID, parentReady := runtimeLeaderDescriptor(parentA, parentB)
 		childMeta, childLeaderStoreID, childReady := runtimeLeaderDescriptor(childA, childB)
 		if !parentReady || !childReady {

--- a/raftstore/integration/restart_recovery_test.go
+++ b/raftstore/integration/restart_recovery_test.go
@@ -20,13 +20,19 @@ func waitForStableLeader(tb testing.TB, ctx context.Context, regionID uint64, no
 	deadline := time.Now().Add(10 * time.Second)
 	var stableLeader uint64
 	var stableCount int
+	var lastErr error
 	for time.Now().Before(deadline) {
 		var leaderNode *testcluster.Node
 		var leaderStatus *adminpb.RegionRuntimeStatusResponse
 		var leaderPeerID uint64
 		consistent := true
 		for _, node := range nodes {
-			status := testcluster.FetchRuntimeStatus(tb, ctx, node.Addr(), regionID)
+			status, err := testcluster.TryPollRuntimeStatus(ctx, node.Addr(), regionID)
+			if err != nil {
+				lastErr = err
+				consistent = false
+				break
+			}
 			if !status.GetKnown() || !status.GetHosted() || status.GetLeaderPeerId() == 0 {
 				consistent = false
 				break
@@ -62,7 +68,7 @@ func waitForStableLeader(tb testing.TB, ctx context.Context, regionID uint64, no
 		}
 		time.Sleep(50 * time.Millisecond)
 	}
-	tb.Fatalf("timed out waiting for stable leader on region %d: %s", regionID, testcluster.DumpStatus(tb, ctx, regionID, nodes...))
+	tb.Fatalf("timed out waiting for stable leader on region %d (last error=%v): %s", regionID, lastErr, testcluster.DumpStatus(tb, ctx, regionID, nodes...))
 	return nil, nil
 }
 

--- a/raftstore/integration/split_merge_recovery_test.go
+++ b/raftstore/integration/split_merge_recovery_test.go
@@ -63,8 +63,11 @@ func TestSplitMergeRestartSafetyAcrossStores(t *testing.T) {
 	}
 	require.NoError(t, parentLeader.Server.Store().ProposeSplit(71, childMeta, childMeta.StartKey))
 	require.Eventually(t, func() bool {
-		a := testcluster.FetchRuntimeStatus(t, ctx, seed.Addr(), 72)
-		b := testcluster.FetchRuntimeStatus(t, ctx, target.Addr(), 72)
+		a, errA := testcluster.TryPollRuntimeStatus(ctx, seed.Addr(), 72)
+		b, errB := testcluster.TryPollRuntimeStatus(ctx, target.Addr(), 72)
+		if errA != nil || errB != nil {
+			return false
+		}
 		return a.GetKnown() && a.GetHosted() && b.GetKnown() && b.GetHosted()
 	}, 5*time.Second, 20*time.Millisecond, testcluster.DumpStatus(t, ctx, 72, seed, target))
 	_, _ = testcluster.FindLeader(t, ctx, 72, seed, target)
@@ -73,27 +76,39 @@ func TestSplitMergeRestartSafetyAcrossStores(t *testing.T) {
 	target.Restart(t, nil, true)
 	wireAll()
 	require.Eventually(t, func() bool {
-		return testcluster.FetchRuntimeStatus(t, ctx, seed.Addr(), 71).GetKnown() &&
-			testcluster.FetchRuntimeStatus(t, ctx, target.Addr(), 71).GetKnown() &&
-			testcluster.FetchRuntimeStatus(t, ctx, seed.Addr(), 72).GetKnown() &&
-			testcluster.FetchRuntimeStatus(t, ctx, target.Addr(), 72).GetKnown()
+		parentSeed, errParentSeed := testcluster.TryPollRuntimeStatus(ctx, seed.Addr(), 71)
+		parentTarget, errParentTarget := testcluster.TryPollRuntimeStatus(ctx, target.Addr(), 71)
+		childSeed, errChildSeed := testcluster.TryPollRuntimeStatus(ctx, seed.Addr(), 72)
+		childTarget, errChildTarget := testcluster.TryPollRuntimeStatus(ctx, target.Addr(), 72)
+		if errParentSeed != nil || errParentTarget != nil || errChildSeed != nil || errChildTarget != nil {
+			return false
+		}
+		return parentSeed.GetKnown() && parentTarget.GetKnown() && childSeed.GetKnown() && childTarget.GetKnown()
 	}, 5*time.Second, 20*time.Millisecond)
 
 	parentLeader, _ = testcluster.FindLeader(t, ctx, 71, seed, target)
 	require.NoError(t, parentLeader.Server.Store().ProposeMerge(71, 72))
 	require.Eventually(t, func() bool {
-		return !testcluster.FetchRuntimeStatus(t, ctx, seed.Addr(), 72).GetKnown() &&
-			!testcluster.FetchRuntimeStatus(t, ctx, target.Addr(), 72).GetKnown()
+		childSeed, errSeed := testcluster.TryPollRuntimeStatus(ctx, seed.Addr(), 72)
+		childTarget, errTarget := testcluster.TryPollRuntimeStatus(ctx, target.Addr(), 72)
+		if errSeed != nil || errTarget != nil {
+			return false
+		}
+		return !childSeed.GetKnown() && !childTarget.GetKnown()
 	}, 5*time.Second, 20*time.Millisecond)
 
 	seed.Restart(t, []workdirmode.Mode{workdirmode.ModeSeeded, workdirmode.ModeCluster}, true)
 	target.Restart(t, nil, true)
 	wireAll()
 	require.Eventually(t, func() bool {
-		return testcluster.FetchRuntimeStatus(t, ctx, seed.Addr(), 71).GetKnown() &&
-			testcluster.FetchRuntimeStatus(t, ctx, target.Addr(), 71).GetKnown() &&
-			!testcluster.FetchRuntimeStatus(t, ctx, seed.Addr(), 72).GetKnown() &&
-			!testcluster.FetchRuntimeStatus(t, ctx, target.Addr(), 72).GetKnown()
+		parentSeed, errParentSeed := testcluster.TryPollRuntimeStatus(ctx, seed.Addr(), 71)
+		parentTarget, errParentTarget := testcluster.TryPollRuntimeStatus(ctx, target.Addr(), 71)
+		childSeed, errChildSeed := testcluster.TryPollRuntimeStatus(ctx, seed.Addr(), 72)
+		childTarget, errChildTarget := testcluster.TryPollRuntimeStatus(ctx, target.Addr(), 72)
+		if errParentSeed != nil || errParentTarget != nil || errChildSeed != nil || errChildTarget != nil {
+			return false
+		}
+		return parentSeed.GetKnown() && parentTarget.GetKnown() && !childSeed.GetKnown() && !childTarget.GetKnown()
 	}, 5*time.Second, 20*time.Millisecond)
 
 	testcluster.AssertValue(t, seed.DB, []byte("bravo"), []byte("v1"))

--- a/raftstore/integration/transport_chaos_test.go
+++ b/raftstore/integration/transport_chaos_test.go
@@ -159,7 +159,10 @@ func TestTransferLeaderRecoversAfterPartitionedTargetReturns(t *testing.T) {
 	target2.UnblockPeer(101)
 
 	require.Eventually(t, func() bool {
-		currentLeader, currentStatus := testcluster.FindLeader(t, ctx, 82, seed, target2, target3)
+		currentLeader, currentStatus, err := testcluster.TryFindLeader(ctx, 82, seed, target2, target3)
+		if err != nil {
+			return false
+		}
 		if currentStatus.GetLeaderPeerId() == 201 {
 			return currentLeader.Addr() == target2.Addr() && currentStatus.GetLeader()
 		}

--- a/raftstore/integration/twopc_fault_model_test.go
+++ b/raftstore/integration/twopc_fault_model_test.go
@@ -132,8 +132,11 @@ func openTwoStoreSplitRuntime(t *testing.T, ctx context.Context) *twopcFaultRunt
 	}
 	require.NoError(t, parentLeader.Server.Store().ProposeSplit(501, childMeta, childMeta.StartKey))
 	require.Eventually(t, func() bool {
-		a := testcluster.FetchRuntimeStatus(t, ctx, seed.Addr(), 502)
-		b := testcluster.FetchRuntimeStatus(t, ctx, target.Addr(), 502)
+		a, errA := testcluster.TryPollRuntimeStatus(ctx, seed.Addr(), 502)
+		b, errB := testcluster.TryPollRuntimeStatus(ctx, target.Addr(), 502)
+		if errA != nil || errB != nil {
+			return false
+		}
 		return a.GetKnown() && a.GetHosted() && b.GetKnown() && b.GetHosted()
 	}, 5*time.Second, 20*time.Millisecond, testcluster.DumpStatus(t, ctx, 502, seed, target))
 

--- a/raftstore/testcluster/cluster.go
+++ b/raftstore/testcluster/cluster.go
@@ -337,56 +337,116 @@ func TryFetchRuntimeStatus(ctx context.Context, addr string, regionID uint64) (*
 func WaitForLeaderPeer(tb testing.TB, ctx context.Context, addr string, regionID, peerID uint64) {
 	tb.Helper()
 	deadline := time.Now().Add(5 * time.Second)
+	var lastStatus *adminpb.RegionRuntimeStatusResponse
+	var lastErr error
 	for time.Now().Before(deadline) {
-		status := FetchRuntimeStatus(tb, ctx, addr, regionID)
+		status, err := TryPollRuntimeStatus(ctx, addr, regionID)
+		if err != nil {
+			lastErr = err
+			time.Sleep(20 * time.Millisecond)
+			continue
+		}
+		lastStatus = status
 		if status.GetKnown() && status.GetLeader() && status.GetLeaderPeerId() == peerID {
 			return
 		}
 		time.Sleep(20 * time.Millisecond)
 	}
-	tb.Fatalf("timed out waiting for leader peer %d on region %d at %s", peerID, regionID, addr)
+	tb.Fatalf("timed out waiting for leader peer %d on region %d at %s (last status=%s, last error=%v)", peerID, regionID, addr, formatRuntimeStatus(lastStatus), lastErr)
 }
 
 func WaitForHostedPeer(tb testing.TB, ctx context.Context, addr string, regionID, peerID uint64) {
 	tb.Helper()
 	deadline := time.Now().Add(5 * time.Second)
+	var lastStatus *adminpb.RegionRuntimeStatusResponse
+	var lastErr error
 	for time.Now().Before(deadline) {
-		status := FetchRuntimeStatus(tb, ctx, addr, regionID)
+		status, err := TryPollRuntimeStatus(ctx, addr, regionID)
+		if err != nil {
+			lastErr = err
+			time.Sleep(20 * time.Millisecond)
+			continue
+		}
+		lastStatus = status
 		if status.GetKnown() && status.GetHosted() && status.GetLocalPeerId() == peerID && status.GetAppliedIndex() > 0 {
 			return
 		}
 		time.Sleep(20 * time.Millisecond)
 	}
-	tb.Fatalf("timed out waiting for hosted peer %d on region %d at %s", peerID, regionID, addr)
+	tb.Fatalf("timed out waiting for hosted peer %d on region %d at %s (last status=%s, last error=%v)", peerID, regionID, addr, formatRuntimeStatus(lastStatus), lastErr)
 }
 
 func WaitForNotHosted(tb testing.TB, ctx context.Context, addr string, regionID uint64) {
 	tb.Helper()
 	deadline := time.Now().Add(5 * time.Second)
+	var lastStatus *adminpb.RegionRuntimeStatusResponse
+	var lastErr error
 	for time.Now().Before(deadline) {
-		status := FetchRuntimeStatus(tb, ctx, addr, regionID)
+		status, err := TryPollRuntimeStatus(ctx, addr, regionID)
+		if err != nil {
+			lastErr = err
+			time.Sleep(20 * time.Millisecond)
+			continue
+		}
+		lastStatus = status
 		if !status.GetHosted() {
 			return
 		}
 		time.Sleep(20 * time.Millisecond)
 	}
-	tb.Fatalf("timed out waiting for region %d at %s to become not hosted", regionID, addr)
+	tb.Fatalf("timed out waiting for region %d at %s to become not hosted (last status=%s, last error=%v)", regionID, addr, formatRuntimeStatus(lastStatus), lastErr)
 }
 
 func FindLeader(tb testing.TB, ctx context.Context, regionID uint64, nodes ...*Node) (*Node, *adminpb.RegionRuntimeStatusResponse) {
 	tb.Helper()
 	deadline := time.Now().Add(5 * time.Second)
+	var lastErr error
 	for time.Now().Before(deadline) {
-		for _, node := range nodes {
-			status := FetchRuntimeStatus(tb, ctx, node.Addr(), regionID)
-			if status.GetKnown() && status.GetLeader() {
-				return node, status
-			}
+		node, status, err := TryFindLeader(ctx, regionID, nodes...)
+		if err == nil {
+			return node, status
 		}
+		lastErr = err
 		time.Sleep(20 * time.Millisecond)
 	}
-	tb.Fatalf("timed out waiting for any leader on region %d", regionID)
+	tb.Fatalf("timed out waiting for any leader on region %d (last error=%v, status=%s)", regionID, lastErr, DumpStatus(tb, ctx, regionID, nodes...))
 	return nil, nil
+}
+
+// TryFindLeader performs one best-effort leader scan without failing the caller's test.
+func TryFindLeader(ctx context.Context, regionID uint64, nodes ...*Node) (*Node, *adminpb.RegionRuntimeStatusResponse, error) {
+	var errs []error
+	statuses := make([]string, 0, len(nodes))
+	for _, node := range nodes {
+		status, err := TryPollRuntimeStatus(ctx, node.Addr(), regionID)
+		if err != nil {
+			errs = append(errs, fmt.Errorf("store %d: %w", node.StoreID, err))
+			continue
+		}
+		statuses = append(statuses, fmt.Sprintf("store=%d %s", node.StoreID, formatRuntimeStatus(status)))
+		if status.GetKnown() && status.GetLeader() {
+			return node, status, nil
+		}
+	}
+	err := fmt.Errorf("no leader for region %d (status=%v)", regionID, statuses)
+	if len(errs) > 0 {
+		err = fmt.Errorf("%w: %w", err, errors.Join(errs...))
+	}
+	return nil, nil, err
+}
+
+// TryPollRuntimeStatus performs one bounded admin status RPC for polling loops.
+func TryPollRuntimeStatus(ctx context.Context, addr string, regionID uint64) (*adminpb.RegionRuntimeStatusResponse, error) {
+	callCtx, cancel := context.WithTimeout(ctx, 250*time.Millisecond)
+	defer cancel()
+	return TryFetchRuntimeStatus(callCtx, addr, regionID)
+}
+
+func formatRuntimeStatus(status *adminpb.RegionRuntimeStatusResponse) string {
+	if status == nil {
+		return "<nil>"
+	}
+	return fmt.Sprintf("known=%v hosted=%v local=%d leader=%v leaderPeer=%d applied=%d", status.GetKnown(), status.GetHosted(), status.GetLocalPeerId(), status.GetLeader(), status.GetLeaderPeerId(), status.GetAppliedIndex())
 }
 
 func AssertValue(tb testing.TB, db *NoKV.DB, key, value []byte) {
@@ -440,8 +500,12 @@ func DumpStatus(tb testing.TB, ctx context.Context, regionID uint64, nodes ...*N
 	tb.Helper()
 	parts := make([]string, 0, len(nodes))
 	for _, node := range nodes {
-		status := FetchRuntimeStatus(tb, ctx, node.Addr(), regionID)
-		parts = append(parts, fmt.Sprintf("store=%d known=%v hosted=%v local=%d leader=%v leaderPeer=%d applied=%d", node.StoreID, status.GetKnown(), status.GetHosted(), status.GetLocalPeerId(), status.GetLeader(), status.GetLeaderPeerId(), status.GetAppliedIndex()))
+		status, err := TryPollRuntimeStatus(ctx, node.Addr(), regionID)
+		if err != nil {
+			parts = append(parts, fmt.Sprintf("store=%d err=%v", node.StoreID, err))
+			continue
+		}
+		parts = append(parts, fmt.Sprintf("store=%d %s", node.StoreID, formatRuntimeStatus(status)))
 	}
 	return fmt.Sprint(parts)
 }

--- a/raftstore/testcluster/cluster.go
+++ b/raftstore/testcluster/cluster.go
@@ -347,6 +347,7 @@ func WaitForLeaderPeer(tb testing.TB, ctx context.Context, addr string, regionID
 			continue
 		}
 		lastStatus = status
+		lastErr = nil
 		if status.GetKnown() && status.GetLeader() && status.GetLeaderPeerId() == peerID {
 			return
 		}
@@ -368,6 +369,7 @@ func WaitForHostedPeer(tb testing.TB, ctx context.Context, addr string, regionID
 			continue
 		}
 		lastStatus = status
+		lastErr = nil
 		if status.GetKnown() && status.GetHosted() && status.GetLocalPeerId() == peerID && status.GetAppliedIndex() > 0 {
 			return
 		}
@@ -389,6 +391,7 @@ func WaitForNotHosted(tb testing.TB, ctx context.Context, addr string, regionID 
 			continue
 		}
 		lastStatus = status
+		lastErr = nil
 		if !status.GetHosted() {
 			return
 		}

--- a/raftstore/testcluster/cluster.go
+++ b/raftstore/testcluster/cluster.go
@@ -334,6 +334,9 @@ func TryFetchRuntimeStatus(ctx context.Context, addr string, regionID uint64) (*
 	return status, nil
 }
 
+// Wait helpers tolerate transient admin RPC failures because raft membership,
+// leader transfer, and process restart tests intentionally create short windows
+// where a node is alive but cannot yet answer a stable runtime status.
 func WaitForLeaderPeer(tb testing.TB, ctx context.Context, addr string, regionID, peerID uint64) {
 	tb.Helper()
 	deadline := time.Now().Add(5 * time.Second)


### PR DESCRIPTION
Summary:
- Renew self-held coordinator metadata tenure before serving GetRegionByKey after lease expiry.
- Remove the invokeRPC forwarding wrapper and keep the validated coordinator client RPC path.
- Make raftstore integration polling helpers tolerate transient status RPC failures until deadline.

Tests:
- go test ./coordinator/client ./coordinator/server -count=1
- go test ./coordinator/... -count=1
- go test ./fsmeta/runtime/raftstore ./fsmeta/server -count=1
- (cd benchmark && go test ./fsmeta -count=1)
- go test ./raftstore/integration -run TestTransferLeaderRecoversAfterPartitionedTargetReturns -count=10
- go test ./raftstore/integration -count=1
- go test ./raftstore/integration -count=3
- go test ./... -count=1