### PR TITLE
Batch percolator protocol apply operations

### DIFF
--- a/db.go
+++ b/db.go
@@ -616,11 +616,16 @@ func (db *DB) nextNonTxnVersion() uint64 {
 	return next
 }
 
-// ApplyInternalEntries writes pre-built internal-key entries through the regular write
-// pipeline.
+// ApplyInternalEntries writes pre-built internal-key entries through the
+// regular write pipeline.
 //
 // The caller must provide entries with internal keys. The entry slices must not
 // be mutated until this call returns.
+//
+// Multi-key internal batches are regrouped by the same key-affinity router used
+// by the commit pipeline before they reach the sharded LSM. That keeps every
+// write/delete for one user key on one shard, which is required for
+// same-version MVCC tombstones such as Percolator lock removal.
 func (db *DB) ApplyInternalEntries(entries []*kv.Entry) error {
 	if db == nil {
 		return fmt.Errorf("db is nil")
@@ -646,7 +651,7 @@ func (db *DB) ApplyInternalEntries(entries []*kv.Entry) error {
 	for _, entry := range entries {
 		entry.IncrRef()
 	}
-	return db.batchSet(entries)
+	return db.batchSetInternalEntries(entries)
 }
 
 // GetInternalEntry retrieves one internal-key record for the provided version.
@@ -1006,6 +1011,64 @@ func (db *DB) batchSet(entries []*kv.Entry) error {
 		return err
 	}
 	return req.Wait()
+}
+
+func (db *DB) batchSetInternalEntries(entries []*kv.Entry) error {
+	groups := db.groupInternalEntriesByShard(entries)
+	for i, group := range groups {
+		if len(group) == 0 {
+			continue
+		}
+		if err := db.batchSet(group); err != nil {
+			// Entries for later shard groups were ref-counted by
+			// ApplyInternalEntries but have not been handed to the commit
+			// pipeline yet. The failing group is cleaned up by batchSet on
+			// enqueue failure, or owned by the pipeline if it reached apply.
+			releaseEntryGroups(groups[i+1:])
+			return err
+		}
+	}
+	return nil
+}
+
+func (db *DB) groupInternalEntriesByShard(entries []*kv.Entry) [][]*kv.Entry {
+	if len(entries) <= 1 {
+		return [][]*kv.Entry{entries}
+	}
+	shardCount := 1
+	if db != nil && db.opt != nil && db.opt.LSMShardCount > 1 {
+		shardCount = db.opt.LSMShardCount
+	}
+	if shardCount <= 1 {
+		return [][]*kv.Entry{entries}
+	}
+	buckets := make([][]*kv.Entry, shardCount)
+	order := make([]int, 0, shardCount)
+	for _, entry := range entries {
+		if entry == nil {
+			continue
+		}
+		shardID := commit.ShardForInternalKey(entry.Key, shardCount)
+		if len(buckets[shardID]) == 0 {
+			order = append(order, shardID)
+		}
+		buckets[shardID] = append(buckets[shardID], entry)
+	}
+	groups := make([][]*kv.Entry, 0, len(order))
+	for _, shardID := range order {
+		groups = append(groups, buckets[shardID])
+	}
+	return groups
+}
+
+func releaseEntryGroups(groups [][]*kv.Entry) {
+	for _, group := range groups {
+		for _, entry := range group {
+			if entry != nil {
+				entry.DecrRef()
+			}
+		}
+	}
 }
 
 func (db *DB) requireOpenLSM() (*lsm.LSM, error) {

--- a/dbcore/commit/pipeline.go
+++ b/dbcore/commit/pipeline.go
@@ -331,7 +331,7 @@ func shardForBatch(batch *CommitBatch, n int, rr *int) int {
 				if !ok || len(userKey) == 0 {
 					continue
 				}
-				return int(fnv1a32(userKey)) & (n - 1)
+				return ShardForUserKey(userKey, n)
 			}
 		}
 	}
@@ -341,6 +341,28 @@ func shardForBatch(batch *CommitBatch, n int, rr *int) int {
 		*rr = 0
 	}
 	return id
+}
+
+// ShardForInternalKey returns the commit-pipeline shard for an internal key.
+// Callers that pre-group multi-key internal batches must use this exact router;
+// otherwise a same-version delete/write pair for one user key can land on
+// different LSM shards and lose last-write-wins semantics during reads.
+func ShardForInternalKey(internalKey []byte, shardCount int) int {
+	_, userKey, _, ok := kv.SplitInternalKey(internalKey)
+	if !ok {
+		return 0
+	}
+	return ShardForUserKey(userKey, shardCount)
+}
+
+// ShardForUserKey hashes a user key into a commit-pipeline shard. shardCount
+// is expected to be a positive power of two; DB.Open normalizes the configured
+// LSMShardCount before the pipeline is started.
+func ShardForUserKey(userKey []byte, shardCount int) int {
+	if shardCount <= 1 || len(userKey) == 0 {
+		return 0
+	}
+	return int(fnv1a32(userKey)) & (shardCount - 1)
 }
 
 // fnv1a32 is the inline FNV-1a 32-bit hash used by shard routing. It

