### PR TITLE
Run fsmeta benchmarks after main merges

### DIFF
--- a/.github/workflows/fsmeta-benchmark.yml
+++ b/.github/workflows/fsmeta-benchmark.yml
@@ -1,6 +1,8 @@
 name: Benchmark
 
 on:
+  push:
+    branches: ["main"]
   pull_request:
     branches: ["main"]
     paths:
@@ -43,7 +45,7 @@ permissions:
 
 jobs:
   fsmeta-medium:
-    if: github.event_name == 'pull_request' || (github.event_name == 'workflow_dispatch' && github.event.inputs.profile == 'medium')
+    if: github.event_name == 'push' || github.event_name == 'pull_request' || (github.event_name == 'workflow_dispatch' && github.event.inputs.profile == 'medium')
     runs-on: ubuntu-latest
     timeout-minutes: 45
     steps:
@@ -84,7 +86,7 @@ jobs:
         run: docker compose down -v || true
 
   fsmeta-long:
-    if: github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && github.event.inputs.profile == 'long')
+    if: github.event_name == 'push' || github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && github.event.inputs.profile == 'long')
     runs-on: ubuntu-latest
     timeout-minutes: 180
     steps:


### PR DESCRIPTION
## Summary

- run the fsmeta medium benchmark on pull requests and main pushes
- run the fsmeta long benchmark on main pushes, scheduled runs, and explicit manual long runs
- keep the existing PR path filter so PRs only pay the fsmeta benchmark cost when relevant code changes

## Validation

- ruby YAML parse for .github/workflows/fsmeta-benchmark.yml
- git diff --check origin/main...HEAD
- make lint
