### PR TITLE
Fix fsmeta 2PC commit timestamp boundary

### DIFF
--- a/fsmeta/contract/harness_test.go
+++ b/fsmeta/contract/harness_test.go
@@ -147,13 +147,21 @@ func (r *versionedRunner) Scan(_ context.Context, startKey []byte, limit uint32,
 }
 
 func (r *versionedRunner) Mutate(_ context.Context, primary []byte, mutations []*kvrpcpb.Mutation, startVersion, commitVersion, _ uint64) (uint64, error) {
+	return r.applyMutations(primary, mutations, startVersion, commitVersion, true)
+}
+
+func (r *versionedRunner) MutateAtCommit(_ context.Context, primary []byte, mutations []*kvrpcpb.Mutation, startVersion, commitVersion, _ uint64) (uint64, error) {
+	return r.applyMutations(primary, mutations, startVersion, commitVersion, false)
+}
+
+func (r *versionedRunner) applyMutations(primary []byte, mutations []*kvrpcpb.Mutation, startVersion, commitVersion uint64, allowCommitPush bool) (uint64, error) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	// The contract fake has no lock table, so it models Percolator's
 	// min-commit push by placing late commits after any timestamp that was
 	// allocated while the transaction was in flight.
 	effectiveCommitVersion := commitVersion