--- a/percolator/crash_matrix_test.go
+++ b/percolator/crash_matrix_test.go
@@ -1,6 +1,7 @@
 package percolator
 
 import (
+	"errors"
 	"path/filepath"
 	"testing"
 
@@ -10,6 +11,51 @@ import (
 	"github.com/feichai0017/NoKV/utils"
 	"github.com/stretchr/testify/require"
 )
+
+func TestPercolatorCrashMatrixBatchPrewriteApplyFailureRetries(t *testing.T) {
+	db := openTestDB(t)
+	store := newCountingStore(db)
+	latches := latch.NewManager(32)
+	primary := []byte("crash-prewrite-primary")
+	secondary := []byte("crash-prewrite-secondary")
+	startTs := uint64(90)
+	injected := errors.New("prewrite batch apply failed")
+	store.failNextApply(injected)
+
+	errs := Prewrite(store, latches, &kvrpcpb.PrewriteRequest{
+		PrimaryLock:  primary,
+		StartVersion: startTs,
+		LockTtl:      3000,
+		Mutations: []*kvrpcpb.Mutation{
+			{Op: kvrpcpb.Mutation_Put, Key: primary, Value: []byte("primary-value")},
+			{Op: kvrpcpb.Mutation_Put, Key: secondary, Value: []byte("secondary-value")},
+		},
+	})
+	require.Len(t, errs, 1)
+	require.Contains(t, errs[0].GetRetryable(), injected.Error())
+
+	reader := NewReader(db)
+	for _, key := range [][]byte{primary, secondary} {
+		lock, err := reader.GetLock(key)
+		require.NoError(t, err)
+		require.Nil(t, lock, "key=%s", key)
+	}
+
+	require.Empty(t, Prewrite(store, latches, &kvrpcpb.PrewriteRequest{
+		PrimaryLock:  primary,
+		StartVersion: startTs,
+		LockTtl:      3000,
+		Mutations: []*kvrpcpb.Mutation{
+			{Op: kvrpcpb.Mutation_Put, Key: primary, Value: []byte("primary-value")},
+			{Op: kvrpcpb.Mutation_Put, Key: secondary, Value: []byte("secondary-value")},
+		},
+	}))
+	for _, key := range [][]byte{primary, secondary} {
+		lock, err := reader.GetLock(key)
+		require.NoError(t, err)
+		require.NotNil(t, lock, "key=%s", key)
+	}
+}
 
 func TestPercolatorCrashMatrixPrimaryCommittedSecondaryRecovered(t *testing.T) {
 	db := openTestDB(t)
@@ -59,6 +105,58 @@ func TestPercolatorCrashMatrixPrimaryCommittedSecondaryRecovered(t *testing.T) {
 	lock, err := reader.GetLock(secondary)
 	require.NoError(t, err)
 	require.Nil(t, lock)
+}
+
+func TestPercolatorCrashMatrixSecondaryResolveApplyFailureRetries(t *testing.T) {
+	db := openTestDB(t)
+	store := newCountingStore(db)
+	latches := latch.NewManager(32)
+	primary := []byte("crash-resolve-primary")
+	secondary := []byte("crash-resolve-secondary")
+	startTs := uint64(130)
+	commitTs := uint64(150)
+
+	require.Empty(t, Prewrite(db, latches, &kvrpcpb.PrewriteRequest{
+		PrimaryLock:  primary,
+		StartVersion: startTs,
+		LockTtl:      3000,
+		Mutations: []*kvrpcpb.Mutation{
+			{Op: kvrpcpb.Mutation_Put, Key: primary, Value: []byte("primary-value")},
+			{Op: kvrpcpb.Mutation_Put, Key: secondary, Value: []byte("secondary-value")},
+		},
+	}))
+	require.Nil(t, Commit(db, latches, &kvrpcpb.CommitRequest{
+		Keys:          [][]byte{primary},
+		StartVersion:  startTs,
+		CommitVersion: commitTs,
+	}))
+
+	injected := errors.New("resolve batch apply failed")
+	store.failNextApply(injected)
+	resolved, keyErr := ResolveLock(store, latches, &kvrpcpb.ResolveLockRequest{
+		StartVersion:  startTs,
+		CommitVersion: commitTs,
+		Keys:          [][]byte{secondary},
+	})
+	require.Zero(t, resolved)
+	require.NotNil(t, keyErr)
+	require.Contains(t, keyErr.GetRetryable(), injected.Error())
+
+	reader := NewReader(db)
+	lock, err := reader.GetLock(secondary)
+	require.NoError(t, err)
+	require.NotNil(t, lock)
+
+	resolved, keyErr = ResolveLock(store, latches, &kvrpcpb.ResolveLockRequest{
+		StartVersion:  startTs,
+		CommitVersion: commitTs,
+		Keys:          [][]byte{secondary},
+	})
+	require.Nil(t, keyErr)
+	require.Equal(t, uint64(1), resolved)
+	value, _, err := reader.GetValue(secondary, commitTs+10)
+	require.NoError(t, err)
+	require.Equal(t, []byte("secondary-value"), value)
 }
 
 func TestPercolatorCrashMatrixPrimaryRollbackSecondaryRecovered(t *testing.T) {

--- a/percolator/txn.go
+++ b/percolator/txn.go
@@ -41,41 +41,55 @@ func Prewrite(db txnstore.Store, latches *latch.Manager, req *kvrpcpb.PrewriteRe
 
 	reader := NewReader(db)
 	var errs []*kvrpcpb.KeyError
+	ops := make([]versionedOp, 0, len(req.Mutations)*3)
 	for _, mut := range req.Mutations {
 		if mut == nil {
 			continue
 		}
-		if err := prewriteMutation(db, reader, req, mut); err != nil {
+		planned, err := planPrewriteMutation(reader, req, mut)
+		if err != nil {
 			errs = append(errs, err)
+			continue
 		}
+		ops = append(ops, planned...)
 	}
-	return errs
+	if len(errs) > 0 {
+		return errs
+	}
+	// Prewrite is the lock admission boundary for a region request. Validation
+	// happens for every mutation before storage is touched, so semantic key
+	// errors never hide partial locks. Storage failures are retryable: replaying
+	// the same start_ts observes its own locks and finishes the missing keys.
+	if err := applyVersionedOps(db, ops...); err != nil {
+		return []*kvrpcpb.KeyError{keyErrorRetryable(err)}
+	}
+	return nil
 }
 
-func prewriteMutation(db txnstore.Store, reader *Reader, req *kvrpcpb.PrewriteRequest, mut *kvrpcpb.Mutation) *kvrpcpb.KeyError {
+func planPrewriteMutation(reader *Reader, req *kvrpcpb.PrewriteRequest, mut *kvrpcpb.Mutation) ([]versionedOp, *kvrpcpb.KeyError) {
 	key := mut.GetKey()
 	if len(key) == 0 {
-		return keyErrorAbort(errEmptyMutationKey)
+		return nil, keyErrorAbort(errEmptyMutationKey)
 	}
 	lock, err := reader.GetLock(key)
 	if err != nil {
-		return keyErrorRetryable(err)
+		return nil, keyErrorRetryable(err)
 	}
 	if lock != nil && lock.Ts != req.StartVersion {
-		return keyErrorLocked(key, lock)
+		return nil, keyErrorLocked(key, lock)
 	}
 	if write, commitTs, err := reader.MostRecentWrite(key); err != nil {
-		return keyErrorRetryable(err)
+		return nil, keyErrorRetryable(err)
 	} else if write != nil && commitTs >= req.StartVersion {
-		return keyErrorWriteConflict(key, req.PrimaryLock, commitTs, write.StartTs, req.StartVersion)
+		return nil, keyErrorWriteConflict(key, req.PrimaryLock, commitTs, write.StartTs, req.StartVersion)
 	}
 	if mut.GetAssertionNotExist() {
 		exists, err := keyExistsAt(reader, key, req.StartVersion)
 		if err != nil {
-			return keyErrorRetryable(err)
+			return nil, keyErrorRetryable(err)
 		}
 		if exists {
-			return keyErrorAlreadyExists(key)
+			return nil, keyErrorAlreadyExists(key)
 		}
 	}
 	ops := make([]versionedOp, 0, 3)
@@ -90,7 +104,7 @@ func prewriteMutation(db txnstore.Store, reader *Reader, req *kvrpcpb.PrewriteRe
 			versionedOp{cf: kv.CFDefault, key: key, version: req.StartVersion, meta: kv.BitDelete},
 		)
 	default:
-		return keyErrorAbortf(errUnsupportedMutationOp, "%v", mut.Op)
+		return nil, keyErrorAbortf(errUnsupportedMutationOp, "%v", mut.Op)
 	}
 	newLock := mvcc.Lock{
 		Primary:     kv.SafeCopy(nil, req.PrimaryLock),
@@ -102,10 +116,7 @@ func prewriteMutation(db txnstore.Store, reader *Reader, req *kvrpcpb.PrewriteRe
 	}
 	encoded := mvcc.EncodeLock(newLock)
 	ops = append(ops, versionedOp{cf: kv.CFLock, key: key, version: lockColumnTs, value: encoded})
-	if err := applyVersionedOps(db, ops...); err != nil {
-		return keyErrorRetryable(err)
-	}
-	return nil
+	return ops, nil
 }
 
 // validateCommitVersion rejects commits that would violate MVCC ordering.
@@ -129,33 +140,19 @@ func Commit(db txnstore.Store, latches *latch.Manager, req *kvrpcpb.CommitReques
 	defer guard.Release()
 
 	reader := NewReader(db)
+	ops := make([]versionedOp, 0, len(req.Keys)*2)
 	for _, key := range req.Keys {
-		if len(key) == 0 {
-			return keyErrorAbort(errEmptyCommitKey)
-		}
-		lock, err := reader.GetLock(key)
+		planned, err := planCommitKey(reader, key, req.StartVersion, req.CommitVersion)
 		if err != nil {
-			return keyErrorRetryable(err)
-		}
-		if lock == nil {
-			write, _, err := reader.GetWriteByStartTs(key, req.StartVersion)
-			if err != nil {
-				return keyErrorRetryable(err)
-			}
-			if write != nil {
-				if write.Kind == kvrpcpb.Mutation_Rollback {
-					return keyErrorAbort(errTxnAlreadyRolledBack)
-				}
-				continue
-			}
-			return keyErrorAbort(errLockNotFound)
-		}
-		if lock.Ts != req.StartVersion {
-			return keyErrorLocked(key, lock)
-		}
-		if err := commitKey(db, reader, key, lock, req.CommitVersion); err != nil {
 			return err
 		}
+		ops = append(ops, planned...)
+	}
+	// Commit remains Percolator-idempotent: already committed keys produce no
+	// write op, while residual locks are cleaned with the commit records for the
+	// same key. The DB may fan multi-key requests out by LSM shard affinity.
+	if err := applyVersionedOps(db, ops...); err != nil {
+		return keyErrorRetryable(err)
 	}
 	return nil
 }
@@ -168,13 +165,19 @@ func BatchRollback(db txnstore.Store, latches *latch.Manager, req *kvrpcpb.Batch
 	guard := latches.Acquire(req.Keys)
 	defer guard.Release()
 	reader := NewReader(db)
+	ops := make([]versionedOp, 0, len(req.Keys)*3)
 	for _, key := range req.Keys {
-		if len(key) == 0 {
-			return keyErrorAbort(errEmptyRollbackKey)
-		}
-		if err := rollbackKey(db, reader, key, req.StartVersion); err != nil {
+		planned, err := planRollbackKey(reader, key, req.StartVersion)
+		if err != nil {
 			return err
 		}
+		ops = append(ops, planned...)
+	}
+	// Rollback markers and lock tombstones for one key must be planned together;
+	// the DB preserves per-key shard affinity when it persists the internal
+	// entries, and retries keep rollback idempotent.
+	if err := applyVersionedOps(db, ops...); err != nil {
+		return keyErrorRetryable(err)
 	}
 	return nil
 }
@@ -195,10 +198,17 @@ func ResolveLock(db txnstore.Store, latches *latch.Manager, req *kvrpcpb.Resolve
 
 	reader := NewReader(db)
 	var resolved uint64
+	ops := make([]versionedOp, 0, len(req.Keys)*3)
+	seen := make(map[string]struct{}, len(req.Keys))
 	for _, key := range req.Keys {
 		if len(key) == 0 {
 			continue
 		}
+		keyID := string(key)
+		if _, ok := seen[keyID]; ok {
+			continue
+		}
+		seen[keyID] = struct{}{}
 		lock, err := reader.GetLock(key)
 		if err != nil {
 			return resolved, keyErrorRetryable(err)
@@ -207,15 +217,22 @@ func ResolveLock(db txnstore.Store, latches *latch.Manager, req *kvrpcpb.Resolve
 			continue
 		}
 		if req.CommitVersion == 0 {
-			if err := rollbackKey(db, reader, key, req.StartVersion); err != nil {
+			planned, err := planRollbackKey(reader, key, req.StartVersion)
+			if err != nil {
 				return resolved, err
 			}
+			ops = append(ops, planned...)
 		} else {
-			if err := commitKey(db, reader, key, lock, req.CommitVersion); err != nil {
+			planned, err := planCommitKeyWithLock(reader, key, lock, req.CommitVersion)
+			if err != nil {
 				return resolved, err
 			}
+			ops = append(ops, planned...)
 		}
 		resolved++
+	}
+	if err := applyVersionedOps(db, ops...); err != nil {
+		return 0, keyErrorRetryable(err)
 	}
 	return resolved, nil
 }
@@ -396,52 +413,98 @@ func keyExistsAt(reader *Reader, key []byte, readTs uint64) (bool, error) {
 	}
 }
 
-func commitKey(db txnstore.Store, reader *Reader, key []byte, lock *mvcc.Lock, commitVersion uint64) *kvrpcpb.KeyError {
+func planCommitKey(reader *Reader, key []byte, startVersion, commitVersion uint64) ([]versionedOp, *kvrpcpb.KeyError) {
+	if len(key) == 0 {
+		return nil, keyErrorAbort(errEmptyCommitKey)
+	}
+	lock, err := reader.GetLock(key)
+	if err != nil {
+		return nil, keyErrorRetryable(err)
+	}
+	if lock == nil {
+		write, _, err := reader.GetWriteByStartTs(key, startVersion)
+		if err != nil {
+			return nil, keyErrorRetryable(err)
+		}
+		if write != nil {
+			if write.Kind == kvrpcpb.Mutation_Rollback {
+				return nil, keyErrorAbort(errTxnAlreadyRolledBack)
+			}
+			return nil, nil
+		}
+		return nil, keyErrorAbort(errLockNotFound)
+	}
+	if lock.Ts != startVersion {
+		return nil, keyErrorLocked(key, lock)
+	}
+	return planCommitKeyWithLock(reader, key, lock, commitVersion)
+}
+
+func planCommitKeyWithLock(reader *Reader, key []byte, lock *mvcc.Lock, commitVersion uint64) ([]versionedOp, *kvrpcpb.KeyError) {
 	write, _, err := reader.GetWriteByStartTs(key, lock.Ts)
 	if err != nil {
-		return keyErrorRetryable(err)
+		return nil, keyErrorRetryable(err)
 	}
 	if write != nil {
 		if write.Kind == kvrpcpb.Mutation_Rollback {
-			return keyErrorAbort(errTxnAlreadyRolledBack)
+			return nil, keyErrorAbort(errTxnAlreadyRolledBack)
 		}
-		if err := applyVersionedOps(db, versionedOp{
+		return []versionedOp{{
 			cf:      kv.CFLock,
 			key:     key,
 			version: lockColumnTs,
 			meta:    kv.BitDelete,
-		}); err != nil {
-			return keyErrorRetryable(err)
-		}
-		return nil
+		}}, nil
 	}
 
 	if lock.MinCommitTs > commitVersion {
-		return keyErrorCommitTsExpired(key, commitVersion, lock.MinCommitTs)
+		return nil, keyErrorCommitTsExpired(key, commitVersion, lock.MinCommitTs)
 	}
 
 	entry := mvcc.EncodeWrite(mvcc.Write{Kind: lock.Kind, StartTs: lock.Ts})
-	if err := applyVersionedOps(db,
-		versionedOp{cf: kv.CFWrite, key: key, version: commitVersion, value: entry},
-		versionedOp{cf: kv.CFLock, key: key, version: lockColumnTs, meta: kv.BitDelete},
-	); err != nil {
+	return []versionedOp{
+		{cf: kv.CFWrite, key: key, version: commitVersion, value: entry},
+		{cf: kv.CFLock, key: key, version: lockColumnTs, meta: kv.BitDelete},
+	}, nil
+}
+
+func commitKey(db txnstore.Store, reader *Reader, key []byte, lock *mvcc.Lock, commitVersion uint64) *kvrpcpb.KeyError {
+	ops, keyErr := planCommitKeyWithLock(reader, key, lock, commitVersion)
+	if keyErr != nil {
+		return keyErr
+	}
+	if err := applyVersionedOps(db, ops...); err != nil {
 		return keyErrorRetryable(err)
 	}
 	return nil
 }
 
 func rollbackKey(db txnstore.Store, reader *Reader, key []byte, startTs uint64) *kvrpcpb.KeyError {
-	write, _, err := reader.GetWriteByStartTs(key, startTs)
-	if err != nil {
+	ops, keyErr := planRollbackKey(reader, key, startTs)
+	if keyErr != nil {
+		return keyErr
+	}
+	if err := applyVersionedOps(db, ops...); err != nil {
 		return keyErrorRetryable(err)
 	}
+	return nil
+}
+
+func planRollbackKey(reader *Reader, key []byte, startTs uint64) ([]versionedOp, *kvrpcpb.KeyError) {
+	if len(key) == 0 {
+		return nil, keyErrorAbort(errEmptyRollbackKey)
+	}
+	write, _, err := reader.GetWriteByStartTs(key, startTs)
+	if err != nil {
+		return nil, keyErrorRetryable(err)
+	}
 	if write != nil {
-		return nil
+		return nil, nil
 	}
 
 	lock, err := reader.GetLock(key)
 	if err != nil {
-		return keyErrorRetryable(err)
+		return nil, keyErrorRetryable(err)
 	}
 
 	rollback := mvcc.EncodeWrite(mvcc.Write{Kind: kvrpcpb.Mutation_Rollback, StartTs: startTs})
@@ -452,10 +515,7 @@ func rollbackKey(db txnstore.Store, reader *Reader, key []byte, startTs uint64) 
 	if lock != nil && lock.Ts == startTs {
 		ops = append(ops, versionedOp{cf: kv.CFLock, key: key, version: lockColumnTs, meta: kv.BitDelete})
 	}
-	if err := applyVersionedOps(db, ops...); err != nil {
-		return keyErrorRetryable(err)
-	}
-	return nil
+	return ops, nil
 }
 
 type versionedOp struct {
@@ -476,6 +536,9 @@ func applyVersionedOps(db txnstore.Store, ops ...versionedOp) error {
 		entry := kv.NewInternalEntry(op.cf, op.key, op.version, op.value, op.meta, op.expires)
 		entries = append(entries, entry)
 	}
+	// NoKV's DB regroups these internal entries by commit-pipeline shard before
+	// they reach the sharded LSM. Percolator batches at the protocol phase
+	// boundary; storage keeps the per-key placement invariant.
 	err := db.ApplyInternalEntries(entries)
 	for _, entry := range entries {
 		if entry != nil {

--- a/percolator/txn_benchmark_test.go
+++ b/percolator/txn_benchmark_test.go
@@ -1,0 +1,67 @@
+package percolator
+
+import (
+	"fmt"
+	"path/filepath"
+	"testing"
+
+	NoKV "github.com/feichai0017/NoKV"
+	kvrpcpb "github.com/feichai0017/NoKV/pb/kv"
+	"github.com/feichai0017/NoKV/percolator/latch"
+)
+
+func openBenchmarkDB(b *testing.B) *NoKV.DB {
+	b.Helper()
+	db, err := NoKV.Open(testOptionsForDir(filepath.Join(b.TempDir(), "db")))
+	if err != nil {
+		b.Fatal(err)
+	}
+	b.Cleanup(func() { _ = db.Close() })
+	return db
+}
+
+func BenchmarkPercolatorBatchApplyFullTransaction(b *testing.B) {
+	for _, keyCount := range []int{2, 3, 5} {
+		b.Run(fmt.Sprintf("keys_%d", keyCount), func(b *testing.B) {
+			db := openBenchmarkDB(b)
+			store := newCountingStore(db)
+			latches := latch.NewManager(128)
+			b.ReportAllocs()
+			b.ResetTimer()
+
+			for i := 0; i < b.N; i++ {
+				startTs := uint64(i*10 + 1)
+				commitTs := startTs + 5
+				mutations := make([]*kvrpcpb.Mutation, 0, keyCount)
+				keys := make([][]byte, 0, keyCount)
+				for keyIdx := range keyCount {
+					key := fmt.Appendf(nil, "bench-%d-%d", i, keyIdx)
+					keys = append(keys, key)
+					mutations = append(mutations, &kvrpcpb.Mutation{
+						Op:    kvrpcpb.Mutation_Put,
+						Key:   key,
+						Value: []byte("value"),
+					})
+				}
+				if errs := Prewrite(store, latches, &kvrpcpb.PrewriteRequest{
+					Mutations:    mutations,
+					PrimaryLock:  keys[0],
+					StartVersion: startTs,
+					LockTtl:      3000,
+				}); len(errs) > 0 {
+					b.Fatalf("prewrite: %v", errs)
+				}
+				if err := Commit(store, latches, &kvrpcpb.CommitRequest{
+					Keys:          keys,
+					StartVersion:  startTs,
+					CommitVersion: commitTs,
+				}); err != nil {
+					b.Fatalf("commit: %v", err)
+				}
+			}
+
+			b.StopTimer()
+			b.ReportMetric(float64(store.applyCalls)/float64(b.N), "apply/op")
+		})
+	}
+}

--- a/percolator/txn_test.go
+++ b/percolator/txn_test.go
@@ -2,6 +2,7 @@ package percolator
 
 import (
 	"errors"
+	"fmt"
 	kvrpcpb "github.com/feichai0017/NoKV/pb/kv"
 	"os"
 	"path/filepath"
@@ -10,6 +11,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	NoKV "github.com/feichai0017/NoKV"
+	"github.com/feichai0017/NoKV/dbcore/commit"
 	"github.com/feichai0017/NoKV/engine/index"
 	"github.com/feichai0017/NoKV/engine/kv"
 	"github.com/feichai0017/NoKV/percolator/latch"
@@ -98,6 +100,41 @@ func (s rollbackTestStore) NewInternalIterator(opt *index.Options) index.Iterato
 		return s.newInternalIterator(opt)
 	}
 	return &testIterator{}
+}
+
+type countingStore struct {
+	base               *NoKV.DB
+	applyCalls         int
+	appliedEntryCounts []int
+	failApplyErr       error
+	failApplyRemaining int
+}
+
+func newCountingStore(base *NoKV.DB) *countingStore {
+	return &countingStore{base: base}
+}
+
+func (s *countingStore) ApplyInternalEntries(entries []*kv.Entry) error {
+	s.applyCalls++
+	s.appliedEntryCounts = append(s.appliedEntryCounts, len(entries))
+	if s.failApplyRemaining > 0 {
+		s.failApplyRemaining--
+		return s.failApplyErr
+	}
+	return s.base.ApplyInternalEntries(entries)
+}
+
+func (s *countingStore) GetInternalEntry(cf kv.ColumnFamily, key []byte, version uint64) (*kv.Entry, error) {
+	return s.base.GetInternalEntry(cf, key, version)
+}
+
+func (s *countingStore) NewInternalIterator(opt *index.Options) index.Iterator {
+	return s.base.NewInternalIterator(opt)
+}
+
+func (s *countingStore) failNextApply(err error) {
+	s.failApplyErr = err
+	s.failApplyRemaining = 1
 }
 
 type testIterator struct {
@@ -401,6 +438,75 @@ func TestPrewriteConflictingLock(t *testing.T) {
 	require.NotNil(t, errs[0].GetLocked())
 }
 
+func TestPrewriteBatchConflictDoesNotApplyPartialLocks(t *testing.T) {
+	db := openTestDB(t)
+	latches := latch.NewManager(32)
+	conflictKey := []byte("batch-prewrite-conflict")
+	require.Empty(t, Prewrite(db, latches, &kvrpcpb.PrewriteRequest{
+		Mutations: []*kvrpcpb.Mutation{{
+			Op:    kvrpcpb.Mutation_Put,
+			Key:   conflictKey,
+			Value: []byte("existing"),
+		}},
+		PrimaryLock:  conflictKey,
+		StartVersion: 5,
+		LockTtl:      1000,
+	}))
+
+	store := newCountingStore(db)
+	keys := [][]byte{[]byte("batch-prewrite-a"), []byte("batch-prewrite-b"), conflictKey}
+	errs := Prewrite(store, latches, &kvrpcpb.PrewriteRequest{
+		Mutations: []*kvrpcpb.Mutation{
+			{Op: kvrpcpb.Mutation_Put, Key: keys[0], Value: []byte("va")},
+			{Op: kvrpcpb.Mutation_Put, Key: keys[1], Value: []byte("vb")},
+			{Op: kvrpcpb.Mutation_Put, Key: keys[2], Value: []byte("vc")},
+		},
+		PrimaryLock:  keys[0],
+		StartVersion: 8,
+		LockTtl:      1000,
+	})
+	require.Len(t, errs, 1)
+	require.NotNil(t, errs[0].GetLocked())
+	require.Zero(t, store.applyCalls)
+
+	reader := NewReader(db)
+	for _, key := range keys[:2] {
+		lock, err := reader.GetLock(key)
+		require.NoError(t, err)
+		require.Nil(t, lock, "key=%s", key)
+		_, err = db.GetInternalEntry(kv.CFDefault, key, 8)
+		require.ErrorIs(t, err, utils.ErrKeyNotFound, "key=%s", key)
+	}
+}
+
+func TestPrewriteBatchAppliesAllMutationsOnce(t *testing.T) {
+	db := openTestDB(t)
+	store := newCountingStore(db)
+	latches := latch.NewManager(32)
+	keys := [][]byte{[]byte("batch-prewrite-ok-a"), []byte("batch-prewrite-ok-b"), []byte("batch-prewrite-ok-c")}
+
+	require.Empty(t, Prewrite(store, latches, &kvrpcpb.PrewriteRequest{
+		Mutations: []*kvrpcpb.Mutation{
+			{Op: kvrpcpb.Mutation_Put, Key: keys[0], Value: []byte("va")},
+			{Op: kvrpcpb.Mutation_Put, Key: keys[1], Value: []byte("vb")},
+			{Op: kvrpcpb.Mutation_Put, Key: keys[2], Value: []byte("vc")},
+		},
+		PrimaryLock:  keys[0],
+		StartVersion: 8,
+		LockTtl:      1000,
+	}))
+	require.Equal(t, 1, store.applyCalls)
+	require.Equal(t, []int{9}, store.appliedEntryCounts)
+
+	reader := NewReader(db)
+	for _, key := range keys {
+		lock, err := reader.GetLock(key)
+		require.NoError(t, err)
+		require.NotNil(t, lock, "key=%s", key)
+		require.Equal(t, uint64(8), lock.Ts)
+	}
+}
+
 func TestCommitMissingLock(t *testing.T) {
 	db := openTestDB(t)
 	latches := latch.NewManager(32)
@@ -588,6 +694,131 @@ func TestCommitRemovesAllLocks(t *testing.T) {
 	}
 }
 
+func TestCommitBatchAppliesAllKeysOnce(t *testing.T) {
+	db := openTestDB(t)
+	latches := latch.NewManager(16)
+	keys := [][]byte{[]byte("commit-once-a"), []byte("commit-once-b"), []byte("commit-once-c")}
+	require.Empty(t, Prewrite(db, latches, &kvrpcpb.PrewriteRequest{
+		Mutations: []*kvrpcpb.Mutation{
+			{Op: kvrpcpb.Mutation_Put, Key: keys[0], Value: []byte("va")},
+			{Op: kvrpcpb.Mutation_Put, Key: keys[1], Value: []byte("vb")},
+			{Op: kvrpcpb.Mutation_Put, Key: keys[2], Value: []byte("vc")},
+		},
+		PrimaryLock:  keys[0],
+		StartVersion: 18,
+		LockTtl:      1000,
+	}))
+
+	store := newCountingStore(db)
+	require.Nil(t, Commit(store, latches, &kvrpcpb.CommitRequest{
+		Keys:          keys,
+		StartVersion:  18,
+		CommitVersion: 25,
+	}))
+	require.Equal(t, 1, store.applyCalls)
+	require.Equal(t, []int{6}, store.appliedEntryCounts)
+}
+
+func TestCommitAfterBatchPrewritePreservesShardAffinityAcrossRestart(t *testing.T) {
+	const shardCount = 4
+
+	dir := filepath.Join(t.TempDir(), "db")
+	opt := testOptionsForDir(dir)
+	opt.LSMShardCount = shardCount
+	db, err := NoKV.Open(opt)
+	require.NoError(t, err)
+
+	first, second := keysWithAscendingCommitShards(t, shardCount)
+	latches := latch.NewManager(32)
+	errs := Prewrite(db, latches, &kvrpcpb.PrewriteRequest{
+		Mutations: []*kvrpcpb.Mutation{
+			{Op: kvrpcpb.Mutation_Put, Key: first, Value: []byte("first")},
+			{Op: kvrpcpb.Mutation_Put, Key: second, Value: []byte("second")},
+		},
+		PrimaryLock:  first,
+		StartVersion: 10,
+		LockTtl:      3000,
+	})
+	require.Empty(t, errs)
+	require.Nil(t, Commit(db, latches, &kvrpcpb.CommitRequest{
+		Keys:          [][]byte{second},
+		StartVersion:  10,
+		CommitVersion: 20,
+	}))
+	require.NoError(t, db.Close())
+
+	db, err = NoKV.Open(opt)
+	require.NoError(t, err)
+	defer func() { _ = db.Close() }()
+
+	// This reproduces the sharded-LSM failure mode behind the review comment:
+	// if a batch prewrite routes every key by the first key's shard, then a
+	// later single-key commit can put the second key's lock tombstone on its
+	// real shard while the stale lock remains on the first shard. After restart
+	// shard hints are cold, so equal-version lock records are resolved by shard
+	// scan order and the stale lock can become visible again.
+	lock, err := NewReader(db).GetLock(second)
+	require.NoError(t, err)
+	require.Nil(t, lock)
+}
+
+func keysWithAscendingCommitShards(t *testing.T, shardCount int) ([]byte, []byte) {
+	t.Helper()
+	keysByShard := make([][]byte, shardCount)
+	for i := range 10000 {
+		key := fmt.Appendf(nil, "affinity-%d", i)
+		shardID := commit.ShardForInternalKey(kv.InternalKey(kv.CFLock, key, lockColumnTs), shardCount)
+		if shardID >= 0 && shardID < shardCount && keysByShard[shardID] == nil {
+			keysByShard[shardID] = key
+		}
+	}
+	for low := range shardCount {
+		for high := low + 1; high < shardCount; high++ {
+			if keysByShard[low] != nil && keysByShard[high] != nil {
+				return keysByShard[low], keysByShard[high]
+			}
+		}
+	}
+	t.Fatalf("could not find keys on ascending shards for shardCount=%d", shardCount)
+	return nil, nil
+}
+
+func TestCommitBatchCommitTsExpiredDoesNotApplyPartialCommits(t *testing.T) {
+	db := openTestDB(t)
+	latches := latch.NewManager(16)
+	keys := [][]byte{[]byte("commit-expired-a"), []byte("commit-expired-b")}
+	require.Empty(t, Prewrite(db, latches, &kvrpcpb.PrewriteRequest{
+		Mutations: []*kvrpcpb.Mutation{
+			{Op: kvrpcpb.Mutation_Put, Key: keys[0], Value: []byte("va")},
+			{Op: kvrpcpb.Mutation_Put, Key: keys[1], Value: []byte("vb")},
+		},
+		PrimaryLock:  keys[0],
+		StartVersion: 18,
+		LockTtl:      1000,
+		MinCommitTs:  30,
+	}))
+
+	store := newCountingStore(db)
+	err := Commit(store, latches, &kvrpcpb.CommitRequest{
+		Keys:          keys,
+		StartVersion:  18,
+		CommitVersion: 25,
+	})
+	require.NotNil(t, err)
+	require.NotNil(t, err.GetCommitTsExpired())
+	require.Zero(t, store.applyCalls)
+
+	reader := NewReader(db)
+	for _, key := range keys {
+		write, _, readErr := reader.GetWriteByStartTs(key, 18)
+		require.NoError(t, readErr)
+		require.Nil(t, write, "key=%s", key)
+		lock, readErr := reader.GetLock(key)
+		require.NoError(t, readErr)
+		require.NotNil(t, lock, "key=%s", key)
+	}
+}
+
 // TestCommitReturnsLockedOnDifferentTransactionLock rejects foreign locks.
 func TestCommitReturnsLockedOnDifferentTransactionLock(t *testing.T) {
 	db := openTestDB(t)
@@ -685,6 +916,30 @@ func TestBatchRollbackRemovesAllLocks(t *testing.T) {
 		require.Equal(t, kvrpcpb.Mutation_Rollback, write.Kind, "key=%s", key)
 		require.Equal(t, uint64(18), commitTs, "key=%s", key)
 	}
+}
+
+func TestBatchRollbackAppliesAllKeysOnce(t *testing.T) {
+	db := openTestDB(t)
+	latches := latch.NewManager(16)
+	keys := [][]byte{[]byte("rollback-once-a"), []byte("rollback-once-b"), []byte("rollback-once-c")}
+	require.Empty(t, Prewrite(db, latches, &kvrpcpb.PrewriteRequest{
+		Mutations: []*kvrpcpb.Mutation{
+			{Op: kvrpcpb.Mutation_Put, Key: keys[0], Value: []byte("va")},
+			{Op: kvrpcpb.Mutation_Delete, Key: keys[1]},
+			{Op: kvrpcpb.Mutation_Put, Key: keys[2], Value: []byte("vc")},
+		},
+		PrimaryLock:  keys[0],
+		StartVersion: 18,
+		LockTtl:      1000,
+	}))
+
+	store := newCountingStore(db)
+	require.Nil(t, BatchRollback(store, latches, &kvrpcpb.BatchRollbackRequest{
+		Keys:         keys,
+		StartVersion: 18,
+	}))
+	require.Equal(t, 1, store.applyCalls)
+	require.Equal(t, []int{9}, store.appliedEntryCounts)
 }
 
 func TestBatchRollbackDoesNotDeleteOtherTransactionLock(t *testing.T) {
@@ -799,6 +1054,32 @@ func TestResolveLockCommit(t *testing.T) {
 	val, _, err := reader.GetValue([]byte("res"), 60)
 	require.NoError(t, err)
 	require.Equal(t, []byte("val"), val)
+}
+
+func TestResolveLockCommitAppliesAllLocksOnce(t *testing.T) {
+	db := openTestDB(t)
+	latches := latch.NewManager(16)
+	keys := [][]byte{[]byte("resolve-once-a"), []byte("resolve-once-b")}
+	require.Empty(t, Prewrite(db, latches, &kvrpcpb.PrewriteRequest{
+		Mutations: []*kvrpcpb.Mutation{
+			{Op: kvrpcpb.Mutation_Put, Key: keys[0], Value: []byte("va")},
+			{Op: kvrpcpb.Mutation_Put, Key: keys[1], Value: []byte("vb")},
+		},
+		PrimaryLock:  keys[0],
+		StartVersion: 40,
+		LockTtl:      1000,
+	}))
+
+	store := newCountingStore(db)
+	count, keyErr := ResolveLock(store, latches, &kvrpcpb.ResolveLockRequest{
+		Keys:          [][]byte{keys[0], keys[1], keys[1]},
+		StartVersion:  40,
+		CommitVersion: 50,
+	})
+	require.Nil(t, keyErr)
+	require.Equal(t, uint64(2), count)
+	require.Equal(t, 1, store.applyCalls)
+	require.Equal(t, []int{4}, store.appliedEntryCounts)
 }
 
 func TestResolveLockCommitsSecondaryAfterPrimaryCommitCrashWindow(t *testing.T) {


### PR DESCRIPTION
## Summary

- Refactor Percolator Prewrite, Commit, BatchRollback, and ResolveLock into validate/plan-then-batch-apply phases.
- Make Prewrite all-or-none within one region request so returned key errors cannot hide partial locks.
- Preserve idempotent commit/rollback/resolve semantics while reducing protocol phase ApplyInternalEntries calls.
- Add targeted benchmark coverage reporting apply/op for 2/3/5-key transactions.

## Correctness

- Commit still treats already committed keys as idempotent success and cleans residual locks.
- BatchRollback remains a no-op for already committed keys and only removes matching transaction locks.
- ResolveLock batches secondary commit/rollback while preserving retry behavior after apply failure.

## Tests

- go test ./percolator ./raftstore/kv ./raftstore/client ./fsmeta/exec
- go test ./...
- go test ./percolator -run '^$' -bench BenchmarkPercolatorBatchApplyFullTransaction -benchtime=100x -count=1

Benchmark apply/op result: 2.000 apply/op for keys_2, keys_3, and keys_5.
