### PR TITLE
Fix fsmeta chaos and nightly correctness checks

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -6,6 +6,7 @@
 /build
 artifacts
 **/*.pprof
+benchmark/ycsb/data
 
 # Module caches
 .gocache

--- a/cmd/nokv-fsmeta-history/main.go
+++ b/cmd/nokv-fsmeta-history/main.go
@@ -2,12 +2,14 @@ package main
 
 import (
 	"context"
+	"errors"
 	"flag"
 	"fmt"
 	"log"
 	"os"
 	"time"
 
+	nokverrors "github.com/feichai0017/NoKV/errors"
 	"github.com/feichai0017/NoKV/fsmeta"
 	fsmetaclient "github.com/feichai0017/NoKV/fsmeta/client"
 	fsmetacontract "github.com/feichai0017/NoKV/fsmeta/contract"
@@ -15,14 +17,15 @@ import (
 
 func main() {
 	var (
-		addr    = flag.String("addr", "127.0.0.1:8090", "FSMetadata gRPC address")
-		mount   = flag.String("mount", "default", "registered mount ID")
-		seeds   = flag.Int("seeds", 1, "number of deterministic seeds to run")
-		start   = flag.Int64("seed-start", 1, "first deterministic seed")
-		steps   = flag.Int("steps", 64, "generated operations per seed before external filtering")
-		batch   = flag.Int("batch", 3, "concurrent history batch size")
-		timeout = flag.Duration("timeout", 60*time.Second, "overall command timeout")
-		scope   = flag.String("scope-prefix", "history", "unique root directory prefix for isolating each generated history")
+		addr               = flag.String("addr", "127.0.0.1:8090", "FSMetadata gRPC address")
+		mount              = flag.String("mount", "default", "registered mount ID")
+		seeds              = flag.Int("seeds", 1, "number of deterministic seeds to run")
+		start              = flag.Int64("seed-start", 1, "first deterministic seed")
+		steps              = flag.Int("steps", 64, "generated operations per seed before external filtering")
+		batch              = flag.Int("batch", 3, "concurrent history batch size")
+		timeout            = flag.Duration("timeout", 60*time.Second, "overall command timeout")
+		scope              = flag.String("scope-prefix", "history", "unique root directory prefix for isolating each generated history")
+		allowIndeterminate = flag.Bool("allow-indeterminate-errors", false, "treat retryable availability errors as operations with unknown commit outcome")
 	)
 	flag.Parse()
 	if *seeds <= 0 || *start <= 0 || *steps <= 0 {
@@ -47,11 +50,19 @@ func main() {
 		unique := time.Now().UnixNano()
 		scopeName := fmt.Sprintf("%s-%06d-%d", *scope, seed, unique)
 		scopeInode := fsmeta.InodeID(9_000_000_000 + seed*1_000_000 + unique%1_000_000)
-		ops := externalHistoryOps(fsmetacontract.GenerateScript(seed, *steps), mountID, scopeName, scopeInode)
+		scopeOp := scopeCreateOperation(mountID, scopeName, scopeInode)
+		if err := createScopeWithRetry(ctx, cli, scopeOp); err != nil {
+			log.Fatalf("create history scope seed=%d: %v", seed, err)
+		}
+		if got := model.Apply(scopeOp); got.Err != nil {
+			log.Fatalf("apply history scope seed=%d: %v", seed, got.Err)
+		}
+		ops := externalHistoryOps(fsmetacontract.GenerateScript(seed, *steps), mountID, scopeInode)
 		if len(ops) == 0 {
 			log.Fatalf("seed %d generated no external-safe operations", seed)
 		}
-		if err := fsmetacontract.RunConcurrentBatches(ctx, cli, model, ops, *batch); err != nil {
+		opts := fsmetacontract.HistoryOptions{AllowIndeterminateErrors: *allowIndeterminate}
+		if err := fsmetacontract.RunConcurrentBatches(ctx, cli, model, ops, *batch, opts); err != nil {
 			fmt.Fprintf(os.Stderr, "fsmeta history failed seed=%d steps=%d filtered_ops=%d\n", seed, *steps, len(ops))
 			log.Fatal(err)
 		}
@@ -59,9 +70,8 @@ func main() {
 	}
 }
 
-func externalHistoryOps(in []fsmetacontract.Operation, mount fsmeta.MountID, scopeName string, scopeInode fsmeta.InodeID) []fsmetacontract.Operation {
-	out := make([]fsmetacontract.Operation, 0, len(in)+1)
-	out = append(out, fsmetacontract.Operation{
+func scopeCreateOperation(mount fsmeta.MountID, scopeName string, scopeInode fsmeta.InodeID) fsmetacontract.Operation {
+	return fsmetacontract.Operation{
 		Kind:   fsmetacontract.OpCreate,
 		Mount:  mount,
 		Parent: fsmeta.RootInode,
@@ -69,7 +79,47 @@ func externalHistoryOps(in []fsmetacontract.Operation, mount fsmeta.MountID, sco
 		Inode:  scopeInode,
 		Type:   fsmeta.InodeTypeDirectory,
 		Mode:   0o755,
-	})
+	}
+}
+
+func createScopeWithRetry(ctx context.Context, cli fsmetaclient.Client, op fsmetacontract.Operation) error {
+	delay := 100 * time.Millisecond
+	for {
+		err := cli.Create(ctx, fsmeta.CreateRequest{
+			Mount:  op.Mount,
+			Parent: op.Parent,
+			Name:   op.Name,
+			Inode:  op.Inode,
+		}, fsmeta.InodeRecord{
+			Type:      op.Type,
+			Mode:      op.Mode,
+			LinkCount: 1,
+		})
+		if err == nil || errors.Is(err, fsmeta.ErrExists) {
+			return nil
+		}
+		// Compose startup can return NotFound until the fsmeta gateway observes
+		// rooted mount/root admission. The scope create is an admission barrier,
+		// so retrying here keeps startup synchronization out of the generated
+		// correctness history.
+		if !nokverrors.Retryable(err) && !nokverrors.IsKind(err, nokverrors.KindNotFound) {
+			return err
+		}
+		timer := time.NewTimer(delay)
+		select {
+		case <-ctx.Done():
+			timer.Stop()
+			return ctx.Err()
+		case <-timer.C:
+		}
+		if delay < time.Second {
+			delay *= 2
+		}
+	}
+}
+
+func externalHistoryOps(in []fsmetacontract.Operation, mount fsmeta.MountID, scopeInode fsmeta.InodeID) []fsmetacontract.Operation {
+	out := make([]fsmetacontract.Operation, 0, len(in))
 	for _, op := range in {
 		switch op.Kind {
 		case fsmetacontract.OpOpenWriteSession,

--- a/cmd/nokv-fsmeta-history/main.go
+++ b/cmd/nokv-fsmeta-history/main.go
@@ -137,12 +137,18 @@ func externalHistoryOps(in []fsmetacontract.Operation, mount fsmeta.MountID, sco
 			op.Inode = scopeGeneratedInode(inodeBase, op.Inode)
 			if op.Parent == fsmeta.RootInode {
 				op.Parent = scopeInode
+			} else {
+				op.Parent = scopeGeneratedInode(inodeBase, op.Parent)
 			}
 			if op.FromParent == fsmeta.RootInode {
 				op.FromParent = scopeInode
+			} else {
+				op.FromParent = scopeGeneratedInode(inodeBase, op.FromParent)
 			}
 			if op.ToParent == fsmeta.RootInode {
 				op.ToParent = scopeInode
+			} else {
+				op.ToParent = scopeGeneratedInode(inodeBase, op.ToParent)
 			}
 			out = append(out, op)
 		}

--- a/cmd/nokv-fsmeta-history/main.go
+++ b/cmd/nokv-fsmeta-history/main.go
@@ -57,7 +57,7 @@ func main() {
 		if got := model.Apply(scopeOp); got.Err != nil {
 			log.Fatalf("apply history scope seed=%d: %v", seed, got.Err)
 		}
-		ops := externalHistoryOps(fsmetacontract.GenerateScript(seed, *steps), mountID, scopeInode)
+		ops := externalHistoryOps(fsmetacontract.GenerateScript(seed, *steps), mountID, scopeInode, scopeInode)
 		if len(ops) == 0 {
 			log.Fatalf("seed %d generated no external-safe operations", seed)
 		}
@@ -118,7 +118,7 @@ func createScopeWithRetry(ctx context.Context, cli fsmetaclient.Client, op fsmet
 	}
 }
 
-func externalHistoryOps(in []fsmetacontract.Operation, mount fsmeta.MountID, scopeInode fsmeta.InodeID) []fsmetacontract.Operation {
+func externalHistoryOps(in []fsmetacontract.Operation, mount fsmeta.MountID, scopeInode, inodeBase fsmeta.InodeID) []fsmetacontract.Operation {
 	out := make([]fsmetacontract.Operation, 0, len(in))
 	for _, op := range in {
 		switch op.Kind {
@@ -130,6 +130,11 @@ func externalHistoryOps(in []fsmetacontract.Operation, mount fsmeta.MountID, sco
 			continue
 		default:
 			op.Mount = mount
+			// The generated inodes are unique only within one in-memory script.
+			// Docker chaos runs multiple seeds against the same mounted system,
+			// so external histories must shift inode ids into the per-seed scope
+			// to avoid cross-seed namespace pollution.
+			op.Inode = scopeGeneratedInode(inodeBase, op.Inode)
 			if op.Parent == fsmeta.RootInode {
 				op.Parent = scopeInode
 			}
@@ -143,4 +148,11 @@ func externalHistoryOps(in []fsmetacontract.Operation, mount fsmeta.MountID, sco
 		}
 	}
 	return out
+}
+
+func scopeGeneratedInode(base, inode fsmeta.InodeID) fsmeta.InodeID {
+	if inode == 0 {
+		return 0
+	}
+	return base + inode
 }

--- a/cmd/nokv-fsmeta-history/main_test.go
+++ b/cmd/nokv-fsmeta-history/main_test.go
@@ -13,23 +13,25 @@ func TestExternalHistoryOpsScopesRootOperationsAndFiltersInternalSessions(t *tes
 		scopeName  = "history-scope"
 		scopeInode = fsmeta.InodeID(9001)
 	)
+	scopeOp := scopeCreateOperation(mount, scopeName, scopeInode)
+	requireOp(t, scopeOp, fsmetacontract.OpCreate, mount, fsmeta.RootInode, scopeName, scopeInode)
+
 	ops := externalHistoryOps([]fsmetacontract.Operation{
 		{Kind: fsmetacontract.OpOpenWriteSession, Mount: "vol", Parent: fsmeta.RootInode, Inode: 10},
 		{Kind: fsmetacontract.OpCreate, Mount: "vol", Parent: fsmeta.RootInode, Name: "alpha", Inode: 11},
 		{Kind: fsmetacontract.OpRenameSubtree, Mount: "vol", FromParent: fsmeta.RootInode, FromName: "alpha", ToParent: fsmeta.RootInode, ToName: "beta"},
 		{Kind: fsmetacontract.OpLink, Mount: "vol", Parent: fsmeta.RootInode, Name: "link", Inode: 11},
 		{Kind: fsmetacontract.OpAdvanceTime, Mount: "vol", AdvanceNs: 1},
-	}, mount, scopeName, scopeInode)
+	}, mount, scopeInode)
 
-	if len(ops) != 4 {
-		t.Fatalf("filtered op count=%d, want 4: %#v", len(ops), ops)
+	if len(ops) != 3 {
+		t.Fatalf("filtered op count=%d, want 3: %#v", len(ops), ops)
 	}
-	requireOp(t, ops[0], fsmetacontract.OpCreate, mount, fsmeta.RootInode, scopeName, scopeInode)
-	requireOp(t, ops[1], fsmetacontract.OpCreate, mount, scopeInode, "alpha", 11)
-	if ops[2].Mount != mount || ops[2].FromParent != scopeInode || ops[2].ToParent != scopeInode {
-		t.Fatalf("rename was not scoped into generated root: %#v", ops[2])
+	requireOp(t, ops[0], fsmetacontract.OpCreate, mount, scopeInode, "alpha", 11)
+	if ops[1].Mount != mount || ops[1].FromParent != scopeInode || ops[1].ToParent != scopeInode {
+		t.Fatalf("rename was not scoped into generated root: %#v", ops[1])
 	}
-	requireOp(t, ops[3], fsmetacontract.OpLink, mount, scopeInode, "link", 11)
+	requireOp(t, ops[2], fsmetacontract.OpLink, mount, scopeInode, "link", 11)
 }
 
 func requireOp(t *testing.T, op fsmetacontract.Operation, kind fsmetacontract.OperationKind, mount fsmeta.MountID, parent fsmeta.InodeID, name string, inode fsmeta.InodeID) {

--- a/cmd/nokv-fsmeta-history/main_test.go
+++ b/cmd/nokv-fsmeta-history/main_test.go
@@ -22,16 +22,19 @@ func TestExternalHistoryOpsScopesRootOperationsAndFiltersInternalSessions(t *tes
 		{Kind: fsmetacontract.OpRenameSubtree, Mount: "vol", FromParent: fsmeta.RootInode, FromName: "alpha", ToParent: fsmeta.RootInode, ToName: "beta"},
 		{Kind: fsmetacontract.OpLink, Mount: "vol", Parent: fsmeta.RootInode, Name: "link", Inode: 11},
 		{Kind: fsmetacontract.OpAdvanceTime, Mount: "vol", AdvanceNs: 1},
-	}, mount, scopeInode)
+	}, mount, scopeInode, scopeInode)
 
 	if len(ops) != 3 {
 		t.Fatalf("filtered op count=%d, want 3: %#v", len(ops), ops)
 	}
-	requireOp(t, ops[0], fsmetacontract.OpCreate, mount, scopeInode, "alpha", 11)
+	requireOp(t, ops[0], fsmetacontract.OpCreate, mount, scopeInode, "alpha", scopeInode+11)
 	if ops[1].Mount != mount || ops[1].FromParent != scopeInode || ops[1].ToParent != scopeInode {
 		t.Fatalf("rename was not scoped into generated root: %#v", ops[1])
 	}
-	requireOp(t, ops[2], fsmetacontract.OpLink, mount, scopeInode, "link", 11)
+	requireOp(t, ops[2], fsmetacontract.OpLink, mount, scopeInode, "link", scopeInode+11)
+	if got := scopeGeneratedInode(scopeInode, 0); got != 0 {
+		t.Fatalf("zero inode remapped to %d", got)
+	}
 }
 
 func requireOp(t *testing.T, op fsmetacontract.Operation, kind fsmetacontract.OperationKind, mount fsmeta.MountID, parent fsmeta.InodeID, name string, inode fsmeta.InodeID) {

--- a/cmd/nokv-fsmeta-soak/main.go
+++ b/cmd/nokv-fsmeta-soak/main.go
@@ -58,7 +58,7 @@ func runRound(ctx context.Context, addr string, mount fsmeta.MountID, seed int64
 	if len(ops) == 0 {
 		return fmt.Errorf("generated no namespace operations")
 	}
-	if err := fsmetacontract.RunConcurrentBatches(roundCtx, cli, model, ops, batch); err != nil {
+	if err := fsmetacontract.RunConcurrentBatches(roundCtx, cli, model, ops, batch, fsmetacontract.HistoryOptions{}); err != nil {
 		return fmt.Errorf("namespace history: %w", err)
 	}
 	if err := runSessionProbe(roundCtx, cli, mount, seed); err != nil {

--- a/coordinator/catalog/cluster.go
+++ b/coordinator/catalog/cluster.go
@@ -793,6 +793,14 @@ func (c *Cluster) validateRootEventAgainstSnapshot(snapshot rootstate.Snapshot, 
 	return applyRootEventToRegionView(regions, event)
 }
 
+// ValidateRootEventAgainstSnapshot validates an event against a caller-provided
+// rooted snapshot. Storage-backed coordinators use this to keep validation on
+// the same authority view that will receive the append, even when the local
+// cache is still catching up through watch/replay.
+func (c *Cluster) ValidateRootEventAgainstSnapshot(snapshot rootstate.Snapshot, event rootevent.Event) error {
+	return c.validateRootEventAgainstSnapshot(snapshot, event)
+}
+
 func (c *Cluster) clonePendingPeerChanges() map[uint64]rootstate.PendingPeerChange {
 	if c == nil {
 		return make(map[uint64]rootstate.PendingPeerChange)

--- a/coordinator/server/service_gateway.go
+++ b/coordinator/server/service_gateway.go
@@ -368,7 +368,7 @@ func (s *Service) PublishRootEvent(ctx context.Context, req *coordpb.PublishRoot
 	if err := s.requireExpectedClusterEpoch(req.GetExpectedClusterEpoch()); err != nil {
 		return nil, err
 	}
-	assessment, err := s.assessRootEventLifecycle(event)
+	assessment, validationSnapshot, storageBacked, err := s.assessRootEventLifecycle(event)
 	if err != nil {
 		return nil, status.Error(codes.FailedPrecondition, err.Error())
 	}
@@ -379,7 +379,17 @@ func (s *Service) PublishRootEvent(ctx context.Context, req *coordpb.PublishRoot
 		resp.Accepted = true
 		return resp, nil
 	}
-	if err := s.cluster.ValidateRootEvent(event); err != nil {
+	var validationErr error
+	if storageBacked {
+		// Durable root storage is the write authority. A coordinator can receive
+		// a valid follow-up event before its local cache has replayed the earlier
+		// event, so validate against the loaded storage snapshot used for the
+		// lifecycle decision instead of the potentially stale cache.
+		validationErr = s.cluster.ValidateRootEventAgainstSnapshot(validationSnapshot, event)
+	} else {
+		validationErr = s.cluster.ValidateRootEvent(event)
+	}
+	if err := validationErr; err != nil {
 		switch {
 		case errors.Is(err, catalog.ErrInvalidRegionID), errors.Is(err, catalog.ErrInvalidMountID):
 			return nil, status.Error(codes.InvalidArgument, err.Error())
@@ -410,16 +420,16 @@ func (s *Service) PublishRootEvent(ctx context.Context, req *coordpb.PublishRoot
 	return resp, nil
 }
 
-func (s *Service) assessRootEventLifecycle(event rootevent.Event) (rootstate.TransitionAssessment, error) {
+func (s *Service) assessRootEventLifecycle(event rootevent.Event) (rootstate.TransitionAssessment, rootstate.Snapshot, bool, error) {
 	if s == nil || s.storage == nil {
 		if s == nil || s.cluster == nil {
-			return rootstate.TransitionAssessment{}, nil
+			return rootstate.TransitionAssessment{}, rootstate.Snapshot{}, false, nil
 		}
-		return s.cluster.ObserveRootEventLifecycle(event), nil
+		return s.cluster.ObserveRootEventLifecycle(event), rootstate.Snapshot{}, false, nil
 	}
 	snapshot, err := s.storage.Load()
 	if err != nil {
-		return rootstate.TransitionAssessment{}, fmt.Errorf("load rooted snapshot: %w", err)
+		return rootstate.TransitionAssessment{}, rootstate.Snapshot{}, false, fmt.Errorf("load rooted snapshot: %w", err)
 	}
 	rooted := rootstate.Snapshot{
 		Stores:              snapshot.Stores,
@@ -432,7 +442,7 @@ func (s *Service) assessRootEventLifecycle(event rootevent.Event) (rootstate.Tra
 	}
 	assessment := rootstate.AssessTransition(rooted, event)
 	_, err = rootstate.EvaluateRootEventLifecycle(rooted, event)
-	return assessment, err
+	return assessment, rooted, true, err
 }
 
 // RemoveRegion deletes region metadata from the Coordinator in-memory catalog.

--- a/coordinator/server/service_test.go
+++ b/coordinator/server/service_test.go
@@ -133,7 +133,10 @@ func (f *fakeStorage) AppendRootEvent(_ context.Context, event rootevent.Event) 
 			LastCommitted: rootstate.Cursor{Term: 1, Index: uint64(f.eventCalls)},
 		},
 		Stores:              rootstate.CloneStoreMemberships(f.snapshot.Stores),
+		SnapshotEpochs:      rootstate.CloneSnapshotEpochs(f.snapshot.SnapshotEpochs),
 		Mounts:              rootstate.CloneMounts(f.snapshot.Mounts),
+		Subtrees:            rootstate.CloneSubtreeAuthorities(f.snapshot.Subtrees),
+		Quotas:              rootstate.CloneQuotaFences(f.snapshot.Quotas),
 		Descriptors:         rootCloneDescriptorsForTest(f.snapshot.Descriptors),
 		PendingPeerChanges:  rootstate.ClonePendingPeerChanges(f.snapshot.PendingPeerChanges),
 		PendingRangeChanges: rootstate.ClonePendingRangeChanges(f.snapshot.PendingRangeChanges),
@@ -1672,6 +1675,32 @@ func TestServiceAssessRootEventUsesStorageSnapshot(t *testing.T) {
 	require.Equal(t, coordpb.TransitionStatus_TRANSITION_STATUS_COMPLETED, resp.GetAssessment().GetStatus())
 	require.Equal(t, coordpb.TransitionDecision_TRANSITION_DECISION_SKIP, resp.GetAssessment().GetDecision())
 	require.Equal(t, "peer:171:add:2:201", resp.GetAssessment().GetTransitionId())
+}
+
+func TestServicePublishRootEventValidatesAgainstStorageSnapshot(t *testing.T) {
+	cluster := catalog.NewCluster()
+	require.NoError(t, cluster.PublishRootEvent(rootevent.MountRegistered("default", 1, 1)))
+
+	var rooted rootstate.Snapshot
+	rootstate.ApplyEventToSnapshot(&rooted, rootstate.Cursor{Term: 1, Index: 1}, rootevent.MountRegistered("default", 1, 1))
+	rootstate.ApplyEventToSnapshot(&rooted, rootstate.Cursor{Term: 1, Index: 2}, rootevent.SubtreeHandoffStarted("default", 1, 21))
+	store := &fakeStorage{
+		leader:   true,
+		snapshot: rootview.SnapshotFromRoot(rooted),
+	}
+	svc := NewService(cluster, idalloc.NewIDAllocator(1), tso.NewAllocator(1), store)
+
+	resp, err := svc.PublishRootEvent(context.Background(), &coordpb.PublishRootEventRequest{
+		Event: metawire.RootEventToProto(rootevent.SubtreeHandoffCompleted("default", 1, 21)),
+	})
+	require.NoError(t, err)
+	require.True(t, resp.GetAccepted())
+	require.Equal(t, 1, store.eventCalls)
+
+	subtree := store.snapshot.Subtrees[rootstate.SubtreeAuthorityKey("default", 1)]
+	require.Equal(t, rootstate.SubtreeAuthorityActive, subtree.State)
+	require.Equal(t, uint64(21), subtree.Frontier)
+	require.Equal(t, "default/1#1", subtree.AuthorityID)
 }
 
 func TestServicePublishRootEventSkipsCompletedSplitPlan(t *testing.T) {

--- a/coordinator/server/transition_service.go
+++ b/coordinator/server/transition_service.go
@@ -43,7 +43,7 @@ func (s *Service) AssessRootEvent(_ context.Context, req *coordpb.AssessRootEven
 	if err != nil {
 		return nil, status.Error(codes.Internal, "normalize root event: "+err.Error())
 	}
-	assessment, err := s.assessRootEventLifecycle(event)
+	assessment, _, _, err := s.assessRootEventLifecycle(event)
 	if err != nil {
 		return nil, status.Error(codes.FailedPrecondition, err.Error())
 	}

--- a/engine/slab/dirpage/cache.go
+++ b/engine/slab/dirpage/cache.go
@@ -50,7 +50,7 @@ type Cache struct {
 	mgr    *slab.Manager
 	pageMu sync.RWMutex
 	pages  map[PageKey]*pageSet // in-memory index of materialized pages
-	epochs sync.Map             // PageKey -> *atomic.Uint64 (current invalidation epoch)
+	epochs sync.Map             // DirectoryKey -> *atomic.Uint64 (current invalidation epoch)
 	stats  stats
 }
 
@@ -133,9 +133,9 @@ func (c *Cache) Close() error {
 	return c.mgr.Close()
 }
 
-// Lookup returns the materialized entries for key if their stored
-// frontier matches frontier. Returns (nil, false) on miss, stale, or
-// any decode error encountered along the way.
+// Lookup returns the materialized entries for key if their stored frontier and
+// page identity match. Returns (nil, false) on miss, stale, or any decode
+// error encountered along the way.
 //
 // frontier is opaque: in fsmeta wiring this is the WatchSubtree event
 // cursor. The cache only requires that callers pass the same value for
@@ -180,7 +180,9 @@ func (c *Cache) Lookup(key PageKey, frontier uint64) ([]Entry, bool) {
 		// Defense in depth: if a segment was truncated under us and the
 		// in-memory locator now points at a different page, drop the
 		// whole set rather than return inconsistent data.
-		if hdr.Mount != key.Mount || hdr.Parent != key.Parent || hdr.Frontier != frontier {
+		if hdr.Mount != key.Mount || hdr.Parent != key.Parent ||
+			hdr.StartAfter != key.StartAfter || hdr.Limit != key.Limit ||
+			hdr.Frontier != frontier {
 			c.stats.misses.Add(1)
 			return nil, false
 		}
@@ -207,17 +209,20 @@ func (c *Cache) Lookup(key PageKey, frontier uint64) ([]Entry, bool) {
 // dropped (counter Dropped++) — the caller's view was stale by the time
 // the write happened.
 func (c *Cache) MaterializeAsync(key PageKey, frontier uint64, entries []Entry) error {
-	if cur := c.currentEpoch(key); cur > frontier {
+	dir := key.Directory()
+	if cur := c.currentEpoch(dir); cur > frontier {
 		c.stats.dropped.Add(1)
 		return nil
 	}
-	pageGroups := splitIntoPages(entries, c.cfg.MaxPageBytes)
+	pageGroups := splitIntoPages(key.StartAfter, entries, c.cfg.MaxPageBytes)
 
 	locs := make([]pageLoc, 0, len(pageGroups))
 	for pageNo, group := range pageGroups {
 		hdr := pageHeader{
 			Mount:      key.Mount,
 			Parent:     key.Parent,
+			StartAfter: key.StartAfter,
+			Limit:      key.Limit,
 			PageNo:     uint32(pageNo),
 			Frontier:   frontier,
 			EntryCount: uint32(len(group)),
@@ -241,7 +246,7 @@ func (c *Cache) MaterializeAsync(key PageKey, frontier uint64, entries []Entry) 
 	// Race: if Invalidate fired after we passed the entry check but
 	// before we got here, we may overwrite the just-bumped epoch's
 	// fresh state. Re-check under the lock.
-	if cur := c.currentEpoch(key); cur > frontier {
+	if cur := c.currentEpoch(dir); cur > frontier {
 		c.pageMu.Unlock()
 		c.stats.dropped.Add(1)
 		return nil
@@ -253,38 +258,42 @@ func (c *Cache) MaterializeAsync(key PageKey, frontier uint64, entries []Entry) 
 	return nil
 }
 
-// Invalidate marks the cache's pages for key as stale and bumps the
-// per-key epoch. Returns the new epoch value so callers that synthesize
-// frontiers (instead of pulling from WatchSubtree) can use it as the
-// next "current" frontier.
+// Invalidate marks all cached pages for a directory as stale and bumps the
+// directory epoch. Returns the new epoch value so callers that synthesize
+// frontiers (instead of pulling from WatchSubtree) can use it as the next
+// "current" frontier.
 //
 // Invalidate is sound regardless of in-flight MaterializeAsync calls: a
 // MaterializeAsync that races sees the bumped epoch on its second check
 // and drops its store rather than publishing stale pages.
-func (c *Cache) Invalidate(key PageKey) uint64 {
+func (c *Cache) Invalidate(key DirectoryKey) uint64 {
 	ep := c.epochFor(key)
 	next := ep.Add(1)
 	c.pageMu.Lock()
-	delete(c.pages, key)
+	for pageKey := range c.pages {
+		if pageKey.Directory() == key {
+			delete(c.pages, pageKey)
+		}
+	}
 	c.pageMu.Unlock()
 	return next
 }
 
-// CurrentEpoch returns the cache's current invalidation epoch for key.
-// Useful for tests and for the consumer's "current frontier" supply
-// when WatchSubtree is not in scope.
-func (c *Cache) CurrentEpoch(key PageKey) uint64 {
+// CurrentEpoch returns the cache's current invalidation epoch for a directory.
+// Useful for tests and for the consumer's "current frontier" supply when
+// WatchSubtree is not in scope.
+func (c *Cache) CurrentEpoch(key DirectoryKey) uint64 {
 	return c.currentEpoch(key)
 }
 
-func (c *Cache) currentEpoch(key PageKey) uint64 {
+func (c *Cache) currentEpoch(key DirectoryKey) uint64 {
 	if v, ok := c.epochs.Load(key); ok {
 		return v.(*atomic.Uint64).Load()
 	}
 	return 0
 }
 
-func (c *Cache) epochFor(key PageKey) *atomic.Uint64 {
+func (c *Cache) epochFor(key DirectoryKey) *atomic.Uint64 {
 	if v, ok := c.epochs.Load(key); ok {
 		return v.(*atomic.Uint64)
 	}
@@ -387,7 +396,7 @@ func (c *Cache) reloadSegment(fid uint32) error {
 			// either unfinished writes or future writers' space.
 			break
 		}
-		key := PageKey{Mount: hdr.Mount, Parent: hdr.Parent}
+		key := PageKey{Mount: hdr.Mount, Parent: hdr.Parent, StartAfter: hdr.StartAfter, Limit: hdr.Limit}
 		groups[key] = append(groups[key], loaded{
 			hdr: hdr,
 			loc: pageLoc{

--- a/engine/slab/dirpage/cache.go
+++ b/engine/slab/dirpage/cache.go
@@ -49,8 +49,9 @@ type Cache struct {
 	cfg    Config
 	mgr    *slab.Manager
 	pageMu sync.RWMutex
-	pages  map[PageKey]*pageSet // in-memory index of materialized pages
-	epochs sync.Map             // DirectoryKey -> *atomic.Uint64 (current invalidation epoch)
+	pages  map[PageKey]*pageSet              // in-memory index of materialized pages
+	dirs   map[DirectoryKey]map[PageKey]bool // reverse index for directory-scoped invalidation
+	epochs sync.Map                          // DirectoryKey -> *atomic.Uint64 (current invalidation epoch)
 	stats  stats
 }
 
@@ -120,6 +121,7 @@ func Open(cfg Config) (*Cache, error) {
 		cfg:   cfg,
 		mgr:   mgr,
 		pages: make(map[PageKey]*pageSet),
+		dirs:  make(map[DirectoryKey]map[PageKey]bool),
 	}
 	if err := c.reload(); err != nil {
 		_ = mgr.Close()
@@ -253,6 +255,7 @@ func (c *Cache) MaterializeAsync(key PageKey, frontier uint64, entries []Entry) 
 	}
 	sort.Slice(locs, func(i, j int) bool { return locs[i].PageNo < locs[j].PageNo })
 	c.pages[key] = &pageSet{frontier: frontier, pages: locs}
+	c.indexPageLocked(key)
 	c.pageMu.Unlock()
 	c.stats.storeOK.Add(1)
 	return nil
@@ -270,11 +273,10 @@ func (c *Cache) Invalidate(key DirectoryKey) uint64 {
 	ep := c.epochFor(key)
 	next := ep.Add(1)
 	c.pageMu.Lock()
-	for pageKey := range c.pages {
-		if pageKey.Directory() == key {
-			delete(c.pages, pageKey)
-		}
+	for pageKey := range c.dirs[key] {
+		delete(c.pages, pageKey)
 	}
+	delete(c.dirs, key)
 	c.pageMu.Unlock()
 	return next
 }
@@ -429,7 +431,18 @@ func (c *Cache) reloadSegment(fid uint32) error {
 		sort.Slice(locs, func(i, j int) bool { return locs[i].PageNo < locs[j].PageNo })
 		if cur, ok := c.pages[key]; !ok || latest > cur.frontier {
 			c.pages[key] = &pageSet{frontier: latest, pages: locs}
+			c.indexPageLocked(key)
 		}
 	}
 	return nil
+}
+
+func (c *Cache) indexPageLocked(key PageKey) {
+	dir := key.Directory()
+	pages := c.dirs[dir]
+	if pages == nil {
+		pages = make(map[PageKey]bool)
+		c.dirs[dir] = pages
+	}
+	pages[key] = true
 }

--- a/engine/slab/dirpage/cache_bench_test.go
+++ b/engine/slab/dirpage/cache_bench_test.go
@@ -115,9 +115,9 @@ func BenchmarkDirPageMaterializeAsync(b *testing.B) {
 }
 
 // BenchmarkDirPageInvalidate measures the cost of bumping the
-// invalidation epoch — what every fsmeta Create/Unlink/Link/Rename
-// pays after a successful commit. The work is one sync.Map lookup +
-// atomic.Add + map delete, all in memory.
+// invalidation epoch — what every fsmeta Create/Unlink/Link/Rename pays after
+// a successful commit. The work is one sync.Map lookup + atomic.Add plus a
+// small in-memory page-index sweep for cached pages under that directory.
 func BenchmarkDirPageInvalidate(b *testing.B) {
 	c := newBenchCache(b, 16<<10)
 	keys := make([]PageKey, 1024)
@@ -128,7 +128,7 @@ func BenchmarkDirPageInvalidate(b *testing.B) {
 	b.ReportAllocs()
 	i := 0
 	for b.Loop() {
-		c.Invalidate(keys[i&1023])
+		c.Invalidate(keys[i&1023].Directory())
 		i++
 	}
 }

--- a/engine/slab/dirpage/cache_bench_test.go
+++ b/engine/slab/dirpage/cache_bench_test.go
@@ -123,6 +123,9 @@ func BenchmarkDirPageInvalidate(b *testing.B) {
 	keys := make([]PageKey, 1024)
 	for i := range keys {
 		keys[i] = PageKey{Mount: 1, Parent: uint64(i)}
+		if err := c.MaterializeAsync(keys[i], 0, makeEntries(1, 16)); err != nil {
+			b.Fatal(err)
+		}
 	}
 	b.ResetTimer()
 	b.ReportAllocs()

--- a/engine/slab/dirpage/cache_test.go
+++ b/engine/slab/dirpage/cache_test.go
@@ -2,6 +2,7 @@ package dirpage
 
 import (
 	"crypto/rand"
+	"encoding/binary"
 	"fmt"
 	"path/filepath"
 	"sync"
@@ -88,12 +89,14 @@ func TestCacheInvalidateDropsAllPagesForDirectory(t *testing.T) {
 
 	require.NoError(t, c.MaterializeAsync(firstPage, 1, makeEntries(1, 16)))
 	require.NoError(t, c.MaterializeAsync(nextPage, 1, makeEntries(1, 16)))
+	require.Len(t, c.dirs[firstPage.Directory()], 2)
 	c.Invalidate(firstPage.Directory())
 
 	_, ok := c.Lookup(firstPage, 1)
 	require.False(t, ok)
 	_, ok = c.Lookup(nextPage, 1)
 	require.False(t, ok)
+	require.Empty(t, c.dirs[firstPage.Directory()])
 }
 
 // TestCacheStaleByFrontier confirms Lookup with the wrong frontier
@@ -349,4 +352,20 @@ func TestDecodeRejectsCorruption(t *testing.T) {
 	bad[0] ^= 0xff
 	_, _, _, err = decodePage(bad)
 	require.ErrorIs(t, err, errPageBadMagic)
+}
+
+func TestDecodeRejectsOversizedStartAfterLength(t *testing.T) {
+	var encoded []byte
+	var fixed [recordHeaderFixed]byte
+	binary.LittleEndian.PutUint32(fixed[0:4], dirPageMagic)
+	binary.LittleEndian.PutUint16(fixed[4:6], dirPageVersion)
+	encoded = append(encoded, fixed[:]...)
+	encoded = binary.AppendUvarint(encoded, 1)     // mount
+	encoded = binary.AppendUvarint(encoded, 1)     // parent
+	encoded = binary.AppendUvarint(encoded, 1<<62) // impossible start_after length
+	encoded = binary.AppendUvarint(encoded, 0)     // limit, unreachable
+	encoded = append(encoded, make([]byte, 4)...)  // checksum tail placeholder
+
+	_, _, _, err := decodePage(encoded)
+	require.ErrorIs(t, err, errPageTruncated)
 }

--- a/engine/slab/dirpage/cache_test.go
+++ b/engine/slab/dirpage/cache_test.go
@@ -69,6 +69,33 @@ func TestCacheLookupMissAndHit(t *testing.T) {
 	require.Equal(t, uint64(1), stats.StoreOK)
 }
 
+func TestCachePageKeyIncludesPagination(t *testing.T) {
+	c, _ := newTestCache(t)
+	afterA := PageKey{Mount: 1, Parent: 42, StartAfter: "a", Limit: 1}
+	firstPage := PageKey{Mount: 1, Parent: 42, Limit: 1}
+
+	require.NoError(t, c.MaterializeAsync(afterA, 1, makeEntries(1, 16)))
+	_, ok := c.Lookup(firstPage, 1)
+	require.False(t, ok, "a page materialized for one cursor must not satisfy a different cursor")
+	_, ok = c.Lookup(afterA, 1)
+	require.True(t, ok)
+}
+
+func TestCacheInvalidateDropsAllPagesForDirectory(t *testing.T) {
+	c, _ := newTestCache(t)
+	firstPage := PageKey{Mount: 1, Parent: 42, Limit: 1}
+	nextPage := PageKey{Mount: 1, Parent: 42, StartAfter: "a", Limit: 1}
+
+	require.NoError(t, c.MaterializeAsync(firstPage, 1, makeEntries(1, 16)))
+	require.NoError(t, c.MaterializeAsync(nextPage, 1, makeEntries(1, 16)))
+	c.Invalidate(firstPage.Directory())
+
+	_, ok := c.Lookup(firstPage, 1)
+	require.False(t, ok)
+	_, ok = c.Lookup(nextPage, 1)
+	require.False(t, ok)
+}
+
 // TestCacheStaleByFrontier confirms Lookup with the wrong frontier
 // returns a stale miss without surfacing the cached entries.
 func TestCacheStaleByFrontier(t *testing.T) {
@@ -95,16 +122,16 @@ func TestCacheInvalidateBumpsEpoch(t *testing.T) {
 	c, _ := newTestCache(t)
 	key := PageKey{Mount: 3, Parent: 11}
 
-	require.Equal(t, uint64(0), c.CurrentEpoch(key))
-	next := c.Invalidate(key)
+	require.Equal(t, uint64(0), c.CurrentEpoch(key.Directory()))
+	next := c.Invalidate(key.Directory())
 	require.Equal(t, uint64(1), next)
-	require.Equal(t, uint64(1), c.CurrentEpoch(key))
+	require.Equal(t, uint64(1), c.CurrentEpoch(key.Directory()))
 
 	require.NoError(t, c.MaterializeAsync(key, next, makeEntries(2, 8)))
 	_, ok := c.Lookup(key, next)
 	require.True(t, ok)
 
-	bumped := c.Invalidate(key)
+	bumped := c.Invalidate(key.Directory())
 	require.Equal(t, uint64(2), bumped)
 	_, ok = c.Lookup(key, next)
 	require.False(t, ok, "Invalidate must drop the prior page set")
@@ -119,9 +146,9 @@ func TestCacheMaterializeDropsAfterInvalidate(t *testing.T) {
 
 	// Bump epoch to 5 first.
 	for range 5 {
-		c.Invalidate(key)
+		c.Invalidate(key.Directory())
 	}
-	require.Equal(t, uint64(5), c.CurrentEpoch(key))
+	require.Equal(t, uint64(5), c.CurrentEpoch(key.Directory()))
 
 	// Materialize against a stale frontier (4) while current epoch is 5.
 	// Cache must drop the write.
@@ -247,10 +274,10 @@ func TestCacheConcurrentAccess(t *testing.T) {
 			defer wg.Done()
 			for i := range ops {
 				key := keyOf(seed + i)
-				ep := c.CurrentEpoch(key)
+				ep := c.CurrentEpoch(key.Directory())
 				_ = c.MaterializeAsync(key, ep, makeEntries(4, 16))
 				if i%17 == 0 {
-					c.Invalidate(key)
+					c.Invalidate(key.Directory())
 				}
 			}
 		}(w)
@@ -260,7 +287,7 @@ func TestCacheConcurrentAccess(t *testing.T) {
 			defer wg.Done()
 			for i := range ops {
 				key := keyOf(seed + i)
-				ep := c.CurrentEpoch(key)
+				ep := c.CurrentEpoch(key.Directory())
 				if entries, ok := c.Lookup(key, ep); ok {
 					require.NotEmpty(t, entries)
 				}

--- a/engine/slab/dirpage/codec.go
+++ b/engine/slab/dirpage/codec.go
@@ -181,6 +181,17 @@ func decodePage(buf []byte) (pageHeader, []Entry, int, error) {
 		cursor += n
 		return v, nil
 	}
+	readBytes := func(n uint64) ([]byte, error) {
+		// Keep corrupted length prefixes from overflowing int conversion or
+		// slicing past the decoded frame. The cache is derived, so corrupt
+		// frames are treated as misses by callers.
+		if n > uint64(len(buf)-cursor) {
+			return nil, errPageTruncated
+		}
+		out := buf[cursor : cursor+int(n)]
+		cursor += int(n)
+		return out, nil
+	}
 
 	mount, err := read()
 	if err != nil {
@@ -194,11 +205,11 @@ func decodePage(buf []byte) (pageHeader, []Entry, int, error) {
 	if err != nil {
 		return pageHeader{}, nil, 0, err
 	}
-	if cursor+int(startAfterLen) > len(buf) {
-		return pageHeader{}, nil, 0, errPageTruncated
+	startAfterBytes, err := readBytes(startAfterLen)
+	if err != nil {
+		return pageHeader{}, nil, 0, err
 	}
-	startAfter := string(buf[cursor : cursor+int(startAfterLen)])
-	cursor += int(startAfterLen)
+	startAfter := string(startAfterBytes)
 	limit, err := read()
 	if err != nil {
 		return pageHeader{}, nil, 0, err
@@ -222,12 +233,12 @@ func decodePage(buf []byte) (pageHeader, []Entry, int, error) {
 		if err != nil {
 			return pageHeader{}, nil, 0, err
 		}
-		if cursor+int(nameLen) > len(buf) {
-			return pageHeader{}, nil, 0, errPageTruncated
+		nameBytes, err := readBytes(nameLen)
+		if err != nil {
+			return pageHeader{}, nil, 0, err
 		}
 		name := make([]byte, nameLen)
-		copy(name, buf[cursor:cursor+int(nameLen)])
-		cursor += int(nameLen)
+		copy(name, nameBytes)
 
 		inode, err := read()
 		if err != nil {
@@ -237,12 +248,12 @@ func decodePage(buf []byte) (pageHeader, []Entry, int, error) {
 		if err != nil {
 			return pageHeader{}, nil, 0, err
 		}
-		if cursor+int(blobLen) > len(buf) {
-			return pageHeader{}, nil, 0, errPageTruncated
+		blobBytes, err := readBytes(blobLen)
+		if err != nil {
+			return pageHeader{}, nil, 0, err
 		}
 		blob := make([]byte, blobLen)
-		copy(blob, buf[cursor:cursor+int(blobLen)])
-		cursor += int(blobLen)
+		copy(blob, blobBytes)
 
 		entries = append(entries, Entry{Name: name, Inode: inode, AttrBlob: blob})
 	}
@@ -301,8 +312,4 @@ func splitIntoPages(startAfter string, entries []Entry, maxPageBytes int) [][]En
 // keyString is a debug helper for error messages.
 func (k PageKey) keyString() string {
 	return fmt.Sprintf("(mount=%d parent=%d start_after=%q limit=%d)", k.Mount, k.Parent, k.StartAfter, k.Limit)
-}
-
-func (k DirectoryKey) keyString() string {
-	return fmt.Sprintf("(mount=%d parent=%d)", k.Mount, k.Parent)
 }

--- a/engine/slab/dirpage/codec.go
+++ b/engine/slab/dirpage/codec.go
@@ -1,8 +1,8 @@
 // Package dirpage implements the DirPageSlab Derived consumer of
-// engine/slab. It materializes (mount, parent_inode) directory listings
-// as packed pages in a slab so that ReadDirPlus can short-circuit a
-// fan-out of N LSM prefix scans + N inode Gets into a single sequential
-// page read.
+// engine/slab. It materializes individual (mount, parent_inode, cursor,
+// limit) directory pages as packed records in a slab so that ReadDirPlus
+// can short-circuit a fan-out of one LSM prefix scan + N inode Gets into
+// a single sequential page read.
 //
 // Wire format and consistency model in brief:
 //
@@ -35,8 +35,9 @@ import (
 // frame. The four ASCII bytes are "DPSL" little-endian.
 const dirPageMagic uint32 = 0x4c535044
 
-// dirPageVersion is the wire-format version. Bumped only on incompatible
-// changes; readers reject mismatched versions.
+// dirPageVersion is the current dirpage slab format. NoKV has not shipped a
+// stable dirpage cache format yet, so development-time incompatible changes
+// keep the clean v1 format instead of carrying migration branches.
 const dirPageVersion uint16 = 1
 
 // recordHeaderFixed is the size of the magic + version prefix we read
@@ -45,14 +46,27 @@ const dirPageVersion uint16 = 1
 // other consumers' records in the future).
 const recordHeaderFixed = 4 + 2 // magic + version
 
-// PageKey identifies one cached directory listing. Mount and Parent are
-// opaque to dirpage; the consumer (typically fsmeta) maps its own typed
-// identifiers to these uint widths. Mount is uint64 — fsmeta's MountID
-// is a string, callers hash it (e.g. xxhash.Sum64) so collision
-// probability across mounts is negligible (~5e-12 at 10K mounts).
-type PageKey struct {
+// DirectoryKey identifies the mutation invalidation scope for one directory.
+// A directory can have many cached PageKeys, but all of them become stale when
+// any child dentry changes.
+type DirectoryKey struct {
 	Mount  uint64
 	Parent uint64
+}
+
+// PageKey identifies one cached directory page. Mount and Parent are opaque to
+// dirpage; the consumer maps its own typed identifiers to these uint widths.
+// StartAfter and Limit are part of the identity because the cache stores one
+// caller-visible page, not a complete logical directory.
+type PageKey struct {
+	Mount      uint64
+	Parent     uint64
+	StartAfter string
+	Limit      uint32
+}
+
+func (k PageKey) Directory() DirectoryKey {
+	return DirectoryKey{Mount: k.Mount, Parent: k.Parent}
 }
 
 // Entry is one materialized directory entry. AttrBlob is the consumer-
@@ -69,6 +83,8 @@ type Entry struct {
 type pageHeader struct {
 	Mount      uint64
 	Parent     uint64
+	StartAfter string
+	Limit      uint32
 	PageNo     uint32
 	Frontier   uint64
 	EntryCount uint32
@@ -77,12 +93,14 @@ type pageHeader struct {
 // estimatePageSize gives the on-disk footprint of a page with the listed
 // entries. Used by the splitter to decide when to roll over to the next
 // page. Slightly pessimistic (assumes max varint width).
-func estimatePageSize(entries []Entry) int {
+func estimatePageSize(startAfter string, entries []Entry) int {
 	const overhead = recordHeaderFixed +
 		binary.MaxVarintLen64*3 + // mount + parent + frontier
-		binary.MaxVarintLen32*2 + // page_no + entry_count
+		binary.MaxVarintLen64 + // start_after_len
+		binary.MaxVarintLen32*3 + // limit + page_no + entry_count
 		4 // crc32
 	total := overhead
+	total += len(startAfter)
 	for _, e := range entries {
 		total += binary.MaxVarintLen64 // name_len
 		total += len(e.Name)
@@ -107,6 +125,9 @@ func encodePage(dst []byte, hdr pageHeader, entries []Entry) []byte {
 	// header (varint)
 	dst = binary.AppendUvarint(dst, hdr.Mount)
 	dst = binary.AppendUvarint(dst, hdr.Parent)
+	dst = binary.AppendUvarint(dst, uint64(len(hdr.StartAfter)))
+	dst = append(dst, hdr.StartAfter...)
+	dst = binary.AppendUvarint(dst, uint64(hdr.Limit))
 	dst = binary.AppendUvarint(dst, uint64(hdr.PageNo))
 	dst = binary.AppendUvarint(dst, hdr.Frontier)
 	dst = binary.AppendUvarint(dst, uint64(hdr.EntryCount))
@@ -169,6 +190,19 @@ func decodePage(buf []byte) (pageHeader, []Entry, int, error) {
 	if err != nil {
 		return pageHeader{}, nil, 0, err
 	}
+	startAfterLen, err := read()
+	if err != nil {
+		return pageHeader{}, nil, 0, err
+	}
+	if cursor+int(startAfterLen) > len(buf) {
+		return pageHeader{}, nil, 0, errPageTruncated
+	}
+	startAfter := string(buf[cursor : cursor+int(startAfterLen)])
+	cursor += int(startAfterLen)
+	limit, err := read()
+	if err != nil {
+		return pageHeader{}, nil, 0, err
+	}
 	pageNo, err := read()
 	if err != nil {
 		return pageHeader{}, nil, 0, err
@@ -226,6 +260,8 @@ func decodePage(buf []byte) (pageHeader, []Entry, int, error) {
 	hdr := pageHeader{
 		Mount:      mount,
 		Parent:     parent,
+		StartAfter: startAfter,
+		Limit:      uint32(limit),
 		PageNo:     uint32(pageNo),
 		Frontier:   frontier,
 		EntryCount: uint32(entryCount),
@@ -236,7 +272,7 @@ func decodePage(buf []byte) (pageHeader, []Entry, int, error) {
 // splitIntoPages partitions entries into groups, each fitting under
 // maxPageBytes when encoded. Empty entries returns one empty page so the
 // caller still records "this directory is materialized as empty".
-func splitIntoPages(entries []Entry, maxPageBytes int) [][]Entry {
+func splitIntoPages(startAfter string, entries []Entry, maxPageBytes int) [][]Entry {
 	if len(entries) == 0 {
 		return [][]Entry{nil}
 	}
@@ -245,13 +281,13 @@ func splitIntoPages(entries []Entry, maxPageBytes int) [][]Entry {
 	}
 	var pages [][]Entry
 	cur := []Entry{}
-	curSize := estimatePageSize(nil)
+	curSize := estimatePageSize(startAfter, nil)
 	for _, e := range entries {
 		entrySize := binary.MaxVarintLen64 + len(e.Name) + binary.MaxVarintLen64 + binary.MaxVarintLen64 + len(e.AttrBlob)
 		if len(cur) > 0 && curSize+entrySize > maxPageBytes {
 			pages = append(pages, cur)
 			cur = []Entry{}
-			curSize = estimatePageSize(nil)
+			curSize = estimatePageSize(startAfter, nil)
 		}
 		cur = append(cur, e)
 		curSize += entrySize
@@ -264,5 +300,9 @@ func splitIntoPages(entries []Entry, maxPageBytes int) [][]Entry {
 
 // keyString is a debug helper for error messages.
 func (k PageKey) keyString() string {
+	return fmt.Sprintf("(mount=%d parent=%d start_after=%q limit=%d)", k.Mount, k.Parent, k.StartAfter, k.Limit)
+}
+
+func (k DirectoryKey) keyString() string {
 	return fmt.Sprintf("(mount=%d parent=%d)", k.Mount, k.Parent)
 }

--- a/fsmeta/contract/history.go
+++ b/fsmeta/contract/history.go
@@ -62,7 +62,7 @@ func RunConcurrentBatches(ctx context.Context, exec Executor, model *Model, ops 
 	if model == nil {
 		return errModelRequired
 	}
-	if batchSize <= 1 {
+	if batchSize <= 1 && !opts.AllowIndeterminateErrors {
 		return Run(ctx, exec, model, ops)
 	}
 	if batchSize > maxConcurrentHistoryBatch {
@@ -135,19 +135,6 @@ func historyBarrier(op Operation) bool {
 	}
 }
 
-func runSequentialObserved(ctx context.Context, exec Executor, model *Model, index int, op Operation, history *[]string) error {
-	got := execute(ctx, exec, model, op)
-	want := applyObserved(model, op, got)
-	*history = append(*history, fmt.Sprintf("%03d sequential %s -> got=%s want=%s", index, op, summarize(got), summarize(want)))
-	if err := compareResult(got, want); err != nil {
-		return fmt.Errorf("step %d failed: %w\nhistory:\n%s", index, err, strings.Join(*history, "\n"))
-	}
-	if err := model.CheckInvariants(); err != nil {
-		return fmt.Errorf("step %d corrupted model invariants: %w\nhistory:\n%s", index, err, strings.Join(*history, "\n"))
-	}
-	return nil
-}
-
 func runSequentialObservedCandidates(ctx context.Context, exec Executor, candidates []*Model, index int, op Operation, opts HistoryOptions, maxCandidates int, history *[]string) ([]*Model, error) {
 	got := execute(ctx, exec, candidates[0], op)
 	next, firstMismatch := advanceCandidates(candidates, op, got, opts, maxCandidates)
@@ -190,18 +177,23 @@ func executeConcurrentBatch(ctx context.Context, exec Executor, model *Model, ba
 
 func linearizeCandidateBatch(base []*Model, observed []observedOperation, opts HistoryOptions, maxCandidates int) ([]*Model, [][]int, error) {
 	next := make([]historyCandidate, 0, len(base))
+	seen := make(map[string]struct{}, maxCandidates)
 	var firstMismatch error
 	for _, candidate := range base {
-		matches, err := linearizeBatchCandidates(candidate, observed, opts, maxCandidates-len(next))
+		matches, err := linearizeBatchCandidates(candidate, observed, opts, maxCandidates)
 		if err != nil && firstMismatch == nil {
 			firstMismatch = err
 		}
-		next = append(next, matches...)
+		for _, match := range matches {
+			next = appendUniqueHistoryCandidate(next, seen, match, maxCandidates)
+			if len(next) >= maxCandidates {
+				break
+			}
+		}
 		if len(next) >= maxCandidates {
 			break
 		}
 	}
-	next = dedupeHistoryCandidates(next, maxCandidates)
 	if len(next) == 0 {
 		if firstMismatch == nil {
 			firstMismatch = fmt.Errorf("no candidate operation respects real-time constraints")
@@ -215,14 +207,6 @@ func linearizeCandidateBatch(base []*Model, observed []observedOperation, opts H
 		orders = append(orders, candidate.order)
 	}
 	return models, orders, nil
-}
-
-func linearizeBatch(base *Model, observed []observedOperation) (*Model, []int, error) {
-	matches, err := linearizeBatchCandidates(base, observed, HistoryOptions{}, 1)
-	if len(matches) != 0 {
-		return matches[0].model, matches[0].order, nil
-	}
-	return nil, nil, err
 }
 
 func linearizeBatchCandidates(base *Model, observed []observedOperation, opts HistoryOptions, limit int) ([]historyCandidate, error) {
@@ -305,6 +289,7 @@ func applyObserved(model *Model, op Operation, got Result) Result {
 
 func advanceCandidates(base []*Model, op Operation, got Result, opts HistoryOptions, maxCandidates int) ([]*Model, error) {
 	out := make([]historyCandidate, 0, len(base))
+	seen := make(map[string]struct{}, maxCandidates)
 	var firstMismatch error
 	for _, candidate := range base {
 		next, err := advanceOneCandidate(candidate, op, got, opts)
@@ -315,7 +300,7 @@ func advanceCandidates(base []*Model, op Operation, got Result, opts HistoryOpti
 			continue
 		}
 		for _, model := range next {
-			out = append(out, historyCandidate{model: model})
+			out = appendUniqueHistoryCandidate(out, seen, historyCandidate{model: model}, maxCandidates)
 			if len(out) >= maxCandidates {
 				break
 			}
@@ -324,7 +309,6 @@ func advanceCandidates(base []*Model, op Operation, got Result, opts HistoryOpti
 			break
 		}
 	}
-	out = dedupeHistoryCandidates(out, maxCandidates)
 	models := make([]*Model, 0, len(out))
 	for _, candidate := range out {
 		models = append(models, candidate.model)
@@ -368,7 +352,7 @@ func isIndeterminateHistoryError(err error) bool {
 		return false
 	}
 	switch nokverrors.KindOf(err) {
-	case nokverrors.KindUnavailable, nokverrors.KindRouteUnavailable, nokverrors.KindRegionRouting, nokverrors.KindNotLeader, nokverrors.KindRetryExhausted, nokverrors.KindAborted:
+	case nokverrors.KindUnavailable, nokverrors.KindRouteUnavailable, nokverrors.KindRegionRouting, nokverrors.KindNotLeader, nokverrors.KindRetryExhausted:
 		return true
 	default:
 		return false
@@ -433,6 +417,18 @@ func dedupeHistoryCandidates(in []historyCandidate, limit int) []historyCandidat
 		}
 	}
 	return out
+}
+
+func appendUniqueHistoryCandidate(out []historyCandidate, seen map[string]struct{}, candidate historyCandidate, limit int) []historyCandidate {
+	if len(out) >= limit {
+		return out
+	}
+	key := modelFingerprint(candidate.model)
+	if _, ok := seen[key]; ok {
+		return out
+	}
+	seen[key] = struct{}{}
+	return append(out, candidate)
 }
 
 func modelFingerprint(m *Model) string {

--- a/fsmeta/contract/history.go
+++ b/fsmeta/contract/history.go
@@ -4,14 +4,19 @@ import (
 	"context"
 	"fmt"
 	"maps"
+	"sort"
 	"strings"
 	"sync"
 	"sync/atomic"
 
+	nokverrors "github.com/feichai0017/NoKV/errors"
 	"github.com/feichai0017/NoKV/fsmeta"
 )
 
-const maxConcurrentHistoryBatch = 5
+const (
+	maxConcurrentHistoryBatch   = 5
+	defaultMaxHistoryCandidates = 128
+)
 
 type scheduledOperation struct {
 	index int
@@ -26,12 +31,30 @@ type observedOperation struct {
 	finished int64
 }
 
+type HistoryOptions struct {
+	// AllowIndeterminateErrors treats retryable transport/availability errors as
+	// operations whose commit outcome is unknown. Docker chaos uses this mode
+	// because a restarted store can return Unavailable after the request crossed
+	// the server boundary; strict in-process tests keep the default false value.
+	AllowIndeterminateErrors bool
+
+	// MaxCandidates bounds the number of ambiguous model states retained after a
+	// concurrent batch. A small cap keeps nightly checks deterministic while still
+	// preserving alternative legal write orders for later reads to disambiguate.
+	MaxCandidates int
+}
+
+type historyCandidate struct {
+	model *Model
+	order []int
+}
+
 // RunConcurrentBatches executes generated fsmeta operations in small
 // overlapping batches and checks every completed batch against a bounded
 // linearization oracle. It is deliberately factorial and bounded: the point is
 // to catch non-serializable metadata histories in nightly runs without turning
 // the regular PR path into a large model checker.
-func RunConcurrentBatches(ctx context.Context, exec Executor, model *Model, ops []Operation, batchSize int) error {
+func RunConcurrentBatches(ctx context.Context, exec Executor, model *Model, ops []Operation, batchSize int, opts HistoryOptions) error {
 	if exec == nil {
 		return errExecutorRequired
 	}
@@ -44,16 +67,21 @@ func RunConcurrentBatches(ctx context.Context, exec Executor, model *Model, ops 
 	if batchSize > maxConcurrentHistoryBatch {
 		return fmt.Errorf("fsmeta/contract: concurrent batch size %d exceeds max %d", batchSize, maxConcurrentHistoryBatch)
 	}
+	maxCandidates := opts.MaxCandidates
+	if maxCandidates <= 0 {
+		maxCandidates = defaultMaxHistoryCandidates
+	}
 
 	history := make([]string, 0, len(ops))
+	candidates := []*Model{cloneModel(model)}
 	batch := make([]scheduledOperation, 0, batchSize)
 	batchID := 0
 	flush := func() error {
 		if len(batch) == 0 {
 			return nil
 		}
-		observed := executeConcurrentBatch(ctx, exec, model, batch)
-		next, order, err := linearizeBatch(model, observed)
+		observed := executeConcurrentBatch(ctx, exec, candidates[0], batch)
+		next, orders, err := linearizeCandidateBatch(candidates, observed, opts, maxCandidates)
 		for _, event := range observed {
 			history = append(history, fmt.Sprintf("%03d batch=%03d start=%d finish=%d %s -> got=%s",
 				event.index, batchID, event.started, event.finished, event.op, summarize(event.result)))
@@ -62,8 +90,10 @@ func RunConcurrentBatches(ctx context.Context, exec Executor, model *Model, ops 
 			return fmt.Errorf("batch %d failed: %w\nbatch:\n%s\nhistory:\n%s",
 				batchID, err, describeObserved(observed), strings.Join(history, "\n"))
 		}
-		history = append(history, fmt.Sprintf("batch %03d linearized_as=%s", batchID, describeOrder(observed, order)))
-		replaceModel(model, next)
+		candidates = next
+		history = append(history, fmt.Sprintf("batch %03d candidates=%d first_linearized_as=%s",
+			batchID, len(candidates), describeOrder(observed, orders[0])))
+		replaceModel(model, candidates[0])
 		if err := model.CheckInvariants(); err != nil {
 			return fmt.Errorf("batch %d corrupted model invariants: %w\nhistory:\n%s", batchID, err, strings.Join(history, "\n"))
 		}
@@ -77,9 +107,12 @@ func RunConcurrentBatches(ctx context.Context, exec Executor, model *Model, ops 
 			if err := flush(); err != nil {
 				return err
 			}
-			if err := runSequentialObserved(ctx, exec, model, i, op, &history); err != nil {
+			next, err := runSequentialObservedCandidates(ctx, exec, candidates, i, op, opts, maxCandidates, &history)
+			if err != nil {
 				return err
 			}
+			candidates = next
+			replaceModel(model, candidates[0])
 			continue
 		}
 		batch = append(batch, scheduledOperation{index: i, op: op})
@@ -114,6 +147,26 @@ func runSequentialObserved(ctx context.Context, exec Executor, model *Model, ind
 	return nil
 }
 
+func runSequentialObservedCandidates(ctx context.Context, exec Executor, candidates []*Model, index int, op Operation, opts HistoryOptions, maxCandidates int, history *[]string) ([]*Model, error) {
+	got := execute(ctx, exec, candidates[0], op)
+	next, firstMismatch := advanceCandidates(candidates, op, got, opts, maxCandidates)
+	want := Result{}
+	if len(candidates) != 0 {
+		want = applyObserved(cloneModel(candidates[0]), op, got)
+	}
+	*history = append(*history, fmt.Sprintf("%03d sequential candidates=%d %s -> got=%s want=%s", index, len(next), op, summarize(got), summarize(want)))
+	if len(next) == 0 {
+		if firstMismatch == nil {
+			firstMismatch = fmt.Errorf("no candidate model accepted observed result")
+		}
+		return nil, fmt.Errorf("step %d failed: %w\nhistory:\n%s", index, firstMismatch, strings.Join(*history, "\n"))
+	}
+	if err := next[0].CheckInvariants(); err != nil {
+		return nil, fmt.Errorf("step %d corrupted model invariants: %w\nhistory:\n%s", index, err, strings.Join(*history, "\n"))
+	}
+	return next, nil
+}
+
 func executeConcurrentBatch(ctx context.Context, exec Executor, model *Model, batch []scheduledOperation) []observedOperation {
 	observed := make([]observedOperation, len(batch))
 	var seq atomic.Int64
@@ -134,54 +187,97 @@ func executeConcurrentBatch(ctx context.Context, exec Executor, model *Model, ba
 	return observed
 }
 
+func linearizeCandidateBatch(base []*Model, observed []observedOperation, opts HistoryOptions, maxCandidates int) ([]*Model, [][]int, error) {
+	next := make([]historyCandidate, 0, len(base))
+	var firstMismatch error
+	for _, candidate := range base {
+		matches, err := linearizeBatchCandidates(candidate, observed, opts, maxCandidates-len(next))
+		if err != nil && firstMismatch == nil {
+			firstMismatch = err
+		}
+		next = append(next, matches...)
+		if len(next) >= maxCandidates {
+			break
+		}
+	}
+	next = dedupeHistoryCandidates(next, maxCandidates)
+	if len(next) == 0 {
+		if firstMismatch == nil {
+			firstMismatch = fmt.Errorf("no candidate operation respects real-time constraints")
+		}
+		return nil, nil, fmt.Errorf("no serial order matched observed concurrent results: %w", firstMismatch)
+	}
+	models := make([]*Model, 0, len(next))
+	orders := make([][]int, 0, len(next))
+	for _, candidate := range next {
+		models = append(models, candidate.model)
+		orders = append(orders, candidate.order)
+	}
+	return models, orders, nil
+}
+
 func linearizeBatch(base *Model, observed []observedOperation) (*Model, []int, error) {
+	matches, err := linearizeBatchCandidates(base, observed, HistoryOptions{}, 1)
+	if len(matches) != 0 {
+		return matches[0].model, matches[0].order, nil
+	}
+	return nil, nil, err
+}
+
+func linearizeBatchCandidates(base *Model, observed []observedOperation, opts HistoryOptions, limit int) ([]historyCandidate, error) {
+	if limit <= 0 {
+		return nil, nil
+	}
 	used := make([]bool, len(observed))
 	order := make([]int, 0, len(observed))
 	var firstMismatch error
+	out := make([]historyCandidate, 0, limit)
 
-	var search func(*Model) (*Model, bool)
-	search = func(current *Model) (*Model, bool) {
+	var search func(*Model)
+	search = func(current *Model) {
+		if len(out) >= limit {
+			return
+		}
 		if len(order) == len(observed) {
-			return current, true
+			out = append(out, historyCandidate{
+				model: current,
+				order: append([]int(nil), order...),
+			})
+			return
 		}
 		for i := range observed {
 			if used[i] || !respectsRealTime(i, used, observed) {
 				continue
 			}
-			next := cloneModel(current)
-			want := applyObserved(next, observed[i].op, observed[i].result)
-			if err := compareResult(observed[i].result, want); err != nil {
+			nextModels, err := advanceOneCandidate(current, observed[i].op, observed[i].result, opts)
+			if err != nil {
 				if firstMismatch == nil {
-					firstMismatch = fmt.Errorf("op %03d %s: %w; got=%s want=%s",
-						observed[i].index, observed[i].op, err, summarize(observed[i].result), summarize(want))
-				}
-				continue
-			}
-			if err := next.CheckInvariants(); err != nil {
-				if firstMismatch == nil {
-					firstMismatch = fmt.Errorf("op %03d %s corrupts candidate invariants: %w", observed[i].index, observed[i].op, err)
+					firstMismatch = fmt.Errorf("op %03d %s: %w", observed[i].index, observed[i].op, err)
 				}
 				continue
 			}
 			used[i] = true
 			order = append(order, i)
-			if final, ok := search(next); ok {
-				return final, true
+			for _, next := range nextModels {
+				search(next)
+				if len(out) >= limit {
+					break
+				}
 			}
 			order = order[:len(order)-1]
 			used[i] = false
 		}
-		return nil, false
 	}
 
-	next, ok := search(cloneModel(base))
-	if ok {
-		return next, append([]int(nil), order...), nil
+	search(cloneModel(base))
+	out = dedupeHistoryCandidates(out, limit)
+	if len(out) != 0 {
+		return out, nil
 	}
 	if firstMismatch == nil {
 		firstMismatch = fmt.Errorf("no candidate operation respects real-time constraints")
 	}
-	return nil, nil, fmt.Errorf("no serial order matched observed concurrent results: %w", firstMismatch)
+	return nil, fmt.Errorf("no serial order matched observed concurrent results: %w", firstMismatch)
 }
 
 func respectsRealTime(candidate int, used []bool, observed []observedOperation) bool {
@@ -204,6 +300,87 @@ func applyObserved(model *Model, op Operation, got Result) Result {
 		return model.Apply(op)
 	}
 	return model.Apply(op)
+}
+
+func advanceCandidates(base []*Model, op Operation, got Result, opts HistoryOptions, maxCandidates int) ([]*Model, error) {
+	out := make([]historyCandidate, 0, len(base))
+	var firstMismatch error
+	for _, candidate := range base {
+		next, err := advanceOneCandidate(candidate, op, got, opts)
+		if err != nil {
+			if firstMismatch == nil {
+				firstMismatch = err
+			}
+			continue
+		}
+		for _, model := range next {
+			out = append(out, historyCandidate{model: model})
+			if len(out) >= maxCandidates {
+				break
+			}
+		}
+		if len(out) >= maxCandidates {
+			break
+		}
+	}
+	out = dedupeHistoryCandidates(out, maxCandidates)
+	models := make([]*Model, 0, len(out))
+	for _, candidate := range out {
+		models = append(models, candidate.model)
+	}
+	return models, firstMismatch
+}
+
+func advanceOneCandidate(current *Model, op Operation, got Result, opts HistoryOptions) ([]*Model, error) {
+	if opts.AllowIndeterminateErrors && isIndeterminateHistoryError(got.Err) {
+		return advanceIndeterminateCandidate(current, op)
+	}
+	next := cloneModel(current)
+	want := applyObserved(next, op, got)
+	if err := compareResult(got, want); err != nil {
+		return nil, fmt.Errorf("%w; got=%s want=%s", err, summarize(got), summarize(want))
+	}
+	if err := next.CheckInvariants(); err != nil {
+		return nil, fmt.Errorf("candidate invariants: %w", err)
+	}
+	return []*Model{next}, nil
+}
+
+func advanceIndeterminateCandidate(current *Model, op Operation) ([]*Model, error) {
+	out := []*Model{cloneModel(current)}
+	if !operationMayMutate(op.Kind) {
+		return out, nil
+	}
+	applied := cloneModel(current)
+	want := applied.Apply(op)
+	if want.Err == nil {
+		if err := applied.CheckInvariants(); err != nil {
+			return nil, fmt.Errorf("candidate invariants after indeterminate apply: %w", err)
+		}
+		out = append(out, applied)
+	}
+	return out, nil
+}
+
+func isIndeterminateHistoryError(err error) bool {
+	if err == nil {
+		return false
+	}
+	switch nokverrors.KindOf(err) {
+	case nokverrors.KindUnavailable, nokverrors.KindRouteUnavailable, nokverrors.KindRegionRouting, nokverrors.KindNotLeader, nokverrors.KindRetryExhausted, nokverrors.KindAborted:
+		return true
+	default:
+		return false
+	}
+}
+
+func operationMayMutate(kind OperationKind) bool {
+	switch kind {
+	case OpCreate, OpUpdateInode, OpRenameSubtree, OpLink, OpUnlink, OpOpenWriteSession, OpHeartbeatSession, OpCloseSession, OpExpireSessions:
+		return true
+	default:
+		return false
+	}
 }
 
 func cloneModel(in *Model) *Model {
@@ -235,6 +412,113 @@ func cloneModel(in *Model) *Model {
 
 func replaceModel(dst *Model, src *Model) {
 	*dst = *src
+}
+
+func dedupeHistoryCandidates(in []historyCandidate, limit int) []historyCandidate {
+	if limit <= 0 || len(in) == 0 {
+		return nil
+	}
+	seen := make(map[string]struct{}, len(in))
+	out := make([]historyCandidate, 0, len(in))
+	for _, candidate := range in {
+		key := modelFingerprint(candidate.model)
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
+		out = append(out, candidate)
+		if len(out) >= limit {
+			break
+		}
+	}
+	return out
+}
+
+func modelFingerprint(m *Model) string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "mount=%s root=%d now=%d|", m.Mount, m.Root, m.NowUnixNs)
+	dentryKeys := make([]dentryKey, 0, len(m.dentries))
+	for key := range m.dentries {
+		dentryKeys = append(dentryKeys, key)
+	}
+	sort.Slice(dentryKeys, func(i, j int) bool {
+		if dentryKeys[i].parent != dentryKeys[j].parent {
+			return dentryKeys[i].parent < dentryKeys[j].parent
+		}
+		return dentryKeys[i].name < dentryKeys[j].name
+	})
+	for _, key := range dentryKeys {
+		dentry := m.dentries[key]
+		fmt.Fprintf(&b, "d:%d/%s=%d/%s;", key.parent, key.name, dentry.Inode, dentry.Type)
+	}
+	inodeIDs := make([]fsmeta.InodeID, 0, len(m.inodes))
+	for inode := range m.inodes {
+		inodeIDs = append(inodeIDs, inode)
+	}
+	sort.Slice(inodeIDs, func(i, j int) bool { return inodeIDs[i] < inodeIDs[j] })
+	for _, id := range inodeIDs {
+		inode := m.inodes[id]
+		fmt.Fprintf(&b, "i:%d=%s/%d/%d/%d/%x;", id, inode.Type, inode.Size, inode.Mode, inode.LinkCount, inode.OpaqueAttrs)
+	}
+	sessionIDs := make([]fsmeta.SessionID, 0, len(m.sessions))
+	for id := range m.sessions {
+		sessionIDs = append(sessionIDs, id)
+	}
+	sort.Slice(sessionIDs, func(i, j int) bool { return sessionIDs[i] < sessionIDs[j] })
+	for _, id := range sessionIDs {
+		session := m.sessions[id]
+		fmt.Fprintf(&b, "s:%s=%d/%d;", id, session.Inode, session.ExpiresUnixNs)
+	}
+	ownerIDs := make([]fsmeta.InodeID, 0, len(m.owners))
+	for id := range m.owners {
+		ownerIDs = append(ownerIDs, id)
+	}
+	sort.Slice(ownerIDs, func(i, j int) bool { return ownerIDs[i] < ownerIDs[j] })
+	for _, id := range ownerIDs {
+		owner := m.owners[id]
+		fmt.Fprintf(&b, "o:%d=%s/%d;", id, owner.Session, owner.ExpiresUnixNs)
+	}
+	refs := make([]int, 0, len(m.snapshotRef))
+	for ref := range m.snapshotRef {
+		refs = append(refs, ref)
+	}
+	sort.Ints(refs)
+	for _, ref := range refs {
+		fmt.Fprintf(&b, "r:%d=%d;", ref, m.snapshotRef[ref])
+	}
+	versions := make([]uint64, 0, len(m.snapshots))
+	for version := range m.snapshots {
+		versions = append(versions, version)
+	}
+	sort.Slice(versions, func(i, j int) bool { return versions[i] < versions[j] })
+	for _, version := range versions {
+		snapshot := m.snapshots[version]
+		fmt.Fprintf(&b, "snap:%d:", version)
+		snapshotDentryKeys := make([]dentryKey, 0, len(snapshot.dentries))
+		for key := range snapshot.dentries {
+			snapshotDentryKeys = append(snapshotDentryKeys, key)
+		}
+		sort.Slice(snapshotDentryKeys, func(i, j int) bool {
+			if snapshotDentryKeys[i].parent != snapshotDentryKeys[j].parent {
+				return snapshotDentryKeys[i].parent < snapshotDentryKeys[j].parent
+			}
+			return snapshotDentryKeys[i].name < snapshotDentryKeys[j].name
+		})
+		for _, key := range snapshotDentryKeys {
+			dentry := snapshot.dentries[key]
+			fmt.Fprintf(&b, "d:%d/%s=%d/%s;", key.parent, key.name, dentry.Inode, dentry.Type)
+		}
+		snapshotInodeIDs := make([]fsmeta.InodeID, 0, len(snapshot.inodes))
+		for inode := range snapshot.inodes {
+			snapshotInodeIDs = append(snapshotInodeIDs, inode)
+		}
+		sort.Slice(snapshotInodeIDs, func(i, j int) bool { return snapshotInodeIDs[i] < snapshotInodeIDs[j] })
+		for _, id := range snapshotInodeIDs {
+			inode := snapshot.inodes[id]
+			fmt.Fprintf(&b, "i:%d=%s/%d/%d/%d/%x;", id, inode.Type, inode.Size, inode.Mode, inode.LinkCount, inode.OpaqueAttrs)
+		}
+	}
+	return b.String()
 }
 
 func describeObserved(observed []observedOperation) string {

--- a/fsmeta/contract/history.go
+++ b/fsmeta/contract/history.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"maps"
+	"slices"
 	"sort"
 	"strings"
 	"sync"
@@ -455,7 +456,7 @@ func modelFingerprint(m *Model) string {
 	for inode := range m.inodes {
 		inodeIDs = append(inodeIDs, inode)
 	}
-	sort.Slice(inodeIDs, func(i, j int) bool { return inodeIDs[i] < inodeIDs[j] })
+	slices.Sort(inodeIDs)
 	for _, id := range inodeIDs {
 		inode := m.inodes[id]
 		fmt.Fprintf(&b, "i:%d=%s/%d/%d/%d/%x;", id, inode.Type, inode.Size, inode.Mode, inode.LinkCount, inode.OpaqueAttrs)
@@ -464,7 +465,7 @@ func modelFingerprint(m *Model) string {
 	for id := range m.sessions {
 		sessionIDs = append(sessionIDs, id)
 	}
-	sort.Slice(sessionIDs, func(i, j int) bool { return sessionIDs[i] < sessionIDs[j] })
+	slices.Sort(sessionIDs)
 	for _, id := range sessionIDs {
 		session := m.sessions[id]
 		fmt.Fprintf(&b, "s:%s=%d/%d;", id, session.Inode, session.ExpiresUnixNs)
@@ -473,7 +474,7 @@ func modelFingerprint(m *Model) string {
 	for id := range m.owners {
 		ownerIDs = append(ownerIDs, id)
 	}
-	sort.Slice(ownerIDs, func(i, j int) bool { return ownerIDs[i] < ownerIDs[j] })
+	slices.Sort(ownerIDs)
 	for _, id := range ownerIDs {
 		owner := m.owners[id]
 		fmt.Fprintf(&b, "o:%d=%s/%d;", id, owner.Session, owner.ExpiresUnixNs)
@@ -490,7 +491,7 @@ func modelFingerprint(m *Model) string {
 	for version := range m.snapshots {
 		versions = append(versions, version)
 	}
-	sort.Slice(versions, func(i, j int) bool { return versions[i] < versions[j] })
+	slices.Sort(versions)
 	for _, version := range versions {
 		snapshot := m.snapshots[version]
 		fmt.Fprintf(&b, "snap:%d:", version)
@@ -512,7 +513,7 @@ func modelFingerprint(m *Model) string {
 		for inode := range snapshot.inodes {
 			snapshotInodeIDs = append(snapshotInodeIDs, inode)
 		}
-		sort.Slice(snapshotInodeIDs, func(i, j int) bool { return snapshotInodeIDs[i] < snapshotInodeIDs[j] })
+		slices.Sort(snapshotInodeIDs)
 		for _, id := range snapshotInodeIDs {
 			inode := snapshot.inodes[id]
 			fmt.Fprintf(&b, "i:%d=%s/%d/%d/%d/%x;", id, inode.Type, inode.Size, inode.Mode, inode.LinkCount, inode.OpaqueAttrs)

--- a/fsmeta/contract/history_test.go
+++ b/fsmeta/contract/history_test.go
@@ -24,7 +24,7 @@ func TestFSMetaExecutorConcurrentHistoryContract(t *testing.T) {
 			require.NoError(t, err)
 
 			ops := GenerateScript(seed, steps)
-			err = RunConcurrentBatches(context.Background(), executor, model, ops, batchSize)
+			err = RunConcurrentBatches(context.Background(), executor, model, ops, batchSize, HistoryOptions{})
 			require.NoError(t, err, "seed=%d steps=%d batch=%d", seed, steps, batchSize)
 		})
 	}

--- a/fsmeta/contract/history_test.go
+++ b/fsmeta/contract/history_test.go
@@ -6,6 +6,8 @@ import (
 	"testing"
 	"time"
 
+	nokverrors "github.com/feichai0017/NoKV/errors"
+	"github.com/feichai0017/NoKV/fsmeta"
 	fsmetaexec "github.com/feichai0017/NoKV/fsmeta/exec"
 	"github.com/stretchr/testify/require"
 )
@@ -28,4 +30,72 @@ func TestFSMetaExecutorConcurrentHistoryContract(t *testing.T) {
 			require.NoError(t, err, "seed=%d steps=%d batch=%d", seed, steps, batchSize)
 		})
 	}
+}
+
+func TestRunConcurrentBatchesHonorsIndeterminateErrorsWithBatchOne(t *testing.T) {
+	model := NewModel("vol")
+	err := RunConcurrentBatches(context.Background(), unavailableCreateExecutor{}, model, []Operation{{
+		Kind:   OpCreate,
+		Mount:  "vol",
+		Parent: fsmeta.RootInode,
+		Name:   "alpha",
+		Inode:  10,
+		Type:   fsmeta.InodeTypeFile,
+	}}, 1, HistoryOptions{AllowIndeterminateErrors: true})
+	require.NoError(t, err)
+}
+
+func TestIndeterminateHistoryErrorExcludesAborted(t *testing.T) {
+	require.False(t, isIndeterminateHistoryError(nokverrors.New(nokverrors.KindAborted, "client canceled")))
+	require.True(t, isIndeterminateHistoryError(nokverrors.New(nokverrors.KindRetryExhausted, "retry budget exhausted")))
+}
+
+type unavailableCreateExecutor struct{}
+
+func (unavailableCreateExecutor) Create(context.Context, fsmeta.CreateRequest, fsmeta.InodeRecord) error {
+	return nokverrors.New(nokverrors.KindRetryExhausted, "store unavailable after retry")
+}
+
+func (unavailableCreateExecutor) UpdateInode(context.Context, fsmeta.UpdateInodeRequest) (fsmeta.InodeRecord, error) {
+	return fsmeta.InodeRecord{}, fsmeta.ErrInvalidRequest
+}
+
+func (unavailableCreateExecutor) Lookup(context.Context, fsmeta.LookupRequest) (fsmeta.DentryRecord, error) {
+	return fsmeta.DentryRecord{}, fsmeta.ErrInvalidRequest
+}
+
+func (unavailableCreateExecutor) ReadDirPlus(context.Context, fsmeta.ReadDirRequest) ([]fsmeta.DentryAttrPair, error) {
+	return nil, fsmeta.ErrInvalidRequest
+}
+
+func (unavailableCreateExecutor) SnapshotSubtree(context.Context, fsmeta.SnapshotSubtreeRequest) (fsmeta.SnapshotSubtreeToken, error) {
+	return fsmeta.SnapshotSubtreeToken{}, fsmeta.ErrInvalidRequest
+}
+
+func (unavailableCreateExecutor) RenameSubtree(context.Context, fsmeta.RenameSubtreeRequest) error {
+	return fsmeta.ErrInvalidRequest
+}
+
+func (unavailableCreateExecutor) Link(context.Context, fsmeta.LinkRequest) error {
+	return fsmeta.ErrInvalidRequest
+}
+
+func (unavailableCreateExecutor) Unlink(context.Context, fsmeta.UnlinkRequest) error {
+	return fsmeta.ErrInvalidRequest
+}
+
+func (unavailableCreateExecutor) OpenWriteSession(context.Context, fsmeta.OpenWriteSessionRequest) (fsmeta.SessionRecord, error) {
+	return fsmeta.SessionRecord{}, fsmeta.ErrInvalidRequest
+}
+
+func (unavailableCreateExecutor) HeartbeatWriteSession(context.Context, fsmeta.HeartbeatWriteSessionRequest) (fsmeta.SessionRecord, error) {
+	return fsmeta.SessionRecord{}, fsmeta.ErrInvalidRequest
+}
+
+func (unavailableCreateExecutor) CloseWriteSession(context.Context, fsmeta.CloseWriteSessionRequest) error {
+	return fsmeta.ErrInvalidRequest
+}
+
+func (unavailableCreateExecutor) ExpireWriteSessions(context.Context, fsmeta.ExpireWriteSessionsRequest) (fsmeta.ExpireWriteSessionsResult, error) {
+	return fsmeta.ExpireWriteSessionsResult{}, fsmeta.ErrInvalidRequest
 }

--- a/fsmeta/contract/model.go
+++ b/fsmeta/contract/model.go
@@ -53,8 +53,8 @@ type Operation struct {
 }
 
 func (op Operation) String() string {
-	return fmt.Sprintf("%s mount=%s parent=%d name=%q inode=%d from=(%d,%q) to=(%d,%q) session=%q advance_ns=%d snapshot=%d",
-		op.Kind, op.Mount, op.Parent, op.Name, op.Inode, op.FromParent, op.FromName, op.ToParent, op.ToName, op.Session, op.AdvanceNs, op.SnapshotRef)
+	return fmt.Sprintf("%s mount=%s parent=%d name=%q inode=%d from=(%d,%q) to=(%d,%q) session=%q start_after=%q limit=%d advance_ns=%d snapshot=%d",
+		op.Kind, op.Mount, op.Parent, op.Name, op.Inode, op.FromParent, op.FromName, op.ToParent, op.ToName, op.Session, op.StartAfter, op.Limit, op.AdvanceNs, op.SnapshotRef)
 }
 
 // Result is the comparable response shape returned by both the reference model

--- a/fsmeta/exec/runner.go
+++ b/fsmeta/exec/runner.go
@@ -501,7 +501,9 @@ func (e *Executor) ReadDirPlus(ctx context.Context, req fsmeta.ReadDirRequest) (
 		pageKey = dirPageKey(req.Mount, req.Parent, req.StartAfter, plan.Limit)
 		frontier = e.dirPages.CurrentEpoch(pageKey.Directory())
 		if entries, ok := e.dirPages.Lookup(pageKey, frontier); ok {
-			return decodeDirPageEntries(pageKey, entries)
+			if cached, err := decodeDirPageEntries(pageKey, entries); err == nil {
+				return cached, nil
+			}
 		}
 	}
 
@@ -551,23 +553,25 @@ func (e *Executor) ReadDirPlus(ctx context.Context, req fsmeta.ReadDirRequest) (
 	}
 	if useDirPage {
 		// Materialize is best-effort: if Invalidate fired since we read,
-		// the cache drops the write and the next call re-fetches.
-		_ = e.dirPages.MaterializeAsync(pageKey, frontier, encodeDirPageEntries(out))
+		// the cache drops the write and the next call re-fetches. Encoding must
+		// be all-or-none: a partial cached page would be worse than a miss.
+		if entries, err := encodeDirPageEntries(out); err == nil {
+			_ = e.dirPages.MaterializeAsync(pageKey, frontier, entries)
+		}
 	}
 	return out, nil
 }
 
 // encodeDirPageEntries converts assembled DentryAttrPairs into the
-// generic dirpage Entry shape. AttrBlob is the encoded InodeRecord; if
-// encoding fails we drop the entry from the materialization so the cache
-// never serves a value the consumer can't decode (the next ReadDirPlus
-// re-runs the runner path).
-func encodeDirPageEntries(pairs []fsmeta.DentryAttrPair) []dirpage.Entry {
+// generic dirpage Entry shape. AttrBlob is the encoded InodeRecord; if any
+// entry cannot be encoded, the whole materialization is skipped so the cache
+// never serves a truncated page as complete.
+func encodeDirPageEntries(pairs []fsmeta.DentryAttrPair) ([]dirpage.Entry, error) {
 	out := make([]dirpage.Entry, 0, len(pairs))
 	for _, p := range pairs {
 		blob, err := fsmeta.EncodeInodeValue(p.Inode)
 		if err != nil {
-			continue
+			return nil, err
 		}
 		out = append(out, dirpage.Entry{
 			Name:     []byte(p.Dentry.Name),
@@ -575,7 +579,7 @@ func encodeDirPageEntries(pairs []fsmeta.DentryAttrPair) []dirpage.Entry {
 			AttrBlob: blob,
 		})
 	}
-	return out
+	return out, nil
 }
 
 // decodeDirPageEntries reverses encodeDirPageEntries. Decode failure on

--- a/fsmeta/exec/runner.go
+++ b/fsmeta/exec/runner.go
@@ -74,10 +74,10 @@ type NegativeCache interface {
 
 // DirPageCache is the ReadDirPlus page memo surface.
 type DirPageCache interface {
-	CurrentEpoch(dirpage.PageKey) uint64
+	CurrentEpoch(dirpage.DirectoryKey) uint64
 	Lookup(dirpage.PageKey, uint64) ([]dirpage.Entry, bool)
 	MaterializeAsync(dirpage.PageKey, uint64, []dirpage.Entry) error
-	Invalidate(dirpage.PageKey) uint64
+	Invalidate(dirpage.DirectoryKey) uint64
 	Stats() dirpage.Stats
 }
 
@@ -417,14 +417,25 @@ func (e *Executor) invalidateNegative(keys ...[]byte) {
 	}
 }
 
-// dirPageKey hashes (mount, parent) into the dirpage cache's PageKey
-// shape. fsmeta.MountID is a string; we use xxhash.Sum64 to fold it into
-// a uint64 mount slot. Collision probability across reasonable mount
-// counts (<= 10K) is ~5e-12, well below "fallback re-warm" tolerance.
-func dirPageKey(mount fsmeta.MountID, parent fsmeta.InodeID) dirpage.PageKey {
-	return dirpage.PageKey{
+// dirPageDirectoryKey hashes (mount, parent) into the dirpage cache's
+// directory invalidation key. fsmeta.MountID is a string; we use xxhash.Sum64
+// to fold it into a uint64 mount slot. Collision probability across reasonable
+// mount counts (<= 10K) is ~5e-12, well below "fallback re-warm" tolerance.
+func dirPageDirectoryKey(mount fsmeta.MountID, parent fsmeta.InodeID) dirpage.DirectoryKey {
+	return dirpage.DirectoryKey{
 		Mount:  xxhash.Sum64String(string(mount)),
 		Parent: uint64(parent),
+	}
+}
+
+// dirPageKey includes the caller-visible page cursor. ReadDirPlus cache hits
+// are only valid for the exact StartAfter/Limit shape that produced them.
+func dirPageKey(mount fsmeta.MountID, parent fsmeta.InodeID, startAfter string, limit uint32) dirpage.PageKey {
+	return dirpage.PageKey{
+		Mount:      xxhash.Sum64String(string(mount)),
+		Parent:     uint64(parent),
+		StartAfter: startAfter,
+		Limit:      limit,
 	}
 }
 
@@ -445,7 +456,7 @@ func (e *Executor) invalidateDirPages(mount fsmeta.MountID, parents ...fsmeta.In
 			continue
 		}
 		seen[p] = struct{}{}
-		e.dirPages.Invalidate(dirPageKey(mount, p))
+		e.dirPages.Invalidate(dirPageDirectoryKey(mount, p))
 	}
 }
 
@@ -487,10 +498,10 @@ func (e *Executor) ReadDirPlus(ctx context.Context, req fsmeta.ReadDirRequest) (
 	var pageKey dirpage.PageKey
 	var frontier uint64
 	if useDirPage {
-		pageKey = dirPageKey(req.Mount, req.Parent)
-		frontier = e.dirPages.CurrentEpoch(pageKey)
+		pageKey = dirPageKey(req.Mount, req.Parent, req.StartAfter, plan.Limit)
+		frontier = e.dirPages.CurrentEpoch(pageKey.Directory())
 		if entries, ok := e.dirPages.Lookup(pageKey, frontier); ok {
-			return decodeDirPageEntries(entries)
+			return decodeDirPageEntries(pageKey, entries)
 		}
 	}
 
@@ -541,7 +552,7 @@ func (e *Executor) ReadDirPlus(ctx context.Context, req fsmeta.ReadDirRequest) (
 	if useDirPage {
 		// Materialize is best-effort: if Invalidate fired since we read,
 		// the cache drops the write and the next call re-fetches.
-		_ = e.dirPages.MaterializeAsync(pageKey, frontier, encodeDirPageEntries(req, out))
+		_ = e.dirPages.MaterializeAsync(pageKey, frontier, encodeDirPageEntries(out))
 	}
 	return out, nil
 }
@@ -551,7 +562,7 @@ func (e *Executor) ReadDirPlus(ctx context.Context, req fsmeta.ReadDirRequest) (
 // encoding fails we drop the entry from the materialization so the cache
 // never serves a value the consumer can't decode (the next ReadDirPlus
 // re-runs the runner path).
-func encodeDirPageEntries(req fsmeta.ReadDirRequest, pairs []fsmeta.DentryAttrPair) []dirpage.Entry {
+func encodeDirPageEntries(pairs []fsmeta.DentryAttrPair) []dirpage.Entry {
 	out := make([]dirpage.Entry, 0, len(pairs))
 	for _, p := range pairs {
 		blob, err := fsmeta.EncodeInodeValue(p.Inode)
@@ -564,14 +575,13 @@ func encodeDirPageEntries(req fsmeta.ReadDirRequest, pairs []fsmeta.DentryAttrPa
 			AttrBlob: blob,
 		})
 	}
-	_ = req // reserved for future per-mount projection (e.g. xattr split)
 	return out
 }
 
 // decodeDirPageEntries reverses encodeDirPageEntries. Decode failure on
 // any entry treats the whole page set as corrupt and forces a fallback
 // to the runner.
-func decodeDirPageEntries(entries []dirpage.Entry) ([]fsmeta.DentryAttrPair, error) {
+func decodeDirPageEntries(key dirpage.PageKey, entries []dirpage.Entry) ([]fsmeta.DentryAttrPair, error) {
 	out := make([]fsmeta.DentryAttrPair, 0, len(entries))
 	for _, e := range entries {
 		inode, err := fsmeta.DecodeInodeValue(e.AttrBlob)
@@ -580,9 +590,10 @@ func decodeDirPageEntries(entries []dirpage.Entry) ([]fsmeta.DentryAttrPair, err
 		}
 		out = append(out, fsmeta.DentryAttrPair{
 			Dentry: fsmeta.DentryRecord{
-				Name:  string(e.Name),
-				Inode: fsmeta.InodeID(e.Inode),
-				Type:  inode.Type,
+				Parent: fsmeta.InodeID(key.Parent),
+				Name:   string(e.Name),
+				Inode:  fsmeta.InodeID(e.Inode),
+				Type:   inode.Type,
 			},
 			Inode: inode,
 		})

--- a/fsmeta/exec/runner_test.go
+++ b/fsmeta/exec/runner_test.go
@@ -1418,6 +1418,40 @@ func TestExecutorDirPageReadDirPlusCacheKeysPagination(t *testing.T) {
 	require.Equal(t, parent, firstPage[0].Dentry.Parent)
 }
 
+func TestExecutorDirPageDecodeFailureFallsBackToRunner(t *testing.T) {
+	runner := newFakeRunner()
+	cache := &corruptDirPageCache{}
+	executor, err := New(runner, WithDirPageCache(cache))
+	require.NoError(t, err)
+
+	mount := fsmeta.MountID("vol")
+	parent := fsmeta.RootInode
+	err = executor.Create(context.Background(), fsmeta.CreateRequest{
+		Mount: mount, Parent: parent, Name: "a", Inode: 10,
+	}, fsmeta.InodeRecord{Type: fsmeta.InodeTypeFile})
+	require.NoError(t, err)
+
+	out, err := executor.ReadDirPlus(context.Background(), fsmeta.ReadDirRequest{
+		Mount: mount, Parent: parent, Limit: 1,
+	})
+	require.NoError(t, err)
+	require.Len(t, out, 1)
+	require.Equal(t, "a", out[0].Dentry.Name)
+	require.NotEmpty(t, runner.scanVersions, "corrupt derived cache must fall back to the runner")
+}
+
+func TestEncodeDirPageEntriesRejectsPartialMaterialization(t *testing.T) {
+	_, err := encodeDirPageEntries([]fsmeta.DentryAttrPair{{
+		Dentry: fsmeta.DentryRecord{Parent: 1, Name: "bad", Inode: 10, Type: fsmeta.InodeTypeFile},
+		Inode: fsmeta.InodeRecord{
+			Inode:       10,
+			Type:        fsmeta.InodeTypeFile,
+			OpaqueAttrs: make([]byte, fsmeta.MaxInodeOpaqueAttrsBytes+1),
+		},
+	}})
+	require.Error(t, err)
+}
+
 func TestExecutorDirPageInvalidatedByCreate(t *testing.T) {
 	runner := newFakeRunner()
 	cache, err := dirpage.Open(dirpage.Config{Dir: t.TempDir()})
@@ -1451,3 +1485,19 @@ func TestExecutorDirPageInvalidatedByCreate(t *testing.T) {
 	require.Greater(t, len(runner.scanVersions), scansBefore,
 		"epoch bump must force a runner scan on the next ReadDirPlus")
 }
+
+type corruptDirPageCache struct{}
+
+func (c *corruptDirPageCache) CurrentEpoch(dirpage.DirectoryKey) uint64 { return 0 }
+
+func (c *corruptDirPageCache) Lookup(dirpage.PageKey, uint64) ([]dirpage.Entry, bool) {
+	return []dirpage.Entry{{Name: []byte("stale"), Inode: 999, AttrBlob: []byte("not-an-inode")}}, true
+}
+
+func (c *corruptDirPageCache) MaterializeAsync(dirpage.PageKey, uint64, []dirpage.Entry) error {
+	return nil
+}
+
+func (c *corruptDirPageCache) Invalidate(dirpage.DirectoryKey) uint64 { return 1 }
+
+func (c *corruptDirPageCache) Stats() dirpage.Stats { return dirpage.Stats{} }

--- a/fsmeta/exec/runner_test.go
+++ b/fsmeta/exec/runner_test.go
@@ -1380,9 +1380,42 @@ func TestExecutorDirPageReadDirPlusCacheHit(t *testing.T) {
 	// Second call: cache hit → no new Scan / BatchGet against the runner.
 	second, err := executor.ReadDirPlus(context.Background(), req)
 	require.NoError(t, err)
-	require.Len(t, second, 3)
+	require.Equal(t, first, second)
 	require.Equal(t, scansAfterFirst, len(runner.scanVersions),
 		"runner.Scan must not be called when dirpage cache hits")
+}
+
+func TestExecutorDirPageReadDirPlusCacheKeysPagination(t *testing.T) {
+	runner := newFakeRunner()
+	cache, err := dirpage.Open(dirpage.Config{Dir: t.TempDir()})
+	require.NoError(t, err)
+	defer func() { _ = cache.Close() }()
+	executor, err := New(runner, WithDirPageCache(cache))
+	require.NoError(t, err)
+
+	mount := fsmeta.MountID("vol")
+	parent := fsmeta.RootInode
+	for i, name := range []string{"a", "b", "c"} {
+		err := executor.Create(context.Background(), fsmeta.CreateRequest{
+			Mount: mount, Parent: parent, Name: name, Inode: fsmeta.InodeID(10 + i),
+		}, fsmeta.InodeRecord{Type: fsmeta.InodeTypeFile})
+		require.NoError(t, err)
+	}
+
+	// Materialize a non-leading page first. A later first-page request must not
+	// reuse it just because both requests target the same parent directory.
+	pageAfterA, err := executor.ReadDirPlus(context.Background(), fsmeta.ReadDirRequest{
+		Mount: mount, Parent: parent, StartAfter: "a", Limit: 1,
+	})
+	require.NoError(t, err)
+	require.Equal(t, "b", pageAfterA[0].Dentry.Name)
+
+	firstPage, err := executor.ReadDirPlus(context.Background(), fsmeta.ReadDirRequest{
+		Mount: mount, Parent: parent, Limit: 1,
+	})
+	require.NoError(t, err)
+	require.Equal(t, "a", firstPage[0].Dentry.Name)
+	require.Equal(t, parent, firstPage[0].Dentry.Parent)
 }
 
 func TestExecutorDirPageInvalidatedByCreate(t *testing.T) {

--- a/fsmeta/integration/history_contract_test.go
+++ b/fsmeta/integration/history_contract_test.go
@@ -26,7 +26,7 @@ func TestRaftstoreRuntimeFSMetaConcurrentHistoryOnSplitCluster(t *testing.T) {
 			}))
 			ops := fsmetacontract.GenerateScript(seed, steps)
 
-			err := fsmetacontract.RunConcurrentBatches(ctx, executor, model, ops, batchSize)
+			err := fsmetacontract.RunConcurrentBatches(ctx, executor, model, ops, batchSize, fsmetacontract.HistoryOptions{})
 			require.NoError(t, err, "seed=%d steps=%d batch=%d", seed, steps, batchSize)
 		})
 	}

--- a/fsmeta/server/errors.go
+++ b/fsmeta/server/errors.go
@@ -47,6 +47,7 @@ func rpcCodeForKind(kind nokverrors.Kind) codes.Code {
 		nokverrors.KindProtocolViolation:
 		return codes.FailedPrecondition
 	case nokverrors.KindRetryable,
+		nokverrors.KindRetryExhausted,
 		nokverrors.KindUnavailable,
 		nokverrors.KindRouteUnavailable,
 		nokverrors.KindRegionRouting,

--- a/fsmeta/server/service_test.go
+++ b/fsmeta/server/service_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	nokverrors "github.com/feichai0017/NoKV/errors"
 	"github.com/feichai0017/NoKV/fsmeta"
 	fsmetapb "github.com/feichai0017/NoKV/pb/fsmeta"
 	"github.com/stretchr/testify/require"
@@ -355,6 +356,7 @@ func TestGRPCServiceErrorMapping(t *testing.T) {
 		{name: "watch overflow", err: fsmeta.ErrWatchOverflow, code: codes.ResourceExhausted},
 		{name: "watch cursor expired", err: fsmeta.ErrWatchCursorExpired, code: codes.OutOfRange},
 		{name: "mount retired", err: fsmeta.ErrMountRetired, code: codes.FailedPrecondition},
+		{name: "retry exhausted", err: nokverrors.New(nokverrors.KindRetryExhausted, "fsmeta: retry exhausted"), code: codes.Unavailable},
 		{name: "internal", err: errors.New("boom"), code: codes.Internal},
 	}
 	for _, tt := range tests {

--- a/scripts/chaos/docker_fsmeta_history.sh
+++ b/scripts/chaos/docker_fsmeta_history.sh
@@ -13,6 +13,7 @@ BATCH="${NOKV_DOCKER_CHAOS_BATCH:-3}"
 TIMEOUT="${NOKV_DOCKER_CHAOS_TIMEOUT:-60s}"
 READY_TIMEOUT="${NOKV_DOCKER_CHAOS_READY_TIMEOUT:-180}"
 CHAOS_INTERVAL="${NOKV_DOCKER_CHAOS_INTERVAL:-5}"
+ALLOW_INDETERMINATE="${NOKV_DOCKER_CHAOS_ALLOW_INDETERMINATE:-1}"
 TOOLS_DIR="$(mktemp -d "${TMPDIR:-/tmp}/nokv-fsmeta-chaos.XXXXXX")"
 chaos_pid=""
 
@@ -172,14 +173,23 @@ if [[ "${NOKV_DOCKER_CHAOS_NEMESIS:-1}" == "1" ]]; then
   chaos_pid="$!"
 fi
 
-"$TOOLS_DIR/nokv-fsmeta-history" \
-  --addr "$ADDR" \
-  --mount "$MOUNT" \
-  --seed-start 1 \
-  --seeds "$SEEDS" \
-  --steps "$STEPS" \
-  --batch "$BATCH" \
+history_args=(
+  --addr "$ADDR"
+  --mount "$MOUNT"
+  --seed-start 1
+  --seeds "$SEEDS"
+  --steps "$STEPS"
+  --batch "$BATCH"
   --timeout "$TIMEOUT"
+)
+if [[ "$ALLOW_INDETERMINATE" == "1" ]]; then
+  # Process chaos can return Unavailable after a request crosses the service
+  # boundary. The checker keeps both commit and no-commit candidates for those
+  # operations instead of reporting a namespace-semantic mismatch.
+  history_args+=(--allow-indeterminate-errors)
+fi
+
+"$TOOLS_DIR/nokv-fsmeta-history" "${history_args[@]}"
 
 stop_chaos
 wait_fsmeta


### PR DESCRIPTION
## Summary

- make fsmeta concurrent history checking keep bounded alternative serializations instead of committing to the first legal order
- model Docker chaos availability errors as indeterminate mutation outcomes where the request may have crossed the service boundary
- isolate external fsmeta history seeds by shifting generated inode IDs into the per-seed scope
- fix dirpage cache identity so ReadDirPlus pages are keyed by mount, parent, StartAfter, and Limit while invalidation remains directory-scoped
- validate storage-backed coordinator root events against the durable root storage snapshot rather than a potentially stale local view

## Tests

- `go test ./coordinator/server ./coordinator/catalog ./fsmeta/contract ./fsmeta/client ./cmd/nokv-fsmeta-history ./cmd/nokv-fsmeta-soak -count=1`
- `NOKV_CONTRACT_HISTORY_SEEDS=64 NOKV_CONTRACT_HISTORY_STEPS=240 NOKV_CONTRACT_HISTORY_BATCH=3 go test ./fsmeta/contract -run TestFSMetaExecutorConcurrentHistoryContract -count=1`
- `go test ./engine/slab/dirpage ./fsmeta/exec -count=1`
- `go test ./fsmeta/... ./engine/slab/dirpage ./cmd/nokv-fsmeta-history -count=1`
- `NOKV_DOCKER_CHAOS_SEEDS=2 NOKV_DOCKER_CHAOS_STEPS=32 NOKV_DOCKER_CHAOS_BATCH=3 NOKV_DOCKER_CHAOS_TIMEOUT=120s NOKV_DOCKER_CHAOS_INTERVAL=2 NOKV_DOCKER_CHAOS_DOWN=1 ./scripts/chaos/docker_fsmeta_history.sh`

## Workflow Verification

- Public Docker Chaos: passed on `957ea6c5`
- Private Docker Chaos: passed on `957ea6c5`
- Public Nightly Correctness: passed on `957ea6c5`
- Private Nightly Correctness: passed on `957ea6c5`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added snapshot-based validation for root events
  * Enhanced error handling for indeterminate scenarios in concurrent operations

* **Bug Fixes**
  * Improved error code mapping for retry exhaustion conditions

* **Tests**
  * Added validation tests for snapshot-backed event verification
  * Expanded cache pagination behavior verification

* **Chores**
  * Optimized Docker build context
  * Updated chaos testing configuration

<!-- end of auto-generated comment: release notes by coderabbit.ai -->