-	if r.latestObservedTS >= effectiveCommitVersion {
+	if allowCommitPush && r.latestObservedTS >= effectiveCommitVersion {
 		effectiveCommitVersion = r.latestObservedTS + 1
 		if r.nextTS <= effectiveCommitVersion {
 			r.nextTS = effectiveCommitVersion + 1

--- a/fsmeta/contract/harness_test.go
+++ b/fsmeta/contract/harness_test.go
@@ -146,7 +146,7 @@ func (r *versionedRunner) Scan(_ context.Context, startKey []byte, limit uint32,
 	return out, nil
 }
 
-func (r *versionedRunner) Mutate(_ context.Context, primary []byte, mutations []*kvrpcpb.Mutation, startVersion, commitVersion, _ uint64) error {
+func (r *versionedRunner) Mutate(_ context.Context, primary []byte, mutations []*kvrpcpb.Mutation, startVersion, commitVersion, _ uint64) (uint64, error) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	// The contract fake has no lock table, so it models Percolator's
@@ -161,7 +161,7 @@ func (r *versionedRunner) Mutate(_ context.Context, primary []byte, mutations []
 	}
 	for _, mut := range mutations {
 		if latest, ok := r.latestVersionLocked(mut.GetKey()); ok && latest > startVersion {
-			return versionedTxnError{errors: []*kvrpcpb.KeyError{{
+			return 0, versionedTxnError{errors: []*kvrpcpb.KeyError{{
 				CommitTsExpired: &kvrpcpb.CommitTsExpired{
 					Key:         append([]byte(nil), mut.GetKey()...),
 					CommitTs:    commitVersion,
@@ -171,15 +171,15 @@ func (r *versionedRunner) Mutate(_ context.Context, primary []byte, mutations []
 		}
 		if mut.GetAssertionNotExist() {
 			if _, ok := r.visibleLocked(mut.GetKey(), startVersion); ok {
-				return fsmeta.ErrExists
+				return 0, fsmeta.ErrExists
 			}
 			if _, ok := r.visibleLatestLocked(mut.GetKey()); ok {
-				return fsmeta.ErrExists
+				return 0, fsmeta.ErrExists
 			}
 		}
 		if bytes.Equal(mut.GetKey(), primary) && mut.GetOp() == kvrpcpb.Mutation_Delete {
 			if _, ok := r.visibleLatestLocked(mut.GetKey()); !ok {
-				return fsmeta.ErrNotFound
+				return 0, fsmeta.ErrNotFound
 			}
 		}
 	}
@@ -197,10 +197,10 @@ func (r *versionedRunner) Mutate(_ context.Context, primary []byte, mutations []
 				deleted: true,
 			})
 		default:
-			return fsmeta.ErrInvalidRequest
+			return 0, fsmeta.ErrInvalidRequest
 		}
 	}
-	return nil
+	return effectiveCommitVersion, nil
 }
 
 func TestVersionedRunnerDelaysPreallocatedCommitPastConcurrentRead(t *testing.T) {
@@ -242,19 +242,21 @@ func TestVersionedRunnerDelaysPreallocatedCommitPastConcurrentRead(t *testing.T)
 
 	seedStart, err := runner.ReserveTimestamp(ctx, 2)
 	require.NoError(t, err)
-	require.NoError(t, runner.Mutate(ctx, epsilonKey, []*kvrpcpb.Mutation{
+	_, err = runner.Mutate(ctx, epsilonKey, []*kvrpcpb.Mutation{
 		{Op: kvrpcpb.Mutation_Put, Key: epsilonKey, Value: epsilonValue},
 		{Op: kvrpcpb.Mutation_Put, Key: inodeKey, Value: inodeValueOneLink},
-	}, seedStart, seedStart+1, 0))
+	}, seedStart, seedStart+1, 0)
+	require.NoError(t, err)
 
 	linkStart, err := runner.ReserveTimestamp(ctx, 2)
 	require.NoError(t, err)
 	readVersion, err := runner.ReserveTimestamp(ctx, 1)
 	require.NoError(t, err)
-	require.NoError(t, runner.Mutate(ctx, etaKey, []*kvrpcpb.Mutation{
+	_, err = runner.Mutate(ctx, etaKey, []*kvrpcpb.Mutation{
 		{Op: kvrpcpb.Mutation_Put, Key: etaKey, Value: etaValue, AssertionNotExist: true},
 		{Op: kvrpcpb.Mutation_Put, Key: inodeKey, Value: inodeValueTwoLinks},
-	}, linkStart, linkStart+1, 0))
+	}, linkStart, linkStart+1, 0)
+	require.NoError(t, err)
 
 	_, ok, err := runner.Get(ctx, etaKey, readVersion)
 	require.NoError(t, err)
@@ -286,13 +288,14 @@ func TestVersionedRunnerRejectsStaleConcurrentMutation(t *testing.T) {
 	require.NoError(t, err)
 	staleStart, err := runner.ReserveTimestamp(ctx, 2)
 	require.NoError(t, err)
-	require.NoError(t, runner.Mutate(ctx, key, []*kvrpcpb.Mutation{{
+	_, err = runner.Mutate(ctx, key, []*kvrpcpb.Mutation{{
 		Op:    kvrpcpb.Mutation_Put,
 		Key:   key,
 		Value: []byte("first"),
-	}}, firstStart, firstStart+1, 0))
+	}}, firstStart, firstStart+1, 0)
+	require.NoError(t, err)
 
-	err = runner.Mutate(ctx, key, []*kvrpcpb.Mutation{{
+	_, err = runner.Mutate(ctx, key, []*kvrpcpb.Mutation{{
 		Op:    kvrpcpb.Mutation_Put,
 		Key:   key,
 		Value: []byte("stale"),

--- a/fsmeta/exec/runner.go
+++ b/fsmeta/exec/runner.go
@@ -31,13 +31,16 @@ type KV struct {
 //
 // ReserveTimestamp returns the first timestamp in a consecutive range of count
 // timestamps. Mutate must provide Percolator-style atomicity for all mutations
-// and return the commit timestamp that made the mutation visible.
+// and return the commit timestamp that made the mutation visible. MutateAtCommit
+// is reserved for operations whose commit timestamp is already part of an
+// external authority protocol, so the runner must not allocate a later commit_ts.
 type TxnRunner interface {
 	ReserveTimestamp(ctx context.Context, count uint64) (uint64, error)
 	Get(ctx context.Context, key []byte, version uint64) ([]byte, bool, error)
 	BatchGet(ctx context.Context, keys [][]byte, version uint64) (map[string][]byte, error)
 	Scan(ctx context.Context, startKey []byte, limit uint32, version uint64) ([]KV, error)
 	Mutate(ctx context.Context, primary []byte, mutations []*kvrpcpb.Mutation, startVersion, commitVersion, lockTTL uint64) (uint64, error)
+	MutateAtCommit(ctx context.Context, primary []byte, mutations []*kvrpcpb.Mutation, startVersion, commitVersion, lockTTL uint64) (uint64, error)
 }
 
 // AtomicMutateFastPath is an optional TxnRunner extension. handled=false
@@ -1164,14 +1167,11 @@ func (e *Executor) RenameSubtree(ctx context.Context, req fsmeta.RenameSubtreeRe
 			return err
 		}
 		handoffStarted = true
-		actualCommitVersion, mutationErr := e.runner.Mutate(ctx, plan.PrimaryKey, mutations, startVersion, commitVersion, e.lockTTL)
-		// Real raftstore 2PC allocates commit_ts after prewrite. The handoff
-		// completion frontier is the data visibility boundary, so it must use the
-		// returned commit timestamp rather than the speculative timestamp used to
-		// open the rooted pending state.
-		if actualCommitVersion == 0 {
-			actualCommitVersion = commitVersion
-		}
+		actualCommitVersion, mutationErr := e.runner.MutateAtCommit(ctx, plan.PrimaryKey, mutations, startVersion, commitVersion, e.lockTTL)
+		// Subtree handoff start publishes a rooted predecessor frontier before the
+		// data mutation runs. That external frontier must be the same commit_ts
+		// used by the data transaction; otherwise concurrent handoffs can observe a
+		// later completed frontier and reject the older pending handoff.
 		// Once StartSubtreeHandoff is rooted, a Mutate error may still be
 		// ambiguous with respect to primary commit. Complete closes the rooted
 		// pending state; at worst this advances an empty era rather than leaving

--- a/fsmeta/exec/runner.go
+++ b/fsmeta/exec/runner.go
@@ -30,13 +30,14 @@ type KV struct {
 // TxnRunner is the NoKV transaction surface required by fsmeta execution.
 //
 // ReserveTimestamp returns the first timestamp in a consecutive range of count
-// timestamps. Mutate must provide Percolator-style atomicity for all mutations.
+// timestamps. Mutate must provide Percolator-style atomicity for all mutations
+// and return the commit timestamp that made the mutation visible.
 type TxnRunner interface {
 	ReserveTimestamp(ctx context.Context, count uint64) (uint64, error)
 	Get(ctx context.Context, key []byte, version uint64) ([]byte, bool, error)
 	BatchGet(ctx context.Context, keys [][]byte, version uint64) (map[string][]byte, error)
 	Scan(ctx context.Context, startKey []byte, limit uint32, version uint64) ([]KV, error)
-	Mutate(ctx context.Context, primary []byte, mutations []*kvrpcpb.Mutation, startVersion, commitVersion, lockTTL uint64) error
+	Mutate(ctx context.Context, primary []byte, mutations []*kvrpcpb.Mutation, startVersion, commitVersion, lockTTL uint64) (uint64, error)
 }
 
 // AtomicMutateFastPath is an optional TxnRunner extension. handled=false
@@ -355,7 +356,8 @@ func (e *Executor) Create(ctx context.Context, req fsmeta.CreateRequest) (fsmeta
 		} else {
 			e.createFastPathSkipQuotaTotal.Add(1)
 		}
-		return e.runner.Mutate(ctx, plan.PrimaryKey, all, startVersion, commitVersion, e.lockTTL)
+		_, err = e.runner.Mutate(ctx, plan.PrimaryKey, all, startVersion, commitVersion, e.lockTTL)
+		return err
 	}); err != nil {
 		return fsmeta.CreateResult{}, err
 	}
@@ -440,7 +442,7 @@ func (e *Executor) UpdateInode(ctx context.Context, req fsmeta.UpdateInodeReques
 			}
 			mutations = append(mutations, quotaMutations...)
 		}
-		if err := e.runner.Mutate(ctx, plan.PrimaryKey, mutations, startVersion, commitVersion, e.lockTTL); err != nil {
+		if _, err := e.runner.Mutate(ctx, plan.PrimaryKey, mutations, startVersion, commitVersion, e.lockTTL); err != nil {
 			return err
 		}
 		updated = inode
@@ -835,7 +837,8 @@ func (e *Executor) Link(ctx context.Context, req fsmeta.LinkRequest) error {
 			return err
 		}
 		mutations = append(mutations, quotaMutations...)
-		return e.runner.Mutate(ctx, plan.PrimaryKey, mutations, startVersion, commitVersion, e.lockTTL)
+		_, err = e.runner.Mutate(ctx, plan.PrimaryKey, mutations, startVersion, commitVersion, e.lockTTL)
+		return err
 	}); err != nil {
 		return err
 	}
@@ -894,7 +897,8 @@ func (e *Executor) Unlink(ctx context.Context, req fsmeta.UnlinkRequest) error {
 			}
 			mutations = append(mutations, quotaMutations...)
 		}
-		return e.runner.Mutate(ctx, plan.PrimaryKey, mutations, startVersion, commitVersion, e.lockTTL)
+		_, err = e.runner.Mutate(ctx, plan.PrimaryKey, mutations, startVersion, commitVersion, e.lockTTL)
+		return err
 	}); err != nil {
 		return err
 	}
@@ -971,7 +975,8 @@ func (e *Executor) OpenWriteSession(ctx context.Context, req fsmeta.OpenWriteSes
 			&kvrpcpb.Mutation{Op: kvrpcpb.Mutation_Put, Key: cloneBytes(plan.MutateKeys[0]), Value: value},
 			&kvrpcpb.Mutation{Op: kvrpcpb.Mutation_Put, Key: cloneBytes(plan.MutateKeys[1]), Value: value},
 		)
-		return e.runner.Mutate(ctx, plan.PrimaryKey, mutations, startVersion, commitVersion, e.lockTTL)
+		_, err = e.runner.Mutate(ctx, plan.PrimaryKey, mutations, startVersion, commitVersion, e.lockTTL)
+		return err
 	}); err != nil {
 		return fsmeta.SessionRecord{}, err
 	}
@@ -1016,7 +1021,8 @@ func (e *Executor) HeartbeatWriteSession(ctx context.Context, req fsmeta.Heartbe
 			{Op: kvrpcpb.Mutation_Put, Key: cloneBytes(plan.MutateKeys[0]), Value: value},
 			{Op: kvrpcpb.Mutation_Put, Key: cloneBytes(plan.MutateKeys[1]), Value: value},
 		}
-		return e.runner.Mutate(ctx, plan.PrimaryKey, mutations, startVersion, commitVersion, e.lockTTL)
+		_, err = e.runner.Mutate(ctx, plan.PrimaryKey, mutations, startVersion, commitVersion, e.lockTTL)
+		return err
 	}); err != nil {
 		return fsmeta.SessionRecord{}, err
 	}
@@ -1048,7 +1054,8 @@ func (e *Executor) CloseWriteSession(ctx context.Context, req fsmeta.CloseWriteS
 		} else if ok && owner.Session == req.Session && owner.Inode == session.Inode {
 			mutations = append(mutations, &kvrpcpb.Mutation{Op: kvrpcpb.Mutation_Delete, Key: ownerKey})
 		}
-		return e.runner.Mutate(ctx, plan.PrimaryKey, mutations, startVersion, commitVersion, e.lockTTL)
+		_, err = e.runner.Mutate(ctx, plan.PrimaryKey, mutations, startVersion, commitVersion, e.lockTTL)
+		return err
 	}); err != nil {
 		return err
 	}
@@ -1118,7 +1125,7 @@ func (e *Executor) ExpireWriteSessions(ctx context.Context, req fsmeta.ExpireWri
 			mutations = append(mutations, &kvrpcpb.Mutation{Op: kvrpcpb.Mutation_Delete, Key: deletes[key]})
 		}
 		primary := deletes[keys[0]]
-		if err := e.runner.Mutate(ctx, primary, mutations, startVersion, commitVersion, e.lockTTL); err != nil {
+		if _, err := e.runner.Mutate(ctx, primary, mutations, startVersion, commitVersion, e.lockTTL); err != nil {
 			return err
 		}
 		expired = uint64(len(expiredSessions))
@@ -1157,12 +1164,19 @@ func (e *Executor) RenameSubtree(ctx context.Context, req fsmeta.RenameSubtreeRe
 			return err
 		}
 		handoffStarted = true
-		mutationErr := e.runner.Mutate(ctx, plan.PrimaryKey, mutations, startVersion, commitVersion, e.lockTTL)
+		actualCommitVersion, mutationErr := e.runner.Mutate(ctx, plan.PrimaryKey, mutations, startVersion, commitVersion, e.lockTTL)
+		// Real raftstore 2PC allocates commit_ts after prewrite. The handoff
+		// completion frontier is the data visibility boundary, so it must use the
+		// returned commit timestamp rather than the speculative timestamp used to
+		// open the rooted pending state.
+		if actualCommitVersion == 0 {
+			actualCommitVersion = commitVersion
+		}
 		// Once StartSubtreeHandoff is rooted, a Mutate error may still be
 		// ambiguous with respect to primary commit. Complete closes the rooted
 		// pending state; at worst this advances an empty era rather than leaving
 		// an unrecoverable handoff.
-		completeErr := e.completeSubtreeHandoff(ctx, req.Mount, authorityRoot, commitVersion)
+		completeErr := e.completeSubtreeHandoff(ctx, req.Mount, authorityRoot, actualCommitVersion)
 		if mutationErr != nil {
 			if completeErr != nil {
 				return errors.Join(mutationErr, fmt.Errorf("complete subtree handoff: %w", completeErr))
@@ -1172,7 +1186,7 @@ func (e *Executor) RenameSubtree(ctx context.Context, req fsmeta.RenameSubtreeRe
 		if completeErr != nil {
 			return completeErr
 		}
-		committedAt = commitVersion
+		committedAt = actualCommitVersion
 		return nil
 	}); err != nil {
 		return err

--- a/fsmeta/exec/runner.go
+++ b/fsmeta/exec/runner.go
@@ -1295,10 +1295,13 @@ func (e *Executor) readVersion(ctx context.Context, snapshotVersion uint64) (uin
 	return e.reserveReadVersion(ctx)
 }
 
-// reserveTxnVersions pre-allocates both start_ts and commit_ts in a single TSO
-// hop. In strict Percolator the commit_ts must be obtained AFTER prewrite to
-// guarantee snapshot isolation; here we rely on two server-side safety nets to
-// make pre-allocation safe in practice:
+// reserveTxnVersions reserves start_ts plus a speculative commit_ts in one TSO
+// hop. AtomicMutate and in-memory runners use the speculative commit version.
+// The real raftstore runner obtains commit_ts after prewrite for regular 2PC,
+// which is the strict Percolator boundary under read/write contention.
+//
+// When a path does use the speculative commit_ts, two server-side safety nets
+// keep pre-allocation from silently violating snapshot isolation:
 //
 //  1. When a concurrent reader at start_ts > our commit_ts encounters our
 //     prewrite lock, it pushes lock.MinCommitTs = reader_start_ts + 1 via
@@ -1306,11 +1309,9 @@ func (e *Executor) readVersion(ctx context.Context, snapshotVersion uint64) (uin
 //  2. commitKey rejects the commit with keyErrorCommitTsExpired when
 //     lock.MinCommitTs > commitVersion (see txn/percolator/txn.go:373-375).
 //
-// Together these force a retry-with-fresh-ts under contention — incorrect
-// pre-allocation is detected at commit time, never silently violated. The
-// optimization saves one TSO RPC per fsmeta operation under the common
-// contention-free path. CommitTsExpired is retried transparently by
-// withTxnRetry below.
+// Together these force a retry-with-fresh-ts under contention: incorrect
+// speculative commit_ts is detected at commit time, never silently accepted.
+// CommitTsExpired is retried transparently by withTxnRetry below.
 func (e *Executor) reserveTxnVersions(ctx context.Context) (uint64, uint64, error) {
 	startVersion, err := e.runner.ReserveTimestamp(ctx, 2)
 	if err != nil {

--- a/fsmeta/exec/runner_test.go
+++ b/fsmeta/exec/runner_test.go
@@ -1040,6 +1040,31 @@ func TestExecutorRetriesCommitTsExpired(t *testing.T) {
 	require.Equal(t, uint64(0), executor.Stats()["txn_retry_exhausted_total"])
 }
 
+func TestExecutorRetriesLostTxnLock(t *testing.T) {
+	runner := newFakeRunner()
+	runner.mutateErrs = []error{
+		fakeTxnKeyError{errors: []*kvrpcpb.KeyError{{
+			Retryable: "percolator: lock not found",
+		}}},
+		nil,
+	}
+	allocator := &fakeInodeAllocator{ids: []fsmeta.InodeID{22}}
+	executor, err := New(runner, WithInodeAllocator(allocator))
+	require.NoError(t, err)
+
+	_, err = executor.Create(context.Background(), fsmeta.CreateRequest{
+		Mount:  "vol",
+		Parent: fsmeta.RootInode,
+		Name:   "file",
+		Attrs:  fsmeta.CreateAttrs{Type: fsmeta.InodeTypeFile},
+	})
+	require.NoError(t, err)
+	require.Len(t, runner.mutations, 1)
+	require.Equal(t, 1, allocator.calls)
+	require.Equal(t, uint64(1), executor.Stats()["txn_retries_total"])
+	require.Equal(t, uint64(0), executor.Stats()["txn_retry_exhausted_total"])
+}
+
 func TestExecutorRetriesLockedTxnContention(t *testing.T) {
 	runner := newFakeRunner()
 	runner.mutateErrs = []error{

--- a/fsmeta/exec/runner_test.go
+++ b/fsmeta/exec/runner_test.go
@@ -291,6 +291,14 @@ func TestExecutorGetQuotaUsageReturnsZeroForMissingCounter(t *testing.T) {
 }
 
 func (r *fakeRunner) Mutate(_ context.Context, primary []byte, mutations []*kvrpcpb.Mutation, _, commitVersion, _ uint64) (uint64, error) {
+	return r.applyMutations(primary, mutations, commitVersion, r.actualCommitVersion)
+}
+
+func (r *fakeRunner) MutateAtCommit(_ context.Context, primary []byte, mutations []*kvrpcpb.Mutation, _, commitVersion, _ uint64) (uint64, error) {
+	return r.applyMutations(primary, mutations, commitVersion, 0)
+}
+
+func (r *fakeRunner) applyMutations(primary []byte, mutations []*kvrpcpb.Mutation, commitVersion, overrideCommitVersion uint64) (uint64, error) {
 	if len(r.mutateErrs) > 0 {
 		err := r.mutateErrs[0]
 		r.mutateErrs = r.mutateErrs[1:]
@@ -326,8 +334,8 @@ func (r *fakeRunner) Mutate(_ context.Context, primary []byte, mutations []*kvrp
 		}
 	}
 	r.mutations = append(r.mutations, cloned)
-	if r.actualCommitVersion != 0 {
-		return r.actualCommitVersion, nil
+	if overrideCommitVersion != 0 {
+		return overrideCommitVersion, nil
 	}
 	return commitVersion, nil
 }
@@ -1391,7 +1399,7 @@ func TestExecutorRenameSubtreeMovesDentry(t *testing.T) {
 	require.Equal(t, []subtreePublishCall{{mount: "vol", root: fsmeta.RootInode, frontier: 2}}, publisher.completes)
 }
 
-func TestExecutorRenameSubtreeCompletesHandoffAtActualCommitVersion(t *testing.T) {
+func TestExecutorRenameSubtreePinsCommitVersionToHandoffFrontier(t *testing.T) {
 	runner := newFakeRunner()
 	runner.actualCommitVersion = 99
 	seedDentry(t, runner, "vol", 7, "old", 22)
@@ -1412,7 +1420,7 @@ func TestExecutorRenameSubtreeCompletesHandoffAtActualCommitVersion(t *testing.T
 	require.NoError(t, err)
 
 	require.Equal(t, []subtreePublishCall{{mount: "vol", root: fsmeta.RootInode, frontier: 2}}, publisher.starts)
-	require.Equal(t, []subtreePublishCall{{mount: "vol", root: fsmeta.RootInode, frontier: 99}}, publisher.completes)
+	require.Equal(t, []subtreePublishCall{{mount: "vol", root: fsmeta.RootInode, frontier: 2}}, publisher.completes)
 }
 
 func TestExecutorRenameSubtreeBlocksMutationWhenStartHandoffFails(t *testing.T) {

--- a/fsmeta/exec/runner_test.go
+++ b/fsmeta/exec/runner_test.go
@@ -18,16 +18,17 @@ import (
 )
 
 type fakeRunner struct {
-	nextTS        uint64
-	data          map[string][]byte
-	mutations     [][]*kvrpcpb.Mutation
-	getCalls      int
-	scanVersions  []uint64
-	batchVersions []uint64
-	scanErrs      []error
-	batchErrs     []error
-	mutateErr     error
-	mutateErrs    []error
+	nextTS              uint64
+	data                map[string][]byte
+	mutations           [][]*kvrpcpb.Mutation
+	getCalls            int
+	scanVersions        []uint64
+	batchVersions       []uint64
+	scanErrs            []error
+	batchErrs           []error
+	mutateErr           error
+	mutateErrs          []error
+	actualCommitVersion uint64
 }
 
 type atomicMutateCall struct {
@@ -289,23 +290,23 @@ func TestExecutorGetQuotaUsageReturnsZeroForMissingCounter(t *testing.T) {
 	require.Equal(t, fsmeta.UsageRecord{}, usage)
 }
 
-func (r *fakeRunner) Mutate(_ context.Context, primary []byte, mutations []*kvrpcpb.Mutation, _, _, _ uint64) error {
+func (r *fakeRunner) Mutate(_ context.Context, primary []byte, mutations []*kvrpcpb.Mutation, _, commitVersion, _ uint64) (uint64, error) {
 	if len(r.mutateErrs) > 0 {
 		err := r.mutateErrs[0]
 		r.mutateErrs = r.mutateErrs[1:]
 		if err != nil {
-			return err
+			return 0, err
 		}
 	}
 	if r.mutateErr != nil {
-		return r.mutateErr
+		return 0, r.mutateErr
 	}
 	cloned := make([]*kvrpcpb.Mutation, 0, len(mutations))
 	hasPrimary := len(mutations) == 0
 	for _, mut := range mutations {
 		if mut.GetAssertionNotExist() {
 			if _, ok := r.data[string(mut.GetKey())]; ok {
-				return fsmeta.ErrExists
+				return 0, fsmeta.ErrExists
 			}
 		}
 		if bytes.Equal(mut.GetKey(), primary) {
@@ -314,7 +315,7 @@ func (r *fakeRunner) Mutate(_ context.Context, primary []byte, mutations []*kvrp
 		cloned = append(cloned, cloneMutation(mut))
 	}
 	if !hasPrimary {
-		return fmt.Errorf("primary key %q not present in mutations", primary)
+		return 0, fmt.Errorf("primary key %q not present in mutations", primary)
 	}
 	for _, mut := range cloned {
 		switch mut.GetOp() {
@@ -325,7 +326,10 @@ func (r *fakeRunner) Mutate(_ context.Context, primary []byte, mutations []*kvrp
 		}
 	}
 	r.mutations = append(r.mutations, cloned)
-	return nil
+	if r.actualCommitVersion != 0 {
+		return r.actualCommitVersion, nil
+	}
+	return commitVersion, nil
 }
 
 func (r *fakeAtomicRunner) TryAtomicMutate(_ context.Context, primary []byte, predicates []*kvrpcpb.AtomicPredicate, mutations []*kvrpcpb.Mutation, startVersion, commitVersion uint64) (bool, error) {
@@ -1385,6 +1389,30 @@ func TestExecutorRenameSubtreeMovesDentry(t *testing.T) {
 	require.True(t, runner.mutations[0][1].GetAssertionNotExist())
 	require.Equal(t, []subtreePublishCall{{mount: "vol", root: fsmeta.RootInode, frontier: 2}}, publisher.starts)
 	require.Equal(t, []subtreePublishCall{{mount: "vol", root: fsmeta.RootInode, frontier: 2}}, publisher.completes)
+}
+
+func TestExecutorRenameSubtreeCompletesHandoffAtActualCommitVersion(t *testing.T) {
+	runner := newFakeRunner()
+	runner.actualCommitVersion = 99
+	seedDentry(t, runner, "vol", 7, "old", 22)
+	publisher := &fakeSubtreePublisher{}
+	resolver := &fakeMountResolver{records: map[fsmeta.MountID]MountAdmission{
+		"vol": {MountID: "vol", RootInode: fsmeta.RootInode, SchemaVersion: 1},
+	}}
+	executor, err := New(runner, WithMountResolver(resolver), WithSubtreeHandoffPublisher(publisher))
+	require.NoError(t, err)
+
+	err = executor.RenameSubtree(context.Background(), fsmeta.RenameSubtreeRequest{
+		Mount:      "vol",
+		FromParent: 7,
+		FromName:   "old",
+		ToParent:   8,
+		ToName:     "new",
+	})
+	require.NoError(t, err)
+
+	require.Equal(t, []subtreePublishCall{{mount: "vol", root: fsmeta.RootInode, frontier: 2}}, publisher.starts)
+	require.Equal(t, []subtreePublishCall{{mount: "vol", root: fsmeta.RootInode, frontier: 99}}, publisher.completes)
 }
 
 func TestExecutorRenameSubtreeBlocksMutationWhenStartHandoffFails(t *testing.T) {

--- a/fsmeta/integration/namespace_chaos_test.go
+++ b/fsmeta/integration/namespace_chaos_test.go
@@ -112,7 +112,9 @@ func TestFSMetadataRenameSubtreePublishesSingleHandoffOnRealCluster(t *testing.T
 	require.Equal(t, mount, publisher.mount)
 	require.Equal(t, fsmeta.RootInode, publisher.root)
 	require.NotZero(t, publisher.startFrontier)
-	require.Equal(t, publisher.startFrontier, publisher.completeFrontier)
+	// Real raftstore 2PC may allocate commit_ts after handoff start. The
+	// successor frontier must cover the predecessor frontier and may be later.
+	require.GreaterOrEqual(t, publisher.completeFrontier, publisher.startFrontier)
 }
 
 func assertNamespaceInvariants(t *testing.T, pairs []fsmeta.DentryAttrPair) {

--- a/fsmeta/runtime/raftstore/quota_cache_test.go
+++ b/fsmeta/runtime/raftstore/quota_cache_test.go
@@ -40,8 +40,8 @@ func (r *fakeTxnRunner) Scan(context.Context, []byte, uint32, uint64) ([]fsmetae
 	return nil, nil
 }
 
-func (r *fakeTxnRunner) Mutate(context.Context, []byte, []*kvrpcpb.Mutation, uint64, uint64, uint64) error {
-	return nil
+func (r *fakeTxnRunner) Mutate(context.Context, []byte, []*kvrpcpb.Mutation, uint64, uint64, uint64) (uint64, error) {
+	return 0, nil
 }
 
 type fakeQuotaLookup struct {

--- a/fsmeta/runtime/raftstore/quota_cache_test.go
+++ b/fsmeta/runtime/raftstore/quota_cache_test.go
@@ -44,6 +44,10 @@ func (r *fakeTxnRunner) Mutate(context.Context, []byte, []*kvrpcpb.Mutation, uin
 	return 0, nil
 }
 
+func (r *fakeTxnRunner) MutateAtCommit(context.Context, []byte, []*kvrpcpb.Mutation, uint64, uint64, uint64) (uint64, error) {
+	return 0, nil
+}
+
 type fakeQuotaLookup struct {
 	fences map[quotaSubject]*coordpb.QuotaFenceInfo
 	calls  int

--- a/fsmeta/runtime/raftstore/runner.go
+++ b/fsmeta/runtime/raftstore/runner.go
@@ -149,6 +149,16 @@ func (r *Runner) Mutate(ctx context.Context, primary []byte, mutations []*kvrpcp
 	return commitVersion, nil
 }
 
+// MutateAtCommit uses the caller-provided commitVersion exactly. fsmeta uses
+// this for root-authority protocols that publish the commit frontier outside the
+// KV data path before the transaction can safely allocate a later timestamp.
+func (r *Runner) MutateAtCommit(ctx context.Context, primary []byte, mutations []*kvrpcpb.Mutation, startVersion, commitVersion, lockTTL uint64) (uint64, error) {
+	if err := r.kv.Mutate(ctx, primary, mutations, startVersion, commitVersion, lockTTL); err != nil {
+		return commitVersion, err
+	}
+	return commitVersion, nil
+}
+
 // Stats returns runtime-adapter counters. Nested KV stats come from the real
 // raftstore client when available, keeping fsmeta expvar useful without making
 // optional observability part of KVClient.

--- a/fsmeta/runtime/raftstore/runner.go
+++ b/fsmeta/runtime/raftstore/runner.go
@@ -21,6 +21,10 @@ type atomicMutateFastPath interface {
 	TryAtomicMutate(ctx context.Context, primary []byte, predicates []*kvrpcpb.AtomicPredicate, mutations []*kvrpcpb.Mutation, startVersion, commitVersion uint64) (bool, error)
 }
 
+type commitTimestampMutator interface {
+	MutateWithCommitTimestamp(ctx context.Context, primary []byte, mutations []*kvrpcpb.Mutation, startVersion, lockTTL uint64, allocateCommitVersion func(context.Context) (uint64, error)) error
+}
+
 type statsProvider interface {
 	Stats() map[string]any
 }
@@ -128,6 +132,14 @@ func (r *Runner) Scan(ctx context.Context, startKey []byte, limit uint32, versio
 
 // Mutate delegates to raftstore's two-phase commit path.
 func (r *Runner) Mutate(ctx context.Context, primary []byte, mutations []*kvrpcpb.Mutation, startVersion, commitVersion, lockTTL uint64) error {
+	if kv, ok := r.kv.(commitTimestampMutator); ok {
+		// The executor still passes a preallocated commitVersion for in-memory
+		// test runners. Real raftstore clients can allocate commit_ts after
+		// prewrite, which avoids repeated CommitTsExpired under mixed reads.
+		return kv.MutateWithCommitTimestamp(ctx, primary, mutations, startVersion, lockTTL, func(ctx context.Context) (uint64, error) {
+			return r.ReserveTimestamp(ctx, 1)
+		})
+	}
 	return r.kv.Mutate(ctx, primary, mutations, startVersion, commitVersion, lockTTL)
 }
 

--- a/fsmeta/runtime/raftstore/runner.go
+++ b/fsmeta/runtime/raftstore/runner.go
@@ -22,7 +22,7 @@ type atomicMutateFastPath interface {
 }
 
 type commitTimestampMutator interface {
-	MutateWithCommitTimestamp(ctx context.Context, primary []byte, mutations []*kvrpcpb.Mutation, startVersion, lockTTL uint64, allocateCommitVersion func(context.Context) (uint64, error)) error
+	MutateWithCommitTimestamp(ctx context.Context, primary []byte, mutations []*kvrpcpb.Mutation, startVersion, lockTTL uint64, allocateCommitVersion func(context.Context) (uint64, error)) (uint64, error)
 }
 
 type statsProvider interface {
@@ -130,8 +130,11 @@ func (r *Runner) Scan(ctx context.Context, startKey []byte, limit uint32, versio
 	return out, nil
 }
 
-// Mutate delegates to raftstore's two-phase commit path.
-func (r *Runner) Mutate(ctx context.Context, primary []byte, mutations []*kvrpcpb.Mutation, startVersion, commitVersion, lockTTL uint64) error {
+// Mutate delegates to raftstore's two-phase commit path and returns the commit
+// timestamp that actually published the mutation. Real raftstore clients may
+// allocate commit_ts after prewrite; callers that publish root frontiers must
+// use the returned timestamp instead of the speculative one they passed in.
+func (r *Runner) Mutate(ctx context.Context, primary []byte, mutations []*kvrpcpb.Mutation, startVersion, commitVersion, lockTTL uint64) (uint64, error) {
 	if kv, ok := r.kv.(commitTimestampMutator); ok {
 		// The executor still passes a preallocated commitVersion for in-memory
 		// test runners. Real raftstore clients can allocate commit_ts after
@@ -140,7 +143,10 @@ func (r *Runner) Mutate(ctx context.Context, primary []byte, mutations []*kvrpcp
 			return r.ReserveTimestamp(ctx, 1)
 		})
 	}
-	return r.kv.Mutate(ctx, primary, mutations, startVersion, commitVersion, lockTTL)
+	if err := r.kv.Mutate(ctx, primary, mutations, startVersion, commitVersion, lockTTL); err != nil {
+		return 0, err
+	}
+	return commitVersion, nil
 }
 
 // Stats returns runtime-adapter counters. Nested KV stats come from the real

--- a/fsmeta/runtime/raftstore/runner_test.go
+++ b/fsmeta/runtime/raftstore/runner_test.go
@@ -37,13 +37,13 @@ type fakeCommitTimestampKV struct {
 	commitVersion uint64
 }
 
-func (f *fakeCommitTimestampKV) MutateWithCommitTimestamp(ctx context.Context, _ []byte, _ []*kvrpcpb.Mutation, _ uint64, _ uint64, allocateCommitVersion func(context.Context) (uint64, error)) error {
+func (f *fakeCommitTimestampKV) MutateWithCommitTimestamp(ctx context.Context, _ []byte, _ []*kvrpcpb.Mutation, _ uint64, _ uint64, allocateCommitVersion func(context.Context) (uint64, error)) (uint64, error) {
 	ts, err := allocateCommitVersion(ctx)
 	if err != nil {
-		return err
+		return 0, err
 	}
 	f.commitVersion = ts
-	return nil
+	return ts, nil
 }
 
 type fakeRunnerTSO struct {
@@ -148,11 +148,12 @@ func TestRunnerMutateAllocatesCommitTimestampAfterPrewrite(t *testing.T) {
 	runner, err := NewRunner(kv, &fakeRunnerTSO{resp: &coordpb.TsoResponse{Timestamp: 20, Count: 1}})
 	require.NoError(t, err)
 
-	err = runner.Mutate(context.Background(), []byte("p"), []*kvrpcpb.Mutation{{
+	actual, err := runner.Mutate(context.Background(), []byte("p"), []*kvrpcpb.Mutation{{
 		Op:  kvrpcpb.Mutation_Put,
 		Key: []byte("p"),
 	}}, 10, 11, 3000)
 	require.NoError(t, err)
+	require.Equal(t, uint64(20), actual)
 	require.Equal(t, uint64(20), kv.commitVersion)
 }
 

--- a/fsmeta/runtime/raftstore/runner_test.go
+++ b/fsmeta/runtime/raftstore/runner_test.go
@@ -32,6 +32,20 @@ func (f *fakeRunnerKV) Mutate(context.Context, []byte, []*kvrpcpb.Mutation, uint
 	return nil
 }
 
+type fakeCommitTimestampKV struct {
+	fakeRunnerKV
+	commitVersion uint64
+}
+
+func (f *fakeCommitTimestampKV) MutateWithCommitTimestamp(ctx context.Context, _ []byte, _ []*kvrpcpb.Mutation, _ uint64, _ uint64, allocateCommitVersion func(context.Context) (uint64, error)) error {
+	ts, err := allocateCommitVersion(ctx)
+	if err != nil {
+		return err
+	}
+	f.commitVersion = ts
+	return nil
+}
+
 type fakeRunnerTSO struct {
 	resp *coordpb.TsoResponse
 	err  error
@@ -127,6 +141,19 @@ func TestRunnerTryAtomicMutateRecordsUnsupportedKV(t *testing.T) {
 	require.False(t, handled)
 	stats := runner.Stats()
 	require.Equal(t, uint64(1), stats["atomic_runner_unsupported_total"])
+}
+
+func TestRunnerMutateAllocatesCommitTimestampAfterPrewrite(t *testing.T) {
+	kv := &fakeCommitTimestampKV{}
+	runner, err := NewRunner(kv, &fakeRunnerTSO{resp: &coordpb.TsoResponse{Timestamp: 20, Count: 1}})
+	require.NoError(t, err)
+
+	err = runner.Mutate(context.Background(), []byte("p"), []*kvrpcpb.Mutation{{
+		Op:  kvrpcpb.Mutation_Put,
+		Key: []byte("p"),
+	}}, 10, 11, 3000)
+	require.NoError(t, err)
+	require.Equal(t, uint64(20), kv.commitVersion)
 }
 
 var _ KVClient = (*fakeRunnerKV)(nil)

--- a/raftstore/client/client_kv.go
+++ b/raftstore/client/client_kv.go
@@ -383,6 +383,23 @@ func (c *Client) callScan(ctx context.Context, region regionSnapshot, startKey [
 // Mutate wraps TwoPhaseCommit with a ready-made mutation slice. The caller must
 // ensure the primary key is part of the mutation set.
 func (c *Client) Mutate(ctx context.Context, primary []byte, mutations []*kvrpcpb.Mutation, startVersion, commitVersion, lockTTL uint64) error {
+	return c.mutateWithCommitTimestamp(ctx, primary, mutations, startVersion, lockTTL, func(context.Context) (uint64, error) {
+		return commitVersion, nil
+	})
+}
+
+// MutateWithCommitTimestamp runs a 2PC mutation and obtains commit_ts after all
+// prewrites have reached Raft. This is the strict Percolator timestamp boundary:
+// readers may push MinCommitTs while locks are live, so fsmeta uses this path to
+// avoid exhausting logical-operation retries under read/write contention.
+func (c *Client) MutateWithCommitTimestamp(ctx context.Context, primary []byte, mutations []*kvrpcpb.Mutation, startVersion, lockTTL uint64, allocateCommitVersion func(context.Context) (uint64, error)) error {
+	if allocateCommitVersion == nil {
+		return &ProtocolError{Operation: "mutate", Detail: "commit timestamp allocator required"}
+	}
+	return c.mutateWithCommitTimestamp(ctx, primary, mutations, startVersion, lockTTL, allocateCommitVersion)
+}
+
+func (c *Client) mutateWithCommitTimestamp(ctx context.Context, primary []byte, mutations []*kvrpcpb.Mutation, startVersion, lockTTL uint64, allocateCommitVersion func(context.Context) (uint64, error)) error {
 	if len(primary) == 0 {
 		return &ProtocolError{Operation: "mutate", Detail: "primary key required"}
 	}
@@ -399,7 +416,7 @@ func (c *Client) Mutate(ctx context.Context, primary []byte, mutations []*kvrpcp
 	if !mutationHasPrimary(cleaned, primary) {
 		return &ProtocolError{Operation: "mutate", Detail: fmt.Sprintf("primary key %q not present in mutations", primary)}
 	}
-	return c.TwoPhaseCommit(ctx, append([]byte(nil), primary...), cleaned, startVersion, commitVersion, lockTTL)
+	return c.twoPhaseCommit(ctx, append([]byte(nil), primary...), cleaned, startVersion, lockTTL, allocateCommitVersion)
 }
 
 // TryAtomicMutate attempts to materialize mutations as one region-local 1PC
@@ -535,6 +552,12 @@ func (c *Client) Delete(ctx context.Context, key []byte, startVersion, commitVer
 
 // TwoPhaseCommit runs Prewrite followed by Commit across the supplied mutations.
 func (c *Client) TwoPhaseCommit(ctx context.Context, primary []byte, mutations []*kvrpcpb.Mutation, startVersion, commitVersion, lockTTL uint64) error {
+	return c.twoPhaseCommit(ctx, primary, mutations, startVersion, lockTTL, func(context.Context) (uint64, error) {
+		return commitVersion, nil
+	})
+}
+
+func (c *Client) twoPhaseCommit(ctx context.Context, primary []byte, mutations []*kvrpcpb.Mutation, startVersion, lockTTL uint64, allocateCommitVersion func(context.Context) (uint64, error)) error {
 	if len(mutations) == 0 {
 		return nil
 	}
@@ -575,6 +598,20 @@ func (c *Client) TwoPhaseCommit(ctx context.Context, primary []byte, mutations [
 			}
 			return err
 		}
+	}
+	commitVersion, err := allocateCommitVersion(ctx)
+	if err != nil {
+		if rollbackErr := c.rollbackPrewrites(ctx, prewritten, startVersion); rollbackErr != nil {
+			return errors.Join(err, fmt.Errorf("client: rollback after commit timestamp allocation failure: %w", rollbackErr))
+		}
+		return err
+	}
+	if commitVersion <= startVersion {
+		err := &ProtocolError{Operation: "two phase commit", Detail: fmt.Sprintf("commit version %d must be greater than start version %d", commitVersion, startVersion)}
+		if rollbackErr := c.rollbackPrewrites(ctx, prewritten, startVersion); rollbackErr != nil {
+			return errors.Join(err, fmt.Errorf("client: rollback after invalid commit timestamp: %w", rollbackErr))
+		}
+		return err
 	}
 	if err := c.commitKeysByRoute(ctx, [][]byte{append([]byte(nil), primary...)}, startVersion, commitVersion); err != nil {
 		if shouldRollbackAfterPrimaryCommitFailure(err) {

--- a/raftstore/client/client_kv.go
+++ b/raftstore/client/client_kv.go
@@ -383,25 +383,26 @@ func (c *Client) callScan(ctx context.Context, region regionSnapshot, startKey [
 // Mutate wraps TwoPhaseCommit with a ready-made mutation slice. The caller must
 // ensure the primary key is part of the mutation set.
 func (c *Client) Mutate(ctx context.Context, primary []byte, mutations []*kvrpcpb.Mutation, startVersion, commitVersion, lockTTL uint64) error {
-	return c.mutateWithCommitTimestamp(ctx, primary, mutations, startVersion, lockTTL, func(context.Context) (uint64, error) {
+	_, err := c.mutateWithCommitTimestamp(ctx, primary, mutations, startVersion, lockTTL, func(context.Context) (uint64, error) {
 		return commitVersion, nil
 	})
+	return err
 }
 
 // MutateWithCommitTimestamp runs a 2PC mutation and obtains commit_ts after all
 // prewrites have reached Raft. This is the strict Percolator timestamp boundary:
 // readers may push MinCommitTs while locks are live, so fsmeta uses this path to
 // avoid exhausting logical-operation retries under read/write contention.
-func (c *Client) MutateWithCommitTimestamp(ctx context.Context, primary []byte, mutations []*kvrpcpb.Mutation, startVersion, lockTTL uint64, allocateCommitVersion func(context.Context) (uint64, error)) error {
+func (c *Client) MutateWithCommitTimestamp(ctx context.Context, primary []byte, mutations []*kvrpcpb.Mutation, startVersion, lockTTL uint64, allocateCommitVersion func(context.Context) (uint64, error)) (uint64, error) {
 	if allocateCommitVersion == nil {
-		return &ProtocolError{Operation: "mutate", Detail: "commit timestamp allocator required"}
+		return 0, &ProtocolError{Operation: "mutate", Detail: "commit timestamp allocator required"}
 	}
 	return c.mutateWithCommitTimestamp(ctx, primary, mutations, startVersion, lockTTL, allocateCommitVersion)
 }
 
-func (c *Client) mutateWithCommitTimestamp(ctx context.Context, primary []byte, mutations []*kvrpcpb.Mutation, startVersion, lockTTL uint64, allocateCommitVersion func(context.Context) (uint64, error)) error {
+func (c *Client) mutateWithCommitTimestamp(ctx context.Context, primary []byte, mutations []*kvrpcpb.Mutation, startVersion, lockTTL uint64, allocateCommitVersion func(context.Context) (uint64, error)) (uint64, error) {
 	if len(primary) == 0 {
-		return &ProtocolError{Operation: "mutate", Detail: "primary key required"}
+		return 0, &ProtocolError{Operation: "mutate", Detail: "primary key required"}
 	}
 	cleaned := make([]*kvrpcpb.Mutation, 0, len(mutations))
 	for _, mut := range mutations {
@@ -411,10 +412,10 @@ func (c *Client) mutateWithCommitTimestamp(ctx context.Context, primary []byte, 
 		cleaned = append(cleaned, cloneMutation(mut))
 	}
 	if len(cleaned) == 0 {
-		return nil
+		return 0, nil
 	}
 	if !mutationHasPrimary(cleaned, primary) {
-		return &ProtocolError{Operation: "mutate", Detail: fmt.Sprintf("primary key %q not present in mutations", primary)}
+		return 0, &ProtocolError{Operation: "mutate", Detail: fmt.Sprintf("primary key %q not present in mutations", primary)}
 	}
 	return c.twoPhaseCommit(ctx, append([]byte(nil), primary...), cleaned, startVersion, lockTTL, allocateCommitVersion)
 }
@@ -552,14 +553,15 @@ func (c *Client) Delete(ctx context.Context, key []byte, startVersion, commitVer
 
 // TwoPhaseCommit runs Prewrite followed by Commit across the supplied mutations.
 func (c *Client) TwoPhaseCommit(ctx context.Context, primary []byte, mutations []*kvrpcpb.Mutation, startVersion, commitVersion, lockTTL uint64) error {
-	return c.twoPhaseCommit(ctx, primary, mutations, startVersion, lockTTL, func(context.Context) (uint64, error) {
+	_, err := c.twoPhaseCommit(ctx, primary, mutations, startVersion, lockTTL, func(context.Context) (uint64, error) {
 		return commitVersion, nil
 	})
+	return err
 }
 
-func (c *Client) twoPhaseCommit(ctx context.Context, primary []byte, mutations []*kvrpcpb.Mutation, startVersion, lockTTL uint64, allocateCommitVersion func(context.Context) (uint64, error)) error {
+func (c *Client) twoPhaseCommit(ctx context.Context, primary []byte, mutations []*kvrpcpb.Mutation, startVersion, lockTTL uint64, allocateCommitVersion func(context.Context) (uint64, error)) (uint64, error) {
 	if len(mutations) == 0 {
-		return nil
+		return 0, nil
 	}
 	cleaned := make([]*kvrpcpb.Mutation, 0, len(mutations))
 	var primaryMutation *kvrpcpb.Mutation
@@ -574,11 +576,11 @@ func (c *Client) twoPhaseCommit(ctx context.Context, primary []byte, mutations [
 		cleaned = append(cleaned, cloned)
 	}
 	if primaryMutation == nil {
-		return &ProtocolError{Operation: "two phase commit", Detail: fmt.Sprintf("primary key %q missing from mutations", primary)}
+		return 0, &ProtocolError{Operation: "two phase commit", Detail: fmt.Sprintf("primary key %q missing from mutations", primary)}
 	}
 	prewritten, err := c.prewriteMutationsByRoute(ctx, primary, startVersion, lockTTL, []*kvrpcpb.Mutation{primaryMutation})
 	if err != nil {
-		return err
+		return 0, err
 	}
 	secondaryMutations := make([]*kvrpcpb.Mutation, 0, len(cleaned)-1)
 	primarySkipped := false
@@ -594,41 +596,43 @@ func (c *Client) twoPhaseCommit(ctx context.Context, primary []byte, mutations [
 		mergePrewritten(prewritten, secondaryPrewritten)
 		if err != nil {
 			if rollbackErr := c.rollbackPrewrites(ctx, prewritten, startVersion); rollbackErr != nil {
-				return errors.Join(err, fmt.Errorf("client: rollback after prewrite failure: %w", rollbackErr))
+				return 0, errors.Join(err, fmt.Errorf("client: rollback after prewrite failure: %w", rollbackErr))
 			}
-			return err
+			return 0, err
 		}
 	}
 	commitVersion, err := allocateCommitVersion(ctx)
 	if err != nil {
 		if rollbackErr := c.rollbackPrewrites(ctx, prewritten, startVersion); rollbackErr != nil {
-			return errors.Join(err, fmt.Errorf("client: rollback after commit timestamp allocation failure: %w", rollbackErr))
+			return 0, errors.Join(err, fmt.Errorf("client: rollback after commit timestamp allocation failure: %w", rollbackErr))
 		}
-		return err
+		return 0, err
 	}
 	if commitVersion <= startVersion {
 		err := &ProtocolError{Operation: "two phase commit", Detail: fmt.Sprintf("commit version %d must be greater than start version %d", commitVersion, startVersion)}
 		if rollbackErr := c.rollbackPrewrites(ctx, prewritten, startVersion); rollbackErr != nil {
-			return errors.Join(err, fmt.Errorf("client: rollback after invalid commit timestamp: %w", rollbackErr))
+			return 0, errors.Join(err, fmt.Errorf("client: rollback after invalid commit timestamp: %w", rollbackErr))
 		}
-		return err
+		return 0, err
 	}
+	// After commit_ts is allocated, callers that publish external frontiers need
+	// to know that timestamp even if a later RPC returns an ambiguous error.
 	if err := c.commitKeysByRoute(ctx, [][]byte{append([]byte(nil), primary...)}, startVersion, commitVersion); err != nil {
 		if shouldRollbackAfterPrimaryCommitFailure(err) {
 			if rollbackErr := c.rollbackPrewrites(ctx, prewritten, startVersion); rollbackErr != nil {
-				return errors.Join(err, fmt.Errorf("client: rollback after primary commit failure: %w", rollbackErr))
+				return commitVersion, errors.Join(err, fmt.Errorf("client: rollback after primary commit failure: %w", rollbackErr))
 			}
 		}
-		return err
+		return commitVersion, err
 	}
 	secondaryKeys := collectKeys(secondaryMutations)
 	if err := c.commitKeysByRoute(ctx, secondaryKeys, startVersion, commitVersion); err != nil {
 		if resolveErr := c.resolveCommittedSecondaries(ctx, secondaryKeys, startVersion, commitVersion); resolveErr != nil {
-			return errors.Join(err, fmt.Errorf("client: resolve committed secondaries: %w", resolveErr))
+			return commitVersion, errors.Join(err, fmt.Errorf("client: resolve committed secondaries: %w", resolveErr))
 		}
-		return nil
+		return commitVersion, nil
 	}
-	return nil
+	return commitVersion, nil
 }
 
 type mutationRouteBatch struct {

--- a/raftstore/client/client_kv_test.go
+++ b/raftstore/client/client_kv_test.go
@@ -1171,7 +1171,7 @@ func TestClientMutateWithCommitTimestampAllocatesAfterPrewrite(t *testing.T) {
 	require.NoError(t, err)
 	defer func() { _ = cli.Close() }()
 
-	err = cli.MutateWithCommitTimestamp(context.Background(), []byte("alfa"), []*kvrpcpb.Mutation{
+	actualCommitVersion, err := cli.MutateWithCommitTimestamp(context.Background(), []byte("alfa"), []*kvrpcpb.Mutation{
 		{Op: kvrpcpb.Mutation_Put, Key: []byte("alfa"), Value: []byte("v1")},
 	}, 50, 3000, func(context.Context) (uint64, error) {
 		require.Equal(t, 1, prewrites)
@@ -1180,6 +1180,7 @@ func TestClientMutateWithCommitTimestampAllocatesAfterPrewrite(t *testing.T) {
 		return 77, nil
 	})
 	require.NoError(t, err)
+	require.Equal(t, uint64(77), actualCommitVersion)
 	require.Equal(t, 1, prewrites)
 	require.Equal(t, 1, allocs)
 	require.Equal(t, 1, commits)
@@ -1210,7 +1211,7 @@ func TestClientMutateWithCommitTimestampRollsBackAfterAllocationFailure(t *testi
 	defer func() { _ = cli.Close() }()
 
 	allocErr := errors.New("tso unavailable")
-	err = cli.MutateWithCommitTimestamp(context.Background(), []byte("alfa"), []*kvrpcpb.Mutation{
+	_, err = cli.MutateWithCommitTimestamp(context.Background(), []byte("alfa"), []*kvrpcpb.Mutation{
 		{Op: kvrpcpb.Mutation_Put, Key: []byte("alfa"), Value: []byte("v1")},
 	}, 50, 3000, func(context.Context) (uint64, error) {
 		return 0, allocErr

--- a/raftstore/client/client_kv_test.go
+++ b/raftstore/client/client_kv_test.go
@@ -1133,6 +1133,98 @@ func TestClientTwoPhaseCommitRollsBackPrewritesAfterPrimaryCommitTsExpired(t *te
 	require.Equal(t, 1, rollbackHits)
 }
 
+func TestClientMutateWithCommitTimestampAllocatesAfterPrewrite(t *testing.T) {
+	cluster := newMockCluster(clusterRegion{
+		meta: &metapb.RegionDescriptor{
+			RegionId: 1,
+			StartKey: []byte("a"),
+			EndKey:   []byte("z"),
+			Epoch:    &metapb.RegionEpoch{Version: 1, ConfVersion: 1},
+			Peers:    []*metapb.RegionPeer{{StoreId: 1, PeerId: 101}},
+		},
+		leaderStore: 1,
+	})
+	svc := &scriptedKVService{mockService: mockService{storeID: 1, cluster: cluster}}
+	var prewrites int
+	var commits int
+	var allocs int
+	svc.prewriteFn = func(ctx context.Context, req *kvrpcpb.KvPrewriteRequest) (*kvrpcpb.KvPrewriteResponse, error) {
+		prewrites++
+		return svc.mockService.Prewrite(ctx, req)
+	}
+	svc.commitFn = func(ctx context.Context, req *kvrpcpb.KvCommitRequest) (*kvrpcpb.KvCommitResponse, error) {
+		require.Equal(t, 1, prewrites)
+		require.Equal(t, 1, allocs)
+		require.Equal(t, uint64(77), req.GetRequest().GetCommitVersion())
+		commits++
+		return svc.mockService.Commit(ctx, req)
+	}
+	addr, stop := startBlockingStore(t, svc)
+	defer stop()
+
+	cli, err := New(Config{
+		StoreResolver:  staticStoreResolver{{StoreID: 1, Addr: addr}},
+		RegionResolver: resolverFromCluster(cluster),
+		DialOptions:    []grpc.DialOption{grpc.WithTransportCredentials(insecure.NewCredentials())},
+		Retry:          RetryPolicy{MaxAttempts: 2, RegionErrorBackoff: 0},
+	})
+	require.NoError(t, err)
+	defer func() { _ = cli.Close() }()
+
+	err = cli.MutateWithCommitTimestamp(context.Background(), []byte("alfa"), []*kvrpcpb.Mutation{
+		{Op: kvrpcpb.Mutation_Put, Key: []byte("alfa"), Value: []byte("v1")},
+	}, 50, 3000, func(context.Context) (uint64, error) {
+		require.Equal(t, 1, prewrites)
+		require.Equal(t, 0, commits)
+		allocs++
+		return 77, nil
+	})
+	require.NoError(t, err)
+	require.Equal(t, 1, prewrites)
+	require.Equal(t, 1, allocs)
+	require.Equal(t, 1, commits)
+}
+
+func TestClientMutateWithCommitTimestampRollsBackAfterAllocationFailure(t *testing.T) {
+	cluster := newMockCluster(clusterRegion{
+		meta: &metapb.RegionDescriptor{
+			RegionId: 1,
+			StartKey: []byte("a"),
+			EndKey:   []byte("z"),
+			Epoch:    &metapb.RegionEpoch{Version: 1, ConfVersion: 1},
+			Peers:    []*metapb.RegionPeer{{StoreId: 1, PeerId: 101}},
+		},
+		leaderStore: 1,
+	})
+	svc := &scriptedKVService{mockService: mockService{storeID: 1, cluster: cluster}}
+	addr, stop := startBlockingStore(t, svc)
+	defer stop()
+
+	cli, err := New(Config{
+		StoreResolver:  staticStoreResolver{{StoreID: 1, Addr: addr}},
+		RegionResolver: resolverFromCluster(cluster),
+		DialOptions:    []grpc.DialOption{grpc.WithTransportCredentials(insecure.NewCredentials())},
+		Retry:          RetryPolicy{MaxAttempts: 2, RegionErrorBackoff: 0},
+	})
+	require.NoError(t, err)
+	defer func() { _ = cli.Close() }()
+
+	allocErr := errors.New("tso unavailable")
+	err = cli.MutateWithCommitTimestamp(context.Background(), []byte("alfa"), []*kvrpcpb.Mutation{
+		{Op: kvrpcpb.Mutation_Put, Key: []byte("alfa"), Value: []byte("v1")},
+	}, 50, 3000, func(context.Context) (uint64, error) {
+		return 0, allocErr
+	})
+	require.ErrorIs(t, err, allocErr)
+
+	cluster.mu.Lock()
+	_, pending := cluster.regions[1].pending[50]
+	rollbackHits := cluster.regions[1].rollbackHits
+	cluster.mu.Unlock()
+	require.False(t, pending, "prewrites must be rolled back when post-prewrite TSO allocation fails")
+	require.Equal(t, 1, rollbackHits)
+}
+
 func TestClientTwoPhaseCommitResolvesSecondariesAfterSecondaryCommitFailure(t *testing.T) {
 	cluster := newMockCluster(
 		clusterRegion{

--- a/txn/percolator/errors.go
+++ b/txn/percolator/errors.go
@@ -61,6 +61,13 @@ func keyErrorTxnAlreadyRolledBack() *kvrpcpb.KeyError {
 	return keyErrorRetryable(errTxnAlreadyRolledBack)
 }
 
+func keyErrorTxnLockLost() *kvrpcpb.KeyError {
+	// A missing lock with no committed write means this start_ts has no safe
+	// commit path left. Retrying the same Commit cannot make progress, but a
+	// semantic caller such as fsmeta can re-read and re-plan with fresh TSO.
+	return keyErrorRetryable(errLockNotFound)
+}
+
 func keyErrorAlreadyExists(key []byte) *kvrpcpb.KeyError {
 	return &kvrpcpb.KeyError{AlreadyExists: &kvrpcpb.KeyAlreadyExists{Key: kv.SafeCopy(nil, key)}}
 }

--- a/txn/percolator/txn.go
+++ b/txn/percolator/txn.go
@@ -659,7 +659,7 @@ func planCommitKey(reader *Reader, key []byte, startVersion, commitVersion uint6
 			}
 			return nil, nil
 		}
-		return nil, keyErrorAbort(errLockNotFound)
+		return nil, keyErrorTxnLockLost()
 	}
 	if lock.Ts != startVersion {
 		return nil, keyErrorLocked(key, lock)

--- a/txn/percolator/txn_test.go
+++ b/txn/percolator/txn_test.go
@@ -655,7 +655,7 @@ func TestCommitMissingLock(t *testing.T) {
 	}
 	err := Commit(db, latches, commit)
 	require.NotNil(t, err)
-	require.Contains(t, err.GetAbort(), "lock not found")
+	require.Contains(t, err.GetRetryable(), "lock not found")
 }
 
 // TestCommitNilRequestReturnsNil verifies Commit ignores nil requests.


### PR DESCRIPTION
## Summary

- classify Percolator commit missing-lock/no-write as retryable transaction loss instead of aborting semantic fsmeta operations
- let real raftstore-backed fsmeta 2PC allocate commit_ts after all prewrites reach Raft
- roll back prewrites if post-prewrite commit timestamp allocation fails
- add targeted tests for missing-lock retry, post-prewrite commit_ts allocation, and rollback on commit timestamp allocation failure

## Root cause

The main fsmeta-long benchmark exposed two related transaction-boundary bugs. First, Percolator Commit returned Abort when a start_ts had no lock and no committed write, causing fsmeta to leak `percolator: lock not found` instead of retrying the logical operation with a fresh timestamp. Second, fsmeta preallocated adjacent start_ts/commit_ts for regular raftstore 2PC; concurrent reads can push lock.MinCommitTs past that speculative commit_ts, so long mixed workloads could exhaust retries with CommitTsExpired.

## Verification

- `go test ./txn/percolator`
- `go test ./fsmeta/exec`
- `go test ./fsmeta/runtime/raftstore ./raftstore/client ./txn/percolator`
- `make fmt`
- `make lint`
- `NOKV_FSMETA_PROFILE=long NOKV_FSMETA_WORKLOADS=mixed NOKV_FSMETA_COMPOSE_BUILD=1 NOKV_FSMETA_OUTPUT_DIR=benchmark/data/fsmeta/results make fsmeta-bench`
- `NOKV_FSMETA_PROFILE=medium NOKV_FSMETA_COMPOSE_BUILD=1 NOKV_FSMETA_OUTPUT_DIR=benchmark/data/fsmeta/results make fsmeta-bench`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced transaction commit-timestamp allocation for improved concurrency control
  * Improved error handling for transaction lock scenarios

* **Bug Fixes**
  * Lost locks during commit now properly trigger transaction retry instead of immediate abort

* **Tests**
  * Added test coverage for transaction retry and lost lock scenarios

<!-- end of auto-generated comment: release notes by coderabbit.ai -->