### PR TITLE
Fix coordinator authority retry and localmeta checkpointing

### DIFF
--- a/coordinator/client/client.go
+++ b/coordinator/client/client.go
@@ -202,7 +202,10 @@ func (c *GRPCClient) RemoveRegion(ctx context.Context, req *coordpb.RemoveRegion
 
 // GetRegionByKey forwards region lookup RPC.
 func (c *GRPCClient) GetRegionByKey(ctx context.Context, req *coordpb.GetRegionByKeyRequest) (*coordpb.GetRegionByKeyResponse, error) {
-	return invokeRPCValidated(c, retryableRead, func(coord coordpb.CoordinatorClient) (*coordpb.GetRegionByKeyResponse, error) {
+	// Region lookup is a metadata authority read: standby coordinators can
+	// reject it with lease-not-held, so it must fail over like TSO/AllocID even
+	// though the RPC does not mutate user metadata.
+	return invokeRPCValidated(c, retryableWrite, func(coord coordpb.CoordinatorClient) (*coordpb.GetRegionByKeyResponse, error) {
 		return coord.GetRegionByKey(ctx, req)
 	}, func(resp *coordpb.GetRegionByKeyResponse) error {
 		return c.validateGetRegionByKeyResponse(req, resp)

--- a/coordinator/client/client_test.go
+++ b/coordinator/client/client_test.go
@@ -311,6 +311,46 @@ func TestGRPCClientRetriesAllocIDAcrossLeaseNotHeldEndpoint(t *testing.T) {
 	require.Equal(t, "passthrough:///holder", cli.orderedEndpoints()[0].addr)
 }
 
+func TestGRPCClientRetriesGetRegionByKeyAcrossLeaseNotHeldEndpoint(t *testing.T) {
+	leaseErr := status.Error(codes.FailedPrecondition, errLeaseNotHeldPrefix+": "+rootstate.ErrPrimacy.Error())
+	servers := map[string]*scriptedCoordinatorServer{
+		"standby": {
+			getErrors: []error{leaseErr},
+		},
+		"holder": {
+			getResponses: []*coordpb.GetRegionByKeyResponse{
+				{
+					RegionDescriptor:           &metapb.RegionDescriptor{RegionId: 11, RootEpoch: 9},
+					ServedRootToken:            &coordpb.RootToken{Term: 2, Index: 8, Revision: 9},
+					CurrentRootToken:           &coordpb.RootToken{Term: 2, Index: 9, Revision: 10},
+					ServedFreshness:            coordpb.Freshness_FRESHNESS_BOUNDED,
+					RootLag:                    1,
+					CatchUpState:               coordpb.CatchUpState_CATCH_UP_STATE_LAGGING,
+					DescriptorRevision:         9,
+					RequiredDescriptorRevision: 8,
+					Era:                        3,
+					ServingClass:               coordpb.ServingClass_SERVING_CLASS_BOUNDED_STALE,
+					SyncHealth:                 coordpb.SyncHealth_SYNC_HEALTH_LAGGING,
+				},
+			},
+		},
+	}
+	cli := newScriptedCoordinatorClient(t, []string{"standby", "holder"}, servers)
+
+	resp, err := cli.GetRegionByKey(context.Background(), &coordpb.GetRegionByKeyRequest{
+		Key:                        []byte("m"),
+		Freshness:                  coordpb.Freshness_FRESHNESS_BOUNDED,
+		RequiredRootToken:          &coordpb.RootToken{Term: 2, Index: 8, Revision: 9},
+		RequiredDescriptorRevision: 8,
+		MaxRootLag:                 proto.Uint64(2),
+	})
+	require.NoError(t, err)
+	require.Equal(t, uint64(11), resp.GetRegionDescriptor().GetRegionId())
+	require.Equal(t, 1, servers["standby"].getCalls)
+	require.Equal(t, 1, servers["holder"].getCalls)
+	require.Equal(t, "passthrough:///holder", cli.orderedEndpoints()[0].addr)
+}
+
 func TestGRPCClientRetriesTSOAfterFullLeaseMissRound(t *testing.T) {
 	leaseErr := status.Error(codes.FailedPrecondition, errLeaseNotHeldPrefix+": "+rootstate.ErrPrimacy.Error())
 	servers := map[string]*scriptedCoordinatorServer{

--- a/raftstore/localmeta/store.go
+++ b/raftstore/localmeta/store.go
@@ -70,6 +70,12 @@ type Store struct {
 
 	mu    sync.RWMutex
 	state diskState
+
+	// persistedRaftPointers mirrors the last successfully written raft-progress
+	// catalog. SaveRaftPointer may keep fresher in-memory progress for runtime
+	// retention, so checkpoint decisions must use this durable baseline to make a
+	// failed checkpoint retryable.
+	persistedRaftPointers map[uint64]RaftLogPointer
 }
 
 // WorkDir returns the local metadata directory backing this store.
@@ -95,9 +101,10 @@ func OpenLocalStore(workdir string, fs vfs.FS) (*Store, error) {
 		return nil, err
 	}
 	return &Store{
-		fs:      fs,
-		workdir: workdir,
-		state:   state,
+		fs:                    fs,
+		workdir:               workdir,
+		state:                 state,
+		persistedRaftPointers: CloneRaftPointers(state.RaftPointers),
 	}, nil
 }
 
@@ -111,7 +118,7 @@ func (s *Store) Snapshot() map[uint64]RegionMeta {
 	return CloneRegionMetas(s.state.Regions)
 }
 
-// RaftPointer returns the last persisted local WAL pointer for one raft group.
+// RaftPointer returns the latest locally recorded WAL pointer for one raft group.
 func (s *Store) RaftPointer(groupID uint64) (RaftLogPointer, bool) {
 	if s == nil || groupID == 0 {
 		return RaftLogPointer{}, false
@@ -122,7 +129,7 @@ func (s *Store) RaftPointer(groupID uint64) (RaftLogPointer, bool) {
 	return ptr, ok
 }
 
-// RaftPointerSnapshot returns a copy of all persisted local WAL pointers.
+// RaftPointerSnapshot returns a copy of all locally recorded WAL pointers.
 func (s *Store) RaftPointerSnapshot() map[uint64]RaftLogPointer {
 	if s == nil {
 		return nil
@@ -247,12 +254,16 @@ func (s *Store) SaveRaftPointer(ptr RaftLogPointer) error {
 	if s.state.RaftPointers == nil {
 		s.state.RaftPointers = make(map[uint64]RaftLogPointer)
 	}
-	prev, existed := s.state.RaftPointers[ptr.GroupID]
+	prev, existed := s.persistedRaftPointers[ptr.GroupID]
 	s.state.RaftPointers[ptr.GroupID] = ptr
 	if !raftPointerCheckpointRequired(prev, ptr, existed) {
 		return nil
 	}
-	return s.persistRaftProgressCatalogLocked()
+	if err := s.persistRaftProgressCatalogLocked(); err != nil {
+		return err
+	}
+	s.persistedRaftPointers = CloneRaftPointers(s.state.RaftPointers)
+	return nil
 }
 
 // SavePendingRootEvent persists one locally applied rooted event until
@@ -339,6 +350,9 @@ func (s *Store) MovePendingRootEventToBlocked(sequence uint64, blocked BlockedRo
 	}
 	if sequence == 0 || blocked.Sequence == 0 {
 		return fmt.Errorf("raftstore/localmeta: blocked rooted event sequence is zero")
+	}
+	if blocked.Sequence != sequence {
+		return fmt.Errorf("raftstore/localmeta: blocked rooted event sequence mismatch (pending=%d blocked=%d)", sequence, blocked.Sequence)
 	}
 	if blocked.Event.Kind == 0 {
 		return fmt.Errorf("raftstore/localmeta: blocked rooted event kind is unknown")

--- a/raftstore/localmeta/store.go
+++ b/raftstore/localmeta/store.go
@@ -213,7 +213,7 @@ func (s *Store) SaveRegion(meta RegionMeta) error {
 		s.state.Regions = make(map[uint64]RegionMeta)
 	}
 	s.state.Regions[meta.ID] = CloneRegionMeta(meta)
-	return s.persistLocked()
+	return s.persistReplicaCatalogLocked()
 }
 
 // DeleteRegion removes one region metadata entry from the local catalog.
@@ -224,10 +224,16 @@ func (s *Store) DeleteRegion(regionID uint64) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	delete(s.state.Regions, regionID)
-	return s.persistLocked()
+	return s.persistReplicaCatalogLocked()
 }
 
-// SaveRaftPointer persists the local WAL checkpoint for one raft group.
+// SaveRaftPointer records the local WAL pointer for one raft group.
+//
+// The in-memory pointer is always current so runtime WAL retention can see the
+// latest raft progress. The on-disk checkpoint is only forced when it advances a
+// restart or retention boundary; same-segment offset/index churn is replayable
+// from the raft WAL after a crash and must not add a metadata fsync to every
+// raft append.
 func (s *Store) SaveRaftPointer(ptr RaftLogPointer) error {
 	if s == nil {
 		return nil
@@ -240,8 +246,12 @@ func (s *Store) SaveRaftPointer(ptr RaftLogPointer) error {
 	if s.state.RaftPointers == nil {
 		s.state.RaftPointers = make(map[uint64]RaftLogPointer)
 	}
+	prev, existed := s.state.RaftPointers[ptr.GroupID]
 	s.state.RaftPointers[ptr.GroupID] = ptr
-	return s.persistLocked()
+	if !raftPointerCheckpointRequired(prev, ptr, existed) {
+		return nil
+	}
+	return s.persistRaftProgressCatalogLocked()
 }
 
 // SavePendingRootEvent persists one locally applied rooted event until
@@ -267,7 +277,7 @@ func (s *Store) SavePendingRootEvent(event PendingRootEvent) error {
 		return fmt.Errorf("raftstore/localmeta: pending rooted event limit exceeded (max=%d)", maxPendingRootEvents)
 	}
 	s.state.PendingRootEvents[event.Sequence] = ClonePendingRootEvent(event)
-	return s.persistLocked()
+	return s.persistPendingRootEventCatalogLocked()
 }
 
 // DeletePendingRootEvent removes one publish-acknowledged rooted event from the
@@ -280,7 +290,7 @@ func (s *Store) DeletePendingRootEvent(sequence uint64) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	delete(s.state.PendingRootEvents, sequence)
-	return s.persistLocked()
+	return s.persistPendingRootEventCatalogLocked()
 }
 
 // SavePendingSchedulerOperation persists one scheduler decision until local
@@ -305,7 +315,7 @@ func (s *Store) SavePendingSchedulerOperation(op PendingSchedulerOperation) erro
 		return fmt.Errorf("raftstore/localmeta: pending scheduler operation limit exceeded (max=%d)", maxPendingSchedulerOperations)
 	}
 	s.state.PendingSchedulerOperations[key] = ClonePendingSchedulerOperation(op)
-	return s.persistLocked()
+	return s.persistPendingSchedulerOperationCatalogLocked()
 }
 
 // DeletePendingSchedulerOperation removes one scheduler decision after local
@@ -317,11 +327,11 @@ func (s *Store) DeletePendingSchedulerOperation(kind PendingSchedulerOperationKi
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	delete(s.state.PendingSchedulerOperations, pendingSchedulerOperationKey(kind, regionID))
-	return s.persistLocked()
+	return s.persistPendingSchedulerOperationCatalogLocked()
 }
 
-// MovePendingRootEventToBlocked atomically removes one retryable rooted event
-// from the pending catalog and records it as a blocked reconciliation item.
+// MovePendingRootEventToBlocked removes one retryable rooted event from the
+// pending catalog and records it as a blocked reconciliation item.
 func (s *Store) MovePendingRootEventToBlocked(sequence uint64, blocked BlockedRootEvent) error {
 	if s == nil {
 		return nil
@@ -342,7 +352,7 @@ func (s *Store) MovePendingRootEventToBlocked(sequence uint64, blocked BlockedRo
 		return fmt.Errorf("raftstore/localmeta: blocked rooted event limit exceeded (max=%d)", maxBlockedRootEvents)
 	}
 	s.state.BlockedRootEvents[blocked.Sequence] = CloneBlockedRootEvent(blocked)
-	return s.persistLocked()
+	return s.persistRootEventCatalogsLocked()
 }
 
 // Close releases resources associated with the metadata store.
@@ -380,23 +390,58 @@ func loadState(fs vfs.FS, workdir string) (diskState, error) {
 	}, nil
 }
 
-func (s *Store) persistLocked() error {
-	if err := persistReplicaCatalog(s.fs, s.workdir, s.state.Regions); err != nil {
-		return err
-	}
-	if err := persistRaftProgressCatalog(s.fs, s.workdir, s.state.RaftPointers); err != nil {
-		return err
-	}
-	if err := persistPendingRootEventCatalog(s.fs, s.workdir, s.state.PendingRootEvents); err != nil {
-		return err
-	}
-	if err := persistPendingSchedulerOperationCatalog(s.fs, s.workdir, s.state.PendingSchedulerOperations); err != nil {
-		return err
-	}
+func (s *Store) persistReplicaCatalogLocked() error {
+	return persistReplicaCatalog(s.fs, s.workdir, s.state.Regions)
+}
+
+func (s *Store) persistRaftProgressCatalogLocked() error {
+	return persistRaftProgressCatalog(s.fs, s.workdir, s.state.RaftPointers)
+}
+
+func (s *Store) persistPendingRootEventCatalogLocked() error {
+	return persistPendingRootEventCatalog(s.fs, s.workdir, s.state.PendingRootEvents)
+}
+
+func (s *Store) persistPendingSchedulerOperationCatalogLocked() error {
+	return persistPendingSchedulerOperationCatalog(s.fs, s.workdir, s.state.PendingSchedulerOperations)
+}
+
+func (s *Store) persistRootEventCatalogsLocked() error {
+	// Permanent publish rejection must not disappear behind a successful pending
+	// deletion. Persist the blocked catalog first so an interrupted move leaves
+	// repair evidence on disk even if the pending catalog still needs cleanup.
 	if err := persistBlockedRootEventCatalog(s.fs, s.workdir, s.state.BlockedRootEvents); err != nil {
 		return err
 	}
-	return nil
+	return persistPendingRootEventCatalog(s.fs, s.workdir, s.state.PendingRootEvents)
+}
+
+func raftPointerCheckpointRequired(prev, next RaftLogPointer, existed bool) bool {
+	if !existed {
+		return true
+	}
+	if prev == next {
+		return false
+	}
+	if prev.Segment == 0 || next.Segment == 0 {
+		return true
+	}
+	if prev.Segment != next.Segment {
+		return true
+	}
+	if next.Offset < prev.Offset {
+		return true
+	}
+	if prev.SnapshotIndex != next.SnapshotIndex || prev.SnapshotTerm != next.SnapshotTerm {
+		return true
+	}
+	if prev.TruncatedIndex != next.TruncatedIndex || prev.TruncatedTerm != next.TruncatedTerm {
+		return true
+	}
+	if prev.SegmentIndex != next.SegmentIndex || prev.TruncatedOffset != next.TruncatedOffset {
+		return true
+	}
+	return false
 }
 
 func loadReplicaCatalog(fs vfs.FS, workdir string) (map[uint64]RegionMeta, error) {

--- a/raftstore/localmeta/store.go
+++ b/raftstore/localmeta/store.go
@@ -233,7 +233,8 @@ func (s *Store) DeleteRegion(regionID uint64) error {
 // latest raft progress. The on-disk checkpoint is only forced when it advances a
 // restart or retention boundary; same-segment offset/index churn is replayable
 // from the raft WAL after a crash and must not add a metadata fsync to every
-// raft append.
+// raft append. The first committed index is a boundary because seeded peers use
+// it as durable restart evidence before normal raft replay has run.
 func (s *Store) SaveRaftPointer(ptr RaftLogPointer) error {
 	if s == nil {
 		return nil
@@ -430,6 +431,9 @@ func raftPointerCheckpointRequired(prev, next RaftLogPointer, existed bool) bool
 		return true
 	}
 	if next.Offset < prev.Offset {
+		return true
+	}
+	if prev.Committed == 0 && next.Committed != 0 {
 		return true
 	}
 	if prev.SnapshotIndex != next.SnapshotIndex || prev.SnapshotTerm != next.SnapshotTerm {

--- a/raftstore/localmeta/store_test.go
+++ b/raftstore/localmeta/store_test.go
@@ -182,6 +182,34 @@ func TestLocalStoreCoalescesRaftPointerWithinSegment(t *testing.T) {
 	require.NoError(t, reopened.Close())
 }
 
+func TestLocalStorePersistsFirstCommittedRaftPointerBoundary(t *testing.T) {
+	dir := t.TempDir()
+	store, err := OpenLocalStore(dir, nil)
+	require.NoError(t, err)
+	defer func() { require.NoError(t, store.Close()) }()
+
+	snapshotPtr := RaftLogPointer{
+		GroupID:       9,
+		Segment:       2,
+		Offset:        128,
+		SnapshotIndex: 1,
+		SnapshotTerm:  1,
+	}
+	require.NoError(t, store.SaveRaftPointer(snapshotPtr))
+
+	committedPtr := snapshotPtr
+	committedPtr.Offset = 256
+	committedPtr.Committed = 1
+	require.NoError(t, store.SaveRaftPointer(committedPtr))
+
+	reopened, err := OpenLocalStore(dir, nil)
+	require.NoError(t, err)
+	disk, ok := reopened.RaftPointer(snapshotPtr.GroupID)
+	require.True(t, ok)
+	require.Equal(t, committedPtr, disk)
+	require.NoError(t, reopened.Close())
+}
+
 func TestLocalStorePersistsPendingRootEvents(t *testing.T) {
 	dir := t.TempDir()
 	store, err := OpenLocalStore(dir, nil)

--- a/raftstore/localmeta/store_test.go
+++ b/raftstore/localmeta/store_test.go
@@ -110,6 +110,78 @@ func TestLocalStorePersistsRaftPointers(t *testing.T) {
 	require.FileExists(t, filepath.Join(dir, RaftProgressFileName))
 }
 
+func TestLocalStoreRaftPointerDoesNotPersistUnrelatedCatalogs(t *testing.T) {
+	dir := t.TempDir()
+	injected := errors.New("unexpected replica catalog write")
+	fs := vfs.NewFaultFSWithPolicy(vfs.OSFS{}, vfs.NewFaultPolicy(
+		vfs.FailOnceRule(vfs.OpOpenFile, filepath.Join(dir, ReplicaStateFileName)+".tmp", injected),
+	))
+	store, err := OpenLocalStore(dir, fs)
+	require.NoError(t, err)
+	defer func() { require.NoError(t, store.Close()) }()
+
+	require.NoError(t, store.SaveRaftPointer(RaftLogPointer{
+		GroupID:      7,
+		Segment:      3,
+		Offset:       2048,
+		AppliedIndex: 42,
+		AppliedTerm:  5,
+	}))
+	require.FileExists(t, filepath.Join(dir, RaftProgressFileName))
+	_, statErr := os.Stat(filepath.Join(dir, ReplicaStateFileName))
+	require.ErrorIs(t, statErr, os.ErrNotExist)
+}
+
+func TestLocalStoreCoalescesRaftPointerWithinSegment(t *testing.T) {
+	dir := t.TempDir()
+	store, err := OpenLocalStore(dir, nil)
+	require.NoError(t, err)
+	defer func() { require.NoError(t, store.Close()) }()
+
+	first := RaftLogPointer{
+		GroupID:      9,
+		Segment:      2,
+		Offset:       128,
+		AppliedIndex: 11,
+		AppliedTerm:  2,
+	}
+	require.NoError(t, store.SaveRaftPointer(first))
+
+	injected := errors.New("unexpected progress checkpoint")
+	store.fs = vfs.NewFaultFSWithPolicy(vfs.OSFS{}, vfs.NewFaultPolicy(
+		vfs.FailOnceRule(vfs.OpOpenFile, filepath.Join(dir, RaftProgressFileName)+".tmp", injected),
+	))
+	advanced := first
+	advanced.Offset = 256
+	advanced.AppliedIndex = 12
+	require.NoError(t, store.SaveRaftPointer(advanced))
+
+	got, ok := store.RaftPointer(first.GroupID)
+	require.True(t, ok)
+	require.Equal(t, advanced, got)
+
+	reopened, err := OpenLocalStore(dir, nil)
+	require.NoError(t, err)
+	disk, ok := reopened.RaftPointer(first.GroupID)
+	require.True(t, ok)
+	require.Equal(t, first, disk)
+	require.NoError(t, reopened.Close())
+
+	store.fs = vfs.OSFS{}
+	nextSegment := advanced
+	nextSegment.Segment = 3
+	nextSegment.Offset = 64
+	nextSegment.AppliedIndex = 13
+	require.NoError(t, store.SaveRaftPointer(nextSegment))
+
+	reopened, err = OpenLocalStore(dir, nil)
+	require.NoError(t, err)
+	disk, ok = reopened.RaftPointer(first.GroupID)
+	require.True(t, ok)
+	require.Equal(t, nextSegment, disk)
+	require.NoError(t, reopened.Close())
+}
+
 func TestLocalStorePersistsPendingRootEvents(t *testing.T) {
 	dir := t.TempDir()
 	store, err := OpenLocalStore(dir, nil)

--- a/raftstore/localmeta/store_test.go
+++ b/raftstore/localmeta/store_test.go
@@ -210,6 +210,51 @@ func TestLocalStorePersistsFirstCommittedRaftPointerBoundary(t *testing.T) {
 	require.NoError(t, reopened.Close())
 }
 
+func TestLocalStoreRetriesFailedRaftPointerCheckpoint(t *testing.T) {
+	dir := t.TempDir()
+	store, err := OpenLocalStore(dir, nil)
+	require.NoError(t, err)
+	defer func() { require.NoError(t, store.Close()) }()
+
+	first := RaftLogPointer{
+		GroupID:      9,
+		Segment:      2,
+		Offset:       128,
+		AppliedIndex: 11,
+		AppliedTerm:  2,
+	}
+	require.NoError(t, store.SaveRaftPointer(first))
+
+	injected := errors.New("progress checkpoint failed")
+	store.fs = vfs.NewFaultFSWithPolicy(vfs.OSFS{}, vfs.NewFaultPolicy(
+		vfs.FailOnceRule(vfs.OpOpenFile, filepath.Join(dir, RaftProgressFileName)+".tmp", injected),
+	))
+	nextSegment := first
+	nextSegment.Segment = 3
+	nextSegment.Offset = 64
+	nextSegment.AppliedIndex = 12
+	require.ErrorIs(t, store.SaveRaftPointer(nextSegment), injected)
+
+	got, ok := store.RaftPointer(first.GroupID)
+	require.True(t, ok)
+	require.Equal(t, nextSegment, got)
+
+	reopened, err := OpenLocalStore(dir, nil)
+	require.NoError(t, err)
+	disk, ok := reopened.RaftPointer(first.GroupID)
+	require.True(t, ok)
+	require.Equal(t, first, disk)
+	require.NoError(t, reopened.Close())
+
+	require.NoError(t, store.SaveRaftPointer(nextSegment))
+	reopened, err = OpenLocalStore(dir, nil)
+	require.NoError(t, err)
+	disk, ok = reopened.RaftPointer(first.GroupID)
+	require.True(t, ok)
+	require.Equal(t, nextSegment, disk)
+	require.NoError(t, reopened.Close())
+}
+
 func TestLocalStorePersistsPendingRootEvents(t *testing.T) {
 	dir := t.TempDir()
 	store, err := OpenLocalStore(dir, nil)
@@ -350,6 +395,28 @@ func TestLocalStoreMovesPendingRootEventToBlocked(t *testing.T) {
 	require.Equal(t, "permanent reject", blocked[0].LastError)
 	require.Equal(t, rootstate.TransitionIDFromEvent(event), blocked[0].TransitionID)
 	require.FileExists(t, filepath.Join(dir, BlockedRootEventsFileName))
+}
+
+func TestLocalStoreRejectsMismatchedBlockedRootEventSequence(t *testing.T) {
+	dir := t.TempDir()
+	store, err := OpenLocalStore(dir, nil)
+	require.NoError(t, err)
+	defer func() { require.NoError(t, store.Close()) }()
+
+	event := rootevent.RegionTombstoned(23)
+	require.NoError(t, store.SavePendingRootEvent(PendingRootEvent{
+		Sequence: 4,
+		Event:    event,
+	}))
+	err = store.MovePendingRootEventToBlocked(4, BlockedRootEvent{
+		Sequence:     5,
+		Event:        event,
+		TransitionID: rootstate.TransitionIDFromEvent(event),
+		LastError:    "permanent reject",
+	})
+	require.ErrorContains(t, err, "sequence mismatch")
+	require.Len(t, store.PendingRootEvents(), 1)
+	require.Empty(t, store.BlockedRootEvents())
 }
 
 func TestLocalStoreHelpersAndSnapshots(t *testing.T) {


### PR DESCRIPTION
## Summary
- retry GetRegionByKey across coordinator authority-miss responses
- split localmeta persistence by catalog instead of rewriting every catalog per update
- coalesce same-segment raft pointer checkpoint writes while keeping in-memory WAL retention state current

## Tests
- go test ./coordinator/client
- go test ./raftstore/localmeta ./raftstore/raftlog ./raftstore/store

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * GetRegionByKey now properly fails over to standby endpoints when the primary fails, improving lookup resilience.
  * Optimized persistence mechanism to write only affected catalogs instead of all catalogs on every operation, reducing unnecessary disk writes.

* **Tests**
  * Added test coverage for failover behavior and raft pointer persistence validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->