### PR TITLE
[FIX] Enable fsmeta dirpage cache in compose

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,7 +36,7 @@ RUN chmod +x /usr/local/lib/nokv-scripts/ops/serve-store.sh /usr/local/lib/nokv-
     && printf '#!/usr/bin/env bash\nexec /usr/local/lib/nokv-scripts/ops/serve-store.sh "$@"\n' > /usr/local/bin/serve-store.sh \
     && printf '#!/usr/bin/env bash\nexec /usr/local/lib/nokv-scripts/ops/bootstrap.sh "$@"\n' > /usr/local/bin/bootstrap.sh \
     && chmod +x /usr/local/bin/serve-store.sh /usr/local/bin/bootstrap.sh \
-    && mkdir -p /etc/nokv /var/lib/nokv/store /var/lib/nokv-meta-root \
+    && mkdir -p /etc/nokv /var/lib/nokv/store /var/lib/nokv/dirpage-cache /var/lib/nokv-meta-root \
                /volumes/store-1 /volumes/store-2 /volumes/store-3 \
     && chown -R nokv:nokv /var/lib/nokv /var/lib/nokv-meta-root /volumes
 COPY raft_config.example.json /etc/nokv/raft_config.json

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -287,6 +287,7 @@ services:
     command:
       - "--addr=0.0.0.0:8090"
       - "--coordinator-addr=nokv-coordinator-1:2379,nokv-coordinator-2:2379,nokv-coordinator-3:2379"
+      - "--dirpage-cache-dir=/var/lib/nokv/dirpage-cache"
       - "--metrics-addr=0.0.0.0:9400"
     ports:
       - "8090:8090"   # FSMetadata gRPC


### PR DESCRIPTION
## Summary
- Enable the fsmeta ReadDirPlus dirpage cache in Docker Compose.
- Pre-create the dirpage cache directory in the runtime image so the non-root nokv user has a compatible writable path.

## Root cause
Docker Compose started nokv-fsmeta without a dirpage cache directory, so the optional ReadDirPlus page cache stayed disabled in the packaged deployment.

## Validation
- docker compose config --quiet
- go test ./cmd/nokv-fsmeta


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Docker configuration to optimize build process and service configuration for improved deployment efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->