### PR TITLE
Harden Eunomia authority protocol

### DIFF
--- a/coordinator/audit/report.go
+++ b/coordinator/audit/report.go
@@ -15,6 +15,7 @@ const (
 	FinalityDefectNone                  FinalityDefect = ""
 	FinalityDefectRetiredNotInherited   FinalityDefect = "retired_not_inherited"
 	FinalityDefectInvalidSuccessorBound FinalityDefect = "invalid_successor_bound"
+	FinalityDefectOrphanInheritance     FinalityDefect = "orphan_inheritance"
 )
 
 const (
@@ -27,6 +28,7 @@ const (
 type SnapshotAnomalies struct {
 	RetiredGrantNotInherited    bool
 	InvalidSuccessorBound       bool
+	OrphanInheritance           bool
 	LeaseStartCoverageViolation bool
 	FinalityDefect              FinalityDefect
 }
@@ -61,9 +63,10 @@ func BuildReport(snapshot rootview.Snapshot, holderID string, nowUnixNano int64)
 		ActiveGrant:            snapshot.ActiveGrant,
 		RetiredGrants:          append([]rootproto.GrantRetirement(nil), snapshot.RetiredGrants...),
 		GrantInheritances:      append([]rootproto.GrantInheritance(nil), snapshot.GrantInheritances...),
+		RetiredEraFloor:        snapshot.RetiredEraFloor,
 	}
 	for _, retirement := range report.RetiredGrants {
-		if retirement.Era > report.RetiredEraFloor {
+		if retirement.InheritedByGrantID != "" && retirement.Era > report.RetiredEraFloor {
 			report.RetiredEraFloor = retirement.Era
 		}
 		if retirement.Present() && retirement.InheritedByGrantID == "" {
@@ -71,7 +74,10 @@ func BuildReport(snapshot rootview.Snapshot, holderID string, nowUnixNano int64)
 		}
 	}
 	report.Anomalies.InvalidSuccessorBound = invalidSuccessorBound(report.ActiveGrant, report.RetiredGrants)
+	report.Anomalies.OrphanInheritance = orphanInheritance(report.RetiredGrants, report.GrantInheritances)
 	switch {
+	case report.Anomalies.OrphanInheritance:
+		report.Anomalies.FinalityDefect = FinalityDefectOrphanInheritance
 	case report.Anomalies.InvalidSuccessorBound:
 		report.Anomalies.FinalityDefect = FinalityDefectInvalidSuccessorBound
 	case report.Anomalies.RetiredGrantNotInherited:
@@ -115,8 +121,8 @@ func invalidSuccessorBound(grant rootproto.AuthorityGrant, retirements []rootpro
 			continue
 		}
 		for _, bound := range retirement.Bounds {
-			duty, ok := grant.Duty(bound.DutyID)
-			if !ok || !authorityBoundCovers(duty.Bound, bound.Bound) {
+			duty, ok := grant.DutyFor(bound.DutyID, bound.Scope)
+			if !ok || !rootproto.DutyBoundCovers(duty.Bound, bound.Bound) {
 				return true
 			}
 		}
@@ -124,21 +130,21 @@ func invalidSuccessorBound(grant rootproto.AuthorityGrant, retirements []rootpro
 	return false
 }
 
-func authorityBoundCovers(grant, usage rootproto.DutyBound) bool {
-	if grant.Kind != usage.Kind {
-		return false
+func orphanInheritance(retirements []rootproto.GrantRetirement, inheritances []rootproto.GrantInheritance) bool {
+	retired := make(map[string]rootproto.GrantRetirement, len(retirements))
+	for _, retirement := range retirements {
+		if retirement.GrantID != "" {
+			retired[retirement.GrantID] = retirement
+		}
 	}
-	switch usage.Kind {
-	case rootproto.DutyBoundMonotone:
-		return usage.MonotoneUpper <= grant.MonotoneUpper
-	case rootproto.DutyBoundVersion:
-		return usage.DescriptorRevisionCeiling <= grant.DescriptorRevisionCeiling &&
-			usage.MaxRootLag <= grant.MaxRootLag
-	case rootproto.DutyBoundBudget:
-		return usage.Budget <= grant.Budget
-	case rootproto.DutyBoundEpoch:
-		return usage.Epoch <= grant.Epoch
-	default:
-		return false
+	for _, inheritance := range inheritances {
+		retirement, ok := retired[inheritance.PredecessorGrantID]
+		if !ok {
+			return true
+		}
+		if retirement.InheritedByGrantID != "" && retirement.InheritedByGrantID != inheritance.SuccessorGrantID {
+			return true
+		}
 	}
+	return false
 }

--- a/coordinator/audit/report_test.go
+++ b/coordinator/audit/report_test.go
@@ -76,6 +76,7 @@ func TestBuildReportSurfacesRetiredNotInherited(t *testing.T) {
 	require.Equal(t, coordaudit.AuthorityCompletionRetiredNotInherited, report.AuthorityCompletion)
 	require.True(t, report.Anomalies.RetiredGrantNotInherited)
 	require.Equal(t, coordaudit.FinalityDefectRetiredNotInherited, report.Anomalies.FinalityDefect)
+	require.Zero(t, report.RetiredEraFloor)
 }
 
 func TestBuildReportSurfacesInvalidSuccessorBound(t *testing.T) {
@@ -99,6 +100,29 @@ func TestBuildReportSurfacesInvalidSuccessorBound(t *testing.T) {
 
 	require.True(t, report.Anomalies.InvalidSuccessorBound)
 	require.Equal(t, coordaudit.FinalityDefectInvalidSuccessorBound, report.Anomalies.FinalityDefect)
+}
+
+func TestBuildReportPreservesCompactedRetiredEraFloor(t *testing.T) {
+	report := coordaudit.BuildReport(rootview.Snapshot{
+		RetiredEraFloor: 3,
+		ActiveGrant: rootproto.AuthorityGrant{
+			GrantID: "g4",
+			Era:     4,
+			Duties:  []rootproto.DutyGrant{rootproto.NewGlobalMonotoneDuty(rootproto.DutyAllocID, 40)},
+		},
+	}, "c4", 1_000)
+
+	require.Equal(t, uint64(3), report.RetiredEraFloor)
+	require.Equal(t, coordaudit.FinalityDefectNone, report.Anomalies.FinalityDefect)
+}
+
+func TestBuildReportSurfacesOrphanInheritance(t *testing.T) {
+	report := coordaudit.BuildReport(rootview.Snapshot{
+		GrantInheritances: []rootproto.GrantInheritance{{PredecessorGrantID: "missing", SuccessorGrantID: "g2"}},
+	}, "c2", 1_000)
+
+	require.True(t, report.Anomalies.OrphanInheritance)
+	require.Equal(t, coordaudit.FinalityDefectOrphanInheritance, report.Anomalies.FinalityDefect)
 }
 
 func TestBuildLeaseStartCoverageReport(t *testing.T) {

--- a/coordinator/audit/trace.go
+++ b/coordinator/audit/trace.go
@@ -6,14 +6,21 @@ import "fmt"
 // It intentionally keeps the schema small so adapters can project external
 // traces into a common authority-gap vocabulary.
 type ReplyTraceRecord struct {
-	Source               string `json:"source,omitempty"`
-	Duty                 string `json:"duty"`
-	GrantID              string `json:"grant_id,omitempty"`
-	Era                  uint64 `json:"era"`
-	UsageUpper           uint64 `json:"usage_upper,omitempty"`
-	GrantUpper           uint64 `json:"grant_upper,omitempty"`
-	ObservedSuccessorEra uint64 `json:"observed_successor_era,omitempty"`
-	Accepted             bool   `json:"accepted"`
+	Source                  string `json:"source,omitempty"`
+	Duty                    string `json:"duty"`
+	GrantID                 string `json:"grant_id,omitempty"`
+	Era                     uint64 `json:"era"`
+	UsageUpper              uint64 `json:"usage_upper,omitempty"`
+	EvidenceUsageUpper      uint64 `json:"evidence_usage_upper,omitempty"`
+	GrantUpper              uint64 `json:"grant_upper,omitempty"`
+	ObservedRetiredEraFloor uint64 `json:"observed_retired_era_floor,omitempty"`
+	ObservedSuccessorEra    uint64 `json:"observed_successor_era,omitempty"`
+	ServedUnixNano          int64  `json:"served_unix_nano,omitempty"`
+	GrantExpiresUnixNano    int64  `json:"grant_expires_unix_nano,omitempty"`
+	MaxReplyAgeNano         int64  `json:"max_reply_age_nano,omitempty"`
+	EvidencePresent         bool   `json:"evidence_present,omitempty"`
+	SignatureValid          bool   `json:"signature_valid,omitempty"`
+	Accepted                bool   `json:"accepted"`
 }
 
 // ReplyTraceAnomaly captures one reply-level legality violation discovered by
@@ -86,6 +93,48 @@ func EvaluateReplyTrace(report Report, records []ReplyTraceRecord) []ReplyTraceA
 		if !record.Accepted {
 			continue
 		}
+		if requiresEunomiaEvidence(record) {
+			if !record.EvidencePresent {
+				anomalies = append(anomalies, ReplyTraceAnomaly{
+					Index:  idx,
+					Kind:   "accepted_missing_evidence",
+					Duty:   record.Duty,
+					Era:    record.Era,
+					Reason: "accepted NoKV authority reply without AuthorityEvidence",
+				})
+				continue
+			}
+			if !record.SignatureValid {
+				anomalies = append(anomalies, ReplyTraceAnomaly{
+					Index:  idx,
+					Kind:   "accepted_invalid_signature",
+					Duty:   record.Duty,
+					Era:    record.Era,
+					Reason: "accepted NoKV authority reply without a valid root grant signature",
+				})
+				continue
+			}
+		}
+		if record.EvidenceUsageUpper != 0 && record.UsageUpper > record.EvidenceUsageUpper {
+			anomalies = append(anomalies, ReplyTraceAnomaly{
+				Index:  idx,
+				Kind:   "reply_usage_not_covered_by_evidence",
+				Duty:   record.Duty,
+				Era:    record.Era,
+				Reason: fmt.Sprintf("accepted usage %d outside evidence usage %d", record.UsageUpper, record.EvidenceUsageUpper),
+			})
+			continue
+		}
+		if record.GrantUpper != 0 && record.EvidenceUsageUpper > record.GrantUpper {
+			anomalies = append(anomalies, ReplyTraceAnomaly{
+				Index:  idx,
+				Kind:   "evidence_outside_grant",
+				Duty:   record.Duty,
+				Era:    record.Era,
+				Reason: fmt.Sprintf("accepted evidence usage %d outside grant upper bound %d", record.EvidenceUsageUpper, record.GrantUpper),
+			})
+			continue
+		}
 		if record.GrantUpper != 0 && record.UsageUpper > record.GrantUpper {
 			anomalies = append(anomalies, ReplyTraceAnomaly{
 				Index:  idx,
@@ -93,6 +142,27 @@ func EvaluateReplyTrace(report Report, records []ReplyTraceRecord) []ReplyTraceA
 				Duty:   record.Duty,
 				Era:    record.Era,
 				Reason: fmt.Sprintf("accepted usage %d outside grant upper bound %d", record.UsageUpper, record.GrantUpper),
+			})
+			continue
+		}
+		if record.GrantExpiresUnixNano > 0 && record.ServedUnixNano > record.GrantExpiresUnixNano {
+			anomalies = append(anomalies, ReplyTraceAnomaly{
+				Index:  idx,
+				Kind:   "reply_served_after_grant_expiry",
+				Duty:   record.Duty,
+				Era:    record.Era,
+				Reason: fmt.Sprintf("accepted reply served at %d after grant expiry %d", record.ServedUnixNano, record.GrantExpiresUnixNano),
+			})
+			continue
+		}
+		if record.MaxReplyAgeNano > 0 && report.NowUnixNano > 0 && record.ServedUnixNano > 0 &&
+			report.NowUnixNano-record.ServedUnixNano > record.MaxReplyAgeNano {
+			anomalies = append(anomalies, ReplyTraceAnomaly{
+				Index:  idx,
+				Kind:   "reply_exceeds_max_age",
+				Duty:   record.Duty,
+				Era:    record.Era,
+				Reason: fmt.Sprintf("accepted reply age %d exceeds max age %d", report.NowUnixNano-record.ServedUnixNano, record.MaxReplyAgeNano),
 			})
 			continue
 		}
@@ -108,13 +178,14 @@ func EvaluateReplyTrace(report Report, records []ReplyTraceRecord) []ReplyTraceA
 				continue
 			}
 		}
-		if report.RetiredEraFloor != 0 && record.Era <= report.RetiredEraFloor {
+		retiredFloor := maxUint64(report.RetiredEraFloor, record.ObservedRetiredEraFloor)
+		if retiredFloor != 0 && record.Era <= retiredFloor {
 			anomalies = append(anomalies, ReplyTraceAnomaly{
 				Index:  idx,
 				Kind:   "accepted_retired_era_reply",
 				Duty:   record.Duty,
 				Era:    record.Era,
-				Reason: fmt.Sprintf("accepted reply era %d at or below retired era floor %d", record.Era, report.RetiredEraFloor),
+				Reason: fmt.Sprintf("accepted reply era %d at or below retired era floor %d", record.Era, retiredFloor),
 			})
 			continue
 		}
@@ -130,4 +201,16 @@ func EvaluateReplyTrace(report Report, records []ReplyTraceRecord) []ReplyTraceA
 		}
 	}
 	return anomalies
+}
+
+func requiresEunomiaEvidence(record ReplyTraceRecord) bool {
+	source := record.Source
+	return source == "" || source == "nokv"
+}
+
+func maxUint64(a, b uint64) uint64 {
+	if a >= b {
+		return a
+	}
+	return b
 }

--- a/coordinator/audit/trace_test.go
+++ b/coordinator/audit/trace_test.go
@@ -18,8 +18,8 @@ func TestEvaluateReplyTraceFlagsRetiredGrantReply(t *testing.T) {
 	}, "c2", 1_000)
 
 	anomalies := coordaudit.EvaluateReplyTrace(report, []coordaudit.ReplyTraceRecord{
-		{Duty: "alloc_id", GrantID: "g1", Era: 1, Accepted: true},
-		{Duty: "alloc_id", GrantID: "g2", Era: 2, Accepted: true},
+		{Source: "nokv", Duty: "alloc_id", GrantID: "g1", Era: 1, EvidencePresent: true, SignatureValid: true, Accepted: true},
+		{Source: "nokv", Duty: "alloc_id", GrantID: "g2", Era: 2, EvidencePresent: true, SignatureValid: true, Accepted: true},
 	})
 	require.Len(t, anomalies, 1)
 	require.Equal(t, "accepted_retired_grant_reply", anomalies[0].Kind)
@@ -28,11 +28,48 @@ func TestEvaluateReplyTraceFlagsRetiredGrantReply(t *testing.T) {
 
 func TestEvaluateReplyTraceFlagsReplyOutsideGrant(t *testing.T) {
 	anomalies := coordaudit.EvaluateReplyTrace(coordaudit.Report{}, []coordaudit.ReplyTraceRecord{
-		{Duty: "alloc_id", Era: 1, UsageUpper: 11, GrantUpper: 10, Accepted: true},
-		{Duty: "alloc_id", Era: 1, UsageUpper: 10, GrantUpper: 10, Accepted: true},
+		{Source: "nokv", Duty: "alloc_id", Era: 1, UsageUpper: 11, EvidenceUsageUpper: 11, GrantUpper: 10, EvidencePresent: true, SignatureValid: true, Accepted: true},
+		{Source: "nokv", Duty: "alloc_id", Era: 1, UsageUpper: 10, EvidenceUsageUpper: 10, GrantUpper: 10, EvidencePresent: true, SignatureValid: true, Accepted: true},
 	})
 	require.Len(t, anomalies, 1)
-	require.Equal(t, "reply_outside_grant", anomalies[0].Kind)
+	require.Equal(t, "evidence_outside_grant", anomalies[0].Kind)
+}
+
+func TestEvaluateReplyTraceFlagsReplyUsageNotCoveredByEvidence(t *testing.T) {
+	anomalies := coordaudit.EvaluateReplyTrace(coordaudit.Report{}, []coordaudit.ReplyTraceRecord{
+		{Source: "nokv", Duty: "alloc_id", Era: 1, UsageUpper: 900, EvidenceUsageUpper: 100, GrantUpper: 1_000, EvidencePresent: true, SignatureValid: true, Accepted: true},
+	})
+	require.Len(t, anomalies, 1)
+	require.Equal(t, "reply_usage_not_covered_by_evidence", anomalies[0].Kind)
+}
+
+func TestEvaluateReplyTraceFlagsMissingOrInvalidEvidence(t *testing.T) {
+	anomalies := coordaudit.EvaluateReplyTrace(coordaudit.Report{}, []coordaudit.ReplyTraceRecord{
+		{Source: "nokv", Duty: "tso", Era: 1, Accepted: true},
+		{Source: "nokv", Duty: "tso", Era: 2, EvidencePresent: true, SignatureValid: false, Accepted: true},
+	})
+	require.Len(t, anomalies, 2)
+	require.Equal(t, "accepted_missing_evidence", anomalies[0].Kind)
+	require.Equal(t, "accepted_invalid_signature", anomalies[1].Kind)
+}
+
+func TestEvaluateReplyTraceFlagsClockViolations(t *testing.T) {
+	report := coordaudit.Report{NowUnixNano: 2_000}
+	anomalies := coordaudit.EvaluateReplyTrace(report, []coordaudit.ReplyTraceRecord{
+		{Source: "nokv", Duty: "tso", Era: 1, ServedUnixNano: 1_100, GrantExpiresUnixNano: 1_000, EvidencePresent: true, SignatureValid: true, Accepted: true},
+		{Source: "nokv", Duty: "tso", Era: 2, ServedUnixNano: 1_000, GrantExpiresUnixNano: 3_000, MaxReplyAgeNano: 500, EvidencePresent: true, SignatureValid: true, Accepted: true},
+	})
+	require.Len(t, anomalies, 2)
+	require.Equal(t, "reply_served_after_grant_expiry", anomalies[0].Kind)
+	require.Equal(t, "reply_exceeds_max_age", anomalies[1].Kind)
+}
+
+func TestEvaluateReplyTraceUsesObservedRetiredFloor(t *testing.T) {
+	anomalies := coordaudit.EvaluateReplyTrace(coordaudit.Report{}, []coordaudit.ReplyTraceRecord{
+		{Source: "nokv", Duty: "region_lookup", Era: 3, ObservedRetiredEraFloor: 3, EvidencePresent: true, SignatureValid: true, Accepted: true},
+	})
+	require.Len(t, anomalies, 1)
+	require.Equal(t, "accepted_retired_era_reply", anomalies[0].Kind)
 }
 
 func TestEvaluateReplyTraceFlagsAcceptedReplyBehindSuccessor(t *testing.T) {

--- a/coordinator/client/client.go
+++ b/coordinator/client/client.go
@@ -47,11 +47,16 @@ type GRPCClient struct {
 	endpoints []grpcEndpoint
 	preferred int
 
-	verifyMu         sync.Mutex
-	allocGen         witnessEraFloor
-	tsoGen           witnessEraFloor
-	metadataGen      witnessEraFloor
-	metadataAttached metadataAttachedFloor
+	verifyMu             sync.Mutex
+	verifierStore        AuthorityVerifierStore
+	verifierClusterID    string
+	authorityClockSkew   time.Duration
+	authorityMaxReplyAge time.Duration
+	now                  func() time.Time
+	allocGen             witnessEraFloor
+	tsoGen               witnessEraFloor
+	metadataGen          witnessEraFloor
+	metadataAttached     metadataAttachedFloor
 }
 
 type grpcEndpoint struct {
@@ -61,9 +66,23 @@ type grpcEndpoint struct {
 }
 
 const maxAuthorityMissRetryRounds = 3
+const defaultAuthorityClockSkewAllowance = time.Second
+const defaultAuthorityMaxReplyAge = 30 * time.Second
+
+type GRPCClientOptions struct {
+	VerifierStore               AuthorityVerifierStore
+	VerifierClusterID           string
+	AuthorityClockSkewAllowance time.Duration
+	AuthorityMaxReplyAge        time.Duration
+	Now                         func() time.Time
+}
 
 // NewGRPCClient dials a Coordinator endpoint and returns a ready client.
 func NewGRPCClient(ctx context.Context, addr string, dialOpts ...grpc.DialOption) (*GRPCClient, error) {
+	return NewGRPCClientWithOptions(ctx, addr, GRPCClientOptions{}, dialOpts...)
+}
+
+func NewGRPCClientWithOptions(ctx context.Context, addr string, clientOpts GRPCClientOptions, dialOpts ...grpc.DialOption) (*GRPCClient, error) {
 	addrs, err := splitAddresses(addr)
 	if err != nil {
 		return nil, err
@@ -87,8 +106,33 @@ func NewGRPCClient(ctx context.Context, addr string, dialOpts ...grpc.DialOption
 			coord: coordpb.NewCoordinatorClient(conn),
 		})
 	}
+	store := clientOpts.VerifierStore
+	if store == nil {
+		store = NewMemoryAuthorityVerifierStore()
+	}
+	clusterID := strings.TrimSpace(clientOpts.VerifierClusterID)
+	if clusterID == "" {
+		clusterID = "default"
+	}
+	clockSkew := clientOpts.AuthorityClockSkewAllowance
+	if clockSkew <= 0 {
+		clockSkew = defaultAuthorityClockSkewAllowance
+	}
+	maxReplyAge := clientOpts.AuthorityMaxReplyAge
+	if maxReplyAge <= 0 {
+		maxReplyAge = defaultAuthorityMaxReplyAge
+	}
+	nowFn := clientOpts.Now
+	if nowFn == nil {
+		nowFn = time.Now
+	}
 	return &GRPCClient{
-		endpoints: endpoints,
+		endpoints:            endpoints,
+		verifierStore:        store,
+		verifierClusterID:    clusterID,
+		authorityClockSkew:   clockSkew,
+		authorityMaxReplyAge: maxReplyAge,
+		now:                  nowFn,
 	}, nil
 }
 
@@ -711,10 +755,10 @@ func (c *GRPCClient) validateMonotoneWitness(kind string, duty rootproto.DutyID,
 	if consumedFrontier != expectedFrontier {
 		return fmt.Errorf("%w: %s consumed_frontier=%d expected=%d", errInvalidWitness, kind, consumedFrontier, expectedFrontier)
 	}
-	if err := validateAuthorityEvidence(kind, duty, era, observedRetiredEraFloor, rootproto.DutyBound{Kind: rootproto.DutyBoundMonotone, MonotoneUpper: consumedFrontier}, evidence); err != nil {
+	if err := c.validateAuthorityEvidence(kind, duty, era, observedRetiredEraFloor, rootproto.DutyBound{Kind: rootproto.DutyBoundMonotone, MonotoneUpper: consumedFrontier}, evidence); err != nil {
 		return err
 	}
-	return c.advanceWitnessEraFloor(kind, era, observedRetiredEraFloor, floor)
+	return c.advanceWitnessEraFloor(kind, duty, era, observedRetiredEraFloor, floor)
 }
 
 func (c *GRPCClient) validateMetadataWitnessEra(resp *coordpb.GetRegionByKeyResponse) error {
@@ -740,13 +784,16 @@ func (c *GRPCClient) validateMetadataWitnessEra(resp *coordpb.GetRegionByKeyResp
 		}
 		return c.advanceAttachedMetadataFloor(resp)
 	}
-	if err := validateAuthorityEvidence("get_region_by_key", rootproto.DutyRegionLookup, era, resp.GetObservedRetiredEraFloor(), rootproto.DutyBound{Kind: rootproto.DutyBoundVersion, DescriptorRevisionCeiling: resp.GetDescriptorRevision()}, resp.GetAuthorityEvidence()); err != nil {
+	if err := c.validateAuthorityEvidence("get_region_by_key", rootproto.DutyRegionLookup, era, resp.GetObservedRetiredEraFloor(), rootproto.DutyBound{Kind: rootproto.DutyBoundVersion, DescriptorRevisionCeiling: resp.GetDescriptorRevision()}, resp.GetAuthorityEvidence()); err != nil {
 		return err
 	}
-	return c.advanceWitnessEraFloor("get_region_by_key", era, resp.GetObservedRetiredEraFloor(), &c.metadataGen)
+	if err := c.advanceWitnessEraFloor("get_region_by_key", rootproto.DutyRegionLookup, era, resp.GetObservedRetiredEraFloor(), &c.metadataGen); err != nil {
+		return err
+	}
+	return c.advanceMetadataVerifierRootFloor(resp)
 }
 
-func validateAuthorityEvidence(kind string, duty rootproto.DutyID, era, observedRetiredEraFloor uint64, required rootproto.DutyBound, pbEvidence *metapb.RootAuthorityEvidence) error {
+func (c *GRPCClient) validateAuthorityEvidence(kind string, duty rootproto.DutyID, era, observedRetiredEraFloor uint64, required rootproto.DutyBound, pbEvidence *metapb.RootAuthorityEvidence) error {
 	if era == rootproto.AuthorityEraAttached {
 		if duty != rootproto.DutyRegionLookup {
 			return fmt.Errorf("%w: %s attached era is only valid for metadata witnesses", errInvalidWitness, kind)
@@ -774,41 +821,51 @@ func validateAuthorityEvidence(kind string, duty rootproto.DutyID, era, observed
 	if cert.Grant.Era != era {
 		return fmt.Errorf("%w: %s grant_era=%d reply_era=%d", errInvalidWitness, kind, cert.Grant.Era, era)
 	}
-	if cert.Grant.ExpiresUnixNano <= time.Now().UnixNano() {
+	nowUnixNano := time.Now().UnixNano()
+	clockSkew := defaultAuthorityClockSkewAllowance
+	maxReplyAge := defaultAuthorityMaxReplyAge
+	if c != nil {
+		if c.now != nil {
+			nowUnixNano = c.now().UnixNano()
+		}
+		if c.authorityClockSkew > 0 {
+			clockSkew = c.authorityClockSkew
+		}
+		if c.authorityMaxReplyAge > 0 {
+			maxReplyAge = c.authorityMaxReplyAge
+		}
+	}
+	if evidence.ServedUnixNano <= 0 {
+		return fmt.Errorf("%w: %s authority evidence missing served_unix_nano", errInvalidWitness, kind)
+	}
+	if evidence.ServedUnixNano > nowUnixNano+clockSkew.Nanoseconds() {
+		return fmt.Errorf("%w: %s authority evidence served in the future", errInvalidWitness, kind)
+	}
+	if nowUnixNano-evidence.ServedUnixNano > maxReplyAge.Nanoseconds() {
+		return fmt.Errorf("%w: %s authority evidence exceeds max reply age", errInvalidWitness, kind)
+	}
+	if evidence.ServedUnixNano > cert.Grant.ExpiresUnixNano {
+		return fmt.Errorf("%w: %s authority evidence served after grant expiry", errInvalidWitness, kind)
+	}
+	if cert.Grant.ExpiresUnixNano+clockSkew.Nanoseconds() <= nowUnixNano {
 		return fmt.Errorf("%w: %s authority evidence expired", errInvalidWitness, kind)
 	}
 	if evidence.Usage.DutyID != duty {
 		return fmt.Errorf("%w: %s evidence_duty=%s required=%s", errInvalidWitness, kind, evidence.Usage.DutyID, duty)
 	}
-	grantDuty, ok := cert.Grant.Duty(duty)
+	if !rootproto.ValidateAuthorityUsage(evidence.Usage) {
+		return fmt.Errorf("%w: %s authority evidence has invalid duty scope or usage", errInvalidWitness, kind)
+	}
+	grantDuty, ok := cert.Grant.DutyFor(duty, evidence.Usage.Scope)
 	if !ok ||
-		!authorityEvidenceBoundCovers(grantDuty.Bound, evidence.Usage.Usage) ||
-		!authorityEvidenceBoundCovers(evidence.Usage.Usage, required) {
+		!rootproto.DutyBoundCovers(grantDuty.Bound, evidence.Usage.Usage) ||
+		!rootproto.DutyBoundCovers(evidence.Usage.Usage, required) {
 		return fmt.Errorf("%w: %s usage outside grant", errInvalidWitness, kind)
 	}
 	if observedRetiredEraFloor != 0 && evidence.ObservedRetiredEraFloor < observedRetiredEraFloor {
 		return fmt.Errorf("%w: %s observed_retired_floor=%d reply_observed=%d", errInvalidWitness, kind, evidence.ObservedRetiredEraFloor, observedRetiredEraFloor)
 	}
 	return nil
-}
-
-func authorityEvidenceBoundCovers(grant, usage rootproto.DutyBound) bool {
-	if grant.Kind != usage.Kind {
-		return false
-	}
-	switch usage.Kind {
-	case rootproto.DutyBoundMonotone:
-		return usage.MonotoneUpper <= grant.MonotoneUpper
-	case rootproto.DutyBoundVersion:
-		return usage.DescriptorRevisionCeiling <= grant.DescriptorRevisionCeiling &&
-			usage.MaxRootLag <= grant.MaxRootLag
-	case rootproto.DutyBoundBudget:
-		return usage.Budget <= grant.Budget
-	case rootproto.DutyBoundEpoch:
-		return usage.Epoch <= grant.Epoch
-	default:
-		return false
-	}
 }
 
 func (c *GRPCClient) advanceAttachedMetadataFloor(resp *coordpb.GetRegionByKeyResponse) error {
@@ -832,35 +889,136 @@ func (c *GRPCClient) advanceAttachedMetadataFloor(resp *coordpb.GetRegionByKeyRe
 			c.metadataAttached.descriptorRevision,
 		)
 	}
+	storeState, err := c.loadVerifierStateLocked(rootproto.DutyRegionLookup)
+	if err != nil {
+		return err
+	}
+	if !authorityRootTokenZero(storeState.MaxRootToken) &&
+		!metadataRootTokenSatisfied(currentToken, authorityRootTokenToCoordProto(storeState.MaxRootToken)) {
+		return fmt.Errorf(
+			"%w: get_region_by_key era=0 current_root_token regressed behind durable verifier floor",
+			errInvalidWitness,
+		)
+	}
+	if storeState.MaxDescriptorRevision != 0 &&
+		resp.GetDescriptorRevision() != 0 &&
+		resp.GetDescriptorRevision() < storeState.MaxDescriptorRevision {
+		return fmt.Errorf(
+			"%w: get_region_by_key era=0 descriptor_revision=%d durable_floor=%d",
+			errInvalidWitness,
+			resp.GetDescriptorRevision(),
+			storeState.MaxDescriptorRevision,
+		)
+	}
 
 	if currentToken != nil {
 		c.metadataAttached.currentToken = proto.Clone(currentToken).(*coordpb.RootToken)
 		c.metadataAttached.hasCurrentToken = true
+		storeState.MaxRootToken = authorityRootTokenFromCoordProto(currentToken)
 	}
 	if resp.GetDescriptorRevision() > c.metadataAttached.descriptorRevision {
 		c.metadataAttached.descriptorRevision = resp.GetDescriptorRevision()
 	}
+	if resp.GetDescriptorRevision() > storeState.MaxDescriptorRevision {
+		storeState.MaxDescriptorRevision = resp.GetDescriptorRevision()
+	}
+	if err := c.saveVerifierStateLocked(storeState); err != nil {
+		return err
+	}
 	return nil
 }
 
-func (c *GRPCClient) advanceWitnessEraFloor(kind string, era, observedRetiredEraFloor uint64, floor *witnessEraFloor) error {
+func (c *GRPCClient) advanceMetadataVerifierRootFloor(resp *coordpb.GetRegionByKeyResponse) error {
+	c.verifyMu.Lock()
+	defer c.verifyMu.Unlock()
+	storeState, err := c.loadVerifierStateLocked(rootproto.DutyRegionLookup)
+	if err != nil {
+		return err
+	}
+	currentToken := resp.GetCurrentRootToken()
+	if !authorityRootTokenZero(storeState.MaxRootToken) &&
+		!metadataRootTokenSatisfied(currentToken, authorityRootTokenToCoordProto(storeState.MaxRootToken)) {
+		return fmt.Errorf("%w: get_region_by_key current_root_token regressed behind durable verifier floor", errInvalidWitness)
+	}
+	if storeState.MaxDescriptorRevision != 0 &&
+		resp.GetDescriptorRevision() != 0 &&
+		resp.GetDescriptorRevision() < storeState.MaxDescriptorRevision {
+		return fmt.Errorf("%w: get_region_by_key descriptor_revision=%d durable_floor=%d", errInvalidWitness, resp.GetDescriptorRevision(), storeState.MaxDescriptorRevision)
+	}
+	if currentToken != nil {
+		storeState.MaxRootToken = authorityRootTokenFromCoordProto(currentToken)
+	}
+	if resp.GetDescriptorRevision() > storeState.MaxDescriptorRevision {
+		storeState.MaxDescriptorRevision = resp.GetDescriptorRevision()
+	}
+	return c.saveVerifierStateLocked(storeState)
+}
+
+func (c *GRPCClient) advanceWitnessEraFloor(kind string, duty rootproto.DutyID, era, observedRetiredEraFloor uint64, floor *witnessEraFloor) error {
 	c.verifyMu.Lock()
 	defer c.verifyMu.Unlock()
 	if era == rootproto.AuthorityEraSuppressed {
 		return fmt.Errorf("%w: %s era suppressed", errInvalidWitness, kind)
 	}
-	nextRetiredSeen := max(observedRetiredEraFloor, floor.retiredSeen)
+	storeState, err := c.loadVerifierStateLocked(duty)
+	if err != nil {
+		return err
+	}
+	currentRetiredSeen := max(floor.retiredSeen, storeState.RetiredEraFloor)
+	currentMaxSeen := max(floor.maxSeen, storeState.MaxSeenEra)
+	nextRetiredSeen := max(observedRetiredEraFloor, currentRetiredSeen)
 	if nextRetiredSeen != 0 && era <= nextRetiredSeen {
 		return fmt.Errorf("%w: %s era=%d retired_floor=%d", errStaleWitnessEra, kind, era, nextRetiredSeen)
 	}
-	if era < floor.maxSeen {
-		return fmt.Errorf("%w: %s era=%d max_seen=%d", errStaleWitnessEra, kind, era, floor.maxSeen)
+	if era < currentMaxSeen {
+		return fmt.Errorf("%w: %s era=%d max_seen=%d", errStaleWitnessEra, kind, era, currentMaxSeen)
+	}
+	nextMaxSeen := max(era, currentMaxSeen)
+	storeState.MaxSeenEra = nextMaxSeen
+	storeState.RetiredEraFloor = nextRetiredSeen
+	if err := c.saveVerifierStateLocked(storeState); err != nil {
+		return err
 	}
 	floor.retiredSeen = nextRetiredSeen
-	if era > floor.maxSeen {
-		floor.maxSeen = era
+	floor.maxSeen = nextMaxSeen
+	return nil
+}
+
+func (c *GRPCClient) loadVerifierStateLocked(duty rootproto.DutyID) (AuthorityVerifierState, error) {
+	key := c.authorityVerifierKey(duty)
+	if c == nil || c.verifierStore == nil {
+		return AuthorityVerifierState{Key: key}, nil
+	}
+	state, err := c.verifierStore.LoadAuthorityVerifier(key)
+	if err != nil {
+		return AuthorityVerifierState{}, fmt.Errorf("%w: load authority verifier state: %v", errInvalidWitness, err)
+	}
+	if state.Key.ClusterID == "" {
+		state.Key = key
+	}
+	return state, nil
+}
+
+func (c *GRPCClient) saveVerifierStateLocked(state AuthorityVerifierState) error {
+	if c == nil || c.verifierStore == nil {
+		return nil
+	}
+	if err := c.verifierStore.SaveAuthorityVerifier(state); err != nil {
+		return fmt.Errorf("%w: save authority verifier state: %v", errInvalidWitness, err)
 	}
 	return nil
+}
+
+func (c *GRPCClient) authorityVerifierKey(duty rootproto.DutyID) AuthorityVerifierKey {
+	clusterID := "default"
+	if c != nil && strings.TrimSpace(c.verifierClusterID) != "" {
+		clusterID = strings.TrimSpace(c.verifierClusterID)
+	}
+	return AuthorityVerifierKey{
+		ClusterID: clusterID,
+		DutyID:    duty,
+		Scope:     rootproto.DutyScope{Kind: rootproto.DutyScopeGlobal},
+	}
 }
 
 func requestedAllocIDCount(req *coordpb.AllocIDRequest) uint64 {
@@ -934,6 +1092,29 @@ func metadataRootTokenSatisfied(current, required *coordpb.RootToken) bool {
 
 func metadataRootTokenZero(token *coordpb.RootToken) bool {
 	return token == nil || (token.GetTerm() == 0 && token.GetIndex() == 0 && token.GetRevision() == 0)
+}
+
+func authorityRootTokenZero(token rootproto.AuthorityRootToken) bool {
+	return token.Term == 0 && token.Index == 0 && token.Revision == 0
+}
+
+func authorityRootTokenFromCoordProto(token *coordpb.RootToken) rootproto.AuthorityRootToken {
+	if token == nil {
+		return rootproto.AuthorityRootToken{}
+	}
+	return rootproto.AuthorityRootToken{
+		Term:     token.GetTerm(),
+		Index:    token.GetIndex(),
+		Revision: token.GetRevision(),
+	}
+}
+
+func authorityRootTokenToCoordProto(token rootproto.AuthorityRootToken) *coordpb.RootToken {
+	return &coordpb.RootToken{
+		Term:     token.Term,
+		Index:    token.Index,
+		Revision: token.Revision,
+	}
 }
 
 func metadataCursorAfter(a, b *coordpb.RootToken) bool {

--- a/coordinator/client/client_test.go
+++ b/coordinator/client/client_test.go
@@ -1062,9 +1062,11 @@ func TestValidateAuthorityEvidenceBindsReplyUsageToEvidence(t *testing.T) {
 			Scope:  rootproto.DutyScope{Kind: rootproto.DutyScopeGlobal},
 			Usage:  rootproto.DutyBound{Kind: rootproto.DutyBoundMonotone, MonotoneUpper: 100},
 		},
+		ServedUnixNano: time.Now().UnixNano(),
 	})
 
-	err = validateAuthorityEvidence("alloc_id", rootproto.DutyAllocID, 2, 0, rootproto.DutyBound{Kind: rootproto.DutyBoundMonotone, MonotoneUpper: 900}, evidence)
+	cli := &GRPCClient{verifierStore: NewMemoryAuthorityVerifierStore(), verifierClusterID: "test", now: time.Now}
+	err = cli.validateAuthorityEvidence("alloc_id", rootproto.DutyAllocID, 2, 0, rootproto.DutyBound{Kind: rootproto.DutyBoundMonotone, MonotoneUpper: 900}, evidence)
 	require.Error(t, err)
 	require.True(t, IsInvalidWitness(err))
 	require.Contains(t, err.Error(), "usage outside grant")
@@ -1074,15 +1076,63 @@ func TestAdvanceWitnessEraFloorDoesNotPersistRejectedFloor(t *testing.T) {
 	cli := &GRPCClient{}
 	floor := witnessEraFloor{maxSeen: 5}
 
-	err := cli.advanceWitnessEraFloor("alloc_id", 4, 10, &floor)
+	err := cli.advanceWitnessEraFloor("alloc_id", rootproto.DutyAllocID, 4, 10, &floor)
 	require.Error(t, err)
 	require.True(t, IsStaleWitnessEra(err))
 	require.Zero(t, floor.retiredSeen)
 	require.Equal(t, uint64(5), floor.maxSeen)
 
-	require.NoError(t, cli.advanceWitnessEraFloor("alloc_id", 6, 0, &floor))
+	require.NoError(t, cli.advanceWitnessEraFloor("alloc_id", rootproto.DutyAllocID, 6, 0, &floor))
 	require.Zero(t, floor.retiredSeen)
 	require.Equal(t, uint64(6), floor.maxSeen)
+}
+
+func TestFileAuthorityVerifierStorePersistsFloorAcrossRestart(t *testing.T) {
+	path := t.TempDir() + "/authority-verifier.pb"
+	store := NewFileAuthorityVerifierStore(path)
+	cli := &GRPCClient{verifierStore: store, verifierClusterID: "cluster-a"}
+	floor := witnessEraFloor{}
+
+	require.NoError(t, cli.advanceWitnessEraFloor("alloc_id", rootproto.DutyAllocID, 2, 1, &floor))
+
+	restarted := &GRPCClient{
+		verifierStore:     NewFileAuthorityVerifierStore(path),
+		verifierClusterID: "cluster-a",
+	}
+	var restartedFloor witnessEraFloor
+	err := restarted.advanceWitnessEraFloor("alloc_id", rootproto.DutyAllocID, 1, 0, &restartedFloor)
+	require.Error(t, err)
+	require.True(t, IsStaleWitnessEra(err))
+	require.Contains(t, err.Error(), "retired_floor=1")
+}
+
+func TestValidateAuthorityEvidenceRejectsMissingServedTime(t *testing.T) {
+	grant := rootproto.AuthorityGrant{
+		GrantID:         "grant-2",
+		HolderID:        "holder",
+		Era:             2,
+		ExpiresUnixNano: time.Now().Add(time.Hour).UnixNano(),
+		Duties:          []rootproto.DutyGrant{rootproto.NewGlobalMonotoneDuty(rootproto.DutyAllocID, 10)},
+	}
+	payload, err := proto.MarshalOptions{Deterministic: true}.Marshal(metawire.RootAuthorityGrantToProto(grant))
+	require.NoError(t, err)
+	evidence := metawire.RootAuthorityEvidenceToProto(rootproto.AuthorityEvidence{
+		Certificate: rootproto.GrantCertificate{
+			Grant:       grant,
+			SignerKeyID: rootproto.GrantSignerKeyID,
+			Signature:   rootproto.SignGrantBytes(payload),
+		},
+		Usage: rootproto.AuthorityUsage{
+			DutyID: rootproto.DutyAllocID,
+			Scope:  rootproto.DutyScope{Kind: rootproto.DutyScopeGlobal},
+			Usage:  rootproto.DutyBound{Kind: rootproto.DutyBoundMonotone, MonotoneUpper: 10},
+		},
+	})
+	cli := &GRPCClient{verifierStore: NewMemoryAuthorityVerifierStore(), verifierClusterID: "test"}
+	err = cli.validateAuthorityEvidence("alloc_id", rootproto.DutyAllocID, 2, 0, rootproto.DutyBound{Kind: rootproto.DutyBoundMonotone, MonotoneUpper: 10}, evidence)
+	require.Error(t, err)
+	require.True(t, IsInvalidWitness(err))
+	require.Contains(t, err.Error(), "missing served_unix_nano")
 }
 
 func TestGRPCClientRejectsReplyAtObservedSealFloor(t *testing.T) {
@@ -1298,6 +1348,7 @@ func defaultAuthorityEvidence(duty rootproto.DutyID, usage rootproto.DutyBound, 
 			Usage:  usage,
 		},
 		ObservedRetiredEraFloor: observedRetiredEra,
+		ServedUnixNano:          time.Now().UnixNano(),
 	})
 }
 

--- a/coordinator/client/verifier_store.go
+++ b/coordinator/client/verifier_store.go
@@ -1,0 +1,230 @@
+package client
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"sync"
+
+	rootproto "github.com/feichai0017/NoKV/meta/root/protocol"
+	metawire "github.com/feichai0017/NoKV/meta/wire"
+	metapb "github.com/feichai0017/NoKV/pb/meta"
+	"google.golang.org/protobuf/proto"
+)
+
+type AuthorityVerifierKey struct {
+	ClusterID string
+	DutyID    rootproto.DutyID
+	Scope     rootproto.DutyScope
+}
+
+type AuthorityVerifierState struct {
+	Key                   AuthorityVerifierKey
+	MaxSeenEra            uint64
+	RetiredEraFloor       uint64
+	MaxRootToken          rootproto.AuthorityRootToken
+	MaxDescriptorRevision uint64
+	MaxFrontier           rootproto.DutyBound
+}
+
+type AuthorityVerifierStore interface {
+	LoadAuthorityVerifier(key AuthorityVerifierKey) (AuthorityVerifierState, error)
+	SaveAuthorityVerifier(state AuthorityVerifierState) error
+}
+
+type MemoryAuthorityVerifierStore struct {
+	mu     sync.Mutex
+	states map[string]AuthorityVerifierState
+}
+
+func NewMemoryAuthorityVerifierStore() *MemoryAuthorityVerifierStore {
+	return &MemoryAuthorityVerifierStore{states: make(map[string]AuthorityVerifierState)}
+}
+
+func (s *MemoryAuthorityVerifierStore) LoadAuthorityVerifier(key AuthorityVerifierKey) (AuthorityVerifierState, error) {
+	if s == nil {
+		return AuthorityVerifierState{Key: key}, nil
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	state, ok := s.states[authorityVerifierKeyString(key)]
+	if !ok {
+		state.Key = key
+	}
+	return state, nil
+}
+
+func (s *MemoryAuthorityVerifierStore) SaveAuthorityVerifier(state AuthorityVerifierState) error {
+	if s == nil {
+		return nil
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.states == nil {
+		s.states = make(map[string]AuthorityVerifierState)
+	}
+	s.states[authorityVerifierKeyString(state.Key)] = state
+	return nil
+}
+
+type FileAuthorityVerifierStore struct {
+	mu     sync.Mutex
+	path   string
+	loaded bool
+	states map[string]AuthorityVerifierState
+}
+
+func NewFileAuthorityVerifierStore(path string) *FileAuthorityVerifierStore {
+	return &FileAuthorityVerifierStore{path: path}
+}
+
+func (s *FileAuthorityVerifierStore) LoadAuthorityVerifier(key AuthorityVerifierKey) (AuthorityVerifierState, error) {
+	if s == nil {
+		return AuthorityVerifierState{Key: key}, nil
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if err := s.loadLocked(); err != nil {
+		return AuthorityVerifierState{}, err
+	}
+	state, ok := s.states[authorityVerifierKeyString(key)]
+	if !ok {
+		state.Key = key
+	}
+	return state, nil
+}
+
+func (s *FileAuthorityVerifierStore) SaveAuthorityVerifier(state AuthorityVerifierState) error {
+	if s == nil {
+		return nil
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if err := s.loadLocked(); err != nil {
+		return err
+	}
+	s.states[authorityVerifierKeyString(state.Key)] = state
+	return s.flushLocked()
+}
+
+func (s *FileAuthorityVerifierStore) loadLocked() error {
+	if s.loaded {
+		return nil
+	}
+	if s.path == "" {
+		return errors.New("authority verifier store path is empty")
+	}
+	s.states = make(map[string]AuthorityVerifierState)
+	raw, err := os.ReadFile(s.path)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			s.loaded = true
+			return nil
+		}
+		return err
+	}
+	var pbStore metapb.RootAuthorityVerifierStore
+	if err := proto.Unmarshal(raw, &pbStore); err != nil {
+		return err
+	}
+	for _, pbState := range pbStore.GetStates() {
+		state := authorityVerifierStateFromProto(pbState)
+		s.states[authorityVerifierKeyString(state.Key)] = state
+	}
+	s.loaded = true
+	return nil
+}
+
+func (s *FileAuthorityVerifierStore) flushLocked() error {
+	keys := make([]string, 0, len(s.states))
+	for key := range s.states {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	pbStore := &metapb.RootAuthorityVerifierStore{States: make([]*metapb.RootAuthorityVerifierState, 0, len(keys))}
+	for _, key := range keys {
+		pbStore.States = append(pbStore.States, authorityVerifierStateToProto(s.states[key]))
+	}
+	raw, err := proto.MarshalOptions{Deterministic: true}.Marshal(pbStore)
+	if err != nil {
+		return err
+	}
+	dir := filepath.Dir(s.path)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return err
+	}
+	tmp, err := os.CreateTemp(dir, ".authority-verifier-*")
+	if err != nil {
+		return err
+	}
+	tmpName := tmp.Name()
+	defer func() { _ = os.Remove(tmpName) }()
+	if _, err := tmp.Write(raw); err != nil {
+		_ = tmp.Close()
+		return err
+	}
+	if err := tmp.Sync(); err != nil {
+		_ = tmp.Close()
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		return err
+	}
+	if err := os.Rename(tmpName, s.path); err != nil {
+		return err
+	}
+	if dirFile, err := os.Open(dir); err == nil {
+		_ = dirFile.Sync()
+		_ = dirFile.Close()
+	}
+	return nil
+}
+
+func authorityVerifierKeyString(key AuthorityVerifierKey) string {
+	scope := key.Scope
+	return fmt.Sprintf("%s\x00%s\x00%d\x00%s\x00%d\x00%x\x00%x",
+		key.ClusterID,
+		key.DutyID,
+		scope.Kind,
+		scope.MountID,
+		scope.SubtreeRoot,
+		scope.StartKey,
+		scope.EndKey,
+	)
+}
+
+func authorityVerifierStateToProto(state AuthorityVerifierState) *metapb.RootAuthorityVerifierState {
+	return &metapb.RootAuthorityVerifierState{
+		Key: &metapb.RootAuthorityVerifierKey{
+			ClusterId: state.Key.ClusterID,
+			DutyId:    string(state.Key.DutyID),
+			Scope:     metawire.RootDutyScopeToProto(state.Key.Scope),
+		},
+		MaxSeenEra:            state.MaxSeenEra,
+		RetiredEraFloor:       state.RetiredEraFloor,
+		MaxRootToken:          metawire.RootTailTokenFromAuthorityToken(state.MaxRootToken),
+		MaxDescriptorRevision: state.MaxDescriptorRevision,
+		MaxFrontier:           metawire.RootDutyBoundToProto(state.MaxFrontier),
+	}
+}
+
+func authorityVerifierStateFromProto(state *metapb.RootAuthorityVerifierState) AuthorityVerifierState {
+	if state == nil {
+		return AuthorityVerifierState{}
+	}
+	key := state.GetKey()
+	return AuthorityVerifierState{
+		Key: AuthorityVerifierKey{
+			ClusterID: key.GetClusterId(),
+			DutyID:    rootproto.DutyID(key.GetDutyId()),
+			Scope:     metawire.RootDutyScopeFromProto(key.GetScope()),
+		},
+		MaxSeenEra:            state.GetMaxSeenEra(),
+		RetiredEraFloor:       state.GetRetiredEraFloor(),
+		MaxRootToken:          metawire.AuthorityTokenFromRootTailToken(state.GetMaxRootToken()),
+		MaxDescriptorRevision: state.GetMaxDescriptorRevision(),
+		MaxFrontier:           metawire.RootDutyBoundFromProto(state.GetMaxFrontier()),
+	}
+}

--- a/coordinator/integration/control_plane_protocol_test.go
+++ b/coordinator/integration/control_plane_protocol_test.go
@@ -19,6 +19,7 @@ import (
 	rootproto "github.com/feichai0017/NoKV/meta/root/protocol"
 	rootstate "github.com/feichai0017/NoKV/meta/root/state"
 	"github.com/feichai0017/NoKV/meta/topology"
+	metawire "github.com/feichai0017/NoKV/meta/wire"
 	coordpb "github.com/feichai0017/NoKV/pb/coordinator"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
@@ -68,10 +69,16 @@ func (s *protocolMatrixStorage) ApplyGrant(_ context.Context, cmd rootproto.Gran
 	holderID := strings.TrimSpace(cmd.HolderID)
 	switch cmd.Kind {
 	case rootproto.GrantActIssue:
-		s.campaigns++
 		if s.campaignErr != nil {
 			return rootstate.EunomiaState{}, rootproto.GrantCertificate{}, s.campaignErr
 		}
+		if s.snapshot.ActiveGrant.Present() &&
+			s.snapshot.ActiveGrant.GrantID == strings.TrimSpace(cmd.GrantID) &&
+			s.snapshot.ActiveGrant.HolderID == holderID &&
+			protocolTestDutiesCover(s.snapshot.ActiveGrant.Duties, cmd.RequestedDuties) {
+			return s.protocolState(), protocolTestGrantCertificate(s.snapshot.ActiveGrant), nil
+		}
+		s.campaigns++
 		if s.snapshot.ActiveGrant.Present() && s.snapshot.ActiveGrant.HolderID != holderID && s.snapshot.ActiveGrant.ActiveAt(cmd.NowUnixNano) {
 			return s.protocolState(), rootproto.GrantCertificate{}, rootstate.ErrPrimacy
 		}
@@ -112,7 +119,7 @@ func (s *protocolMatrixStorage) ApplyGrant(_ context.Context, cmd rootproto.Gran
 			}
 		}
 		s.advanceRootToken()
-		return s.protocolState(), rootproto.GrantCertificate{Grant: s.snapshot.ActiveGrant, SignerKeyID: rootproto.GrantSignerKeyID, Signature: []byte("test")}, nil
+		return s.protocolState(), protocolTestGrantCertificate(s.snapshot.ActiveGrant), nil
 	case rootproto.GrantActSeal:
 		if !s.snapshot.ActiveGrant.Present() || s.snapshot.ActiveGrant.HolderID != strings.TrimSpace(cmd.HolderID) {
 			return s.protocolState(), rootproto.GrantCertificate{}, rootstate.ErrPrimacy
@@ -188,6 +195,31 @@ func dutyGrantsFromUsagesForProtocolTest(usages []rootproto.AuthorityUsage) []ro
 		out = append(out, rootproto.DutyGrant{DutyID: usage.DutyID, Scope: usage.Scope, Bound: usage.Usage})
 	}
 	return out
+}
+
+func protocolTestGrantCertificate(grant rootproto.AuthorityGrant) rootproto.GrantCertificate {
+	payload, _ := proto.MarshalOptions{Deterministic: true}.Marshal(metawire.RootAuthorityGrantToProto(grant))
+	return rootproto.GrantCertificate{
+		Grant:       grant,
+		SignerKeyID: rootproto.GrantSignerKeyID,
+		Signature:   rootproto.SignGrantBytes(payload),
+	}
+}
+
+func protocolTestDutiesCover(grants, usages []rootproto.DutyGrant) bool {
+	for _, usage := range usages {
+		found := false
+		for _, grant := range grants {
+			if grant.DutyID == usage.DutyID && rootproto.ScopeEqual(grant.Scope, usage.Scope) && rootproto.DutyBoundCovers(grant.Bound, usage.Bound) {
+				found = true
+				break
+			}
+		}
+		if !found {
+			return false
+		}
+	}
+	return true
 }
 
 func (s *protocolMatrixStorage) Refresh() error { return nil }

--- a/coordinator/rootview/root.go
+++ b/coordinator/rootview/root.go
@@ -396,7 +396,8 @@ func (s *RootStore) applyAndReload(run func() (rootstate.EunomiaState, error)) (
 func eunomiaStatePresent(state rootstate.EunomiaState) bool {
 	return state.ActiveGrant.Present() ||
 		len(state.RetiredGrants) > 0 ||
-		len(state.GrantInheritances) > 0
+		len(state.GrantInheritances) > 0 ||
+		state.RetiredEraFloor != 0
 }
 
 // mergeEunomiaState overlays the committed authority grant lifecycle from an
@@ -411,12 +412,14 @@ func (s *RootStore) mergeEunomiaState(state rootstate.EunomiaState) {
 		ActiveGrant:       state.ActiveGrant,
 		RetiredGrants:     append([]rootproto.GrantRetirement(nil), state.RetiredGrants...),
 		GrantInheritances: append([]rootproto.GrantInheritance(nil), state.GrantInheritances...),
+		RetiredEraFloor:   state.RetiredEraFloor,
 	}
 	s.mu.Lock()
 	merged := PreserveNewerAuthorityState(incoming, s.snapshot)
 	s.snapshot.ActiveGrant = merged.ActiveGrant
 	s.snapshot.RetiredGrants = append([]rootproto.GrantRetirement(nil), merged.RetiredGrants...)
 	s.snapshot.GrantInheritances = append([]rootproto.GrantInheritance(nil), merged.GrantInheritances...)
+	s.snapshot.RetiredEraFloor = merged.RetiredEraFloor
 	s.mu.Unlock()
 }
 

--- a/coordinator/rootview/snapshot.go
+++ b/coordinator/rootview/snapshot.go
@@ -59,6 +59,7 @@ type Snapshot struct {
 	ActiveGrant         rootproto.AuthorityGrant
 	RetiredGrants       []rootproto.GrantRetirement
 	GrantInheritances   []rootproto.GrantInheritance
+	RetiredEraFloor     uint64
 }
 
 func CloneSnapshot(snapshot Snapshot) Snapshot {
@@ -78,6 +79,7 @@ func CloneSnapshot(snapshot Snapshot) Snapshot {
 		ActiveGrant:         snapshot.ActiveGrant,
 		RetiredGrants:       append([]rootproto.GrantRetirement(nil), snapshot.RetiredGrants...),
 		GrantInheritances:   append([]rootproto.GrantInheritance(nil), snapshot.GrantInheritances...),
+		RetiredEraFloor:     snapshot.RetiredEraFloor,
 	}
 }
 
@@ -93,6 +95,7 @@ func PreserveNewerAuthorityState(observed, current Snapshot) Snapshot {
 	out.ActiveGrant = current.ActiveGrant
 	out.RetiredGrants = append([]rootproto.GrantRetirement(nil), current.RetiredGrants...)
 	out.GrantInheritances = append([]rootproto.GrantInheritance(nil), current.GrantInheritances...)
+	out.RetiredEraFloor = current.RetiredEraFloor
 	return out
 }
 
@@ -126,7 +129,7 @@ func observedRetiresGrant(observed Snapshot, grant rootproto.AuthorityGrant) boo
 }
 
 func authorityGeneration(snapshot Snapshot) uint64 {
-	generation := snapshot.ActiveGrant.Era
+	generation := max(snapshot.RetiredEraFloor, snapshot.ActiveGrant.Era)
 	for _, retirement := range snapshot.RetiredGrants {
 		if retirement.Era > generation {
 			generation = retirement.Era
@@ -173,6 +176,7 @@ func SnapshotFromRoot(snapshot rootstate.Snapshot) Snapshot {
 		ActiveGrant:       snapshot.State.ActiveGrant,
 		RetiredGrants:     append([]rootproto.GrantRetirement(nil), snapshot.State.RetiredGrants...),
 		GrantInheritances: append([]rootproto.GrantInheritance(nil), snapshot.State.GrantInheritances...),
+		RetiredEraFloor:   snapshot.State.RetiredEraFloor,
 	}
 }
 
@@ -186,6 +190,7 @@ func (s Snapshot) RootSnapshot() rootstate.Snapshot {
 			ActiveGrant:       s.ActiveGrant,
 			RetiredGrants:     append([]rootproto.GrantRetirement(nil), s.RetiredGrants...),
 			GrantInheritances: append([]rootproto.GrantInheritance(nil), s.GrantInheritances...),
+			RetiredEraFloor:   s.RetiredEraFloor,
 		},
 		Stores:              rootstate.CloneStoreMemberships(s.Stores),
 		SnapshotEpochs:      rootstate.CloneSnapshotEpochs(s.SnapshotEpochs),

--- a/coordinator/server/diagnostics.go
+++ b/coordinator/server/diagnostics.go
@@ -376,7 +376,7 @@ func diagnosticsInvalidSuccessorBound(grant rootproto.AuthorityGrant, retirement
 		}
 		for _, bound := range retirement.Bounds {
 			duty, ok := grant.Duty(bound.DutyID)
-			if !ok || !authorityBoundCovers(duty.Bound, bound.Bound) {
+			if !ok || !rootproto.DutyBoundCovers(duty.Bound, bound.Bound) {
 				return true
 			}
 		}

--- a/coordinator/server/service.go
+++ b/coordinator/server/service.go
@@ -95,9 +95,11 @@ func (s authorityServingState) String() string {
 }
 
 type coordinatorGrantView struct {
-	grant        rootproto.AuthorityGrant
-	retirements  []rootproto.GrantRetirement
-	inheritances []rootproto.GrantInheritance
+	grant           rootproto.AuthorityGrant
+	certificate     rootproto.GrantCertificate
+	retirements     []rootproto.GrantRetirement
+	inheritances    []rootproto.GrantInheritance
+	retiredEraFloor uint64
 }
 
 type coordinatorRootSnapshotView struct {
@@ -112,21 +114,35 @@ func (v *coordinatorGrantView) Reset() {
 		return
 	}
 	v.grant = rootproto.AuthorityGrant{}
+	v.certificate = rootproto.GrantCertificate{}
 	v.retirements = nil
 	v.inheritances = nil
+	v.retiredEraFloor = 0
 }
 
 func (v *coordinatorGrantView) Refresh(snapshot rootview.Snapshot) {
 	if v == nil {
 		return
 	}
-	v.grant = snapshot.ActiveGrant
+	cert := v.certificate
+	if grantCertificateCoversGrant(cert, snapshot.ActiveGrant) {
+		v.grant = cert.Grant
+		v.certificate = cert
+	} else {
+		v.grant = snapshot.ActiveGrant
+		v.certificate = rootproto.GrantCertificate{}
+	}
 	v.retirements = append([]rootproto.GrantRetirement(nil), snapshot.RetiredGrants...)
 	v.inheritances = append([]rootproto.GrantInheritance(nil), snapshot.GrantInheritances...)
+	v.retiredEraFloor = snapshot.RetiredEraFloor
 }
 
 func (v coordinatorGrantView) Grant() rootproto.AuthorityGrant {
 	return v.grant
+}
+
+func (v coordinatorGrantView) Certificate() rootproto.GrantCertificate {
+	return v.certificate
 }
 
 func (v coordinatorGrantView) Retirements() []rootproto.GrantRetirement {

--- a/coordinator/server/service_admission.go
+++ b/coordinator/server/service_admission.go
@@ -12,6 +12,22 @@ import (
 	"google.golang.org/grpc/status"
 )
 
+type dutyAdmission struct {
+	grant           rootproto.AuthorityGrant
+	certificate     rootproto.GrantCertificate
+	retirements     []rootproto.GrantRetirement
+	retiredEraFloor uint64
+	duty            rootproto.DutyID
+	servedUnixNano  int64
+	done            func()
+}
+
+func (a dutyAdmission) Done() {
+	if a.done != nil {
+		a.done()
+	}
+}
+
 func (s *Service) resetAuthorityServing() {
 	if s == nil {
 		return
@@ -22,29 +38,31 @@ func (s *Service) resetAuthorityServing() {
 	s.authorityMu.Unlock()
 }
 
-func (s *Service) beginDutyAdmission(ctx context.Context, duty rootproto.DutyID) (func(), error) {
+func (s *Service) beginDutyAdmission(ctx context.Context, duty rootproto.DutyID) (dutyAdmission, error) {
 	if s == nil || !s.coordinatorGrantEnabled() {
-		return func() {}, nil
+		return dutyAdmission{done: func() {}}, nil
 	}
 	if err := s.rejectIfAuthorityClosed(); err != nil {
-		return nil, err
+		return dutyAdmission{}, err
 	}
 	if err := s.ensureGrant(ctx); err != nil {
-		return nil, translateGrantError(err)
+		return dutyAdmission{}, translateGrantError(err)
 	}
 	if s.grantInheritanceCandidate() {
 		if err := s.InheritRetiredGrants(ctx); err != nil {
-			return nil, err
+			return dutyAdmission{}, err
 		}
 	}
-	if err := s.eunomiaGate(gateDutyAdmission, duty); err != nil {
-		return nil, err
+	admission, err := s.admitDutyFromCachedGrant(duty)
+	if err != nil {
+		return dutyAdmission{}, err
 	}
 	done, err := s.beginAuthorityServing(ctx, duty)
 	if err != nil {
-		return nil, err
+		return dutyAdmission{}, err
 	}
-	return done, nil
+	admission.done = done
+	return admission, nil
 }
 
 func (s *Service) beginAuthorityServing(ctx context.Context, duty rootproto.DutyID) (func(), error) {
@@ -133,15 +151,6 @@ const (
 	gateDutyAdmission gateKind = iota
 )
 
-// eunomiaGate checks the cached grant mirror on authority-bearing hot paths.
-// The mirror is kept current by rooted-tail refresh and by ApplyGrant responses.
-func (s *Service) eunomiaGate(kind gateKind, duty rootproto.DutyID) error {
-	if s == nil || !s.coordinatorGrantEnabled() || s.storage == nil {
-		return nil
-	}
-	return s.eunomiaGateCached(kind, duty)
-}
-
 func (s *Service) rejectIfAuthorityClosed() error {
 	if s == nil || !s.coordinatorGrantEnabled() {
 		return nil
@@ -161,8 +170,38 @@ func (s *Service) rejectIfAuthorityClosed() error {
 	}
 }
 
-func (s *Service) eunomiaGateCached(kind gateKind, duty rootproto.DutyID) error {
-	return s.validateGateGrant(kind, duty, s.currentGrant())
+func (s *Service) admitDutyFromCachedGrant(duty rootproto.DutyID) (dutyAdmission, error) {
+	if s == nil {
+		return dutyAdmission{}, nil
+	}
+	nowUnixNano := s.nowUnixNano()
+	s.grantMu.RLock()
+	view := s.grantView
+	holderID := strings.TrimSpace(s.coordinatorID)
+	clockSkew := s.grantClockSkew
+	s.grantMu.RUnlock()
+	if err := s.validateGateGrant(gateDutyAdmission, duty, view.grant); err != nil {
+		return dutyAdmission{}, err
+	}
+	if view.grant.ExpiresUnixNano <= nowUnixNano+clockSkew.Nanoseconds() {
+		s.eunomiaMetrics.recordGateRejection(gateDutyAdmission)
+		return dutyAdmission{}, statusGrant(fmt.Errorf("%w: grant inside clock-skew window era=%d", rootstate.ErrInvalidGrant, view.grant.Era))
+	}
+	if holderID == "" || view.grant.HolderID != holderID {
+		return dutyAdmission{}, statusGrant(fmt.Errorf("%w: rooted holder=%s local_holder=%s", rootstate.ErrPrimacy, view.grant.HolderID, holderID))
+	}
+	if !grantCertificateMatches(view.certificate, view.grant) {
+		s.eunomiaMetrics.recordGateRejection(gateDutyAdmission)
+		return dutyAdmission{}, statusGrant(fmt.Errorf("%w: missing root-issued grant certificate grant_id=%s era=%d", rootstate.ErrInvalidGrant, view.grant.GrantID, view.grant.Era))
+	}
+	return dutyAdmission{
+		grant:           view.grant,
+		certificate:     view.certificate,
+		retirements:     append([]rootproto.GrantRetirement(nil), view.retirements...),
+		retiredEraFloor: view.retiredEraFloor,
+		duty:            duty,
+		servedUnixNano:  nowUnixNano,
+	}, nil
 }
 
 func (s *Service) validateGateGrant(kind gateKind, duty rootproto.DutyID, grant rootproto.AuthorityGrant) error {

--- a/coordinator/server/service_alloc.go
+++ b/coordinator/server/service_alloc.go
@@ -274,11 +274,11 @@ func (s *Service) AllocID(ctx context.Context, req *coordpb.AllocIDRequest) (*co
 	if err := s.requireRootWriteAccess(); err != nil {
 		return nil, err
 	}
-	done, err := s.beginDutyAdmission(ctx, rootproto.DutyAllocID)
+	admission, err := s.beginDutyAdmission(ctx, rootproto.DutyAllocID)
 	if err != nil {
 		return nil, err
 	}
-	defer done()
+	defer admission.Done()
 	first, err := s.reserveIDs(ctx, count)
 	if err != nil {
 		if errors.Is(err, idalloc.ErrInvalidBatch) {
@@ -287,7 +287,7 @@ func (s *Service) AllocID(ctx context.Context, req *coordpb.AllocIDRequest) (*co
 		return nil, status.Error(codes.Internal, "persist allocator state: "+err.Error())
 	}
 	consumedFrontier := allocationConsumedFrontier(first, count)
-	proof, err := s.authorityEvidenceSnapshot(ctx, rootproto.DutyAllocID, rootproto.DutyBound{Kind: rootproto.DutyBoundMonotone, MonotoneUpper: consumedFrontier})
+	proof, err := admission.authorityEvidence(rootproto.DutyBound{Kind: rootproto.DutyBoundMonotone, MonotoneUpper: consumedFrontier})
 	if err != nil {
 		return nil, err
 	}
@@ -316,11 +316,11 @@ func (s *Service) Tso(ctx context.Context, req *coordpb.TsoRequest) (*coordpb.Ts
 	if err := s.requireRootWriteAccess(); err != nil {
 		return nil, err
 	}
-	done, err := s.beginDutyAdmission(ctx, rootproto.DutyTSO)
+	admission, err := s.beginDutyAdmission(ctx, rootproto.DutyTSO)
 	if err != nil {
 		return nil, err
 	}
-	defer done()
+	defer admission.Done()
 	first, got, err := s.reserveTSO(ctx, count)
 	if err != nil {
 		if errors.Is(err, idalloc.ErrInvalidBatch) {
@@ -329,7 +329,7 @@ func (s *Service) Tso(ctx context.Context, req *coordpb.TsoRequest) (*coordpb.Ts
 		return nil, status.Error(codes.Internal, "persist allocator state: "+err.Error())
 	}
 	consumedFrontier := allocationConsumedFrontier(first, got)
-	proof, err := s.authorityEvidenceSnapshot(ctx, rootproto.DutyTSO, rootproto.DutyBound{Kind: rootproto.DutyBoundMonotone, MonotoneUpper: consumedFrontier})
+	proof, err := admission.authorityEvidence(rootproto.DutyBound{Kind: rootproto.DutyBoundMonotone, MonotoneUpper: consumedFrontier})
 	if err != nil {
 		return nil, err
 	}

--- a/coordinator/server/service_certificate.go
+++ b/coordinator/server/service_certificate.go
@@ -1,16 +1,13 @@
 package server
 
 import (
-	"context"
-	"fmt"
+	"reflect"
 
-	"github.com/feichai0017/NoKV/coordinator/rootview"
 	rootproto "github.com/feichai0017/NoKV/meta/root/protocol"
 	metawire "github.com/feichai0017/NoKV/meta/wire"
 	metapb "github.com/feichai0017/NoKV/pb/meta"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
-	"google.golang.org/protobuf/proto"
 )
 
 type authorityProof struct {
@@ -19,123 +16,60 @@ type authorityProof struct {
 	Evidence                *metapb.RootAuthorityEvidence
 }
 
-func (s *Service) authorityEvidence(ctx context.Context, duty rootproto.DutyID, usage rootproto.DutyBound) (*metapb.RootAuthorityEvidence, error) {
-	proof, err := s.authorityEvidenceSnapshot(ctx, duty, usage)
-	if err != nil {
-		return nil, err
-	}
-	return proof.Evidence, nil
-}
-
-func (s *Service) authorityEvidenceSnapshot(ctx context.Context, duty rootproto.DutyID, usage rootproto.DutyBound) (authorityProof, error) {
-	if s == nil || !s.coordinatorGrantEnabled() {
+func (a dutyAdmission) authorityEvidence(usage rootproto.DutyBound) (authorityProof, error) {
+	if !a.grant.Present() {
 		return authorityProof{}, nil
 	}
-	if ctx == nil {
-		ctx = context.Background()
+	if !grantCertificateMatches(a.certificate, a.grant) {
+		return authorityProof{}, status.Error(codes.Internal, "root-issued grant certificate is missing or stale")
 	}
-	if err := ctx.Err(); err != nil {
-		return authorityProof{}, status.FromContextError(err).Err()
+	if a.grant.ExpiresUnixNano <= a.servedUnixNano {
+		return authorityProof{}, status.Error(codes.FailedPrecondition, "admitted grant expired before evidence generation")
 	}
-	snapshot, err := s.currentRootSnapshotCoveringAuthority(duty, usage)
-	if err != nil {
-		return authorityProof{}, status.Error(codes.FailedPrecondition, "load rooted authority evidence snapshot: "+err.Error())
-	}
-	grant := snapshot.ActiveGrant
-	cert, err := grantCertificate(grant)
-	if err != nil {
-		return authorityProof{}, status.Error(codes.Internal, err.Error())
-	}
-	observedFloor := uint64(0)
-	for _, retirement := range snapshot.RetiredGrants {
-		if retirement.Era > observedFloor {
-			observedFloor = retirement.Era
-		}
+	scope := rootproto.DutyScope{Kind: rootproto.DutyScopeGlobal}
+	dutyGrant, ok := a.grant.DutyFor(a.duty, scope)
+	if !ok || !rootproto.DutyBoundCovers(dutyGrant.Bound, usage) {
+		return authorityProof{}, status.Errorf(codes.FailedPrecondition, "admitted grant does not cover duty=%s grant_id=%s era=%d", rootproto.DutyName(a.duty), a.grant.GrantID, a.grant.Era)
 	}
 	evidence := metawire.RootAuthorityEvidenceToProto(rootproto.AuthorityEvidence{
-		Certificate: cert,
+		Certificate: a.certificate,
 		Usage: rootproto.AuthorityUsage{
-			DutyID: duty,
-			Scope:  rootproto.DutyScope{Kind: rootproto.DutyScopeGlobal},
+			DutyID: a.duty,
+			Scope:  scope,
 			Usage:  usage,
 		},
-		ObservedRetirements:     snapshot.RetiredGrants,
-		ObservedRetiredEraFloor: observedFloor,
+		ObservedRetirements:     a.retirements,
+		ObservedRetiredEraFloor: a.retiredEraFloor,
+		ServedUnixNano:          a.servedUnixNano,
 	})
 	return authorityProof{
-		Grant:                   grant,
-		ObservedRetiredEraFloor: observedFloor,
+		Grant:                   a.grant,
+		ObservedRetiredEraFloor: a.retiredEraFloor,
 		Evidence:                evidence,
 	}, nil
 }
 
-func (s *Service) currentRootSnapshotCoveringAuthority(duty rootproto.DutyID, usage rootproto.DutyBound) (rootview.Snapshot, error) {
-	snapshot, err := s.currentRootSnapshot()
-	if err != nil {
-		return rootview.Snapshot{}, err
-	}
-	if authoritySnapshotCovers(snapshot, duty, usage) {
-		return snapshot, nil
-	}
-	snapshot, err = s.reloadRootedView(true)
-	if err != nil {
-		return rootview.Snapshot{}, err
-	}
-	if authoritySnapshotCovers(snapshot, duty, usage) {
-		return snapshot, nil
-	}
-	return rootview.Snapshot{}, status.Errorf(
-		codes.FailedPrecondition,
-		"rooted grant does not cover duty=%s grant_id=%s era=%d",
-		rootproto.DutyName(duty),
-		snapshot.ActiveGrant.GrantID,
-		snapshot.ActiveGrant.Era,
-	)
+func grantCertificateMatches(cert rootproto.GrantCertificate, grant rootproto.AuthorityGrant) bool {
+	return grantCertificatePresent(cert) &&
+		grant.Present() &&
+		reflect.DeepEqual(cert.Grant, grant)
 }
 
-func authoritySnapshotCovers(snapshot rootview.Snapshot, duty rootproto.DutyID, usage rootproto.DutyBound) bool {
-	grant := snapshot.ActiveGrant
-	if !grant.Present() {
+func grantCertificateCoversGrant(cert rootproto.GrantCertificate, grant rootproto.AuthorityGrant) bool {
+	if !grantCertificatePresent(cert) || !grant.Present() {
 		return false
 	}
-	dutyGrant, ok := grant.Duty(duty)
-	if !ok {
-		return false
-	}
-	return authorityBoundCovers(dutyGrant.Bound, usage)
+	certGrant := cert.Grant
+	return certGrant.GrantID == grant.GrantID &&
+		certGrant.HolderID == grant.HolderID &&
+		certGrant.Era == grant.Era &&
+		certGrant.ExpiresUnixNano == grant.ExpiresUnixNano &&
+		reflect.DeepEqual(certGrant.Duties, grant.Duties) &&
+		reflect.DeepEqual(certGrant.PredecessorRetirements, grant.PredecessorRetirements)
 }
 
-func authorityBoundCovers(grant, usage rootproto.DutyBound) bool {
-	if grant.Kind != usage.Kind {
-		return false
-	}
-	switch usage.Kind {
-	case rootproto.DutyBoundMonotone:
-		return usage.MonotoneUpper <= grant.MonotoneUpper
-	case rootproto.DutyBoundVersion:
-		return usage.DescriptorRevisionCeiling <= grant.DescriptorRevisionCeiling &&
-			usage.MaxRootLag <= grant.MaxRootLag
-	case rootproto.DutyBoundBudget:
-		return usage.Budget <= grant.Budget
-	case rootproto.DutyBoundEpoch:
-		return usage.Epoch <= grant.Epoch
-	default:
-		return false
-	}
-}
-
-func grantCertificate(grant rootproto.AuthorityGrant) (rootproto.GrantCertificate, error) {
-	payload, err := proto.MarshalOptions{Deterministic: true}.Marshal(metawire.RootAuthorityGrantToProto(grant))
-	if err != nil {
-		return rootproto.GrantCertificate{}, err
-	}
-	signature := rootproto.SignGrantBytes(payload)
-	if len(signature) == 0 {
-		return rootproto.GrantCertificate{}, fmt.Errorf("root grant signing key is not configured")
-	}
-	return rootproto.GrantCertificate{
-		Grant:       grant,
-		SignerKeyID: rootproto.GrantSignerKeyID,
-		Signature:   signature,
-	}, nil
+func grantCertificatePresent(cert rootproto.GrantCertificate) bool {
+	return cert.Grant.Present() &&
+		cert.SignerKeyID != "" &&
+		len(cert.Signature) != 0
 }

--- a/coordinator/server/service_grant.go
+++ b/coordinator/server/service_grant.go
@@ -356,6 +356,12 @@ func (s *Service) ensureGrant(ctx context.Context) error {
 	if s.coordinatorGrantStillValid(holderID, nowUnixNano, renewIn, clockSkew) {
 		return nil
 	}
+	if err := s.refreshCurrentGrantCertificateIfNeeded(ctx, holderID, nowUnixNano); err != nil {
+		return err
+	}
+	if s.coordinatorGrantStillValid(holderID, nowUnixNano, renewIn, clockSkew) {
+		return nil
+	}
 	if err := s.activeOtherGrantError(holderID, nowUnixNano); err != nil {
 		return err
 	}
@@ -374,7 +380,7 @@ func (s *Service) ensureGrant(ctx context.Context) error {
 		return nil
 	}
 	currentEra := s.currentGrant().Era
-	protocolState, _, err := s.storage.ApplyGrant(ctx, rootproto.GrantCommand{
+	protocolState, cert, err := s.storage.ApplyGrant(ctx, rootproto.GrantCommand{
 		Kind:            rootproto.GrantActIssue,
 		HolderID:        holderID,
 		GrantID:         nextCoordinatorGrantID(holderID, currentEra),
@@ -396,6 +402,7 @@ func (s *Service) ensureGrant(ctx context.Context) error {
 		return err
 	}
 	s.publishEunomiaState(protocolState)
+	s.cacheGrantCertificate(cert)
 	s.eunomiaMetrics.recordGrantEraTransition(currentEra, protocolState.ActiveGrant.Era)
 	return s.reloadAndFenceAllocators(true)
 }
@@ -435,7 +442,44 @@ func (s *Service) coordinatorGrantStillValid(holderID string, nowUnixNano int64,
 		current.ExpiresUnixNano <= nowUnixNano+clockSkew.Nanoseconds() {
 		return false
 	}
+	if !s.currentGrantCertificateValid(current) {
+		return false
+	}
 	return !s.coordinatorGrantNeedsRenewal(current)
+}
+
+func (s *Service) currentGrantCertificateValid(grant rootproto.AuthorityGrant) bool {
+	if s == nil || !grant.Present() {
+		return false
+	}
+	s.grantMu.RLock()
+	cert := s.grantView.Certificate()
+	s.grantMu.RUnlock()
+	return grantCertificateMatches(cert, grant)
+}
+
+func (s *Service) refreshCurrentGrantCertificateIfNeeded(ctx context.Context, holderID string, nowUnixNano int64) error {
+	current := s.currentGrant()
+	if !current.Present() ||
+		strings.TrimSpace(current.HolderID) != strings.TrimSpace(holderID) ||
+		!current.ActiveAt(nowUnixNano) ||
+		s.currentGrantCertificateValid(current) {
+		return nil
+	}
+	protocolState, cert, err := s.storage.ApplyGrant(ctx, rootproto.GrantCommand{
+		Kind:            rootproto.GrantActIssue,
+		HolderID:        holderID,
+		GrantID:         current.GrantID,
+		ExpiresUnixNano: current.ExpiresUnixNano,
+		NowUnixNano:     nowUnixNano,
+		RequestedDuties: append([]rootproto.DutyGrant(nil), current.Duties...),
+	})
+	if err != nil {
+		return err
+	}
+	s.publishEunomiaState(protocolState)
+	s.cacheGrantCertificate(cert)
+	return nil
 }
 
 func (s *Service) coordinatorGrantNeedsRenewal(grant rootproto.AuthorityGrant) bool {

--- a/coordinator/server/service_metadata.go
+++ b/coordinator/server/service_metadata.go
@@ -44,16 +44,21 @@ func (s *Service) GetRegionByKey(ctx context.Context, req *coordpb.GetRegionByKe
 	if err != nil {
 		return nil, err
 	}
-	done, err := s.beginAuthorityServing(ctx, rootproto.DutyRegionLookup)
-	if err != nil {
-		return nil, err
+	var authorityAdmission dutyAdmission
+	var authorityAdmitted bool
+	if s != nil && s.coordinatorGrantEnabled() && admission.state.era != rootproto.AuthorityEraAttached && admission.state.era != rootproto.AuthorityEraSuppressed {
+		authorityAdmission, err = s.beginDutyAdmission(ctx, rootproto.DutyRegionLookup)
+		if err != nil {
+			return nil, err
+		}
+		authorityAdmitted = true
+		defer authorityAdmission.Done()
 	}
-	defer done()
 	desc, ok := s.cluster.GetRegionDescriptorByKey(req.GetKey())
 	if !ok {
 		resp := admission.responseBase()
 		resp.NotFound = true
-		if err := s.attachMetadataAuthorityEvidence(ctx, resp); err != nil {
+		if err := s.attachMetadataAuthorityEvidence(resp, authorityAdmission, authorityAdmitted); err != nil {
 			return nil, err
 		}
 		return resp, nil
@@ -67,7 +72,7 @@ func (s *Service) GetRegionByKey(ctx context.Context, req *coordpb.GetRegionByKe
 	resp := admission.responseBase()
 	resp.RegionDescriptor = metawire.DescriptorToProto(desc)
 	resp.DescriptorRevision = desc.RootEpoch
-	if err := s.attachMetadataAuthorityEvidence(ctx, resp); err != nil {
+	if err := s.attachMetadataAuthorityEvidence(resp, authorityAdmission, authorityAdmitted); err != nil {
 		return nil, err
 	}
 	return resp, nil
@@ -135,15 +140,20 @@ func (a metadataAnswerability) responseBase() *coordpb.GetRegionByKeyResponse {
 	}
 }
 
-func (s *Service) attachMetadataAuthorityEvidence(ctx context.Context, resp *coordpb.GetRegionByKeyResponse) error {
+func (s *Service) attachMetadataAuthorityEvidence(resp *coordpb.GetRegionByKeyResponse, admission dutyAdmission, admitted bool) error {
 	if s == nil || resp == nil || resp.GetEra() == rootproto.AuthorityEraAttached || resp.GetEra() == rootproto.AuthorityEraSuppressed {
 		return nil
 	}
-	evidence, err := s.authorityEvidence(ctx, rootproto.DutyRegionLookup, rootproto.DutyBound{Kind: rootproto.DutyBoundVersion, DescriptorRevisionCeiling: resp.GetDescriptorRevision()})
+	if !admitted {
+		return statusGrant(fmt.Errorf("%w: missing region_lookup admission", rootstate.ErrDuty))
+	}
+	proof, err := admission.authorityEvidence(rootproto.DutyBound{Kind: rootproto.DutyBoundVersion, DescriptorRevisionCeiling: resp.GetDescriptorRevision()})
 	if err != nil {
 		return err
 	}
-	resp.AuthorityEvidence = evidence
+	resp.Era = proof.Grant.Era
+	resp.ObservedRetiredEraFloor = proof.ObservedRetiredEraFloor
+	resp.AuthorityEvidence = proof.Evidence
 	return nil
 }
 
@@ -238,6 +248,7 @@ func (s *Service) currentReadState() (readState, error) {
 		state.grantHolderID = snapshot.ActiveGrant.HolderID
 		state.grantExpiresAt = snapshot.ActiveGrant.ExpiresUnixNano
 	}
+	state.retiredEraFloor = snapshot.RetiredEraFloor
 	for _, retirement := range snapshot.RetiredGrants {
 		if retirement.Era > state.retiredEraFloor {
 			state.retiredEraFloor = retirement.Era

--- a/coordinator/server/service_rootcache.go
+++ b/coordinator/server/service_rootcache.go
@@ -59,6 +59,18 @@ func (s *Service) refreshGrantMirror(snapshot rootview.Snapshot) {
 	s.grantMu.Unlock()
 }
 
+func (s *Service) cacheGrantCertificate(cert rootproto.GrantCertificate) {
+	if s == nil || !cert.Grant.Present() {
+		return
+	}
+	s.grantMu.Lock()
+	if grantCertificateCoversGrant(cert, s.grantView.grant) {
+		s.grantView.grant = cert.Grant
+		s.grantView.certificate = cert
+	}
+	s.grantMu.Unlock()
+}
+
 func (s *Service) rootSnapshotRefreshWindow() time.Duration {
 	if s == nil || s.rootViewTTL <= 0 {
 		return defaultRootSnapshotRefreshInterval
@@ -126,6 +138,7 @@ func (s *Service) currentAuthoritySnapshot() rootview.Snapshot {
 		ActiveGrant:       s.grantView.grant,
 		RetiredGrants:     append([]rootproto.GrantRetirement(nil), s.grantView.retirements...),
 		GrantInheritances: append([]rootproto.GrantInheritance(nil), s.grantView.inheritances...),
+		RetiredEraFloor:   s.grantView.retiredEraFloor,
 	}
 }
 
@@ -137,6 +150,7 @@ func (s *Service) publishEunomiaState(state rootstate.EunomiaState) {
 		ActiveGrant:       state.ActiveGrant,
 		RetiredGrants:     append([]rootproto.GrantRetirement(nil), state.RetiredGrants...),
 		GrantInheritances: append([]rootproto.GrantInheritance(nil), state.GrantInheritances...),
+		RetiredEraFloor:   state.RetiredEraFloor,
 	}
 	s.refreshGrantMirror(snapshot)
 	s.rootViewMu.Lock()
@@ -144,6 +158,7 @@ func (s *Service) publishEunomiaState(state rootstate.EunomiaState) {
 		s.rootView.snapshot.ActiveGrant = snapshot.ActiveGrant
 		s.rootView.snapshot.RetiredGrants = append([]rootproto.GrantRetirement(nil), snapshot.RetiredGrants...)
 		s.rootView.snapshot.GrantInheritances = append([]rootproto.GrantInheritance(nil), snapshot.GrantInheritances...)
+		s.rootView.snapshot.RetiredEraFloor = snapshot.RetiredEraFloor
 	}
 	s.rootViewMu.Unlock()
 }
@@ -151,7 +166,8 @@ func (s *Service) publishEunomiaState(state rootstate.EunomiaState) {
 func serviceEunomiaStatePresent(state rootstate.EunomiaState) bool {
 	return state.ActiveGrant.Present() ||
 		len(state.RetiredGrants) > 0 ||
-		len(state.GrantInheritances) > 0
+		len(state.GrantInheritances) > 0 ||
+		state.RetiredEraFloor != 0
 }
 
 func (s *Service) publishRootSnapshot(snapshot rootview.Snapshot) {
@@ -167,6 +183,7 @@ func (s *Service) publishRootSnapshot(snapshot rootview.Snapshot) {
 				ActiveGrant:       snapshot.ActiveGrant,
 				RetiredGrants:     append([]rootproto.GrantRetirement(nil), snapshot.RetiredGrants...),
 				GrantInheritances: append([]rootproto.GrantInheritance(nil), snapshot.GrantInheritances...),
+				RetiredEraFloor:   snapshot.RetiredEraFloor,
 			},
 			Stores:              snapshot.Stores,
 			Subtrees:            snapshot.Subtrees,

--- a/coordinator/server/service_test.go
+++ b/coordinator/server/service_test.go
@@ -96,7 +96,35 @@ func (f *fakeStorage) protocolState() rootstate.EunomiaState {
 		ActiveGrant:       f.snapshot.ActiveGrant,
 		RetiredGrants:     append([]rootproto.GrantRetirement(nil), f.snapshot.RetiredGrants...),
 		GrantInheritances: append([]rootproto.GrantInheritance(nil), f.snapshot.GrantInheritances...),
+		RetiredEraFloor:   f.snapshot.RetiredEraFloor,
 	}
+}
+
+func testGrantCertificate(grant rootproto.AuthorityGrant) rootproto.GrantCertificate {
+	payload, _ := proto.MarshalOptions{Deterministic: true}.Marshal(metawire.RootAuthorityGrantToProto(grant))
+	return rootproto.GrantCertificate{
+		Grant:       grant,
+		SignerKeyID: rootproto.GrantSignerKeyID,
+		Signature:   rootproto.SignGrantBytes(payload),
+	}
+}
+
+func testDutyGrantsCover(grants, usages []rootproto.DutyGrant) bool {
+	for _, usage := range usages {
+		found := false
+		for _, grant := range grants {
+			if grant.DutyID == usage.DutyID &&
+				rootproto.ScopeEqual(grant.Scope, usage.Scope) &&
+				rootproto.DutyBoundCovers(grant.Bound, usage.Bound) {
+				found = true
+				break
+			}
+		}
+		if !found {
+			return false
+		}
+	}
+	return true
 }
 
 func (f *fakeStorage) Load() (rootview.Snapshot, error) {
@@ -143,10 +171,16 @@ func (f *fakeStorage) ApplyGrant(_ context.Context, cmd rootproto.GrantCommand) 
 	holderID := strings.TrimSpace(cmd.HolderID)
 	switch cmd.Kind {
 	case rootproto.GrantActIssue:
-		f.campaignCalls++
 		if f.campaignErr != nil {
 			return rootstate.EunomiaState{}, rootproto.GrantCertificate{}, f.campaignErr
 		}
+		if f.snapshot.ActiveGrant.Present() &&
+			f.snapshot.ActiveGrant.GrantID == strings.TrimSpace(cmd.GrantID) &&
+			f.snapshot.ActiveGrant.HolderID == holderID &&
+			testDutyGrantsCover(f.snapshot.ActiveGrant.Duties, cmd.RequestedDuties) {
+			return f.protocolState(), testGrantCertificate(f.snapshot.ActiveGrant), nil
+		}
+		f.campaignCalls++
 		if f.snapshot.ActiveGrant.Present() &&
 			f.snapshot.ActiveGrant.HolderID != holderID &&
 			f.snapshot.ActiveGrant.ActiveAt(cmd.NowUnixNano) {
@@ -207,7 +241,7 @@ func (f *fakeStorage) ApplyGrant(_ context.Context, cmd rootproto.GrantCommand) 
 			}
 		}
 		f.advanceRootToken()
-		return f.protocolState(), rootproto.GrantCertificate{Grant: f.snapshot.ActiveGrant, SignerKeyID: rootproto.GrantSignerKeyID, Signature: []byte("test-signature")}, nil
+		return f.protocolState(), testGrantCertificate(f.snapshot.ActiveGrant), nil
 	case rootproto.GrantActSeal:
 		f.sealCalls++
 		if f.sealErr != nil {
@@ -2081,9 +2115,15 @@ func TestServiceAuthorityEvidenceRejectsUnrootedAllocatorFrontier(t *testing.T) 
 	svc.ConfigureAuthorityGrant("c1", 10*time.Second, 3*time.Second)
 	require.NoError(t, svc.RefreshFromStorage())
 
-	evidence, err := svc.authorityEvidence(context.Background(), rootproto.DutyAllocID, rootproto.DutyBound{Kind: rootproto.DutyBoundMonotone, MonotoneUpper: 6})
+	admission := dutyAdmission{
+		grant:          store.snapshot.ActiveGrant,
+		certificate:    rootproto.GrantCertificate{Grant: store.snapshot.ActiveGrant, SignerKeyID: rootproto.GrantSignerKeyID, Signature: []byte("test-signature")},
+		duty:           rootproto.DutyAllocID,
+		servedUnixNano: time.Now().UnixNano(),
+	}
+	proof, err := admission.authorityEvidence(rootproto.DutyBound{Kind: rootproto.DutyBoundMonotone, MonotoneUpper: 6})
 	require.Error(t, err)
-	require.Nil(t, evidence)
+	require.Nil(t, proof.Evidence)
 	require.Equal(t, codes.FailedPrecondition, status.Code(err))
 }
 
@@ -2324,7 +2364,7 @@ func TestServiceDrainAndSealBlocksNewAuthorityRequests(t *testing.T) {
 	require.Equal(t, codes.FailedPrecondition, status.Code(err))
 	require.Contains(t, status.Convert(err).Message(), "authority is draining")
 
-	doneAdmission()
+	doneAdmission.Done()
 	require.NoError(t, <-drainDone)
 	state, inflight := svc.authorityServingSnapshot()
 	require.Equal(t, authoritySealed, state)

--- a/docs/coordinator.md
+++ b/docs/coordinator.md
@@ -109,9 +109,10 @@ The mapping to concrete implementation types is direct:
 | `GrantInheritance` | `GrantInheritance` / `RootGrantInheritance` |
 | `AuthorityEvidence` | `AuthorityEvidence` / `RootAuthorityEvidence` |
 
-Do not reintroduce `Tenure` / `Legacy` / `Handover` as public aliases. V2 is a
-grant protocol: graceful shutdown records exact usage, while crash-before-seal
-is handled by retiring the predecessor at its root-known grant bound.
+Do not reintroduce `Tenure` / `Legacy` / `Handover` as public aliases. Eunomia
+is a grant protocol: graceful shutdown records exact usage, while
+crash-before-seal is handled by retiring the predecessor at its root-known grant
+bound.
 
 Grant certificates use Ed25519. Processes that sign grant certificates read
 `NOKV_EUNOMIA_GRANT_SIGNING_PRIVATE_KEY` as a base64 Ed25519 seed or private
@@ -122,46 +123,33 @@ ephemeral key with `NOKV_EUNOMIA_GRANT_ALLOW_EPHEMERAL_KEYS=1`; distributed
 deployments must not use ephemeral keys because certificates signed in one
 process cannot be verified after restart or by another process.
 
-### Eunomia production-hardening backlog
+### Eunomia production-hardening status
 
-The current grant protocol gives NoKV a bounded authority model for the
-implemented duties, but several engineering items remain before treating it as
-a production security boundary. Track these as protocol work, not as
-compatibility shims.
+The grant protocol is now hardened around root-issued bounded authority:
 
-#### P0: certificate ownership and verifier durability
+- `ApplyGrant(Issue)` returns a committed `GrantCertificate`, and coordinators
+  cache and forward that certificate. Serving code does not synthesize or sign
+  grant certificates.
+- Authority RPC admission returns an immutable admitted-grant token. Reply era,
+  usage, and `AuthorityEvidence` are derived from that same token, so a slow RPC
+  cannot be admitted under one grant and return evidence for a successor grant.
+- Every authority evidence record carries `served_unix_nano`. Coordinators stop
+  admission inside the configured clock-skew window before expiry; clients check
+  served time, max reply age, expiry, signature, duty, scope, usage coverage, and
+  monotonic floors.
+- Clients use a pluggable `AuthorityVerifierStore`. The default is in-memory for
+  tests and local development; production can opt into the protobuf file-backed
+  store, which writes with temp file, fsync, and atomic rename.
+- Root rejects unregistered duties through a `DutySpec` registry. The closed
+  implemented set is `alloc_id`, `tso`, and `region_lookup`.
+- Root persists `retired_era_floor` and compacts inherited retired-grant details
+  while keeping pending retirements and the floor needed by client/audit
+  finality checks.
+- The current TLA model and audit trace checker use the same grant vocabulary:
+  issue, exact seal, expiry-bound retirement, inheritance, reply-carried
+  evidence usage, and verifier retired floors.
 
-- Root-issued certificate cache: `ApplyGrant(Issue)` returns a committed
-  `GrantCertificate`. The coordinator should persist that certificate in its
-  local grant view and attach it to every `AuthorityEvidence` reply. A
-  coordinator must not re-sign the grant certificate; the private signing key
-  belongs to meta-root, a root-quorum signer, or KMS.
-- Verifier-only coordinator mode: a coordinator with cached root-issued
-  certificates and only public verification material should still serve
-  authority RPCs. Missing certificates or locally synthesized certificates must
-  fail closed.
-- Durable client verifier store: production clients need a pluggable
-  `AuthorityVerifierStore`. Tests can keep using an in-memory store, but
-  production clients should persist monotonic floors before accepting later
-  replies from newer eras.
-- Verifier state format: store compact protobuf records, not ad hoc JSON. The
-  record key should include `cluster_id`, `duty`, and `scope`; the value should
-  include `max_seen_era`, `retired_era_floor`, `retired_grant_ids`,
-  `max_root_token`, `max_descriptor_revision`, and per-duty usage frontier.
-  File-backed stores should use temp-write, fsync, and rename.
-
-#### P1: clock and evidence time
-
-- Add `served_unix_nano` to `AuthorityEvidence`. A verifier should check that
-  the served timestamp is within the grant expiry and within a configured
-  maximum reply age.
-- Coordinators should stop serving a grant at `expiry - max_clock_skew` and
-  renew before that local deadline. Root expiry remains the authority boundary;
-  the local skew margin is an admission policy.
-- Diagnostics should expose the skew policy, grant remaining time, renew
-  deadline, and whether admission is open, draining, or expired.
-
-#### P2: production key management
+#### Remaining production key management
 
 - Split signing and verification behind `GrantSigner`, `GrantVerifier`, and
   `KeySetProvider` interfaces. Environment variables should remain a dev/test
@@ -173,7 +161,7 @@ compatibility shims.
   active-plus-retired verification key set until all grants signed by retired
   keys have expired and their verifier floors are durable.
 
-#### P3: duty extension contract
+#### Duty extension contract
 
 Every new duty must register a complete `DutySpec`; adding a string name is not
 enough. The spec must define:
@@ -185,31 +173,8 @@ enough. The spec must define:
 - client verifier rule and audit checker rule
 
 The initial closed set is `alloc_id`, `tso`, and `region_lookup`. Unknown or
-unregistered duties should be rejected by root, coordinator admission, client
-verification, and audit.
-
-#### P4: tests and audit
-
-- Root tests: deterministic root certificate bytes, tamper rejection, key-id
-  lookup, rotation window, and missing signer failure.
-- Coordinator tests: cached root-issued certificate survives reload; a
-  verifier-only coordinator can serve; no locally re-signed certificates appear
-  in replies.
-- Client tests: durable verifier floors survive restart and still reject delayed
-  old-era replies; floor updates happen only after full evidence validation.
-- Clock tests: fast coordinator clock, slow coordinator clock, delayed reply,
-  and near-expiry renew admission.
-- Audit tests: every reply usage is covered by its evidence usage, every
-  evidence usage is inside the grant bound, retired floors are monotonic, and
-  metadata replies obey root-token and descriptor-revision rules.
-
-Recommended implementation order:
-
-1. Root-issued certificate cache in coordinator grant view.
-2. Durable verifier-state protobuf plus file/local-meta store.
-3. `served_unix_nano` and clock-skew admission policy.
-4. Key provider and key rotation.
-5. `DutySpec` registry and audit integration.
+unregistered duties are rejected by root, coordinator admission, client
+verification, and audit-facing checks.
 
 ---
 

--- a/docs/rooted_truth.md
+++ b/docs/rooted_truth.md
@@ -137,8 +137,9 @@ These are **validated, typed writes** that internally:
 2. Emit the appropriate `KindGrantIssued` / `KindGrantSealed` /
    `KindGrantRetired` / `KindGrantInherited` event
 3. Append through the normal log path
-4. Return the new `EunomiaState = { ActiveGrant, RetiredGrants, GrantInheritances }`
-   and, for issue, a root-signed deterministic `GrantCertificate`
+4. Return the new `EunomiaState = { ActiveGrant, RetiredGrants,
+   GrantInheritances, RetiredEraFloor }` and, for issue, a root-signed
+   deterministic `GrantCertificate`
 
 Crash-before-seal is handled conservatively: root never fabricates an exact
 served frontier. After expiry, the successor retires the predecessor using the

--- a/meta/root/protocol/duty_registry.go
+++ b/meta/root/protocol/duty_registry.go
@@ -1,0 +1,102 @@
+package protocol
+
+import "bytes"
+
+type DutySpec struct {
+	ID        DutyID
+	ScopeKind DutyScopeKind
+	BoundKind DutyBoundKind
+}
+
+var builtinDutySpecs = map[DutyID]DutySpec{
+	DutyAllocID: {
+		ID:        DutyAllocID,
+		ScopeKind: DutyScopeGlobal,
+		BoundKind: DutyBoundMonotone,
+	},
+	DutyTSO: {
+		ID:        DutyTSO,
+		ScopeKind: DutyScopeGlobal,
+		BoundKind: DutyBoundMonotone,
+	},
+	DutyRegionLookup: {
+		ID:        DutyRegionLookup,
+		ScopeKind: DutyScopeGlobal,
+		BoundKind: DutyBoundVersion,
+	},
+}
+
+func LookupDutySpec(duty DutyID) (DutySpec, bool) {
+	spec, ok := builtinDutySpecs[duty]
+	return spec, ok
+}
+
+func ValidateDutyGrant(grant DutyGrant) bool {
+	spec, ok := LookupDutySpec(grant.DutyID)
+	if !ok {
+		return false
+	}
+	return validateDutyScope(spec, grant.Scope) && grant.Bound.Kind == spec.BoundKind
+}
+
+func ValidateAuthorityUsage(usage AuthorityUsage) bool {
+	spec, ok := LookupDutySpec(usage.DutyID)
+	if !ok {
+		return false
+	}
+	return validateDutyScope(spec, usage.Scope) && usage.Usage.Kind == spec.BoundKind
+}
+
+func ScopeEqual(left, right DutyScope) bool {
+	return left.Kind == right.Kind &&
+		left.MountID == right.MountID &&
+		left.SubtreeRoot == right.SubtreeRoot &&
+		bytes.Equal(left.StartKey, right.StartKey) &&
+		bytes.Equal(left.EndKey, right.EndKey)
+}
+
+func DutyBoundCovers(grant, usage DutyBound) bool {
+	if grant.Kind != usage.Kind {
+		return false
+	}
+	switch usage.Kind {
+	case DutyBoundMonotone:
+		return usage.MonotoneUpper <= grant.MonotoneUpper
+	case DutyBoundVersion:
+		return usage.DescriptorRevisionCeiling <= grant.DescriptorRevisionCeiling &&
+			usage.MaxRootLag <= grant.MaxRootLag
+	case DutyBoundBudget:
+		return usage.Budget <= grant.Budget
+	case DutyBoundEpoch:
+		return usage.Epoch <= grant.Epoch
+	default:
+		return false
+	}
+}
+
+func validateDutyScope(spec DutySpec, scope DutyScope) bool {
+	if scope.Kind != spec.ScopeKind {
+		return false
+	}
+	switch scope.Kind {
+	case DutyScopeGlobal:
+		return scope.MountID == "" &&
+			scope.SubtreeRoot == 0 &&
+			len(scope.StartKey) == 0 &&
+			len(scope.EndKey) == 0
+	case DutyScopeMount:
+		return scope.MountID != "" &&
+			scope.SubtreeRoot == 0 &&
+			len(scope.StartKey) == 0 &&
+			len(scope.EndKey) == 0
+	case DutyScopeSubtree:
+		return scope.MountID != "" &&
+			scope.SubtreeRoot != 0 &&
+			len(scope.StartKey) == 0 &&
+			len(scope.EndKey) == 0
+	case DutyScopeRegionRange:
+		return len(scope.StartKey) != 0 || len(scope.EndKey) != 0
+	default:
+		return false
+	}
+}

--- a/meta/root/protocol/types.go
+++ b/meta/root/protocol/types.go
@@ -121,6 +121,22 @@ type AuthorityEvidence struct {
 	Usage                   AuthorityUsage
 	ObservedRetirements     []GrantRetirement
 	ObservedRetiredEraFloor uint64
+	ServedUnixNano          int64
+}
+
+type AuthorityVerifierKey struct {
+	ClusterID string
+	DutyID    DutyID
+	Scope     DutyScope
+}
+
+type AuthorityVerifierState struct {
+	Key                   AuthorityVerifierKey
+	MaxSeenEra            uint64
+	RetiredEraFloor       uint64
+	MaxRootToken          AuthorityRootToken
+	MaxDescriptorRevision uint64
+	MaxFrontier           DutyBound
 }
 
 type GrantAct uint8
@@ -269,6 +285,15 @@ func (g AuthorityGrant) ActiveAt(nowUnixNano int64) bool {
 func (g AuthorityGrant) Duty(duty DutyID) (DutyGrant, bool) {
 	for _, entry := range g.Duties {
 		if entry.DutyID == duty {
+			return entry, true
+		}
+	}
+	return DutyGrant{}, false
+}
+
+func (g AuthorityGrant) DutyFor(duty DutyID, scope DutyScope) (DutyGrant, bool) {
+	for _, entry := range g.Duties {
+		if entry.DutyID == duty && ScopeEqual(entry.Scope, scope) {
 			return entry, true
 		}
 	}

--- a/meta/root/replicated/store.go
+++ b/meta/root/replicated/store.go
@@ -338,6 +338,9 @@ func (s *Store) issueGrantLocked(ctx context.Context, cmd rootproto.GrantCommand
 	if holderID == "" || cmd.ExpiresUnixNano <= cmd.NowUnixNano || len(cmd.RequestedDuties) == 0 {
 		return s.state.Eunomia(), rootproto.GrantCertificate{}, rootstate.ErrInvalidGrant
 	}
+	if !validDutyGrants(cmd.RequestedDuties) || !validAuthorityUsages(cmd.ExactUsages) {
+		return s.state.Eunomia(), rootproto.GrantCertificate{}, rootstate.ErrDuty
+	}
 	requestedGrantID := strings.TrimSpace(cmd.GrantID)
 	if requestedGrantID != "" &&
 		s.state.ActiveGrant.Present() &&
@@ -434,6 +437,9 @@ func (s *Store) sealGrantLocked(ctx context.Context, cmd rootproto.GrantCommand)
 	if cmd.GrantID != "" && cmd.GrantID != active.GrantID {
 		return s.state.Eunomia(), rootstate.ErrPrimacy
 	}
+	if !validAuthorityUsages(cmd.ExactUsages) {
+		return s.state.Eunomia(), rootstate.ErrDuty
+	}
 	bounds := exactUsageBounds(active, cmd.ExactUsages)
 	if !dutyBoundsCovered(active.Duties, bounds) {
 		return s.state.Eunomia(), rootstate.ErrInheritance
@@ -484,9 +490,28 @@ func (s *Store) inheritGrantLocked(ctx context.Context, cmd rootproto.GrantComma
 	}
 	successor := s.state.ActiveGrant.GrantID
 	events := make([]rootevent.Event, 0, len(cmd.PredecessorGrantIDs))
+	seen := make(map[string]struct{}, len(cmd.PredecessorGrantIDs))
 	for _, predecessor := range cmd.PredecessorGrantIDs {
-		if strings.TrimSpace(predecessor) == "" {
+		predecessor = strings.TrimSpace(predecessor)
+		if predecessor == "" {
 			continue
+		}
+		if _, duplicate := seen[predecessor]; duplicate {
+			continue
+		}
+		seen[predecessor] = struct{}{}
+		retirement, ok := findRetirementByGrantID(s.state.RetiredGrants, predecessor)
+		if !ok {
+			return s.state.Eunomia(), rootstate.ErrInheritance
+		}
+		if retirement.InheritedByGrantID != "" {
+			if retirement.InheritedByGrantID == successor {
+				continue
+			}
+			return s.state.Eunomia(), rootstate.ErrFinality
+		}
+		if !predecessorRetirementCovered(s.state.ActiveGrant, retirement) {
+			return s.state.Eunomia(), rootstate.ErrInheritance
 		}
 		events = append(events, rootevent.GrantInherited(rootproto.GrantInheritance{
 			PredecessorGrantID: predecessor,
@@ -526,40 +551,69 @@ func exactUsageBounds(grant rootproto.AuthorityGrant, usages []rootproto.Authori
 
 func dutyBoundsCovered(grantBounds, usageBounds []rootproto.DutyGrant) bool {
 	for _, usage := range usageBounds {
-		grant, ok := findDutyGrant(grantBounds, usage.DutyID)
-		if !ok || !dutyBoundCovers(grant.Bound, usage.Bound) {
+		grant, ok := findDutyGrant(grantBounds, usage.DutyID, usage.Scope)
+		if !ok || !rootproto.DutyBoundCovers(grant.Bound, usage.Bound) {
 			return false
 		}
 	}
 	return true
 }
 
-func findDutyGrant(grants []rootproto.DutyGrant, duty rootproto.DutyID) (rootproto.DutyGrant, bool) {
+func findDutyGrant(grants []rootproto.DutyGrant, duty rootproto.DutyID, scope rootproto.DutyScope) (rootproto.DutyGrant, bool) {
 	for _, grant := range grants {
-		if grant.DutyID == duty {
+		if grant.DutyID == duty && rootproto.ScopeEqual(grant.Scope, scope) {
 			return grant, true
 		}
 	}
 	return rootproto.DutyGrant{}, false
 }
 
-func dutyBoundCovers(grant, usage rootproto.DutyBound) bool {
-	if grant.Kind != usage.Kind {
-		return false
+func validDutyGrants(grants []rootproto.DutyGrant) bool {
+	seen := make(map[string]struct{}, len(grants))
+	for _, grant := range grants {
+		if !rootproto.ValidateDutyGrant(grant) {
+			return false
+		}
+		key := string(grant.DutyID) + "\x00" + dutyScopeKey(grant.Scope)
+		if _, duplicate := seen[key]; duplicate {
+			return false
+		}
+		seen[key] = struct{}{}
 	}
-	switch usage.Kind {
-	case rootproto.DutyBoundMonotone:
-		return usage.MonotoneUpper <= grant.MonotoneUpper
-	case rootproto.DutyBoundVersion:
-		return usage.DescriptorRevisionCeiling <= grant.DescriptorRevisionCeiling &&
-			usage.MaxRootLag <= grant.MaxRootLag
-	case rootproto.DutyBoundBudget:
-		return usage.Budget <= grant.Budget
-	case rootproto.DutyBoundEpoch:
-		return usage.Epoch <= grant.Epoch
-	default:
-		return false
+	return true
+}
+
+func validAuthorityUsages(usages []rootproto.AuthorityUsage) bool {
+	for _, usage := range usages {
+		if !rootproto.ValidateAuthorityUsage(usage) {
+			return false
+		}
 	}
+	return true
+}
+
+func predecessorRetirementCovered(successor rootproto.AuthorityGrant, retirement rootproto.GrantRetirement) bool {
+	for _, inherited := range successor.PredecessorRetirements {
+		if inherited.GrantID == retirement.GrantID &&
+			inherited.Era == retirement.Era &&
+			dutyBoundsCovered(successor.Duties, retirement.Bounds) {
+			return true
+		}
+	}
+	return false
+}
+
+func findRetirementByGrantID(retirements []rootproto.GrantRetirement, grantID string) (rootproto.GrantRetirement, bool) {
+	for _, retirement := range retirements {
+		if retirement.GrantID == grantID {
+			return retirement, true
+		}
+	}
+	return rootproto.GrantRetirement{}, false
+}
+
+func dutyScopeKey(scope rootproto.DutyScope) string {
+	return fmt.Sprintf("%d/%s/%d/%x/%x", scope.Kind, scope.MountID, scope.SubtreeRoot, scope.StartKey, scope.EndKey)
 }
 
 func signGrantCertificate(grant rootproto.AuthorityGrant) (rootproto.GrantCertificate, error) {
@@ -644,8 +698,13 @@ func (s *Store) maybeCompactLocked() {
 	if s == nil {
 		return
 	}
+	plan := rootstorage.PlanTailCompaction(s.records, s.state.LastCommitted, s.maxRetainedRecords)
+	snapshotState := s.state
+	if plan.Compacted {
+		snapshotState = rootstate.CompactEunomiaState(snapshotState)
+	}
 	snapshot := rootstate.Snapshot{
-		State:               s.state,
+		State:               snapshotState,
 		Stores:              rootstate.CloneStoreMemberships(s.stores),
 		SnapshotEpochs:      rootstate.CloneSnapshotEpochs(s.snapshots),
 		Mounts:              rootstate.CloneMounts(s.mounts),
@@ -655,7 +714,6 @@ func (s *Store) maybeCompactLocked() {
 		PendingPeerChanges:  rootstate.ClonePendingPeerChanges(s.pending),
 		PendingRangeChanges: rootstate.ClonePendingRangeChanges(s.pendingRange),
 	}
-	plan := rootstorage.PlanTailCompaction(s.records, s.state.LastCommitted, s.maxRetainedRecords)
 	if !plan.Compacted {
 		s.records = plan.Tail.Records
 		s.retainFrom = plan.RetainFrom
@@ -664,6 +722,7 @@ func (s *Store) maybeCompactLocked() {
 	if err := s.driver.InstallBootstrap(plan.Observed(snapshot)); err != nil {
 		return
 	}
+	s.state = snapshotState
 	s.records = plan.Tail.Records
 	s.retainFrom = plan.RetainFrom
 }

--- a/meta/root/replicated/store_test.go
+++ b/meta/root/replicated/store_test.go
@@ -427,6 +427,66 @@ func TestReplicatedStoreRejectsSuccessorWithoutRetirementCoverage(t *testing.T) 
 	require.Len(t, successor.PredecessorRetirements, 1)
 }
 
+func TestReplicatedStoreRejectsUnregisteredDuty(t *testing.T) {
+	stores, _, leaderID := openNetworkTestCluster(t, 4)
+	_, _, err := stores[leaderID].ApplyGrant(context.Background(), rootproto.GrantCommand{
+		Kind:            rootproto.GrantActIssue,
+		HolderID:        "c1",
+		ExpiresUnixNano: 1_000,
+		NowUnixNano:     100,
+		RequestedDuties: []rootproto.DutyGrant{
+			rootproto.NewGlobalMonotoneDuty(rootproto.DutyLeaseStart, 10),
+		},
+	})
+	require.ErrorIs(t, err, rootstate.ErrDuty)
+}
+
+func TestReplicatedStoreRejectsInvalidGrantInheritance(t *testing.T) {
+	stores, _, leaderID := openNetworkTestCluster(t, 4)
+	_, err := issueGrantWithDuties(stores[leaderID], "c1", 1_000, 100, []rootproto.DutyGrant{
+		rootproto.NewGlobalMonotoneDuty(rootproto.DutyAllocID, 10),
+	})
+	require.NoError(t, err)
+
+	_, err = inheritGrant(stores[leaderID], "c1", "missing-grant")
+	require.ErrorIs(t, err, rootstate.ErrInheritance)
+}
+
+func TestReplicatedStoreCompactsInheritedRetirementButKeepsFloorAndPending(t *testing.T) {
+	stores, drivers, leaderID := openNetworkTestCluster(t, 1)
+	store := stores[leaderID]
+
+	c1, _, err := issueGrant(store, "c1", 1_000, 100, 10, 20, 1)
+	require.NoError(t, err)
+	_, err = sealGrant(store, "c1", c1.GrantID, nil)
+	require.NoError(t, err)
+	c2, err := issueGrantWithDuties(store, "c2", 1_200, 200, []rootproto.DutyGrant{
+		rootproto.NewGlobalMonotoneDuty(rootproto.DutyAllocID, 20),
+		rootproto.NewGlobalMonotoneDuty(rootproto.DutyTSO, 40),
+		rootproto.NewGlobalVersionDuty(rootproto.DutyRegionLookup, rootproto.AuthorityRootToken{}, 1, 0),
+	})
+	require.NoError(t, err)
+	_, err = inheritGrant(store, "c2", c1.GrantID)
+	require.NoError(t, err)
+	_, err = sealGrant(store, "c2", c2.GrantID, nil)
+	require.NoError(t, err)
+
+	current, err := store.Current()
+	require.NoError(t, err)
+	require.Equal(t, uint64(1), current.RetiredEraFloor)
+	require.Len(t, current.RetiredGrants, 1)
+	require.Equal(t, c2.GrantID, current.RetiredGrants[0].GrantID)
+	require.Empty(t, current.GrantInheritances)
+
+	reopened, err := Open(Config{Driver: drivers[leaderID], MaxRetainedRecords: 1})
+	require.NoError(t, err)
+	reopenedState, err := reopened.Current()
+	require.NoError(t, err)
+	require.Equal(t, uint64(1), reopenedState.RetiredEraFloor)
+	require.Len(t, reopenedState.RetiredGrants, 1)
+	require.Equal(t, c2.GrantID, reopenedState.RetiredGrants[0].GrantID)
+}
+
 func TestReplicatedStoreGrantFenceSurvivesLeaderChange(t *testing.T) {
 	stores, drivers, leaderID := openNetworkTestCluster(t, 8)
 	followerID := uint64(1)

--- a/meta/root/state/eunomia.go
+++ b/meta/root/state/eunomia.go
@@ -6,6 +6,7 @@ type EunomiaState struct {
 	ActiveGrant       rootproto.AuthorityGrant
 	RetiredGrants     []rootproto.GrantRetirement
 	GrantInheritances []rootproto.GrantInheritance
+	RetiredEraFloor   uint64
 }
 
 func (s State) Eunomia() EunomiaState {
@@ -13,5 +14,6 @@ func (s State) Eunomia() EunomiaState {
 		ActiveGrant:       s.ActiveGrant,
 		RetiredGrants:     append([]rootproto.GrantRetirement(nil), s.RetiredGrants...),
 		GrantInheritances: append([]rootproto.GrantInheritance(nil), s.GrantInheritances...),
+		RetiredEraFloor:   s.RetiredEraFloor,
 	}
 }

--- a/meta/root/state/state.go
+++ b/meta/root/state/state.go
@@ -42,6 +42,7 @@ type State struct {
 	ActiveGrant       rootproto.AuthorityGrant
 	RetiredGrants     []rootproto.GrantRetirement
 	GrantInheritances []rootproto.GrantInheritance
+	RetiredEraFloor   uint64
 }
 
 type StoreMembershipState uint8
@@ -526,8 +527,53 @@ func applyGrantInheritanceToState(state *State, cursor Cursor, event rootevent.E
 	for i := range state.RetiredGrants {
 		if state.RetiredGrants[i].GrantID == inheritance.PredecessorGrantID {
 			state.RetiredGrants[i].InheritedByGrantID = inheritance.SuccessorGrantID
+			if state.RetiredGrants[i].Era > state.RetiredEraFloor {
+				state.RetiredEraFloor = state.RetiredGrants[i].Era
+			}
 		}
 	}
+}
+
+func CompactEunomiaState(state State) State {
+	if state.RetiredEraFloor == 0 {
+		return state
+	}
+	originalRetirements := append([]rootproto.GrantRetirement(nil), state.RetiredGrants...)
+	activePredecessors := make(map[string]struct{}, len(state.ActiveGrant.PredecessorRetirements))
+	for _, retirement := range state.ActiveGrant.PredecessorRetirements {
+		if retirement.GrantID != "" {
+			activePredecessors[retirement.GrantID] = struct{}{}
+		}
+	}
+	retirements := make([]rootproto.GrantRetirement, 0, len(originalRetirements))
+	for _, retirement := range originalRetirements {
+		if retirement.InheritedByGrantID != "" && retirement.Era <= state.RetiredEraFloor {
+			if _, active := activePredecessors[retirement.GrantID]; !active {
+				continue
+			}
+		}
+		retirements = append(retirements, retirement)
+	}
+	inheritances := make([]rootproto.GrantInheritance, 0, len(state.GrantInheritances))
+	for _, inheritance := range state.GrantInheritances {
+		keep := true
+		for _, retirement := range originalRetirements {
+			if retirement.GrantID == inheritance.PredecessorGrantID &&
+				retirement.InheritedByGrantID != "" &&
+				retirement.Era <= state.RetiredEraFloor {
+				if _, active := activePredecessors[retirement.GrantID]; !active {
+					keep = false
+				}
+				break
+			}
+		}
+		if keep {
+			inheritances = append(inheritances, inheritance)
+		}
+	}
+	state.RetiredGrants = retirements
+	state.GrantInheritances = inheritances
+	return state
 }
 
 // NextCursor returns the next ordered root cursor.

--- a/meta/wire/root.go
+++ b/meta/wire/root.go
@@ -29,6 +29,7 @@ func RootStateToProto(state rootstate.State) *metapb.RootState {
 		ActiveGrant:       RootAuthorityGrantToProto(state.ActiveGrant),
 		RetiredGrants:     RootGrantRetirementsToProto(state.RetiredGrants),
 		GrantInheritances: RootGrantInheritancesToProto(state.GrantInheritances),
+		RetiredEraFloor:   state.RetiredEraFloor,
 	}
 }
 
@@ -45,6 +46,7 @@ func RootStateFromProto(pbState *metapb.RootState) rootstate.State {
 		ActiveGrant:       RootAuthorityGrantFromProto(pbState.GetActiveGrant()),
 		RetiredGrants:     RootGrantRetirementsFromProto(pbState.GetRetiredGrants()),
 		GrantInheritances: RootGrantInheritancesFromProto(pbState.GetGrantInheritances()),
+		RetiredEraFloor:   pbState.GetRetiredEraFloor(),
 	}
 }
 
@@ -190,6 +192,7 @@ func RootEunomiaStateToProto(state rootstate.EunomiaState) *metapb.RootEunomiaSt
 		ActiveGrant:       RootAuthorityGrantToProto(state.ActiveGrant),
 		RetiredGrants:     RootGrantRetirementsToProto(state.RetiredGrants),
 		GrantInheritances: RootGrantInheritancesToProto(state.GrantInheritances),
+		RetiredEraFloor:   state.RetiredEraFloor,
 	}
 }
 
@@ -201,6 +204,7 @@ func RootEunomiaStateFromProto(state *metapb.RootEunomiaState) rootstate.Eunomia
 		ActiveGrant:       RootAuthorityGrantFromProto(state.GetActiveGrant()),
 		RetiredGrants:     RootGrantRetirementsFromProto(state.GetRetiredGrants()),
 		GrantInheritances: RootGrantInheritancesFromProto(state.GetGrantInheritances()),
+		RetiredEraFloor:   state.GetRetiredEraFloor(),
 	}
 }
 
@@ -580,6 +584,7 @@ func RootAuthorityEvidenceToProto(evidence rootproto.AuthorityEvidence) *metapb.
 		Usage:                   RootAuthorityUsageToProto(evidence.Usage),
 		ObservedRetirements:     RootGrantRetirementsToProto(evidence.ObservedRetirements),
 		ObservedRetiredEraFloor: evidence.ObservedRetiredEraFloor,
+		ServedUnixNano:          evidence.ServedUnixNano,
 	}
 }
 
@@ -592,6 +597,7 @@ func RootAuthorityEvidenceFromProto(evidence *metapb.RootAuthorityEvidence) root
 		Usage:                   RootAuthorityUsageFromProto(evidence.GetUsage()),
 		ObservedRetirements:     RootGrantRetirementsFromProto(evidence.GetObservedRetirements()),
 		ObservedRetiredEraFloor: evidence.GetObservedRetiredEraFloor(),
+		ServedUnixNano:          evidence.GetServedUnixNano(),
 	}
 }
 

--- a/pb/meta/root.pb.go
+++ b/pb/meta/root.pb.go
@@ -726,6 +726,7 @@ type RootState struct {
 	ActiveGrant       *RootAuthorityGrant     `protobuf:"bytes,7,opt,name=active_grant,json=activeGrant,proto3" json:"active_grant,omitempty"`
 	RetiredGrants     []*RootGrantRetirement  `protobuf:"bytes,8,rep,name=retired_grants,json=retiredGrants,proto3" json:"retired_grants,omitempty"`
 	GrantInheritances []*RootGrantInheritance `protobuf:"bytes,9,rep,name=grant_inheritances,json=grantInheritances,proto3" json:"grant_inheritances,omitempty"`
+	RetiredEraFloor   uint64                  `protobuf:"varint,10,opt,name=retired_era_floor,json=retiredEraFloor,proto3" json:"retired_era_floor,omitempty"`
 	unknownFields     protoimpl.UnknownFields
 	sizeCache         protoimpl.SizeCache
 }
@@ -814,6 +815,13 @@ func (x *RootState) GetGrantInheritances() []*RootGrantInheritance {
 		return x.GrantInheritances
 	}
 	return nil
+}
+
+func (x *RootState) GetRetiredEraFloor() uint64 {
+	if x != nil {
+		return x.RetiredEraFloor
+	}
+	return 0
 }
 
 type RootCheckpoint struct {
@@ -2332,6 +2340,7 @@ type RootAuthorityEvidence struct {
 	Usage                   *RootAuthorityUsage    `protobuf:"bytes,2,opt,name=usage,proto3" json:"usage,omitempty"`
 	ObservedRetirements     []*RootGrantRetirement `protobuf:"bytes,3,rep,name=observed_retirements,json=observedRetirements,proto3" json:"observed_retirements,omitempty"`
 	ObservedRetiredEraFloor uint64                 `protobuf:"varint,4,opt,name=observed_retired_era_floor,json=observedRetiredEraFloor,proto3" json:"observed_retired_era_floor,omitempty"`
+	ServedUnixNano          int64                  `protobuf:"varint,5,opt,name=served_unix_nano,json=servedUnixNano,proto3" json:"served_unix_nano,omitempty"`
 	unknownFields           protoimpl.UnknownFields
 	sizeCache               protoimpl.SizeCache
 }
@@ -2394,6 +2403,201 @@ func (x *RootAuthorityEvidence) GetObservedRetiredEraFloor() uint64 {
 	return 0
 }
 
+func (x *RootAuthorityEvidence) GetServedUnixNano() int64 {
+	if x != nil {
+		return x.ServedUnixNano
+	}
+	return 0
+}
+
+type RootAuthorityVerifierKey struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	ClusterId     string                 `protobuf:"bytes,1,opt,name=cluster_id,json=clusterId,proto3" json:"cluster_id,omitempty"`
+	DutyId        string                 `protobuf:"bytes,2,opt,name=duty_id,json=dutyId,proto3" json:"duty_id,omitempty"`
+	Scope         *RootDutyScope         `protobuf:"bytes,3,opt,name=scope,proto3" json:"scope,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *RootAuthorityVerifierKey) Reset() {
+	*x = RootAuthorityVerifierKey{}
+	mi := &file_meta_root_proto_msgTypes[23]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *RootAuthorityVerifierKey) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*RootAuthorityVerifierKey) ProtoMessage() {}
+
+func (x *RootAuthorityVerifierKey) ProtoReflect() protoreflect.Message {
+	mi := &file_meta_root_proto_msgTypes[23]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use RootAuthorityVerifierKey.ProtoReflect.Descriptor instead.
+func (*RootAuthorityVerifierKey) Descriptor() ([]byte, []int) {
+	return file_meta_root_proto_rawDescGZIP(), []int{23}
+}
+
+func (x *RootAuthorityVerifierKey) GetClusterId() string {
+	if x != nil {
+		return x.ClusterId
+	}
+	return ""
+}
+
+func (x *RootAuthorityVerifierKey) GetDutyId() string {
+	if x != nil {
+		return x.DutyId
+	}
+	return ""
+}
+
+func (x *RootAuthorityVerifierKey) GetScope() *RootDutyScope {
+	if x != nil {
+		return x.Scope
+	}
+	return nil
+}
+
+type RootAuthorityVerifierState struct {
+	state                 protoimpl.MessageState    `protogen:"open.v1"`
+	Key                   *RootAuthorityVerifierKey `protobuf:"bytes,1,opt,name=key,proto3" json:"key,omitempty"`
+	MaxSeenEra            uint64                    `protobuf:"varint,2,opt,name=max_seen_era,json=maxSeenEra,proto3" json:"max_seen_era,omitempty"`
+	RetiredEraFloor       uint64                    `protobuf:"varint,3,opt,name=retired_era_floor,json=retiredEraFloor,proto3" json:"retired_era_floor,omitempty"`
+	MaxRootToken          *RootTailToken            `protobuf:"bytes,4,opt,name=max_root_token,json=maxRootToken,proto3" json:"max_root_token,omitempty"`
+	MaxDescriptorRevision uint64                    `protobuf:"varint,5,opt,name=max_descriptor_revision,json=maxDescriptorRevision,proto3" json:"max_descriptor_revision,omitempty"`
+	MaxFrontier           *RootDutyBound            `protobuf:"bytes,6,opt,name=max_frontier,json=maxFrontier,proto3" json:"max_frontier,omitempty"`
+	unknownFields         protoimpl.UnknownFields
+	sizeCache             protoimpl.SizeCache
+}
+
+func (x *RootAuthorityVerifierState) Reset() {
+	*x = RootAuthorityVerifierState{}
+	mi := &file_meta_root_proto_msgTypes[24]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *RootAuthorityVerifierState) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*RootAuthorityVerifierState) ProtoMessage() {}
+
+func (x *RootAuthorityVerifierState) ProtoReflect() protoreflect.Message {
+	mi := &file_meta_root_proto_msgTypes[24]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use RootAuthorityVerifierState.ProtoReflect.Descriptor instead.
+func (*RootAuthorityVerifierState) Descriptor() ([]byte, []int) {
+	return file_meta_root_proto_rawDescGZIP(), []int{24}
+}
+
+func (x *RootAuthorityVerifierState) GetKey() *RootAuthorityVerifierKey {
+	if x != nil {
+		return x.Key
+	}
+	return nil
+}
+
+func (x *RootAuthorityVerifierState) GetMaxSeenEra() uint64 {
+	if x != nil {
+		return x.MaxSeenEra
+	}
+	return 0
+}
+
+func (x *RootAuthorityVerifierState) GetRetiredEraFloor() uint64 {
+	if x != nil {
+		return x.RetiredEraFloor
+	}
+	return 0
+}
+
+func (x *RootAuthorityVerifierState) GetMaxRootToken() *RootTailToken {
+	if x != nil {
+		return x.MaxRootToken
+	}
+	return nil
+}
+
+func (x *RootAuthorityVerifierState) GetMaxDescriptorRevision() uint64 {
+	if x != nil {
+		return x.MaxDescriptorRevision
+	}
+	return 0
+}
+
+func (x *RootAuthorityVerifierState) GetMaxFrontier() *RootDutyBound {
+	if x != nil {
+		return x.MaxFrontier
+	}
+	return nil
+}
+
+type RootAuthorityVerifierStore struct {
+	state         protoimpl.MessageState        `protogen:"open.v1"`
+	States        []*RootAuthorityVerifierState `protobuf:"bytes,1,rep,name=states,proto3" json:"states,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *RootAuthorityVerifierStore) Reset() {
+	*x = RootAuthorityVerifierStore{}
+	mi := &file_meta_root_proto_msgTypes[25]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *RootAuthorityVerifierStore) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*RootAuthorityVerifierStore) ProtoMessage() {}
+
+func (x *RootAuthorityVerifierStore) ProtoReflect() protoreflect.Message {
+	mi := &file_meta_root_proto_msgTypes[25]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use RootAuthorityVerifierStore.ProtoReflect.Descriptor instead.
+func (*RootAuthorityVerifierStore) Descriptor() ([]byte, []int) {
+	return file_meta_root_proto_rawDescGZIP(), []int{25}
+}
+
+func (x *RootAuthorityVerifierStore) GetStates() []*RootAuthorityVerifierState {
+	if x != nil {
+		return x.States
+	}
+	return nil
+}
+
 type RootRegionDescriptor struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	Descriptor_   *RegionDescriptor      `protobuf:"bytes,1,opt,name=descriptor,proto3" json:"descriptor,omitempty"`
@@ -2403,7 +2607,7 @@ type RootRegionDescriptor struct {
 
 func (x *RootRegionDescriptor) Reset() {
 	*x = RootRegionDescriptor{}
-	mi := &file_meta_root_proto_msgTypes[23]
+	mi := &file_meta_root_proto_msgTypes[26]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2415,7 +2619,7 @@ func (x *RootRegionDescriptor) String() string {
 func (*RootRegionDescriptor) ProtoMessage() {}
 
 func (x *RootRegionDescriptor) ProtoReflect() protoreflect.Message {
-	mi := &file_meta_root_proto_msgTypes[23]
+	mi := &file_meta_root_proto_msgTypes[26]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2428,7 +2632,7 @@ func (x *RootRegionDescriptor) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RootRegionDescriptor.ProtoReflect.Descriptor instead.
 func (*RootRegionDescriptor) Descriptor() ([]byte, []int) {
-	return file_meta_root_proto_rawDescGZIP(), []int{23}
+	return file_meta_root_proto_rawDescGZIP(), []int{26}
 }
 
 func (x *RootRegionDescriptor) GetDescriptor_() *RegionDescriptor {
@@ -2447,7 +2651,7 @@ type RootRegionRemoval struct {
 
 func (x *RootRegionRemoval) Reset() {
 	*x = RootRegionRemoval{}
-	mi := &file_meta_root_proto_msgTypes[24]
+	mi := &file_meta_root_proto_msgTypes[27]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2459,7 +2663,7 @@ func (x *RootRegionRemoval) String() string {
 func (*RootRegionRemoval) ProtoMessage() {}
 
 func (x *RootRegionRemoval) ProtoReflect() protoreflect.Message {
-	mi := &file_meta_root_proto_msgTypes[24]
+	mi := &file_meta_root_proto_msgTypes[27]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2472,7 +2676,7 @@ func (x *RootRegionRemoval) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RootRegionRemoval.ProtoReflect.Descriptor instead.
 func (*RootRegionRemoval) Descriptor() ([]byte, []int) {
-	return file_meta_root_proto_rawDescGZIP(), []int{24}
+	return file_meta_root_proto_rawDescGZIP(), []int{27}
 }
 
 func (x *RootRegionRemoval) GetRegionId() uint64 {
@@ -2495,7 +2699,7 @@ type RootRangeSplit struct {
 
 func (x *RootRangeSplit) Reset() {
 	*x = RootRangeSplit{}
-	mi := &file_meta_root_proto_msgTypes[25]
+	mi := &file_meta_root_proto_msgTypes[28]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2507,7 +2711,7 @@ func (x *RootRangeSplit) String() string {
 func (*RootRangeSplit) ProtoMessage() {}
 
 func (x *RootRangeSplit) ProtoReflect() protoreflect.Message {
-	mi := &file_meta_root_proto_msgTypes[25]
+	mi := &file_meta_root_proto_msgTypes[28]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2520,7 +2724,7 @@ func (x *RootRangeSplit) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RootRangeSplit.ProtoReflect.Descriptor instead.
 func (*RootRangeSplit) Descriptor() ([]byte, []int) {
-	return file_meta_root_proto_rawDescGZIP(), []int{25}
+	return file_meta_root_proto_rawDescGZIP(), []int{28}
 }
 
 func (x *RootRangeSplit) GetParentRegionId() uint64 {
@@ -2571,7 +2775,7 @@ type RootRangeMerge struct {
 
 func (x *RootRangeMerge) Reset() {
 	*x = RootRangeMerge{}
-	mi := &file_meta_root_proto_msgTypes[26]
+	mi := &file_meta_root_proto_msgTypes[29]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2583,7 +2787,7 @@ func (x *RootRangeMerge) String() string {
 func (*RootRangeMerge) ProtoMessage() {}
 
 func (x *RootRangeMerge) ProtoReflect() protoreflect.Message {
-	mi := &file_meta_root_proto_msgTypes[26]
+	mi := &file_meta_root_proto_msgTypes[29]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2596,7 +2800,7 @@ func (x *RootRangeMerge) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RootRangeMerge.ProtoReflect.Descriptor instead.
 func (*RootRangeMerge) Descriptor() ([]byte, []int) {
-	return file_meta_root_proto_rawDescGZIP(), []int{26}
+	return file_meta_root_proto_rawDescGZIP(), []int{29}
 }
 
 func (x *RootRangeMerge) GetLeftRegionId() uint64 {
@@ -2647,7 +2851,7 @@ type RootPeerChange struct {
 
 func (x *RootPeerChange) Reset() {
 	*x = RootPeerChange{}
-	mi := &file_meta_root_proto_msgTypes[27]
+	mi := &file_meta_root_proto_msgTypes[30]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2659,7 +2863,7 @@ func (x *RootPeerChange) String() string {
 func (*RootPeerChange) ProtoMessage() {}
 
 func (x *RootPeerChange) ProtoReflect() protoreflect.Message {
-	mi := &file_meta_root_proto_msgTypes[27]
+	mi := &file_meta_root_proto_msgTypes[30]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2672,7 +2876,7 @@ func (x *RootPeerChange) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RootPeerChange.ProtoReflect.Descriptor instead.
 func (*RootPeerChange) Descriptor() ([]byte, []int) {
-	return file_meta_root_proto_rawDescGZIP(), []int{27}
+	return file_meta_root_proto_rawDescGZIP(), []int{30}
 }
 
 func (x *RootPeerChange) GetRegionId() uint64 {
@@ -2724,7 +2928,7 @@ type RootPendingPeerChange struct {
 
 func (x *RootPendingPeerChange) Reset() {
 	*x = RootPendingPeerChange{}
-	mi := &file_meta_root_proto_msgTypes[28]
+	mi := &file_meta_root_proto_msgTypes[31]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2736,7 +2940,7 @@ func (x *RootPendingPeerChange) String() string {
 func (*RootPendingPeerChange) ProtoMessage() {}
 
 func (x *RootPendingPeerChange) ProtoReflect() protoreflect.Message {
-	mi := &file_meta_root_proto_msgTypes[28]
+	mi := &file_meta_root_proto_msgTypes[31]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2749,7 +2953,7 @@ func (x *RootPendingPeerChange) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RootPendingPeerChange.ProtoReflect.Descriptor instead.
 func (*RootPendingPeerChange) Descriptor() ([]byte, []int) {
-	return file_meta_root_proto_rawDescGZIP(), []int{28}
+	return file_meta_root_proto_rawDescGZIP(), []int{31}
 }
 
 func (x *RootPendingPeerChange) GetRegionId() uint64 {
@@ -2813,7 +3017,7 @@ type RootPendingRangeChange struct {
 
 func (x *RootPendingRangeChange) Reset() {
 	*x = RootPendingRangeChange{}
-	mi := &file_meta_root_proto_msgTypes[29]
+	mi := &file_meta_root_proto_msgTypes[32]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2825,7 +3029,7 @@ func (x *RootPendingRangeChange) String() string {
 func (*RootPendingRangeChange) ProtoMessage() {}
 
 func (x *RootPendingRangeChange) ProtoReflect() protoreflect.Message {
-	mi := &file_meta_root_proto_msgTypes[29]
+	mi := &file_meta_root_proto_msgTypes[32]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2838,7 +3042,7 @@ func (x *RootPendingRangeChange) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RootPendingRangeChange.ProtoReflect.Descriptor instead.
 func (*RootPendingRangeChange) Descriptor() ([]byte, []int) {
-	return file_meta_root_proto_rawDescGZIP(), []int{29}
+	return file_meta_root_proto_rawDescGZIP(), []int{32}
 }
 
 func (x *RootPendingRangeChange) GetRegionId() uint64 {
@@ -2944,7 +3148,7 @@ type RootEvent struct {
 
 func (x *RootEvent) Reset() {
 	*x = RootEvent{}
-	mi := &file_meta_root_proto_msgTypes[30]
+	mi := &file_meta_root_proto_msgTypes[33]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2956,7 +3160,7 @@ func (x *RootEvent) String() string {
 func (*RootEvent) ProtoMessage() {}
 
 func (x *RootEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_meta_root_proto_msgTypes[30]
+	mi := &file_meta_root_proto_msgTypes[33]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2969,7 +3173,7 @@ func (x *RootEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RootEvent.ProtoReflect.Descriptor instead.
 func (*RootEvent) Descriptor() ([]byte, []int) {
-	return file_meta_root_proto_rawDescGZIP(), []int{30}
+	return file_meta_root_proto_rawDescGZIP(), []int{33}
 }
 
 func (x *RootEvent) GetKind() RootEventKind {
@@ -3208,7 +3412,7 @@ type MetadataRootSnapshotRequest struct {
 
 func (x *MetadataRootSnapshotRequest) Reset() {
 	*x = MetadataRootSnapshotRequest{}
-	mi := &file_meta_root_proto_msgTypes[31]
+	mi := &file_meta_root_proto_msgTypes[34]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3220,7 +3424,7 @@ func (x *MetadataRootSnapshotRequest) String() string {
 func (*MetadataRootSnapshotRequest) ProtoMessage() {}
 
 func (x *MetadataRootSnapshotRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_meta_root_proto_msgTypes[31]
+	mi := &file_meta_root_proto_msgTypes[34]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3233,7 +3437,7 @@ func (x *MetadataRootSnapshotRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use MetadataRootSnapshotRequest.ProtoReflect.Descriptor instead.
 func (*MetadataRootSnapshotRequest) Descriptor() ([]byte, []int) {
-	return file_meta_root_proto_rawDescGZIP(), []int{31}
+	return file_meta_root_proto_rawDescGZIP(), []int{34}
 }
 
 type MetadataRootSnapshotResponse struct {
@@ -3245,7 +3449,7 @@ type MetadataRootSnapshotResponse struct {
 
 func (x *MetadataRootSnapshotResponse) Reset() {
 	*x = MetadataRootSnapshotResponse{}
-	mi := &file_meta_root_proto_msgTypes[32]
+	mi := &file_meta_root_proto_msgTypes[35]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3257,7 +3461,7 @@ func (x *MetadataRootSnapshotResponse) String() string {
 func (*MetadataRootSnapshotResponse) ProtoMessage() {}
 
 func (x *MetadataRootSnapshotResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_meta_root_proto_msgTypes[32]
+	mi := &file_meta_root_proto_msgTypes[35]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3270,7 +3474,7 @@ func (x *MetadataRootSnapshotResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use MetadataRootSnapshotResponse.ProtoReflect.Descriptor instead.
 func (*MetadataRootSnapshotResponse) Descriptor() ([]byte, []int) {
-	return file_meta_root_proto_rawDescGZIP(), []int{32}
+	return file_meta_root_proto_rawDescGZIP(), []int{35}
 }
 
 func (x *MetadataRootSnapshotResponse) GetCheckpoint() *RootCheckpoint {
@@ -3289,7 +3493,7 @@ type MetadataRootAppendRequest struct {
 
 func (x *MetadataRootAppendRequest) Reset() {
 	*x = MetadataRootAppendRequest{}
-	mi := &file_meta_root_proto_msgTypes[33]
+	mi := &file_meta_root_proto_msgTypes[36]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3301,7 +3505,7 @@ func (x *MetadataRootAppendRequest) String() string {
 func (*MetadataRootAppendRequest) ProtoMessage() {}
 
 func (x *MetadataRootAppendRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_meta_root_proto_msgTypes[33]
+	mi := &file_meta_root_proto_msgTypes[36]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3314,7 +3518,7 @@ func (x *MetadataRootAppendRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use MetadataRootAppendRequest.ProtoReflect.Descriptor instead.
 func (*MetadataRootAppendRequest) Descriptor() ([]byte, []int) {
-	return file_meta_root_proto_rawDescGZIP(), []int{33}
+	return file_meta_root_proto_rawDescGZIP(), []int{36}
 }
 
 func (x *MetadataRootAppendRequest) GetEvents() []*RootEvent {
@@ -3334,7 +3538,7 @@ type MetadataRootAppendResponse struct {
 
 func (x *MetadataRootAppendResponse) Reset() {
 	*x = MetadataRootAppendResponse{}
-	mi := &file_meta_root_proto_msgTypes[34]
+	mi := &file_meta_root_proto_msgTypes[37]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3346,7 +3550,7 @@ func (x *MetadataRootAppendResponse) String() string {
 func (*MetadataRootAppendResponse) ProtoMessage() {}
 
 func (x *MetadataRootAppendResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_meta_root_proto_msgTypes[34]
+	mi := &file_meta_root_proto_msgTypes[37]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3359,7 +3563,7 @@ func (x *MetadataRootAppendResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use MetadataRootAppendResponse.ProtoReflect.Descriptor instead.
 func (*MetadataRootAppendResponse) Descriptor() ([]byte, []int) {
-	return file_meta_root_proto_rawDescGZIP(), []int{34}
+	return file_meta_root_proto_rawDescGZIP(), []int{37}
 }
 
 func (x *MetadataRootAppendResponse) GetCursor() *RootCursor {
@@ -3386,7 +3590,7 @@ type MetadataRootFenceAllocatorRequest struct {
 
 func (x *MetadataRootFenceAllocatorRequest) Reset() {
 	*x = MetadataRootFenceAllocatorRequest{}
-	mi := &file_meta_root_proto_msgTypes[35]
+	mi := &file_meta_root_proto_msgTypes[38]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3398,7 +3602,7 @@ func (x *MetadataRootFenceAllocatorRequest) String() string {
 func (*MetadataRootFenceAllocatorRequest) ProtoMessage() {}
 
 func (x *MetadataRootFenceAllocatorRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_meta_root_proto_msgTypes[35]
+	mi := &file_meta_root_proto_msgTypes[38]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3411,7 +3615,7 @@ func (x *MetadataRootFenceAllocatorRequest) ProtoReflect() protoreflect.Message 
 
 // Deprecated: Use MetadataRootFenceAllocatorRequest.ProtoReflect.Descriptor instead.
 func (*MetadataRootFenceAllocatorRequest) Descriptor() ([]byte, []int) {
-	return file_meta_root_proto_rawDescGZIP(), []int{35}
+	return file_meta_root_proto_rawDescGZIP(), []int{38}
 }
 
 func (x *MetadataRootFenceAllocatorRequest) GetKind() RootAllocatorKind {
@@ -3437,7 +3641,7 @@ type MetadataRootFenceAllocatorResponse struct {
 
 func (x *MetadataRootFenceAllocatorResponse) Reset() {
 	*x = MetadataRootFenceAllocatorResponse{}
-	mi := &file_meta_root_proto_msgTypes[36]
+	mi := &file_meta_root_proto_msgTypes[39]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3449,7 +3653,7 @@ func (x *MetadataRootFenceAllocatorResponse) String() string {
 func (*MetadataRootFenceAllocatorResponse) ProtoMessage() {}
 
 func (x *MetadataRootFenceAllocatorResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_meta_root_proto_msgTypes[36]
+	mi := &file_meta_root_proto_msgTypes[39]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3462,7 +3666,7 @@ func (x *MetadataRootFenceAllocatorResponse) ProtoReflect() protoreflect.Message
 
 // Deprecated: Use MetadataRootFenceAllocatorResponse.ProtoReflect.Descriptor instead.
 func (*MetadataRootFenceAllocatorResponse) Descriptor() ([]byte, []int) {
-	return file_meta_root_proto_rawDescGZIP(), []int{36}
+	return file_meta_root_proto_rawDescGZIP(), []int{39}
 }
 
 func (x *MetadataRootFenceAllocatorResponse) GetCurrent() uint64 {
@@ -3480,7 +3684,7 @@ type MetadataRootStatusRequest struct {
 
 func (x *MetadataRootStatusRequest) Reset() {
 	*x = MetadataRootStatusRequest{}
-	mi := &file_meta_root_proto_msgTypes[37]
+	mi := &file_meta_root_proto_msgTypes[40]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3492,7 +3696,7 @@ func (x *MetadataRootStatusRequest) String() string {
 func (*MetadataRootStatusRequest) ProtoMessage() {}
 
 func (x *MetadataRootStatusRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_meta_root_proto_msgTypes[37]
+	mi := &file_meta_root_proto_msgTypes[40]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3505,7 +3709,7 @@ func (x *MetadataRootStatusRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use MetadataRootStatusRequest.ProtoReflect.Descriptor instead.
 func (*MetadataRootStatusRequest) Descriptor() ([]byte, []int) {
-	return file_meta_root_proto_rawDescGZIP(), []int{37}
+	return file_meta_root_proto_rawDescGZIP(), []int{40}
 }
 
 type MetadataRootStatusResponse struct {
@@ -3518,7 +3722,7 @@ type MetadataRootStatusResponse struct {
 
 func (x *MetadataRootStatusResponse) Reset() {
 	*x = MetadataRootStatusResponse{}
-	mi := &file_meta_root_proto_msgTypes[38]
+	mi := &file_meta_root_proto_msgTypes[41]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3530,7 +3734,7 @@ func (x *MetadataRootStatusResponse) String() string {
 func (*MetadataRootStatusResponse) ProtoMessage() {}
 
 func (x *MetadataRootStatusResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_meta_root_proto_msgTypes[38]
+	mi := &file_meta_root_proto_msgTypes[41]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3543,7 +3747,7 @@ func (x *MetadataRootStatusResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use MetadataRootStatusResponse.ProtoReflect.Descriptor instead.
 func (*MetadataRootStatusResponse) Descriptor() ([]byte, []int) {
-	return file_meta_root_proto_rawDescGZIP(), []int{38}
+	return file_meta_root_proto_rawDescGZIP(), []int{41}
 }
 
 func (x *MetadataRootStatusResponse) GetIsLeader() bool {
@@ -3565,13 +3769,14 @@ type RootEunomiaState struct {
 	ActiveGrant       *RootAuthorityGrant     `protobuf:"bytes,1,opt,name=active_grant,json=activeGrant,proto3" json:"active_grant,omitempty"`
 	RetiredGrants     []*RootGrantRetirement  `protobuf:"bytes,2,rep,name=retired_grants,json=retiredGrants,proto3" json:"retired_grants,omitempty"`
 	GrantInheritances []*RootGrantInheritance `protobuf:"bytes,3,rep,name=grant_inheritances,json=grantInheritances,proto3" json:"grant_inheritances,omitempty"`
+	RetiredEraFloor   uint64                  `protobuf:"varint,4,opt,name=retired_era_floor,json=retiredEraFloor,proto3" json:"retired_era_floor,omitempty"`
 	unknownFields     protoimpl.UnknownFields
 	sizeCache         protoimpl.SizeCache
 }
 
 func (x *RootEunomiaState) Reset() {
 	*x = RootEunomiaState{}
-	mi := &file_meta_root_proto_msgTypes[39]
+	mi := &file_meta_root_proto_msgTypes[42]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3583,7 +3788,7 @@ func (x *RootEunomiaState) String() string {
 func (*RootEunomiaState) ProtoMessage() {}
 
 func (x *RootEunomiaState) ProtoReflect() protoreflect.Message {
-	mi := &file_meta_root_proto_msgTypes[39]
+	mi := &file_meta_root_proto_msgTypes[42]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3596,7 +3801,7 @@ func (x *RootEunomiaState) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RootEunomiaState.ProtoReflect.Descriptor instead.
 func (*RootEunomiaState) Descriptor() ([]byte, []int) {
-	return file_meta_root_proto_rawDescGZIP(), []int{39}
+	return file_meta_root_proto_rawDescGZIP(), []int{42}
 }
 
 func (x *RootEunomiaState) GetActiveGrant() *RootAuthorityGrant {
@@ -3620,6 +3825,13 @@ func (x *RootEunomiaState) GetGrantInheritances() []*RootGrantInheritance {
 	return nil
 }
 
+func (x *RootEunomiaState) GetRetiredEraFloor() uint64 {
+	if x != nil {
+		return x.RetiredEraFloor
+	}
+	return 0
+}
+
 type RootGrantCommand struct {
 	state               protoimpl.MessageState `protogen:"open.v1"`
 	Kind                RootGrantAct           `protobuf:"varint,1,opt,name=kind,proto3,enum=nokv.meta.v1.RootGrantAct" json:"kind,omitempty"`
@@ -3636,7 +3848,7 @@ type RootGrantCommand struct {
 
 func (x *RootGrantCommand) Reset() {
 	*x = RootGrantCommand{}
-	mi := &file_meta_root_proto_msgTypes[40]
+	mi := &file_meta_root_proto_msgTypes[43]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3648,7 +3860,7 @@ func (x *RootGrantCommand) String() string {
 func (*RootGrantCommand) ProtoMessage() {}
 
 func (x *RootGrantCommand) ProtoReflect() protoreflect.Message {
-	mi := &file_meta_root_proto_msgTypes[40]
+	mi := &file_meta_root_proto_msgTypes[43]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3661,7 +3873,7 @@ func (x *RootGrantCommand) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RootGrantCommand.ProtoReflect.Descriptor instead.
 func (*RootGrantCommand) Descriptor() ([]byte, []int) {
-	return file_meta_root_proto_rawDescGZIP(), []int{40}
+	return file_meta_root_proto_rawDescGZIP(), []int{43}
 }
 
 func (x *RootGrantCommand) GetKind() RootGrantAct {
@@ -3729,7 +3941,7 @@ type MetadataRootApplyGrantRequest struct {
 
 func (x *MetadataRootApplyGrantRequest) Reset() {
 	*x = MetadataRootApplyGrantRequest{}
-	mi := &file_meta_root_proto_msgTypes[41]
+	mi := &file_meta_root_proto_msgTypes[44]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3741,7 +3953,7 @@ func (x *MetadataRootApplyGrantRequest) String() string {
 func (*MetadataRootApplyGrantRequest) ProtoMessage() {}
 
 func (x *MetadataRootApplyGrantRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_meta_root_proto_msgTypes[41]
+	mi := &file_meta_root_proto_msgTypes[44]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3754,7 +3966,7 @@ func (x *MetadataRootApplyGrantRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use MetadataRootApplyGrantRequest.ProtoReflect.Descriptor instead.
 func (*MetadataRootApplyGrantRequest) Descriptor() ([]byte, []int) {
-	return file_meta_root_proto_rawDescGZIP(), []int{41}
+	return file_meta_root_proto_rawDescGZIP(), []int{44}
 }
 
 func (x *MetadataRootApplyGrantRequest) GetCommand() *RootGrantCommand {
@@ -3775,7 +3987,7 @@ type MetadataRootApplyGrantResponse struct {
 
 func (x *MetadataRootApplyGrantResponse) Reset() {
 	*x = MetadataRootApplyGrantResponse{}
-	mi := &file_meta_root_proto_msgTypes[42]
+	mi := &file_meta_root_proto_msgTypes[45]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3787,7 +3999,7 @@ func (x *MetadataRootApplyGrantResponse) String() string {
 func (*MetadataRootApplyGrantResponse) ProtoMessage() {}
 
 func (x *MetadataRootApplyGrantResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_meta_root_proto_msgTypes[42]
+	mi := &file_meta_root_proto_msgTypes[45]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3800,7 +4012,7 @@ func (x *MetadataRootApplyGrantResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use MetadataRootApplyGrantResponse.ProtoReflect.Descriptor instead.
 func (*MetadataRootApplyGrantResponse) Descriptor() ([]byte, []int) {
-	return file_meta_root_proto_rawDescGZIP(), []int{42}
+	return file_meta_root_proto_rawDescGZIP(), []int{45}
 }
 
 func (x *MetadataRootApplyGrantResponse) GetState() *RootEunomiaState {
@@ -3834,7 +4046,7 @@ type RootTailToken struct {
 
 func (x *RootTailToken) Reset() {
 	*x = RootTailToken{}
-	mi := &file_meta_root_proto_msgTypes[43]
+	mi := &file_meta_root_proto_msgTypes[46]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3846,7 +4058,7 @@ func (x *RootTailToken) String() string {
 func (*RootTailToken) ProtoMessage() {}
 
 func (x *RootTailToken) ProtoReflect() protoreflect.Message {
-	mi := &file_meta_root_proto_msgTypes[43]
+	mi := &file_meta_root_proto_msgTypes[46]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3859,7 +4071,7 @@ func (x *RootTailToken) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RootTailToken.ProtoReflect.Descriptor instead.
 func (*RootTailToken) Descriptor() ([]byte, []int) {
-	return file_meta_root_proto_rawDescGZIP(), []int{43}
+	return file_meta_root_proto_rawDescGZIP(), []int{46}
 }
 
 func (x *RootTailToken) GetCursor() *RootCursor {
@@ -3886,7 +4098,7 @@ type RootCommittedEvent struct {
 
 func (x *RootCommittedEvent) Reset() {
 	*x = RootCommittedEvent{}
-	mi := &file_meta_root_proto_msgTypes[44]
+	mi := &file_meta_root_proto_msgTypes[47]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3898,7 +4110,7 @@ func (x *RootCommittedEvent) String() string {
 func (*RootCommittedEvent) ProtoMessage() {}
 
 func (x *RootCommittedEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_meta_root_proto_msgTypes[44]
+	mi := &file_meta_root_proto_msgTypes[47]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3911,7 +4123,7 @@ func (x *RootCommittedEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RootCommittedEvent.ProtoReflect.Descriptor instead.
 func (*RootCommittedEvent) Descriptor() ([]byte, []int) {
-	return file_meta_root_proto_rawDescGZIP(), []int{44}
+	return file_meta_root_proto_rawDescGZIP(), []int{47}
 }
 
 func (x *RootCommittedEvent) GetCursor() *RootCursor {
@@ -3940,7 +4152,7 @@ type RootCommittedTail struct {
 
 func (x *RootCommittedTail) Reset() {
 	*x = RootCommittedTail{}
-	mi := &file_meta_root_proto_msgTypes[45]
+	mi := &file_meta_root_proto_msgTypes[48]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3952,7 +4164,7 @@ func (x *RootCommittedTail) String() string {
 func (*RootCommittedTail) ProtoMessage() {}
 
 func (x *RootCommittedTail) ProtoReflect() protoreflect.Message {
-	mi := &file_meta_root_proto_msgTypes[45]
+	mi := &file_meta_root_proto_msgTypes[48]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3965,7 +4177,7 @@ func (x *RootCommittedTail) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RootCommittedTail.ProtoReflect.Descriptor instead.
 func (*RootCommittedTail) Descriptor() ([]byte, []int) {
-	return file_meta_root_proto_rawDescGZIP(), []int{45}
+	return file_meta_root_proto_rawDescGZIP(), []int{48}
 }
 
 func (x *RootCommittedTail) GetRequestedOffset() int64 {
@@ -4005,7 +4217,7 @@ type MetadataRootObserveCommittedRequest struct {
 
 func (x *MetadataRootObserveCommittedRequest) Reset() {
 	*x = MetadataRootObserveCommittedRequest{}
-	mi := &file_meta_root_proto_msgTypes[46]
+	mi := &file_meta_root_proto_msgTypes[49]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4017,7 +4229,7 @@ func (x *MetadataRootObserveCommittedRequest) String() string {
 func (*MetadataRootObserveCommittedRequest) ProtoMessage() {}
 
 func (x *MetadataRootObserveCommittedRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_meta_root_proto_msgTypes[46]
+	mi := &file_meta_root_proto_msgTypes[49]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4030,7 +4242,7 @@ func (x *MetadataRootObserveCommittedRequest) ProtoReflect() protoreflect.Messag
 
 // Deprecated: Use MetadataRootObserveCommittedRequest.ProtoReflect.Descriptor instead.
 func (*MetadataRootObserveCommittedRequest) Descriptor() ([]byte, []int) {
-	return file_meta_root_proto_rawDescGZIP(), []int{46}
+	return file_meta_root_proto_rawDescGZIP(), []int{49}
 }
 
 func (x *MetadataRootObserveCommittedRequest) GetRequestedOffset() int64 {
@@ -4050,7 +4262,7 @@ type MetadataRootObserveCommittedResponse struct {
 
 func (x *MetadataRootObserveCommittedResponse) Reset() {
 	*x = MetadataRootObserveCommittedResponse{}
-	mi := &file_meta_root_proto_msgTypes[47]
+	mi := &file_meta_root_proto_msgTypes[50]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4062,7 +4274,7 @@ func (x *MetadataRootObserveCommittedResponse) String() string {
 func (*MetadataRootObserveCommittedResponse) ProtoMessage() {}
 
 func (x *MetadataRootObserveCommittedResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_meta_root_proto_msgTypes[47]
+	mi := &file_meta_root_proto_msgTypes[50]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4075,7 +4287,7 @@ func (x *MetadataRootObserveCommittedResponse) ProtoReflect() protoreflect.Messa
 
 // Deprecated: Use MetadataRootObserveCommittedResponse.ProtoReflect.Descriptor instead.
 func (*MetadataRootObserveCommittedResponse) Descriptor() ([]byte, []int) {
-	return file_meta_root_proto_rawDescGZIP(), []int{47}
+	return file_meta_root_proto_rawDescGZIP(), []int{50}
 }
 
 func (x *MetadataRootObserveCommittedResponse) GetCheckpoint() *RootCheckpoint {
@@ -4101,7 +4313,7 @@ type MetadataRootObserveTailRequest struct {
 
 func (x *MetadataRootObserveTailRequest) Reset() {
 	*x = MetadataRootObserveTailRequest{}
-	mi := &file_meta_root_proto_msgTypes[48]
+	mi := &file_meta_root_proto_msgTypes[51]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4113,7 +4325,7 @@ func (x *MetadataRootObserveTailRequest) String() string {
 func (*MetadataRootObserveTailRequest) ProtoMessage() {}
 
 func (x *MetadataRootObserveTailRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_meta_root_proto_msgTypes[48]
+	mi := &file_meta_root_proto_msgTypes[51]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4126,7 +4338,7 @@ func (x *MetadataRootObserveTailRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use MetadataRootObserveTailRequest.ProtoReflect.Descriptor instead.
 func (*MetadataRootObserveTailRequest) Descriptor() ([]byte, []int) {
-	return file_meta_root_proto_rawDescGZIP(), []int{48}
+	return file_meta_root_proto_rawDescGZIP(), []int{51}
 }
 
 func (x *MetadataRootObserveTailRequest) GetAfter() *RootTailToken {
@@ -4148,7 +4360,7 @@ type MetadataRootObserveTailResponse struct {
 
 func (x *MetadataRootObserveTailResponse) Reset() {
 	*x = MetadataRootObserveTailResponse{}
-	mi := &file_meta_root_proto_msgTypes[49]
+	mi := &file_meta_root_proto_msgTypes[52]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4160,7 +4372,7 @@ func (x *MetadataRootObserveTailResponse) String() string {
 func (*MetadataRootObserveTailResponse) ProtoMessage() {}
 
 func (x *MetadataRootObserveTailResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_meta_root_proto_msgTypes[49]
+	mi := &file_meta_root_proto_msgTypes[52]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4173,7 +4385,7 @@ func (x *MetadataRootObserveTailResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use MetadataRootObserveTailResponse.ProtoReflect.Descriptor instead.
 func (*MetadataRootObserveTailResponse) Descriptor() ([]byte, []int) {
-	return file_meta_root_proto_rawDescGZIP(), []int{49}
+	return file_meta_root_proto_rawDescGZIP(), []int{52}
 }
 
 func (x *MetadataRootObserveTailResponse) GetAfter() *RootTailToken {
@@ -4214,7 +4426,7 @@ type MetadataRootWaitTailRequest struct {
 
 func (x *MetadataRootWaitTailRequest) Reset() {
 	*x = MetadataRootWaitTailRequest{}
-	mi := &file_meta_root_proto_msgTypes[50]
+	mi := &file_meta_root_proto_msgTypes[53]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4226,7 +4438,7 @@ func (x *MetadataRootWaitTailRequest) String() string {
 func (*MetadataRootWaitTailRequest) ProtoMessage() {}
 
 func (x *MetadataRootWaitTailRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_meta_root_proto_msgTypes[50]
+	mi := &file_meta_root_proto_msgTypes[53]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4239,7 +4451,7 @@ func (x *MetadataRootWaitTailRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use MetadataRootWaitTailRequest.ProtoReflect.Descriptor instead.
 func (*MetadataRootWaitTailRequest) Descriptor() ([]byte, []int) {
-	return file_meta_root_proto_rawDescGZIP(), []int{50}
+	return file_meta_root_proto_rawDescGZIP(), []int{53}
 }
 
 func (x *MetadataRootWaitTailRequest) GetAfter() *RootTailToken {
@@ -4268,7 +4480,7 @@ type MetadataRootWaitTailResponse struct {
 
 func (x *MetadataRootWaitTailResponse) Reset() {
 	*x = MetadataRootWaitTailResponse{}
-	mi := &file_meta_root_proto_msgTypes[51]
+	mi := &file_meta_root_proto_msgTypes[54]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4280,7 +4492,7 @@ func (x *MetadataRootWaitTailResponse) String() string {
 func (*MetadataRootWaitTailResponse) ProtoMessage() {}
 
 func (x *MetadataRootWaitTailResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_meta_root_proto_msgTypes[51]
+	mi := &file_meta_root_proto_msgTypes[54]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4293,7 +4505,7 @@ func (x *MetadataRootWaitTailResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use MetadataRootWaitTailResponse.ProtoReflect.Descriptor instead.
 func (*MetadataRootWaitTailResponse) Descriptor() ([]byte, []int) {
-	return file_meta_root_proto_rawDescGZIP(), []int{51}
+	return file_meta_root_proto_rawDescGZIP(), []int{54}
 }
 
 func (x *MetadataRootWaitTailResponse) GetAfter() *RootTailToken {
@@ -4332,7 +4544,7 @@ const file_meta_root_proto_rawDesc = "" +
 	"\n" +
 	"RootCursor\x12\x12\n" +
 	"\x04term\x18\x01 \x01(\x04R\x04term\x12\x14\n" +
-	"\x05index\x18\x02 \x01(\x04R\x05index\"\xb6\x03\n" +
+	"\x05index\x18\x02 \x01(\x04R\x05index\"\xe2\x03\n" +
 	"\tRootState\x12#\n" +
 	"\rcluster_epoch\x18\x01 \x01(\x04R\fclusterEpoch\x12)\n" +
 	"\x10membership_epoch\x18\x02 \x01(\x04R\x0fmembershipEpoch\x12?\n" +
@@ -4341,7 +4553,9 @@ const file_meta_root_proto_rawDesc = "" +
 	"\ttso_fence\x18\x06 \x01(\x04R\btsoFence\x12C\n" +
 	"\factive_grant\x18\a \x01(\v2 .nokv.meta.v1.RootAuthorityGrantR\vactiveGrant\x12H\n" +
 	"\x0eretired_grants\x18\b \x03(\v2!.nokv.meta.v1.RootGrantRetirementR\rretiredGrants\x12Q\n" +
-	"\x12grant_inheritances\x18\t \x03(\v2\".nokv.meta.v1.RootGrantInheritanceR\x11grantInheritances\"\xf5\x04\n" +
+	"\x12grant_inheritances\x18\t \x03(\v2\".nokv.meta.v1.RootGrantInheritanceR\x11grantInheritances\x12*\n" +
+	"\x11retired_era_floor\x18\n" +
+	" \x01(\x04R\x0fretiredEraFloor\"\xf5\x04\n" +
 	"\x0eRootCheckpoint\x12-\n" +
 	"\x05state\x18\x01 \x01(\v2\x17.nokv.meta.v1.RootStateR\x05state\x12@\n" +
 	"\vdescriptors\x18\x02 \x03(\v2\x1e.nokv.meta.v1.RegionDescriptorR\vdescriptors\x12\x1f\n" +
@@ -4472,12 +4686,28 @@ const file_meta_root_proto_rawDesc = "" +
 	"\x12RootAuthorityUsage\x12\x17\n" +
 	"\aduty_id\x18\x01 \x01(\tR\x06dutyId\x121\n" +
 	"\x05scope\x18\x02 \x01(\v2\x1b.nokv.meta.v1.RootDutyScopeR\x05scope\x121\n" +
-	"\x05usage\x18\x03 \x01(\v2\x1b.nokv.meta.v1.RootDutyBoundR\x05usage\"\xa8\x02\n" +
+	"\x05usage\x18\x03 \x01(\v2\x1b.nokv.meta.v1.RootDutyBoundR\x05usage\"\xd2\x02\n" +
 	"\x15RootAuthorityEvidence\x12D\n" +
 	"\vcertificate\x18\x01 \x01(\v2\".nokv.meta.v1.RootGrantCertificateR\vcertificate\x126\n" +
 	"\x05usage\x18\x02 \x01(\v2 .nokv.meta.v1.RootAuthorityUsageR\x05usage\x12T\n" +
 	"\x14observed_retirements\x18\x03 \x03(\v2!.nokv.meta.v1.RootGrantRetirementR\x13observedRetirements\x12;\n" +
-	"\x1aobserved_retired_era_floor\x18\x04 \x01(\x04R\x17observedRetiredEraFloor\"V\n" +
+	"\x1aobserved_retired_era_floor\x18\x04 \x01(\x04R\x17observedRetiredEraFloor\x12(\n" +
+	"\x10served_unix_nano\x18\x05 \x01(\x03R\x0eservedUnixNano\"\x85\x01\n" +
+	"\x18RootAuthorityVerifierKey\x12\x1d\n" +
+	"\n" +
+	"cluster_id\x18\x01 \x01(\tR\tclusterId\x12\x17\n" +
+	"\aduty_id\x18\x02 \x01(\tR\x06dutyId\x121\n" +
+	"\x05scope\x18\x03 \x01(\v2\x1b.nokv.meta.v1.RootDutyScopeR\x05scope\"\xdf\x02\n" +
+	"\x1aRootAuthorityVerifierState\x128\n" +
+	"\x03key\x18\x01 \x01(\v2&.nokv.meta.v1.RootAuthorityVerifierKeyR\x03key\x12 \n" +
+	"\fmax_seen_era\x18\x02 \x01(\x04R\n" +
+	"maxSeenEra\x12*\n" +
+	"\x11retired_era_floor\x18\x03 \x01(\x04R\x0fretiredEraFloor\x12A\n" +
+	"\x0emax_root_token\x18\x04 \x01(\v2\x1b.nokv.meta.v1.RootTailTokenR\fmaxRootToken\x126\n" +
+	"\x17max_descriptor_revision\x18\x05 \x01(\x04R\x15maxDescriptorRevision\x12>\n" +
+	"\fmax_frontier\x18\x06 \x01(\v2\x1b.nokv.meta.v1.RootDutyBoundR\vmaxFrontier\"^\n" +
+	"\x1aRootAuthorityVerifierStore\x12@\n" +
+	"\x06states\x18\x01 \x03(\v2(.nokv.meta.v1.RootAuthorityVerifierStateR\x06states\"V\n" +
 	"\x14RootRegionDescriptor\x12>\n" +
 	"\n" +
 	"descriptor\x18\x01 \x01(\v2\x1e.nokv.meta.v1.RegionDescriptorR\n" +
@@ -4566,11 +4796,12 @@ const file_meta_root_proto_rawDesc = "" +
 	"\x19MetadataRootStatusRequest\"V\n" +
 	"\x1aMetadataRootStatusResponse\x12\x1b\n" +
 	"\tis_leader\x18\x01 \x01(\bR\bisLeader\x12\x1b\n" +
-	"\tleader_id\x18\x02 \x01(\x04R\bleaderId\"\xf4\x01\n" +
+	"\tleader_id\x18\x02 \x01(\x04R\bleaderId\"\xa0\x02\n" +
 	"\x10RootEunomiaState\x12C\n" +
 	"\factive_grant\x18\x01 \x01(\v2 .nokv.meta.v1.RootAuthorityGrantR\vactiveGrant\x12H\n" +
 	"\x0eretired_grants\x18\x02 \x03(\v2!.nokv.meta.v1.RootGrantRetirementR\rretiredGrants\x12Q\n" +
-	"\x12grant_inheritances\x18\x03 \x03(\v2\".nokv.meta.v1.RootGrantInheritanceR\x11grantInheritances\"\x8b\x03\n" +
+	"\x12grant_inheritances\x18\x03 \x03(\v2\".nokv.meta.v1.RootGrantInheritanceR\x11grantInheritances\x12*\n" +
+	"\x11retired_era_floor\x18\x04 \x01(\x04R\x0fretiredEraFloor\"\x8b\x03\n" +
 	"\x10RootGrantCommand\x12.\n" +
 	"\x04kind\x18\x01 \x01(\x0e2\x1a.nokv.meta.v1.RootGrantActR\x04kind\x12\x1b\n" +
 	"\tholder_id\x18\x02 \x01(\tR\bholderId\x12\x19\n" +
@@ -4728,7 +4959,7 @@ func file_meta_root_proto_rawDescGZIP() []byte {
 }
 
 var file_meta_root_proto_enumTypes = make([]protoimpl.EnumInfo, 11)
-var file_meta_root_proto_msgTypes = make([]protoimpl.MessageInfo, 52)
+var file_meta_root_proto_msgTypes = make([]protoimpl.MessageInfo, 55)
 var file_meta_root_proto_goTypes = []any{
 	(RootEventKind)(0),                           // 0: nokv.meta.v1.RootEventKind
 	(RootStoreState)(0),                          // 1: nokv.meta.v1.RootStoreState
@@ -4764,36 +4995,39 @@ var file_meta_root_proto_goTypes = []any{
 	(*RootGrantCertificate)(nil),                 // 31: nokv.meta.v1.RootGrantCertificate
 	(*RootAuthorityUsage)(nil),                   // 32: nokv.meta.v1.RootAuthorityUsage
 	(*RootAuthorityEvidence)(nil),                // 33: nokv.meta.v1.RootAuthorityEvidence
-	(*RootRegionDescriptor)(nil),                 // 34: nokv.meta.v1.RootRegionDescriptor
-	(*RootRegionRemoval)(nil),                    // 35: nokv.meta.v1.RootRegionRemoval
-	(*RootRangeSplit)(nil),                       // 36: nokv.meta.v1.RootRangeSplit
-	(*RootRangeMerge)(nil),                       // 37: nokv.meta.v1.RootRangeMerge
-	(*RootPeerChange)(nil),                       // 38: nokv.meta.v1.RootPeerChange
-	(*RootPendingPeerChange)(nil),                // 39: nokv.meta.v1.RootPendingPeerChange
-	(*RootPendingRangeChange)(nil),               // 40: nokv.meta.v1.RootPendingRangeChange
-	(*RootEvent)(nil),                            // 41: nokv.meta.v1.RootEvent
-	(*MetadataRootSnapshotRequest)(nil),          // 42: nokv.meta.v1.MetadataRootSnapshotRequest
-	(*MetadataRootSnapshotResponse)(nil),         // 43: nokv.meta.v1.MetadataRootSnapshotResponse
-	(*MetadataRootAppendRequest)(nil),            // 44: nokv.meta.v1.MetadataRootAppendRequest
-	(*MetadataRootAppendResponse)(nil),           // 45: nokv.meta.v1.MetadataRootAppendResponse
-	(*MetadataRootFenceAllocatorRequest)(nil),    // 46: nokv.meta.v1.MetadataRootFenceAllocatorRequest
-	(*MetadataRootFenceAllocatorResponse)(nil),   // 47: nokv.meta.v1.MetadataRootFenceAllocatorResponse
-	(*MetadataRootStatusRequest)(nil),            // 48: nokv.meta.v1.MetadataRootStatusRequest
-	(*MetadataRootStatusResponse)(nil),           // 49: nokv.meta.v1.MetadataRootStatusResponse
-	(*RootEunomiaState)(nil),                     // 50: nokv.meta.v1.RootEunomiaState
-	(*RootGrantCommand)(nil),                     // 51: nokv.meta.v1.RootGrantCommand
-	(*MetadataRootApplyGrantRequest)(nil),        // 52: nokv.meta.v1.MetadataRootApplyGrantRequest
-	(*MetadataRootApplyGrantResponse)(nil),       // 53: nokv.meta.v1.MetadataRootApplyGrantResponse
-	(*RootTailToken)(nil),                        // 54: nokv.meta.v1.RootTailToken
-	(*RootCommittedEvent)(nil),                   // 55: nokv.meta.v1.RootCommittedEvent
-	(*RootCommittedTail)(nil),                    // 56: nokv.meta.v1.RootCommittedTail
-	(*MetadataRootObserveCommittedRequest)(nil),  // 57: nokv.meta.v1.MetadataRootObserveCommittedRequest
-	(*MetadataRootObserveCommittedResponse)(nil), // 58: nokv.meta.v1.MetadataRootObserveCommittedResponse
-	(*MetadataRootObserveTailRequest)(nil),       // 59: nokv.meta.v1.MetadataRootObserveTailRequest
-	(*MetadataRootObserveTailResponse)(nil),      // 60: nokv.meta.v1.MetadataRootObserveTailResponse
-	(*MetadataRootWaitTailRequest)(nil),          // 61: nokv.meta.v1.MetadataRootWaitTailRequest
-	(*MetadataRootWaitTailResponse)(nil),         // 62: nokv.meta.v1.MetadataRootWaitTailResponse
-	(*RegionDescriptor)(nil),                     // 63: nokv.meta.v1.RegionDescriptor
+	(*RootAuthorityVerifierKey)(nil),             // 34: nokv.meta.v1.RootAuthorityVerifierKey
+	(*RootAuthorityVerifierState)(nil),           // 35: nokv.meta.v1.RootAuthorityVerifierState
+	(*RootAuthorityVerifierStore)(nil),           // 36: nokv.meta.v1.RootAuthorityVerifierStore
+	(*RootRegionDescriptor)(nil),                 // 37: nokv.meta.v1.RootRegionDescriptor
+	(*RootRegionRemoval)(nil),                    // 38: nokv.meta.v1.RootRegionRemoval
+	(*RootRangeSplit)(nil),                       // 39: nokv.meta.v1.RootRangeSplit
+	(*RootRangeMerge)(nil),                       // 40: nokv.meta.v1.RootRangeMerge
+	(*RootPeerChange)(nil),                       // 41: nokv.meta.v1.RootPeerChange
+	(*RootPendingPeerChange)(nil),                // 42: nokv.meta.v1.RootPendingPeerChange
+	(*RootPendingRangeChange)(nil),               // 43: nokv.meta.v1.RootPendingRangeChange
+	(*RootEvent)(nil),                            // 44: nokv.meta.v1.RootEvent
+	(*MetadataRootSnapshotRequest)(nil),          // 45: nokv.meta.v1.MetadataRootSnapshotRequest
+	(*MetadataRootSnapshotResponse)(nil),         // 46: nokv.meta.v1.MetadataRootSnapshotResponse
+	(*MetadataRootAppendRequest)(nil),            // 47: nokv.meta.v1.MetadataRootAppendRequest
+	(*MetadataRootAppendResponse)(nil),           // 48: nokv.meta.v1.MetadataRootAppendResponse
+	(*MetadataRootFenceAllocatorRequest)(nil),    // 49: nokv.meta.v1.MetadataRootFenceAllocatorRequest
+	(*MetadataRootFenceAllocatorResponse)(nil),   // 50: nokv.meta.v1.MetadataRootFenceAllocatorResponse
+	(*MetadataRootStatusRequest)(nil),            // 51: nokv.meta.v1.MetadataRootStatusRequest
+	(*MetadataRootStatusResponse)(nil),           // 52: nokv.meta.v1.MetadataRootStatusResponse
+	(*RootEunomiaState)(nil),                     // 53: nokv.meta.v1.RootEunomiaState
+	(*RootGrantCommand)(nil),                     // 54: nokv.meta.v1.RootGrantCommand
+	(*MetadataRootApplyGrantRequest)(nil),        // 55: nokv.meta.v1.MetadataRootApplyGrantRequest
+	(*MetadataRootApplyGrantResponse)(nil),       // 56: nokv.meta.v1.MetadataRootApplyGrantResponse
+	(*RootTailToken)(nil),                        // 57: nokv.meta.v1.RootTailToken
+	(*RootCommittedEvent)(nil),                   // 58: nokv.meta.v1.RootCommittedEvent
+	(*RootCommittedTail)(nil),                    // 59: nokv.meta.v1.RootCommittedTail
+	(*MetadataRootObserveCommittedRequest)(nil),  // 60: nokv.meta.v1.MetadataRootObserveCommittedRequest
+	(*MetadataRootObserveCommittedResponse)(nil), // 61: nokv.meta.v1.MetadataRootObserveCommittedResponse
+	(*MetadataRootObserveTailRequest)(nil),       // 62: nokv.meta.v1.MetadataRootObserveTailRequest
+	(*MetadataRootObserveTailResponse)(nil),      // 63: nokv.meta.v1.MetadataRootObserveTailResponse
+	(*MetadataRootWaitTailRequest)(nil),          // 64: nokv.meta.v1.MetadataRootWaitTailRequest
+	(*MetadataRootWaitTailResponse)(nil),         // 65: nokv.meta.v1.MetadataRootWaitTailResponse
+	(*RegionDescriptor)(nil),                     // 66: nokv.meta.v1.RegionDescriptor
 }
 var file_meta_root_proto_depIdxs = []int32{
 	11,  // 0: nokv.meta.v1.RootState.last_committed:type_name -> nokv.meta.v1.RootCursor
@@ -4801,9 +5035,9 @@ var file_meta_root_proto_depIdxs = []int32{
 	29,  // 2: nokv.meta.v1.RootState.retired_grants:type_name -> nokv.meta.v1.RootGrantRetirement
 	30,  // 3: nokv.meta.v1.RootState.grant_inheritances:type_name -> nokv.meta.v1.RootGrantInheritance
 	12,  // 4: nokv.meta.v1.RootCheckpoint.state:type_name -> nokv.meta.v1.RootState
-	63,  // 5: nokv.meta.v1.RootCheckpoint.descriptors:type_name -> nokv.meta.v1.RegionDescriptor
-	39,  // 6: nokv.meta.v1.RootCheckpoint.pending_peer_changes:type_name -> nokv.meta.v1.RootPendingPeerChange
-	40,  // 7: nokv.meta.v1.RootCheckpoint.pending_range_changes:type_name -> nokv.meta.v1.RootPendingRangeChange
+	66,  // 5: nokv.meta.v1.RootCheckpoint.descriptors:type_name -> nokv.meta.v1.RegionDescriptor
+	42,  // 6: nokv.meta.v1.RootCheckpoint.pending_peer_changes:type_name -> nokv.meta.v1.RootPendingPeerChange
+	43,  // 7: nokv.meta.v1.RootCheckpoint.pending_range_changes:type_name -> nokv.meta.v1.RootPendingRangeChange
 	15,  // 8: nokv.meta.v1.RootCheckpoint.stores:type_name -> nokv.meta.v1.RootStore
 	16,  // 9: nokv.meta.v1.RootCheckpoint.snapshot_epochs:type_name -> nokv.meta.v1.RootSnapshotEpoch
 	17,  // 10: nokv.meta.v1.RootCheckpoint.mounts:type_name -> nokv.meta.v1.RootMount
@@ -4822,7 +5056,7 @@ var file_meta_root_proto_depIdxs = []int32{
 	11,  // 23: nokv.meta.v1.RootSubtreeAuthority.handoff_completed_at:type_name -> nokv.meta.v1.RootCursor
 	11,  // 24: nokv.meta.v1.RootQuotaFence.updated_at:type_name -> nokv.meta.v1.RootCursor
 	4,   // 25: nokv.meta.v1.RootDutyScope.kind:type_name -> nokv.meta.v1.RootDutyScopeKind
-	54,  // 26: nokv.meta.v1.RootVersionBound.root_token:type_name -> nokv.meta.v1.RootTailToken
+	57,  // 26: nokv.meta.v1.RootVersionBound.root_token:type_name -> nokv.meta.v1.RootTailToken
 	22,  // 27: nokv.meta.v1.RootDutyBound.monotone:type_name -> nokv.meta.v1.RootMonotoneBound
 	23,  // 28: nokv.meta.v1.RootDutyBound.version:type_name -> nokv.meta.v1.RootVersionBound
 	24,  // 29: nokv.meta.v1.RootDutyBound.budget:type_name -> nokv.meta.v1.RootBudgetBound
@@ -4830,7 +5064,7 @@ var file_meta_root_proto_depIdxs = []int32{
 	21,  // 31: nokv.meta.v1.RootDutyGrant.scope:type_name -> nokv.meta.v1.RootDutyScope
 	26,  // 32: nokv.meta.v1.RootDutyGrant.bound:type_name -> nokv.meta.v1.RootDutyBound
 	11,  // 33: nokv.meta.v1.RootAuthorityGrant.issued_at:type_name -> nokv.meta.v1.RootCursor
-	54,  // 34: nokv.meta.v1.RootAuthorityGrant.issued_root_token:type_name -> nokv.meta.v1.RootTailToken
+	57,  // 34: nokv.meta.v1.RootAuthorityGrant.issued_root_token:type_name -> nokv.meta.v1.RootTailToken
 	27,  // 35: nokv.meta.v1.RootAuthorityGrant.duties:type_name -> nokv.meta.v1.RootDutyGrant
 	29,  // 36: nokv.meta.v1.RootAuthorityGrant.predecessor_retirements:type_name -> nokv.meta.v1.RootGrantRetirement
 	5,   // 37: nokv.meta.v1.RootGrantRetirement.mode:type_name -> nokv.meta.v1.RootGrantRetirementMode
@@ -4843,92 +5077,97 @@ var file_meta_root_proto_depIdxs = []int32{
 	31,  // 44: nokv.meta.v1.RootAuthorityEvidence.certificate:type_name -> nokv.meta.v1.RootGrantCertificate
 	32,  // 45: nokv.meta.v1.RootAuthorityEvidence.usage:type_name -> nokv.meta.v1.RootAuthorityUsage
 	29,  // 46: nokv.meta.v1.RootAuthorityEvidence.observed_retirements:type_name -> nokv.meta.v1.RootGrantRetirement
-	63,  // 47: nokv.meta.v1.RootRegionDescriptor.descriptor:type_name -> nokv.meta.v1.RegionDescriptor
-	63,  // 48: nokv.meta.v1.RootRangeSplit.left:type_name -> nokv.meta.v1.RegionDescriptor
-	63,  // 49: nokv.meta.v1.RootRangeSplit.right:type_name -> nokv.meta.v1.RegionDescriptor
-	63,  // 50: nokv.meta.v1.RootRangeSplit.base_parent:type_name -> nokv.meta.v1.RegionDescriptor
-	63,  // 51: nokv.meta.v1.RootRangeMerge.merged:type_name -> nokv.meta.v1.RegionDescriptor
-	63,  // 52: nokv.meta.v1.RootRangeMerge.base_left:type_name -> nokv.meta.v1.RegionDescriptor
-	63,  // 53: nokv.meta.v1.RootRangeMerge.base_right:type_name -> nokv.meta.v1.RegionDescriptor
-	63,  // 54: nokv.meta.v1.RootPeerChange.target:type_name -> nokv.meta.v1.RegionDescriptor
-	63,  // 55: nokv.meta.v1.RootPeerChange.base:type_name -> nokv.meta.v1.RegionDescriptor
-	6,   // 56: nokv.meta.v1.RootPendingPeerChange.kind:type_name -> nokv.meta.v1.RootPendingPeerChangeKind
-	63,  // 57: nokv.meta.v1.RootPendingPeerChange.target:type_name -> nokv.meta.v1.RegionDescriptor
-	63,  // 58: nokv.meta.v1.RootPendingPeerChange.base:type_name -> nokv.meta.v1.RegionDescriptor
-	7,   // 59: nokv.meta.v1.RootPendingRangeChange.kind:type_name -> nokv.meta.v1.RootPendingRangeChangeKind
-	63,  // 60: nokv.meta.v1.RootPendingRangeChange.left:type_name -> nokv.meta.v1.RegionDescriptor
-	63,  // 61: nokv.meta.v1.RootPendingRangeChange.right:type_name -> nokv.meta.v1.RegionDescriptor
-	63,  // 62: nokv.meta.v1.RootPendingRangeChange.merged:type_name -> nokv.meta.v1.RegionDescriptor
-	63,  // 63: nokv.meta.v1.RootPendingRangeChange.base_parent:type_name -> nokv.meta.v1.RegionDescriptor
-	63,  // 64: nokv.meta.v1.RootPendingRangeChange.base_left:type_name -> nokv.meta.v1.RegionDescriptor
-	63,  // 65: nokv.meta.v1.RootPendingRangeChange.base_right:type_name -> nokv.meta.v1.RegionDescriptor
-	0,   // 66: nokv.meta.v1.RootEvent.kind:type_name -> nokv.meta.v1.RootEventKind
-	14,  // 67: nokv.meta.v1.RootEvent.store_membership:type_name -> nokv.meta.v1.RootStoreMembership
-	20,  // 68: nokv.meta.v1.RootEvent.allocator_fence:type_name -> nokv.meta.v1.RootAllocatorFence
-	34,  // 69: nokv.meta.v1.RootEvent.region_descriptor:type_name -> nokv.meta.v1.RootRegionDescriptor
-	35,  // 70: nokv.meta.v1.RootEvent.region_removal:type_name -> nokv.meta.v1.RootRegionRemoval
-	36,  // 71: nokv.meta.v1.RootEvent.range_split:type_name -> nokv.meta.v1.RootRangeSplit
-	37,  // 72: nokv.meta.v1.RootEvent.range_merge:type_name -> nokv.meta.v1.RootRangeMerge
-	38,  // 73: nokv.meta.v1.RootEvent.peer_change:type_name -> nokv.meta.v1.RootPeerChange
-	28,  // 74: nokv.meta.v1.RootEvent.grant:type_name -> nokv.meta.v1.RootAuthorityGrant
-	29,  // 75: nokv.meta.v1.RootEvent.grant_retirement:type_name -> nokv.meta.v1.RootGrantRetirement
-	30,  // 76: nokv.meta.v1.RootEvent.grant_inheritance:type_name -> nokv.meta.v1.RootGrantInheritance
-	16,  // 77: nokv.meta.v1.RootEvent.snapshot_epoch:type_name -> nokv.meta.v1.RootSnapshotEpoch
-	17,  // 78: nokv.meta.v1.RootEvent.mount:type_name -> nokv.meta.v1.RootMount
-	18,  // 79: nokv.meta.v1.RootEvent.subtree_authority:type_name -> nokv.meta.v1.RootSubtreeAuthority
-	19,  // 80: nokv.meta.v1.RootEvent.quota_fence:type_name -> nokv.meta.v1.RootQuotaFence
-	13,  // 81: nokv.meta.v1.MetadataRootSnapshotResponse.checkpoint:type_name -> nokv.meta.v1.RootCheckpoint
-	41,  // 82: nokv.meta.v1.MetadataRootAppendRequest.events:type_name -> nokv.meta.v1.RootEvent
-	11,  // 83: nokv.meta.v1.MetadataRootAppendResponse.cursor:type_name -> nokv.meta.v1.RootCursor
-	12,  // 84: nokv.meta.v1.MetadataRootAppendResponse.state:type_name -> nokv.meta.v1.RootState
-	8,   // 85: nokv.meta.v1.MetadataRootFenceAllocatorRequest.kind:type_name -> nokv.meta.v1.RootAllocatorKind
-	28,  // 86: nokv.meta.v1.RootEunomiaState.active_grant:type_name -> nokv.meta.v1.RootAuthorityGrant
-	29,  // 87: nokv.meta.v1.RootEunomiaState.retired_grants:type_name -> nokv.meta.v1.RootGrantRetirement
-	30,  // 88: nokv.meta.v1.RootEunomiaState.grant_inheritances:type_name -> nokv.meta.v1.RootGrantInheritance
-	9,   // 89: nokv.meta.v1.RootGrantCommand.kind:type_name -> nokv.meta.v1.RootGrantAct
-	27,  // 90: nokv.meta.v1.RootGrantCommand.requested_duties:type_name -> nokv.meta.v1.RootDutyGrant
-	32,  // 91: nokv.meta.v1.RootGrantCommand.exact_usages:type_name -> nokv.meta.v1.RootAuthorityUsage
-	51,  // 92: nokv.meta.v1.MetadataRootApplyGrantRequest.command:type_name -> nokv.meta.v1.RootGrantCommand
-	50,  // 93: nokv.meta.v1.MetadataRootApplyGrantResponse.state:type_name -> nokv.meta.v1.RootEunomiaState
-	10,  // 94: nokv.meta.v1.MetadataRootApplyGrantResponse.status:type_name -> nokv.meta.v1.RootGrantApplyStatus
-	31,  // 95: nokv.meta.v1.MetadataRootApplyGrantResponse.certificate:type_name -> nokv.meta.v1.RootGrantCertificate
-	11,  // 96: nokv.meta.v1.RootTailToken.cursor:type_name -> nokv.meta.v1.RootCursor
-	11,  // 97: nokv.meta.v1.RootCommittedEvent.cursor:type_name -> nokv.meta.v1.RootCursor
-	41,  // 98: nokv.meta.v1.RootCommittedEvent.event:type_name -> nokv.meta.v1.RootEvent
-	55,  // 99: nokv.meta.v1.RootCommittedTail.records:type_name -> nokv.meta.v1.RootCommittedEvent
-	13,  // 100: nokv.meta.v1.MetadataRootObserveCommittedResponse.checkpoint:type_name -> nokv.meta.v1.RootCheckpoint
-	56,  // 101: nokv.meta.v1.MetadataRootObserveCommittedResponse.tail:type_name -> nokv.meta.v1.RootCommittedTail
-	54,  // 102: nokv.meta.v1.MetadataRootObserveTailRequest.after:type_name -> nokv.meta.v1.RootTailToken
-	54,  // 103: nokv.meta.v1.MetadataRootObserveTailResponse.after:type_name -> nokv.meta.v1.RootTailToken
-	54,  // 104: nokv.meta.v1.MetadataRootObserveTailResponse.token:type_name -> nokv.meta.v1.RootTailToken
-	13,  // 105: nokv.meta.v1.MetadataRootObserveTailResponse.checkpoint:type_name -> nokv.meta.v1.RootCheckpoint
-	56,  // 106: nokv.meta.v1.MetadataRootObserveTailResponse.tail:type_name -> nokv.meta.v1.RootCommittedTail
-	54,  // 107: nokv.meta.v1.MetadataRootWaitTailRequest.after:type_name -> nokv.meta.v1.RootTailToken
-	54,  // 108: nokv.meta.v1.MetadataRootWaitTailResponse.after:type_name -> nokv.meta.v1.RootTailToken
-	54,  // 109: nokv.meta.v1.MetadataRootWaitTailResponse.token:type_name -> nokv.meta.v1.RootTailToken
-	13,  // 110: nokv.meta.v1.MetadataRootWaitTailResponse.checkpoint:type_name -> nokv.meta.v1.RootCheckpoint
-	56,  // 111: nokv.meta.v1.MetadataRootWaitTailResponse.tail:type_name -> nokv.meta.v1.RootCommittedTail
-	42,  // 112: nokv.meta.v1.MetadataRoot.Snapshot:input_type -> nokv.meta.v1.MetadataRootSnapshotRequest
-	44,  // 113: nokv.meta.v1.MetadataRoot.Append:input_type -> nokv.meta.v1.MetadataRootAppendRequest
-	46,  // 114: nokv.meta.v1.MetadataRoot.FenceAllocator:input_type -> nokv.meta.v1.MetadataRootFenceAllocatorRequest
-	48,  // 115: nokv.meta.v1.MetadataRoot.Status:input_type -> nokv.meta.v1.MetadataRootStatusRequest
-	52,  // 116: nokv.meta.v1.MetadataRoot.ApplyGrant:input_type -> nokv.meta.v1.MetadataRootApplyGrantRequest
-	57,  // 117: nokv.meta.v1.MetadataRoot.ObserveCommitted:input_type -> nokv.meta.v1.MetadataRootObserveCommittedRequest
-	59,  // 118: nokv.meta.v1.MetadataRoot.ObserveTail:input_type -> nokv.meta.v1.MetadataRootObserveTailRequest
-	61,  // 119: nokv.meta.v1.MetadataRoot.WaitTail:input_type -> nokv.meta.v1.MetadataRootWaitTailRequest
-	43,  // 120: nokv.meta.v1.MetadataRoot.Snapshot:output_type -> nokv.meta.v1.MetadataRootSnapshotResponse
-	45,  // 121: nokv.meta.v1.MetadataRoot.Append:output_type -> nokv.meta.v1.MetadataRootAppendResponse
-	47,  // 122: nokv.meta.v1.MetadataRoot.FenceAllocator:output_type -> nokv.meta.v1.MetadataRootFenceAllocatorResponse
-	49,  // 123: nokv.meta.v1.MetadataRoot.Status:output_type -> nokv.meta.v1.MetadataRootStatusResponse
-	53,  // 124: nokv.meta.v1.MetadataRoot.ApplyGrant:output_type -> nokv.meta.v1.MetadataRootApplyGrantResponse
-	58,  // 125: nokv.meta.v1.MetadataRoot.ObserveCommitted:output_type -> nokv.meta.v1.MetadataRootObserveCommittedResponse
-	60,  // 126: nokv.meta.v1.MetadataRoot.ObserveTail:output_type -> nokv.meta.v1.MetadataRootObserveTailResponse
-	62,  // 127: nokv.meta.v1.MetadataRoot.WaitTail:output_type -> nokv.meta.v1.MetadataRootWaitTailResponse
-	120, // [120:128] is the sub-list for method output_type
-	112, // [112:120] is the sub-list for method input_type
-	112, // [112:112] is the sub-list for extension type_name
-	112, // [112:112] is the sub-list for extension extendee
-	0,   // [0:112] is the sub-list for field type_name
+	21,  // 47: nokv.meta.v1.RootAuthorityVerifierKey.scope:type_name -> nokv.meta.v1.RootDutyScope
+	34,  // 48: nokv.meta.v1.RootAuthorityVerifierState.key:type_name -> nokv.meta.v1.RootAuthorityVerifierKey
+	57,  // 49: nokv.meta.v1.RootAuthorityVerifierState.max_root_token:type_name -> nokv.meta.v1.RootTailToken
+	26,  // 50: nokv.meta.v1.RootAuthorityVerifierState.max_frontier:type_name -> nokv.meta.v1.RootDutyBound
+	35,  // 51: nokv.meta.v1.RootAuthorityVerifierStore.states:type_name -> nokv.meta.v1.RootAuthorityVerifierState
+	66,  // 52: nokv.meta.v1.RootRegionDescriptor.descriptor:type_name -> nokv.meta.v1.RegionDescriptor
+	66,  // 53: nokv.meta.v1.RootRangeSplit.left:type_name -> nokv.meta.v1.RegionDescriptor
+	66,  // 54: nokv.meta.v1.RootRangeSplit.right:type_name -> nokv.meta.v1.RegionDescriptor
+	66,  // 55: nokv.meta.v1.RootRangeSplit.base_parent:type_name -> nokv.meta.v1.RegionDescriptor
+	66,  // 56: nokv.meta.v1.RootRangeMerge.merged:type_name -> nokv.meta.v1.RegionDescriptor
+	66,  // 57: nokv.meta.v1.RootRangeMerge.base_left:type_name -> nokv.meta.v1.RegionDescriptor
+	66,  // 58: nokv.meta.v1.RootRangeMerge.base_right:type_name -> nokv.meta.v1.RegionDescriptor
+	66,  // 59: nokv.meta.v1.RootPeerChange.target:type_name -> nokv.meta.v1.RegionDescriptor
+	66,  // 60: nokv.meta.v1.RootPeerChange.base:type_name -> nokv.meta.v1.RegionDescriptor
+	6,   // 61: nokv.meta.v1.RootPendingPeerChange.kind:type_name -> nokv.meta.v1.RootPendingPeerChangeKind
+	66,  // 62: nokv.meta.v1.RootPendingPeerChange.target:type_name -> nokv.meta.v1.RegionDescriptor
+	66,  // 63: nokv.meta.v1.RootPendingPeerChange.base:type_name -> nokv.meta.v1.RegionDescriptor
+	7,   // 64: nokv.meta.v1.RootPendingRangeChange.kind:type_name -> nokv.meta.v1.RootPendingRangeChangeKind
+	66,  // 65: nokv.meta.v1.RootPendingRangeChange.left:type_name -> nokv.meta.v1.RegionDescriptor
+	66,  // 66: nokv.meta.v1.RootPendingRangeChange.right:type_name -> nokv.meta.v1.RegionDescriptor
+	66,  // 67: nokv.meta.v1.RootPendingRangeChange.merged:type_name -> nokv.meta.v1.RegionDescriptor
+	66,  // 68: nokv.meta.v1.RootPendingRangeChange.base_parent:type_name -> nokv.meta.v1.RegionDescriptor
+	66,  // 69: nokv.meta.v1.RootPendingRangeChange.base_left:type_name -> nokv.meta.v1.RegionDescriptor
+	66,  // 70: nokv.meta.v1.RootPendingRangeChange.base_right:type_name -> nokv.meta.v1.RegionDescriptor
+	0,   // 71: nokv.meta.v1.RootEvent.kind:type_name -> nokv.meta.v1.RootEventKind
+	14,  // 72: nokv.meta.v1.RootEvent.store_membership:type_name -> nokv.meta.v1.RootStoreMembership
+	20,  // 73: nokv.meta.v1.RootEvent.allocator_fence:type_name -> nokv.meta.v1.RootAllocatorFence
+	37,  // 74: nokv.meta.v1.RootEvent.region_descriptor:type_name -> nokv.meta.v1.RootRegionDescriptor
+	38,  // 75: nokv.meta.v1.RootEvent.region_removal:type_name -> nokv.meta.v1.RootRegionRemoval
+	39,  // 76: nokv.meta.v1.RootEvent.range_split:type_name -> nokv.meta.v1.RootRangeSplit
+	40,  // 77: nokv.meta.v1.RootEvent.range_merge:type_name -> nokv.meta.v1.RootRangeMerge
+	41,  // 78: nokv.meta.v1.RootEvent.peer_change:type_name -> nokv.meta.v1.RootPeerChange
+	28,  // 79: nokv.meta.v1.RootEvent.grant:type_name -> nokv.meta.v1.RootAuthorityGrant
+	29,  // 80: nokv.meta.v1.RootEvent.grant_retirement:type_name -> nokv.meta.v1.RootGrantRetirement
+	30,  // 81: nokv.meta.v1.RootEvent.grant_inheritance:type_name -> nokv.meta.v1.RootGrantInheritance
+	16,  // 82: nokv.meta.v1.RootEvent.snapshot_epoch:type_name -> nokv.meta.v1.RootSnapshotEpoch
+	17,  // 83: nokv.meta.v1.RootEvent.mount:type_name -> nokv.meta.v1.RootMount
+	18,  // 84: nokv.meta.v1.RootEvent.subtree_authority:type_name -> nokv.meta.v1.RootSubtreeAuthority
+	19,  // 85: nokv.meta.v1.RootEvent.quota_fence:type_name -> nokv.meta.v1.RootQuotaFence
+	13,  // 86: nokv.meta.v1.MetadataRootSnapshotResponse.checkpoint:type_name -> nokv.meta.v1.RootCheckpoint
+	44,  // 87: nokv.meta.v1.MetadataRootAppendRequest.events:type_name -> nokv.meta.v1.RootEvent
+	11,  // 88: nokv.meta.v1.MetadataRootAppendResponse.cursor:type_name -> nokv.meta.v1.RootCursor
+	12,  // 89: nokv.meta.v1.MetadataRootAppendResponse.state:type_name -> nokv.meta.v1.RootState
+	8,   // 90: nokv.meta.v1.MetadataRootFenceAllocatorRequest.kind:type_name -> nokv.meta.v1.RootAllocatorKind
+	28,  // 91: nokv.meta.v1.RootEunomiaState.active_grant:type_name -> nokv.meta.v1.RootAuthorityGrant
+	29,  // 92: nokv.meta.v1.RootEunomiaState.retired_grants:type_name -> nokv.meta.v1.RootGrantRetirement
+	30,  // 93: nokv.meta.v1.RootEunomiaState.grant_inheritances:type_name -> nokv.meta.v1.RootGrantInheritance
+	9,   // 94: nokv.meta.v1.RootGrantCommand.kind:type_name -> nokv.meta.v1.RootGrantAct
+	27,  // 95: nokv.meta.v1.RootGrantCommand.requested_duties:type_name -> nokv.meta.v1.RootDutyGrant
+	32,  // 96: nokv.meta.v1.RootGrantCommand.exact_usages:type_name -> nokv.meta.v1.RootAuthorityUsage
+	54,  // 97: nokv.meta.v1.MetadataRootApplyGrantRequest.command:type_name -> nokv.meta.v1.RootGrantCommand
+	53,  // 98: nokv.meta.v1.MetadataRootApplyGrantResponse.state:type_name -> nokv.meta.v1.RootEunomiaState
+	10,  // 99: nokv.meta.v1.MetadataRootApplyGrantResponse.status:type_name -> nokv.meta.v1.RootGrantApplyStatus
+	31,  // 100: nokv.meta.v1.MetadataRootApplyGrantResponse.certificate:type_name -> nokv.meta.v1.RootGrantCertificate
+	11,  // 101: nokv.meta.v1.RootTailToken.cursor:type_name -> nokv.meta.v1.RootCursor
+	11,  // 102: nokv.meta.v1.RootCommittedEvent.cursor:type_name -> nokv.meta.v1.RootCursor
+	44,  // 103: nokv.meta.v1.RootCommittedEvent.event:type_name -> nokv.meta.v1.RootEvent
+	58,  // 104: nokv.meta.v1.RootCommittedTail.records:type_name -> nokv.meta.v1.RootCommittedEvent
+	13,  // 105: nokv.meta.v1.MetadataRootObserveCommittedResponse.checkpoint:type_name -> nokv.meta.v1.RootCheckpoint
+	59,  // 106: nokv.meta.v1.MetadataRootObserveCommittedResponse.tail:type_name -> nokv.meta.v1.RootCommittedTail
+	57,  // 107: nokv.meta.v1.MetadataRootObserveTailRequest.after:type_name -> nokv.meta.v1.RootTailToken
+	57,  // 108: nokv.meta.v1.MetadataRootObserveTailResponse.after:type_name -> nokv.meta.v1.RootTailToken
+	57,  // 109: nokv.meta.v1.MetadataRootObserveTailResponse.token:type_name -> nokv.meta.v1.RootTailToken
+	13,  // 110: nokv.meta.v1.MetadataRootObserveTailResponse.checkpoint:type_name -> nokv.meta.v1.RootCheckpoint
+	59,  // 111: nokv.meta.v1.MetadataRootObserveTailResponse.tail:type_name -> nokv.meta.v1.RootCommittedTail
+	57,  // 112: nokv.meta.v1.MetadataRootWaitTailRequest.after:type_name -> nokv.meta.v1.RootTailToken
+	57,  // 113: nokv.meta.v1.MetadataRootWaitTailResponse.after:type_name -> nokv.meta.v1.RootTailToken
+	57,  // 114: nokv.meta.v1.MetadataRootWaitTailResponse.token:type_name -> nokv.meta.v1.RootTailToken
+	13,  // 115: nokv.meta.v1.MetadataRootWaitTailResponse.checkpoint:type_name -> nokv.meta.v1.RootCheckpoint
+	59,  // 116: nokv.meta.v1.MetadataRootWaitTailResponse.tail:type_name -> nokv.meta.v1.RootCommittedTail
+	45,  // 117: nokv.meta.v1.MetadataRoot.Snapshot:input_type -> nokv.meta.v1.MetadataRootSnapshotRequest
+	47,  // 118: nokv.meta.v1.MetadataRoot.Append:input_type -> nokv.meta.v1.MetadataRootAppendRequest
+	49,  // 119: nokv.meta.v1.MetadataRoot.FenceAllocator:input_type -> nokv.meta.v1.MetadataRootFenceAllocatorRequest
+	51,  // 120: nokv.meta.v1.MetadataRoot.Status:input_type -> nokv.meta.v1.MetadataRootStatusRequest
+	55,  // 121: nokv.meta.v1.MetadataRoot.ApplyGrant:input_type -> nokv.meta.v1.MetadataRootApplyGrantRequest
+	60,  // 122: nokv.meta.v1.MetadataRoot.ObserveCommitted:input_type -> nokv.meta.v1.MetadataRootObserveCommittedRequest
+	62,  // 123: nokv.meta.v1.MetadataRoot.ObserveTail:input_type -> nokv.meta.v1.MetadataRootObserveTailRequest
+	64,  // 124: nokv.meta.v1.MetadataRoot.WaitTail:input_type -> nokv.meta.v1.MetadataRootWaitTailRequest
+	46,  // 125: nokv.meta.v1.MetadataRoot.Snapshot:output_type -> nokv.meta.v1.MetadataRootSnapshotResponse
+	48,  // 126: nokv.meta.v1.MetadataRoot.Append:output_type -> nokv.meta.v1.MetadataRootAppendResponse
+	50,  // 127: nokv.meta.v1.MetadataRoot.FenceAllocator:output_type -> nokv.meta.v1.MetadataRootFenceAllocatorResponse
+	52,  // 128: nokv.meta.v1.MetadataRoot.Status:output_type -> nokv.meta.v1.MetadataRootStatusResponse
+	56,  // 129: nokv.meta.v1.MetadataRoot.ApplyGrant:output_type -> nokv.meta.v1.MetadataRootApplyGrantResponse
+	61,  // 130: nokv.meta.v1.MetadataRoot.ObserveCommitted:output_type -> nokv.meta.v1.MetadataRootObserveCommittedResponse
+	63,  // 131: nokv.meta.v1.MetadataRoot.ObserveTail:output_type -> nokv.meta.v1.MetadataRootObserveTailResponse
+	65,  // 132: nokv.meta.v1.MetadataRoot.WaitTail:output_type -> nokv.meta.v1.MetadataRootWaitTailResponse
+	125, // [125:133] is the sub-list for method output_type
+	117, // [117:125] is the sub-list for method input_type
+	117, // [117:117] is the sub-list for extension type_name
+	117, // [117:117] is the sub-list for extension extendee
+	0,   // [0:117] is the sub-list for field type_name
 }
 
 func init() { file_meta_root_proto_init() }
@@ -4943,7 +5182,7 @@ func file_meta_root_proto_init() {
 		(*RootDutyBound_Budget)(nil),
 		(*RootDutyBound_Epoch)(nil),
 	}
-	file_meta_root_proto_msgTypes[30].OneofWrappers = []any{
+	file_meta_root_proto_msgTypes[33].OneofWrappers = []any{
 		(*RootEvent_StoreMembership)(nil),
 		(*RootEvent_AllocatorFence)(nil),
 		(*RootEvent_RegionDescriptor)(nil),
@@ -4965,7 +5204,7 @@ func file_meta_root_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_meta_root_proto_rawDesc), len(file_meta_root_proto_rawDesc)),
 			NumEnums:      11,
-			NumMessages:   52,
+			NumMessages:   55,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/pb/meta/root.proto
+++ b/pb/meta/root.proto
@@ -56,6 +56,7 @@ message RootState {
   RootAuthorityGrant active_grant = 7;
   repeated RootGrantRetirement retired_grants = 8;
   repeated RootGrantInheritance grant_inheritances = 9;
+  uint64 retired_era_floor = 10;
 }
 
 message RootCheckpoint {
@@ -250,6 +251,26 @@ message RootAuthorityEvidence {
   RootAuthorityUsage usage = 2;
   repeated RootGrantRetirement observed_retirements = 3;
   uint64 observed_retired_era_floor = 4;
+  int64 served_unix_nano = 5;
+}
+
+message RootAuthorityVerifierKey {
+  string cluster_id = 1;
+  string duty_id = 2;
+  RootDutyScope scope = 3;
+}
+
+message RootAuthorityVerifierState {
+  RootAuthorityVerifierKey key = 1;
+  uint64 max_seen_era = 2;
+  uint64 retired_era_floor = 3;
+  RootTailToken max_root_token = 4;
+  uint64 max_descriptor_revision = 5;
+  RootDutyBound max_frontier = 6;
+}
+
+message RootAuthorityVerifierStore {
+  repeated RootAuthorityVerifierState states = 1;
 }
 
 message RootRegionDescriptor {
@@ -380,6 +401,7 @@ message RootEunomiaState {
   RootAuthorityGrant active_grant = 1;
   repeated RootGrantRetirement retired_grants = 2;
   repeated RootGrantInheritance grant_inheritances = 3;
+  uint64 retired_era_floor = 4;
 }
 
 enum RootGrantAct {

--- a/raftstore/client/client.go
+++ b/raftstore/client/client.go
@@ -50,21 +50,22 @@ type RetryPolicy struct {
 
 // Client provides Region-aware helpers for StoreKV RPCs, including 2PC.
 type Client struct {
-	mu                       sync.RWMutex
-	stores                   map[uint64]*storeConn
-	regions                  map[uint64]*regionState
-	regionIndex              []regionRange
-	regionResolver           RegionResolver
-	storeResolver            StoreResolver
-	routeLookupTimeout       time.Duration
-	storeRevalidateIn        time.Duration
-	dialTimeout              time.Duration
-	dialOpts                 []grpc.DialOption
-	retry                    RetryPolicy
-	atomicRouteSingleTotal   atomic.Uint64
-	atomicRouteMultiTotal    atomic.Uint64
-	atomicLocalFallbackTotal atomic.Uint64
-	atomicSuccessTotal       atomic.Uint64
+	mu                         sync.RWMutex
+	stores                     map[uint64]*storeConn
+	regions                    map[uint64]*regionState
+	regionIndex                []regionRange
+	regionResolver             RegionResolver
+	storeResolver              StoreResolver
+	requiredDescriptorRevision uint64
+	routeLookupTimeout         time.Duration
+	storeRevalidateIn          time.Duration
+	dialTimeout                time.Duration
+	dialOpts                   []grpc.DialOption
+	retry                      RetryPolicy
+	atomicRouteSingleTotal     atomic.Uint64
+	atomicRouteMultiTotal      atomic.Uint64
+	atomicLocalFallbackTotal   atomic.Uint64
+	atomicSuccessTotal         atomic.Uint64
 }
 
 // New constructs a Client using the provided configuration.

--- a/raftstore/client/client_route_cache.go
+++ b/raftstore/client/client_route_cache.go
@@ -99,7 +99,12 @@ func (c *Client) regionForKeyFromCache(key []byte) (regionSnapshot, bool) {
 func (c *Client) regionForKeyFromResolver(ctx context.Context, key []byte) (regionSnapshot, error) {
 	ctx, cancel := contextWithTimeout(ctx, c.routeLookupTimeout)
 	defer cancel()
-	resp, err := c.regionResolver.GetRegionByKey(ctx, &coordpb.GetRegionByKeyRequest{Key: append([]byte(nil), key...)})
+	req := &coordpb.GetRegionByKeyRequest{Key: append([]byte(nil), key...)}
+	requiredDescriptorRevision := c.requiredRouteDescriptorRevision()
+	if requiredDescriptorRevision != 0 {
+		req.RequiredDescriptorRevision = requiredDescriptorRevision
+	}
+	resp, err := c.regionResolver.GetRegionByKey(ctx, req)
 	if err != nil {
 		return regionSnapshot{}, &RouteUnavailableError{
 			Key: append([]byte(nil), key...),
@@ -112,6 +117,14 @@ func (c *Client) regionForKeyFromResolver(ctx context.Context, key []byte) (regi
 	desc := metawire.DescriptorFromProto(resp.GetRegionDescriptor())
 	if desc.RegionID == 0 {
 		return regionSnapshot{}, errResolvedRegionIDMissing
+	}
+	if requiredDescriptorRevision != 0 && desc.RootEpoch < requiredDescriptorRevision {
+		return regionSnapshot{}, &RegionRoutingError{
+			Operation: "resolve region",
+			RegionID:  desc.RegionID,
+			Key:       append([]byte(nil), key...),
+			Detail:    fmt.Sprintf("descriptor revision %d is below required %d", desc.RootEpoch, requiredDescriptorRevision),
+		}
 	}
 	if len(desc.Peers) == 0 {
 		return regionSnapshot{}, &RegionRoutingError{
@@ -126,6 +139,7 @@ func (c *Client) regionForKeyFromResolver(ctx context.Context, key []byte) (regi
 		leader = old.leader
 	}
 	c.mu.Lock()
+	c.advanceRouteDescriptorRevisionLocked(desc.RootEpoch)
 	c.upsertRegionLocked(desc, leader)
 	c.mu.Unlock()
 	if !containsKey(desc, key) {
@@ -160,6 +174,7 @@ func (c *Client) handleRegionError(regionID uint64, err *errorpb.RegionError) er
 	}
 	if epochMismatch := err.GetEpochNotMatch(); epochMismatch != nil {
 		c.mu.Lock()
+		c.observeEpochMismatchLocked(regionID, epochMismatch)
 		c.removeRegionLocked(regionID)
 		for _, meta := range epochMismatch.GetRegions() {
 			if meta == nil {
@@ -196,6 +211,42 @@ func (c *Client) handleRegionError(regionID uint64, err *errorpb.RegionError) er
 		RegionID:  regionID,
 		Detail:    fmt.Sprintf("protobuf region error: %v", err),
 	}
+}
+
+func (c *Client) requiredRouteDescriptorRevision() uint64 {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return c.requiredDescriptorRevision
+}
+
+func (c *Client) observeEpochMismatchLocked(regionID uint64, mismatch *errorpb.EpochNotMatch) {
+	if c == nil || mismatch == nil {
+		return
+	}
+	if region, ok := c.regions[regionID]; ok && region != nil && region.desc.RootEpoch != 0 {
+		c.advanceRouteDescriptorRevisionLocked(nextDescriptorRevision(region.desc.RootEpoch))
+	}
+	for _, meta := range mismatch.GetRegions() {
+		if meta == nil {
+			continue
+		}
+		desc := metawire.DescriptorFromProto(meta)
+		c.advanceRouteDescriptorRevisionLocked(desc.RootEpoch)
+	}
+}
+
+func (c *Client) advanceRouteDescriptorRevisionLocked(revision uint64) {
+	if c == nil || revision == 0 || revision <= c.requiredDescriptorRevision {
+		return
+	}
+	c.requiredDescriptorRevision = revision
+}
+
+func nextDescriptorRevision(revision uint64) uint64 {
+	if revision == ^uint64(0) {
+		return revision
+	}
+	return revision + 1
 }
 
 func (c *Client) upsertRegionLocked(desc topology.Descriptor, leader uint64) {

--- a/raftstore/client/client_test.go
+++ b/raftstore/client/client_test.go
@@ -84,14 +84,15 @@ func (mc *mockCluster) regionMeta(id uint64) (*metapb.RegionDescriptor, bool) {
 }
 
 type mockRegionResolver struct {
-	mu       sync.Mutex
-	region   *metapb.RegionDescriptor
-	regions  []*metapb.RegionDescriptor
-	err      error
-	errs     []error
-	calls    int
-	closed   bool
-	closeErr error
+	mu                             sync.Mutex
+	region                         *metapb.RegionDescriptor
+	regions                        []*metapb.RegionDescriptor
+	err                            error
+	errs                           []error
+	calls                          int
+	lastRequiredDescriptorRevision uint64
+	closed                         bool
+	closeErr                       error
 }
 
 type testStoreEndpoint struct {
@@ -183,6 +184,9 @@ func (mr *mockRegionResolver) GetRegionByKey(_ context.Context, req *coordpb.Get
 	mr.mu.Lock()
 	defer mr.mu.Unlock()
 	mr.calls++
+	if req != nil {
+		mr.lastRequiredDescriptorRevision = req.GetRequiredDescriptorRevision()
+	}
 	if len(mr.errs) > 0 {
 		err := mr.errs[0]
 		mr.errs = mr.errs[1:]
@@ -1591,6 +1595,40 @@ func TestClientHandleRegionErrorUpdatesIndexedCache(t *testing.T) {
 	got, ok = cli.regionForKeyFromCache([]byte("omega"))
 	require.True(t, ok)
 	require.Equal(t, uint64(12), got.desc.RegionID)
+}
+
+func TestClientEpochMismatchRaisesRouteLookupDescriptorFloor(t *testing.T) {
+	resolver := &mockRegionResolver{region: &metapb.RegionDescriptor{
+		RegionId:  2,
+		StartKey:  []byte("a"),
+		EndKey:    []byte("z"),
+		Epoch:     &metapb.RegionEpoch{Version: 2, ConfVersion: 1},
+		RootEpoch: 8,
+		Peers:     []*metapb.RegionPeer{{StoreId: 1, PeerId: 201}},
+	}}
+	cli, err := New(Config{
+		StoreResolver:  staticStoreResolver{{StoreID: 1, Addr: "unused"}},
+		RegionResolver: resolver,
+	})
+	require.NoError(t, err)
+	defer func() { _ = cli.Close() }()
+	cli.upsertRegionLocked(metawire.DescriptorFromProto(&metapb.RegionDescriptor{
+		RegionId:  1,
+		StartKey:  []byte("a"),
+		EndKey:    []byte("z"),
+		Epoch:     &metapb.RegionEpoch{Version: 1, ConfVersion: 1},
+		RootEpoch: 7,
+		Peers:     []*metapb.RegionPeer{{StoreId: 1, PeerId: 101}},
+	}), 1)
+
+	err = cli.handleRegionError(1, &errorpb.RegionError{EpochNotMatch: &errorpb.EpochNotMatch{}})
+	require.NoError(t, err)
+	_, err = cli.regionForKeyFromResolver(context.Background(), []byte("b"))
+	require.NoError(t, err)
+
+	resolver.mu.Lock()
+	require.Equal(t, uint64(8), resolver.lastRequiredDescriptorRevision)
+	resolver.mu.Unlock()
 }
 
 func TestClientHandleRegionErrorDropsIndexedCacheWhenLeaderUnknown(t *testing.T) {

--- a/raftstore/testcluster/cluster.go
+++ b/raftstore/testcluster/cluster.go
@@ -38,6 +38,7 @@ import (
 	storepkg "github.com/feichai0017/NoKV/raftstore/store"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/protobuf/proto"
 )
 
 type Node struct {
@@ -200,6 +201,15 @@ func (s *coordinatorRootStorage) ApplyGrant(_ context.Context, cmd rootproto.Gra
 	switch cmd.Kind {
 	case rootproto.GrantActIssue:
 		active := s.snapshot.ActiveGrant
+		requestedGrantID := strings.TrimSpace(cmd.GrantID)
+		if requestedGrantID != "" &&
+			active.Present() &&
+			active.GrantID == requestedGrantID &&
+			active.HolderID == holderID &&
+			coordinatorDutyGrantsCover(active.Duties, cmd.RequestedDuties) {
+			cert, err := coordinatorRootGrantCertificate(active)
+			return s.protocolStateLocked(), cert, err
+		}
 		if active.Present() && active.HolderID != holderID && active.ActiveAt(cmd.NowUnixNano) {
 			return s.protocolStateLocked(), rootproto.GrantCertificate{}, rootstate.ErrPrimacy
 		}
@@ -209,7 +219,7 @@ func (s *coordinatorRootStorage) ApplyGrant(_ context.Context, cmd rootproto.Gra
 				era = retirement.Era + 1
 			}
 		}
-		grantID := strings.TrimSpace(cmd.GrantID)
+		grantID := requestedGrantID
 		if grantID == "" {
 			grantID = fmt.Sprintf("%s/%d", holderID, era)
 		}
@@ -226,7 +236,8 @@ func (s *coordinatorRootStorage) ApplyGrant(_ context.Context, cmd rootproto.Gra
 			Duties: append([]rootproto.DutyGrant(nil), cmd.RequestedDuties...),
 		}
 		s.applyEventLocked(rootevent.GrantIssued(grant))
-		return s.protocolStateLocked(), rootproto.GrantCertificate{Grant: s.snapshot.ActiveGrant, SignerKeyID: rootproto.GrantSignerKeyID}, nil
+		cert, err := coordinatorRootGrantCertificate(s.snapshot.ActiveGrant)
+		return s.protocolStateLocked(), cert, err
 	case rootproto.GrantActSeal:
 		if !s.snapshot.ActiveGrant.Present() || s.snapshot.ActiveGrant.HolderID != holderID {
 			return s.protocolStateLocked(), rootproto.GrantCertificate{}, rootstate.ErrPrimacy
@@ -279,7 +290,42 @@ func (s *coordinatorRootStorage) protocolStateLocked() rootstate.EunomiaState {
 		ActiveGrant:       s.snapshot.ActiveGrant,
 		RetiredGrants:     append([]rootproto.GrantRetirement(nil), s.snapshot.RetiredGrants...),
 		GrantInheritances: append([]rootproto.GrantInheritance(nil), s.snapshot.GrantInheritances...),
+		RetiredEraFloor:   s.snapshot.RetiredEraFloor,
 	}
+}
+
+func coordinatorRootGrantCertificate(grant rootproto.AuthorityGrant) (rootproto.GrantCertificate, error) {
+	payload, err := proto.MarshalOptions{Deterministic: true}.Marshal(metawire.RootAuthorityGrantToProto(grant))
+	if err != nil {
+		return rootproto.GrantCertificate{}, err
+	}
+	signature := rootproto.SignGrantBytes(payload)
+	if len(signature) == 0 {
+		return rootproto.GrantCertificate{}, fmt.Errorf("testcluster root grant signing key is not configured")
+	}
+	return rootproto.GrantCertificate{
+		Grant:       grant,
+		SignerKeyID: rootproto.GrantSignerKeyID,
+		Signature:   signature,
+	}, nil
+}
+
+func coordinatorDutyGrantsCover(grants, usages []rootproto.DutyGrant) bool {
+	for _, usage := range usages {
+		var matched bool
+		for _, grant := range grants {
+			if grant.DutyID == usage.DutyID &&
+				rootproto.ScopeEqual(grant.Scope, usage.Scope) &&
+				rootproto.DutyBoundCovers(grant.Bound, usage.Bound) {
+				matched = true
+				break
+			}
+		}
+		if !matched {
+			return false
+		}
+	}
+	return true
 }
 
 func coordinatorDutyGrantsFromUsages(usages []rootproto.AuthorityUsage) []rootproto.DutyGrant {

--- a/spec/Eunomia.cfg
+++ b/spec/Eunomia.cfg
@@ -3,11 +3,15 @@ SPECIFICATION Spec
 CONSTANTS
     MaxEra = 3
     MaxFrontier = 2
+    MaxInflight = 1
 
 INVARIANTS
     TypeOK
-    G1_Eunomia
-    G2_Primacy
-    G2_PrimacyInductive
-    G3_Silence
-    G4_Finality
+    Primacy
+    BoundedInheritance
+    EvidenceBounded
+    VerifierSilence
+    Finality
+    RetiredFloorCoversInherited
+    ServedWithinGrant
+    RetirementWithinGrant

--- a/spec/Eunomia.tla
+++ b/spec/Eunomia.tla
@@ -1,243 +1,291 @@
 ------------------------------ MODULE Eunomia ------------------------------
 EXTENDS Naturals, FiniteSets
 
-\* Repeated-handoff positive model for the control-plane paper.
-\* This module intentionally models only service-level authority lineage,
-\* not the underlying consensus protocol.
+\* Bounded positive model for the current Eunomia grant protocol.
 \*
-\* The working fault vocabulary is kept inline for now rather than split
-\* into a separate Fault.tla:
-\*   delayed_reply
-\*   revived_holder
-\*   root_unreach
-\*   lease_expiry
-\*   successor_campaign
-\*   budget_exhaustion
-\*   descriptor_publish_race
+\* The model intentionally ignores the underlying consensus protocol. The
+\* root log is represented by these committed state transitions:
+\*
+\*   IssueGrant        == GrantIssued
+\*   SealExact         == GrantSealed(sealed_exact)
+\*   RetireExpired     == GrantRetired(expired_bound)
+\*   InheritRetirement == GrantInherited
+\*
+\* Each authority reply carries evidence from the admitted grant:
+\*
+\*   era, reply usage, evidence usage, and observed retired floor.
+\*
+\* This is a single monotone-duty abstraction. alloc_id and tso map directly to
+\* the monotone bound. region_lookup uses the same shape with descriptor
+\* revision as the monotone coordinate; the implementation adds root-token and
+\* storage-epoch checks around that duty.
 
 CONSTANTS
     \* @type: Int;
     MaxEra,
     \* @type: Int;
-    MaxFrontier
+    MaxFrontier,
+    \* @type: Int;
+    MaxInflight
 
-Eras        == 0..MaxEra
-Frontiers   == 0..MaxFrontier
-Phases      == {"Attached", "Active", "Sealed", "Covered", "Closed"}
-NoPending   == MaxEra + 1
-ReplySet    == { [era |-> e, frontier |-> f] : e \in Eras, f \in Frontiers }
-NoDelivered == [valid |-> FALSE, era |-> 0, frontier |-> 0]
+Eras          == 1..MaxEra
+Frontiers     == 0..MaxFrontier
+NoGrant       == MaxEra + 1
+RetireModes   == {"none", "sealed_exact", "expired_bound"}
+ReplySet      == { [era |-> e,
+                    usage |-> u,
+                    evidenceUsage |-> eu,
+                    observedFloor |-> f] :
+                    e \in Eras,
+                    u \in Frontiers,
+                    eu \in Frontiers,
+                    f \in 0..MaxEra }
+NoAccepted    == [valid |-> FALSE,
+                  era |-> 0,
+                  usage |-> 0,
+                  evidenceUsage |-> 0,
+                  floorAtAccept |-> 0,
+                  observedFloor |-> 0]
 
 VARIABLES
-    \* @type: Str;
-    phase,
     \* @type: Set(Int);
     issued,
     \* @type: Int;
-    activeEra,
-    \* @type: Int;
-    pendingSeal,
-    \* @type: Set(Int);
-    sealed,
-    \* @type: Set(Int);
-    covered,
-    \* @type: Set(Int);
-    closed,
+    active,
     \* @type: Int -> Int;
-    frontier,
-    \* @type: Set([era: Int, frontier: Int]);
+    bound,
+    \* @type: Int -> Int;
+    served,
+    \* @type: Set(Int);
+    retired,
+    \* @type: Int -> Int;
+    retirementBound,
+    \* @type: Int -> Str;
+    retirementMode,
+    \* @type: Int -> Int;
+    inheritedBy,
+    \* @type: Int;
+    retiredFloor,
+    \* @type: Int;
+    verifierFloor,
+    \* @type: Set([era: Int, usage: Int, evidenceUsage: Int, observedFloor: Int]);
     inflight,
-    \* @type: [valid: Bool, era: Int, frontier: Int];
-    delivered
+    \* @type: [valid: Bool, era: Int, usage: Int, evidenceUsage: Int, floorAtAccept: Int, observedFloor: Int];
+    accepted
 
-Vars == <<phase, issued, activeEra, pendingSeal, sealed, covered, closed, frontier, inflight, delivered>>
+Vars ==
+    << issued, active, bound, served, retired, retirementBound,
+       retirementMode, inheritedBy, retiredFloor, verifierFloor, inflight,
+       accepted >>
 
 Init ==
-    /\ phase = "Attached"
     /\ issued = {}
-    /\ activeEra = 0
-    /\ pendingSeal = NoPending
-    /\ sealed = {}
-    /\ covered = {}
-    /\ closed = {}
-    /\ frontier = [e \in Eras |-> 0]
+    /\ active = NoGrant
+    /\ bound = [e \in Eras |-> 0]
+    /\ served = [e \in Eras |-> 0]
+    /\ retired = {}
+    /\ retirementBound = [e \in Eras |-> 0]
+    /\ retirementMode = [e \in Eras |-> "none"]
+    /\ inheritedBy = [e \in Eras |-> NoGrant]
+    /\ retiredFloor = 0
+    /\ verifierFloor = 0
     /\ inflight = {}
-    /\ delivered = NoDelivered
+    /\ accepted = NoAccepted
 
-Issue ==
-    \E e \in Eras:
-        /\ phase \in {"Attached", "Sealed"}
-        /\ e \notin issued
-        /\ e > activeEra
-        /\ issued' = issued \cup {e}
-        /\ frontier' = [frontier EXCEPT ![e] = frontier[activeEra]]
-        /\ activeEra' = e
-        /\ phase' = "Active"
-        /\ delivered' = NoDelivered
-        /\ UNCHANGED <<pendingSeal, sealed, covered, closed, inflight>>
+NextEra == Cardinality(issued) + 1
 
-ActiveReply ==
-    /\ phase = "Active"
-    /\ activeEra \in issued
-    /\ activeEra \notin sealed
-    /\ \E f \in Frontiers:
-        /\ f >= frontier[activeEra]
-        /\ frontier' = [frontier EXCEPT ![activeEra] = f]
-        /\ inflight' = inflight \cup {[era |-> activeEra, frontier |-> f]}
-    /\ delivered' = NoDelivered
-    /\ UNCHANGED <<issued, activeEra, pendingSeal, sealed, covered, closed>>
-    /\ phase' = phase
+PendingRetired ==
+    { e \in retired : inheritedBy[e] = NoGrant }
 
-DeliverReply ==
+Max(a, b) ==
+    IF a >= b THEN a ELSE b
+
+IssueGrant ==
+    /\ active = NoGrant
+    /\ NextEra \in Eras
+    /\ \E b \in Frontiers:
+        /\ \A p \in PendingRetired:
+            b >= retirementBound[p]
+        /\ issued' = issued \cup {NextEra}
+        /\ active' = NextEra
+        /\ bound' = [bound EXCEPT ![NextEra] = b]
+        /\ served' = [served EXCEPT ![NextEra] = 0]
+    /\ accepted' = NoAccepted
+    /\ UNCHANGED <<retired, retirementBound, retirementMode, inheritedBy,
+                   retiredFloor, verifierFloor, inflight>>
+
+ServeReply ==
+    /\ active # NoGrant
+    /\ Cardinality(inflight) < MaxInflight
+    /\ \E u \in Frontiers:
+        \E eu \in Frontiers:
+            /\ u <= eu
+            /\ eu <= bound[active]
+            /\ inflight' = inflight \cup
+                {[era |-> active,
+                  usage |-> u,
+                  evidenceUsage |-> eu,
+                  observedFloor |-> retiredFloor]}
+            /\ served' = [served EXCEPT ![active] = Max(served[active], u)]
+    /\ accepted' = NoAccepted
+    /\ UNCHANGED <<issued, active, bound, retired, retirementBound,
+                   retirementMode, inheritedBy, retiredFloor, verifierFloor>>
+
+DeliverAcceptedReply ==
     /\ \E r \in inflight:
-        /\ r.era \notin sealed
+        /\ r.usage <= r.evidenceUsage
+        /\ r.evidenceUsage <= bound[r.era]
+        /\ r.era > verifierFloor
+        /\ r.era > r.observedFloor
         /\ inflight' = inflight \ {r}
-        /\ delivered' = [valid |-> TRUE, era |-> r.era, frontier |-> r.frontier]
-    /\ UNCHANGED <<phase, issued, activeEra, pendingSeal, sealed, covered, closed, frontier>>
+        /\ accepted' = [valid |-> TRUE,
+                        era |-> r.era,
+                        usage |-> r.usage,
+                        evidenceUsage |-> r.evidenceUsage,
+                        floorAtAccept |-> verifierFloor,
+                        observedFloor |-> r.observedFloor]
+        /\ verifierFloor' = Max(verifierFloor, r.observedFloor)
+    /\ UNCHANGED <<issued, active, bound, served, retired, retirementBound,
+                   retirementMode, inheritedBy, retiredFloor>>
 
 DropReply ==
     /\ \E r \in inflight:
         /\ inflight' = inflight \ {r}
-    /\ delivered' = NoDelivered
-    /\ UNCHANGED <<phase, issued, activeEra, pendingSeal, sealed, covered, closed, frontier>>
+    /\ accepted' = NoAccepted
+    /\ UNCHANGED <<issued, active, bound, served, retired, retirementBound,
+                   retirementMode, inheritedBy, retiredFloor, verifierFloor>>
 
-ClearDelivered ==
-    /\ delivered.valid
-    /\ delivered' = NoDelivered
-    /\ UNCHANGED <<phase, issued, activeEra, pendingSeal, sealed, covered, closed, frontier, inflight>>
+ClearAccepted ==
+    /\ accepted.valid
+    /\ accepted' = NoAccepted
+    /\ UNCHANGED <<issued, active, bound, served, retired, retirementBound,
+                   retirementMode, inheritedBy, retiredFloor, verifierFloor,
+                   inflight>>
 
-Seal ==
-    /\ phase = "Active"
-    /\ pendingSeal = NoPending
-    /\ activeEra \notin sealed
-    /\ sealed' = sealed \cup {activeEra}
-    /\ pendingSeal' = activeEra
-    /\ phase' = "Sealed"
-    /\ delivered' = NoDelivered
-    /\ UNCHANGED <<issued, activeEra, covered, closed, frontier, inflight>>
+SealExact ==
+    /\ active # NoGrant
+    /\ active \notin retired
+    /\ retired' = retired \cup {active}
+    /\ retirementBound' = [retirementBound EXCEPT ![active] = served[active]]
+    /\ retirementMode' = [retirementMode EXCEPT ![active] = "sealed_exact"]
+    /\ active' = NoGrant
+    /\ accepted' = NoAccepted
+    /\ UNCHANGED <<issued, bound, served, inheritedBy, retiredFloor,
+                   verifierFloor, inflight>>
 
-Cover ==
-    /\ phase \in {"Sealed", "Active"}
-    /\ pendingSeal # NoPending
-    /\ activeEra \in issued
-    /\ activeEra > pendingSeal
-    /\ frontier[activeEra] >= frontier[pendingSeal]
-    /\ covered' = covered \cup {pendingSeal}
-    /\ pendingSeal' = NoPending
-    /\ phase' = "Covered"
-    /\ delivered' = NoDelivered
-    /\ UNCHANGED <<issued, activeEra, sealed, closed, frontier, inflight>>
+RetireExpired ==
+    /\ active # NoGrant
+    /\ active \notin retired
+    /\ retired' = retired \cup {active}
+    /\ retirementBound' = [retirementBound EXCEPT ![active] = bound[active]]
+    /\ retirementMode' = [retirementMode EXCEPT ![active] = "expired_bound"]
+    /\ active' = NoGrant
+    /\ accepted' = NoAccepted
+    /\ UNCHANGED <<issued, bound, served, inheritedBy, retiredFloor,
+                   verifierFloor, inflight>>
 
-Close ==
-    /\ phase = "Covered"
-    /\ \E e \in covered \ closed:
-        /\ closed' = closed \cup {e}
-        /\ phase' = "Closed"
-    /\ delivered' = NoDelivered
-    /\ UNCHANGED <<issued, activeEra, pendingSeal, sealed, covered, frontier, inflight>>
-
-Reattach ==
-    /\ phase = "Closed"
-    /\ \A e \in sealed: e \in covered \/ e \in closed
-    \* Reattach completes the predecessor handover and returns the successor to
-    \* steady-state serving, so the next seal/issue cycle can proceed.
-    /\ phase' = "Active"
-    /\ delivered' = NoDelivered
-    /\ UNCHANGED <<issued, activeEra, pendingSeal, sealed, covered, closed, frontier, inflight>>
+InheritRetirement ==
+    /\ active # NoGrant
+    /\ \E p \in PendingRetired:
+        /\ bound[active] >= retirementBound[p]
+        /\ inheritedBy' = [inheritedBy EXCEPT ![p] = active]
+        /\ retiredFloor' = Max(retiredFloor, p)
+    /\ accepted' = NoAccepted
+    /\ UNCHANGED <<issued, active, bound, served, retired, retirementBound,
+                   retirementMode, verifierFloor, inflight>>
 
 Stutter ==
     UNCHANGED Vars
 
 Next ==
-    \/ Issue
-    \/ ActiveReply
-    \/ DeliverReply
+    \/ IssueGrant
+    \/ ServeReply
+    \/ DeliverAcceptedReply
     \/ DropReply
-    \/ ClearDelivered
-    \/ Seal
-    \/ Cover
-    \/ Close
-    \/ Reattach
+    \/ ClearAccepted
+    \/ SealExact
+    \/ RetireExpired
+    \/ InheritRetirement
     \/ Stutter
 
 TypeOK ==
-    /\ phase \in Phases
     /\ issued \subseteq Eras
-    /\ activeEra \in Eras
-    /\ pendingSeal \in 0..(MaxEra + 1)
-    /\ sealed \subseteq issued
-    /\ covered \subseteq sealed
-    /\ closed \subseteq covered
-    /\ frontier \in [Eras -> Frontiers]
+    /\ active \in Eras \cup {NoGrant}
+    /\ bound \in [Eras -> Frontiers]
+    /\ served \in [Eras -> Frontiers]
+    /\ retired \subseteq issued
+    /\ retirementBound \in [Eras -> Frontiers]
+    /\ retirementMode \in [Eras -> RetireModes]
+    /\ inheritedBy \in [Eras -> (Eras \cup {NoGrant})]
+    /\ retiredFloor \in 0..MaxEra
+    /\ verifierFloor \in 0..MaxEra
     /\ inflight \subseteq ReplySet
-    /\ delivered \in [valid : BOOLEAN, era : Eras, frontier : Frontiers]
+    /\ accepted \in [valid : BOOLEAN,
+                     era : 0..MaxEra,
+                     usage : Frontiers,
+                     evidenceUsage : Frontiers,
+                     floorAtAccept : 0..MaxEra,
+                     observedFloor : 0..MaxEra]
 
-LiveEras == issued \ sealed
-
-\* Stronger Primacy shape invariant: every issued era that is not the
-\* current active era has already been sealed. This is induction-friendly
-\* and does not depend on the concrete era bound; the bound only limits
-\* how many times TLC can exercise the repeated cycle in one run.
-OnlyCurrentMayRemainUnsealed ==
-    \A e \in issued:
-        e # activeEra => e \in sealed
-
-ActiveEraIssued ==
-    issued = {} \/ activeEra \in issued
-
-PrimacyInductive ==
-    /\ ActiveEraIssued
-    /\ OnlyCurrentMayRemainUnsealed
-
-\* Primacy: at most one era is live for serving.
+\* Primacy: at most one root-active grant can serve.
 Primacy ==
-    Cardinality(LiveEras) <= 1
+    active = NoGrant \/ (active \in issued /\ active \notin retired)
 
-\* Inheritance: any sealed predecessor that is marked covered must be covered by a
-\* strictly newer era whose frontier is no smaller.
-Inheritance ==
-    \A e \in covered:
-        \E h \in issued:
-            /\ h > e
-            /\ h = activeEra \/ h \in LiveEras
-            /\ frontier[h] >= frontier[e]
+\* Bounded inheritance: every pending predecessor retirement is covered by the
+\* current successor grant before that successor can serve as the active grant.
+BoundedInheritance ==
+    active = NoGrant \/
+        \A p \in PendingRetired:
+            bound[active] >= retirementBound[p]
 
-\* Silence: once an era is sealed, a valid reply may not still cite it.
-Silence ==
-    delivered.valid => delivered.era \notin sealed
+\* Root-issued bounded evidence: every accepted reply is covered by its
+\* evidence usage, and that evidence usage is inside the signed grant bound.
+EvidenceBounded ==
+    accepted.valid =>
+        /\ accepted.usage <= accepted.evidenceUsage
+        /\ accepted.evidenceUsage <= bound[accepted.era]
 
-\* Finality: every sealed predecessor must be pending cover,
-\* already covered, or already closed before reattach is legal.
+\* Silence is client-local and monotone: after a verifier has observed a
+\* retired floor, it never accepts a reply at or below that floor. A delayed old
+\* reply can only be accepted by a verifier that has not yet seen the successor
+\* floor, and it must still be inside the predecessor's signed grant bound.
+VerifierSilence ==
+    accepted.valid =>
+        /\ accepted.era > accepted.floorAtAccept
+        /\ accepted.era > accepted.observedFloor
+
+\* Finality: inherited grants are real retired predecessors, and the successor
+\* grant covers the predecessor's retirement bound. Retired-but-not-inherited is
+\* allowed as explicit pending audit state, never as silent completion.
 Finality ==
-    \A e \in sealed:
-        /\ e = pendingSeal \/ e \in covered \/ e \in closed
+    \A e \in retired:
+        inheritedBy[e] = NoGrant \/
+            /\ inheritedBy[e] \in issued
+            /\ inheritedBy[e] > e
+            /\ bound[inheritedBy[e]] >= retirementBound[e]
 
-G1_Eunomia ==
-    Inheritance
+RetiredFloorCoversInherited ==
+    \A e \in retired:
+        inheritedBy[e] # NoGrant => e <= retiredFloor
 
-G2_Primacy ==
-    Primacy
+ServedWithinGrant ==
+    \A e \in issued:
+        served[e] <= bound[e]
 
-G2_PrimacyInductive ==
-    PrimacyInductive
-
-G3_Silence ==
-    Silence
-
-G4_Finality ==
-    Finality
+RetirementWithinGrant ==
+    \A e \in retired:
+        /\ retirementMode[e] # "none"
+        /\ retirementBound[e] <= bound[e]
 
 EunomiaGuarantees ==
-    /\ G1_Eunomia
-    /\ G2_Primacy
-    /\ G3_Silence
-    /\ G4_Finality
-
-\* Stronger lemma used to support an induction-style argument for Primacy:
-\* if only the current active era may remain unsealed, then there can be
-\* at most one live era.
-THEOREM PrimacyInductiveImpliesPrimacy ==
-    PrimacyInductive => Primacy
+    /\ Primacy
+    /\ BoundedInheritance
+    /\ EvidenceBounded
+    /\ VerifierSilence
+    /\ Finality
+    /\ RetiredFloorCoversInherited
+    /\ ServedWithinGrant
+    /\ RetirementWithinGrant
 
 Spec ==
     Init /\ [][Next]_Vars

--- a/spec/README.md
+++ b/spec/README.md
@@ -29,7 +29,7 @@ counterexamples.
 
 | Spec | Coverage boundary | Main invariants | Related implementation tests |
 | --- | --- | --- | --- |
-| `Eunomia.tla` | Repeated rooted handoff for the control-plane authority lineage. | Inheritance, Primacy, Silence, Finality. | `coordinator/integration/*`, `meta/root/state/*`. |
+| `Eunomia.tla` | Current root-issued bounded-grant authority protocol for detached coordinators. | Primacy, bounded inheritance, evidence usage coverage, verifier silence, retired-floor finality. | `coordinator/integration/*`, `coordinator/audit/*`, `meta/root/state/*`, `meta/root/replicated/*`. |
 | `EunomiaMultiDim.tla` | Lease-start coverage model for served-read handoff. | No write behind a served read after successor issue. | `coordinator/integration/root_model_test.go`. |
 | `MountLifecycle.tla` | Rooted fsmeta mount registration and retirement. | No implicit mount, terminal retirement, stable mount identity. | `fsmeta/exec/mount_test.go`, `fsmeta/server/service_test.go`. |
 | `SubtreeAuthority.tla` | Namespace subtree authority handoff consumed by subtree rename. | One active authority, successor frontier coverage, sealed-reply rejection, predecessor finality. | `fsmeta/integration/namespace_chaos_test.go`, `fsmeta/contract/*`. |

--- a/spec/artifacts/tlc-eunomia.out
+++ b/spec/artifacts/tlc-eunomia.out
@@ -3,5 +3,5 @@ spec=spec/Eunomia.tla
 status=success
 
 Model checking completed. No error has been found.
-22876 states generated, 3924 distinct states found, 0 states left on queue.
-The depth of the complete state graph search is 20.
+1258664 states generated, 298747 distinct states found, 0 states left on queue.
+The depth of the complete state graph search is 17.


### PR DESCRIPTION
## Summary
- bind reply evidence to the grant admitted at RPC entry and carry root-issued grant certificates from the cached grant view
- add durable verifier-store support, explicit served-time/clock policy checks, and duty registry validation
- harden grant retirement/inheritance/semantic GC and align audit/TLA trace semantics with the implemented protocol
- feed storage epoch mismatches back into route lookup freshness floors

## Validation
- make fmt
- make lint
- make test

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Persistent grant certificate caching and durable authority verifier state storage
  * Enhanced authority evidence validation with clock-skew handling and served-timestamp tracking
  * Improved audit detection for orphan inheritance and evidence anomalies

* **Bug Fixes**
  * Refined retirement state tracking and compaction logic
  * Strengthened grant coverage validation across duty boundaries

* **Documentation**
  * Updated protocol hardening status and production-readiness documentation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->