### PR TITLE
[PERF] Optimize peer proposal batching

### DIFF
--- a/raftstore/peer/bench_test.go
+++ b/raftstore/peer/bench_test.go
@@ -1,0 +1,134 @@
+package peer
+
+import (
+	"fmt"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	myraft "github.com/feichai0017/NoKV/raft"
+	"github.com/feichai0017/NoKV/raftstore/raftlog"
+)
+
+type slowStorage struct {
+	raftlog.PeerStorage
+	appendDelay time.Duration
+}
+
+func (s *slowStorage) Append(entries []myraft.Entry) error {
+	time.Sleep(s.appendDelay)
+	return s.PeerStorage.Append(entries)
+}
+
+func (s *slowStorage) AppendWithHardState(entries []myraft.Entry, st myraft.HardState) error {
+	time.Sleep(s.appendDelay)
+	if aws, ok := s.PeerStorage.(raftlog.AppendWithHardStateStorage); ok {
+		return aws.AppendWithHardState(entries, st)
+	}
+	if err := s.PeerStorage.Append(entries); err != nil {
+		return err
+	}
+	return s.PeerStorage.SetHardState(st)
+}
+
+func newBenchPeer(b *testing.B, batchSize int, batchWait time.Duration, fsyncDelay time.Duration) *Peer {
+	b.Helper()
+	memStore := myraft.NewMemoryStorage()
+	var storage raftlog.PeerStorage = raftlog.PeerStorage(memStore)
+	if fsyncDelay > 0 {
+		storage = &slowStorage{PeerStorage: storage, appendDelay: fsyncDelay}
+	}
+	apply := func([]myraft.Entry) error { return nil }
+	cfg := &Config{
+		RaftConfig: myraft.Config{
+			ID:              1,
+			ElectionTick:    5,
+			HeartbeatTick:   1,
+			MaxSizePerMsg:   1 << 20,
+			MaxInflightMsgs: 256,
+			PreVote:         true,
+			Storage:         memStore,
+		},
+		Transport:    noopPayloadTransport{},
+		Apply:        apply,
+		Storage:      storage,
+		GroupID:      1,
+		BatchMaxSize: batchSize,
+		BatchMaxWait: batchWait,
+	}
+	p, err := NewPeer(cfg)
+	if err != nil {
+		b.Fatal(err)
+	}
+	b.Cleanup(func() { _ = p.Close() })
+	if err := p.Bootstrap([]myraft.Peer{{ID: 1}}); err != nil {
+		b.Fatal(err)
+	}
+	if err := p.Campaign(); err != nil {
+		b.Fatal(err)
+	}
+	if err := p.Flush(); err != nil {
+		b.Fatal(err)
+	}
+	return p
+}
+
+func benchmarkPeerPropose(b *testing.B, batchSize int, batchWait time.Duration, fsyncDelay time.Duration, concurrency int) {
+	p := newBenchPeer(b, batchSize, batchWait, fsyncDelay)
+	payload := []byte("bench-proposal-data-32-bytes--")
+
+	total := b.N
+	perGoroutine := total / concurrency
+	extra := total % concurrency
+
+	var count atomic.Int64
+	var wg sync.WaitGroup
+	wg.Add(concurrency)
+
+	b.ResetTimer()
+	for g := 0; g < concurrency; g++ {
+		n := perGoroutine
+		if g < extra {
+			n++
+		}
+		go func(n int) {
+			defer wg.Done()
+			for i := 0; i < n; i++ {
+				if err := p.Propose(payload); err != nil {
+					b.Error(err)
+					return
+				}
+				count.Add(1)
+			}
+		}(n)
+	}
+	wg.Wait()
+	b.StopTimer()
+
+	if int(count.Load()) != total {
+		b.Errorf("proposed %d, expected %d", count.Load(), total)
+	}
+	qps := float64(count.Load()) / b.Elapsed().Seconds()
+	fmt.Fprintf(b.Output(), "  %.0f proposals/sec\n", qps)
+}
+
+func BenchmarkPeerPropose(b *testing.B) {
+	b.Run("batch64_1ms/conc1", func(b *testing.B) { benchmarkPeerPropose(b, 64, time.Millisecond, 0, 1) })
+	b.Run("batch64_1ms/conc8", func(b *testing.B) { benchmarkPeerPropose(b, 64, time.Millisecond, 0, 8) })
+	b.Run("batch64_1ms/conc64", func(b *testing.B) { benchmarkPeerPropose(b, 64, time.Millisecond, 0, 64) })
+	b.Run("batch64_1ms/conc256", func(b *testing.B) { benchmarkPeerPropose(b, 64, time.Millisecond, 0, 256) })
+	b.Run("batch256_1ms/conc8", func(b *testing.B) { benchmarkPeerPropose(b, 256, time.Millisecond, 0, 8) })
+	b.Run("batch256_1ms/conc64", func(b *testing.B) { benchmarkPeerPropose(b, 256, time.Millisecond, 0, 64) })
+	b.Run("batch256_1ms/conc256", func(b *testing.B) { benchmarkPeerPropose(b, 256, time.Millisecond, 0, 256) })
+}
+
+func BenchmarkPeerProposeFsync(b *testing.B) {
+	b.Run("batch64_1ms/conc1", func(b *testing.B) { benchmarkPeerPropose(b, 64, time.Millisecond, time.Millisecond, 1) })
+	b.Run("batch64_1ms/conc8", func(b *testing.B) { benchmarkPeerPropose(b, 64, time.Millisecond, time.Millisecond, 8) })
+	b.Run("batch64_1ms/conc64", func(b *testing.B) { benchmarkPeerPropose(b, 64, time.Millisecond, time.Millisecond, 64) })
+	b.Run("batch64_1ms/conc256", func(b *testing.B) { benchmarkPeerPropose(b, 64, time.Millisecond, time.Millisecond, 256) })
+	b.Run("batch256_1ms/conc8", func(b *testing.B) { benchmarkPeerPropose(b, 256, time.Millisecond, time.Millisecond, 8) })
+	b.Run("batch256_1ms/conc64", func(b *testing.B) { benchmarkPeerPropose(b, 256, time.Millisecond, time.Millisecond, 64) })
+	b.Run("batch256_1ms/conc256", func(b *testing.B) { benchmarkPeerPropose(b, 256, time.Millisecond, time.Millisecond, 256) })
+}

--- a/raftstore/peer/bench_test.go
+++ b/raftstore/peer/bench_test.go
@@ -29,13 +29,13 @@ func (s *slowStorage) AppendWithHardState(entries []myraft.Entry, st myraft.Hard
 	if err := s.PeerStorage.Append(entries); err != nil {
 		return err
 	}
-	return s.PeerStorage.SetHardState(st)
+	return s.SetHardState(st)
 }
 
 func newBenchPeer(b *testing.B, batchSize int, batchWait time.Duration, fsyncDelay time.Duration) *Peer {
 	b.Helper()
 	memStore := myraft.NewMemoryStorage()
-	var storage raftlog.PeerStorage = raftlog.PeerStorage(memStore)
+	storage := raftlog.PeerStorage(memStore)
 	if fsyncDelay > 0 {
 		storage = &slowStorage{PeerStorage: storage, appendDelay: fsyncDelay}
 	}
@@ -87,14 +87,14 @@ func benchmarkPeerPropose(b *testing.B, batchSize int, batchWait time.Duration, 
 	wg.Add(concurrency)
 
 	b.ResetTimer()
-	for g := 0; g < concurrency; g++ {
+	for g := range concurrency {
 		n := perGoroutine
 		if g < extra {
 			n++
 		}
 		go func(n int) {
 			defer wg.Done()
-			for i := 0; i < n; i++ {
+			for range n {
 				if err := p.Propose(payload); err != nil {
 					b.Error(err)
 					return
@@ -110,7 +110,7 @@ func benchmarkPeerPropose(b *testing.B, batchSize int, batchWait time.Duration, 
 		b.Errorf("proposed %d, expected %d", count.Load(), total)
 	}
 	qps := float64(count.Load()) / b.Elapsed().Seconds()
-	fmt.Fprintf(b.Output(), "  %.0f proposals/sec\n", qps)
+	_, _ = fmt.Fprintf(b.Output(), "  %.0f proposals/sec\n", qps)
 }
 
 func BenchmarkPeerPropose(b *testing.B) {

--- a/raftstore/peer/config.go
+++ b/raftstore/peer/config.go
@@ -2,6 +2,7 @@ package peer
 
 import (
 	"path/filepath"
+	"time"
 
 	myraft "github.com/feichai0017/NoKV/raft"
 	localmeta "github.com/feichai0017/NoKV/raftstore/localmeta"
@@ -33,6 +34,12 @@ type Config struct {
 	// state that was previously written by an unpublished install attempt. It is
 	// only intended for store-local install-before-publish retry paths.
 	AllowSnapshotInstallRetry bool
+	// BatchMaxSize is the number of proposals collected before flushing
+	// as a single Ready cycle. Defaults to 64 when zero.
+	BatchMaxSize int
+	// BatchMaxWait is the maximum time the batcher waits before flushing
+	// a non-full batch. Defaults to 1ms when zero.
+	BatchMaxWait time.Duration
 }
 
 // ResolveStorage chooses the backing log engine (in-memory, on-disk, or WAL).

--- a/raftstore/peer/peer.go
+++ b/raftstore/peer/peer.go
@@ -5,9 +5,10 @@ import (
 	"encoding/binary"
 	"errors"
 	"fmt"
-	raftcmdpb "github.com/feichai0017/NoKV/pb/raft"
 	"sync"
 	"sync/atomic"
+
+	raftcmdpb "github.com/feichai0017/NoKV/pb/raft"
 
 	myraft "github.com/feichai0017/NoKV/raft"
 	"github.com/feichai0017/NoKV/raftstore/command"
@@ -61,6 +62,7 @@ type Peer struct {
 	readMu                    sync.Mutex
 	pendingReads              map[string]chan uint64
 	allowSnapshotInstallRetry bool
+	batcher                   *proposalBatcher
 }
 
 const defaultMaxInFlightApply = 8192
@@ -138,6 +140,7 @@ func NewPeer(cfg *Config) (*Peer, error) {
 	} else {
 		peer.applyLimit = defaultMaxInFlightApply
 	}
+	peer.batcher = newProposalBatcher(peer, cfg.BatchMaxSize, cfg.BatchMaxWait)
 	return peer, nil
 }
 
@@ -229,13 +232,7 @@ func (p *Peer) Propose(data []byte) error {
 	if err := p.waitForApplyBacklog(); err != nil {
 		return err
 	}
-	p.mu.Lock()
-	err := p.node.Propose(data)
-	p.mu.Unlock()
-	if err != nil {
-		return err
-	}
-	return p.processReady()
+	return p.batcher.propose(data).Wait()
 }
 
 // ProposeCommand encodes the provided raft command request and submits it to
@@ -668,6 +665,7 @@ func (p *Peer) Close() error {
 	if p == nil {
 		return nil
 	}
+	p.batcher.close()
 	p.stopCancel()
 	if p.applyCloser != nil {
 		p.applyCloser.Close()

--- a/raftstore/peer/proposal_batcher.go
+++ b/raftstore/peer/proposal_batcher.go
@@ -1,0 +1,155 @@
+package peer
+
+import (
+	"sync"
+	"time"
+)
+
+const (
+	// defaultBatchMaxSize is the default number of proposals collected before
+	// the batcher flushes them as a single Ready cycle.
+	defaultBatchMaxSize = 64
+	// defaultBatchMaxWait is the maximum time the batcher waits before flushing
+	// a non-full batch.
+	defaultBatchMaxWait = time.Millisecond
+)
+
+// proposalBatcher collects proposals and flushes them as a batch, calling
+// processReady once for the entire batch instead of once per proposal.
+//
+// The batcher is the single proposal path for Peer. It batches proposals up
+// to maxSize or maxWait, whichever comes first, then flushes them under a
+// single lock acquisition + processReady call. This amortizes the cost of
+// raft Ready processing across multiple proposals, dramatically improving
+// throughput under I/O-bound workloads.
+type proposalBatcher struct {
+	peer    *Peer
+	ch      chan *proposalItem
+	maxSize int
+	maxWait time.Duration
+	stopCh  chan struct{}
+	wg      sync.WaitGroup
+}
+
+func newProposalBatcher(p *Peer, maxSize int, maxWait time.Duration) *proposalBatcher {
+	if maxSize <= 0 {
+		maxSize = defaultBatchMaxSize
+	}
+	if maxWait <= 0 {
+		maxWait = defaultBatchMaxWait
+	}
+	b := &proposalBatcher{
+		peer:    p,
+		ch:      make(chan *proposalItem, maxSize*2),
+		maxSize: maxSize,
+		maxWait: maxWait,
+		stopCh:  make(chan struct{}),
+	}
+	b.wg.Add(1)
+	go b.run()
+	return b
+}
+
+// propose submits a proposal to the batcher and returns a proposalResult
+// whose Done channel receives the error once the proposal is flushed.
+func (b *proposalBatcher) propose(data []byte) *proposalResult {
+	r := &proposalResult{Done: make(chan error, 1)}
+	b.ch <- &proposalItem{data: data, result: r}
+	return r
+}
+
+// proposalResult carries the outcome of an asynchronously submitted proposal.
+type proposalResult struct {
+	Done chan error
+}
+
+// Wait blocks until the proposal has been flushed and returns its error.
+func (r *proposalResult) Wait() error {
+	return <-r.Done
+}
+
+// close signals the batcher goroutine to stop and waits for it to drain
+// all pending proposals.
+func (b *proposalBatcher) close() {
+	close(b.stopCh)
+	b.wg.Wait()
+}
+
+func (b *proposalBatcher) run() {
+	defer b.wg.Done()
+	batch := make([]*proposalItem, 0, b.maxSize)
+	timer := time.NewTimer(b.maxWait)
+	defer timer.Stop()
+
+	for {
+		select {
+		case item := <-b.ch:
+			batch = append(batch, item)
+			if len(batch) >= b.maxSize {
+				b.flush(batch)
+				batch = batch[:0]
+				timer.Reset(b.maxWait)
+			} else if len(batch) == 1 {
+				// First item: start the wait timer.
+				timer.Reset(b.maxWait)
+			}
+
+		case <-timer.C:
+			if len(batch) > 0 {
+				b.flush(batch)
+				batch = batch[:0]
+			}
+			timer.Reset(b.maxWait)
+
+		case <-b.stopCh:
+			// Flush any partial batch that was already collected.
+			if len(batch) > 0 {
+				b.flush(batch)
+			}
+			// Drain any remaining items in the channel.
+			for {
+				select {
+				case item := <-b.ch:
+					b.flush([]*proposalItem{item})
+				default:
+					return
+				}
+			}
+		}
+	}
+}
+
+func (b *proposalBatcher) flush(batch []*proposalItem) {
+	p := b.peer
+	p.mu.Lock()
+	// Propose all items under a single lock hold. node.Propose only
+	// appends to the pending list, so this is safe.
+	for _, item := range batch {
+		if err := p.node.Propose(item.data); err != nil {
+			item.result.Done <- err
+		}
+	}
+	p.mu.Unlock()
+
+	// Process Ready once for the entire batch. If this fails, propagate
+	// the error to any item that hasn't already received a per-propose error.
+	if err := p.processReady(); err != nil {
+		for _, item := range batch {
+			select {
+			case item.result.Done <- err:
+			default:
+			}
+		}
+		return
+	}
+
+	for _, item := range batch {
+		item.result.Done <- nil
+	}
+}
+
+// proposalItem is a single proposal submitted to the batcher.
+type proposalItem struct {
+	data   []byte
+	result *proposalResult
+}

--- a/raftstore/peer/proposal_batcher.go
+++ b/raftstore/peer/proposal_batcher.go
@@ -27,8 +27,9 @@ type proposalBatcher struct {
 	ch      chan *proposalItem
 	maxSize int
 	maxWait time.Duration
-	stopCh  chan struct{}
 	wg      sync.WaitGroup
+	mu      sync.Mutex
+	closed  bool
 }
 
 func newProposalBatcher(p *Peer, maxSize int, maxWait time.Duration) *proposalBatcher {
@@ -43,7 +44,6 @@ func newProposalBatcher(p *Peer, maxSize int, maxWait time.Duration) *proposalBa
 		ch:      make(chan *proposalItem, maxSize*2),
 		maxSize: maxSize,
 		maxWait: maxWait,
-		stopCh:  make(chan struct{}),
 	}
 	b.wg.Add(1)
 	go b.run()
@@ -54,6 +54,12 @@ func newProposalBatcher(p *Peer, maxSize int, maxWait time.Duration) *proposalBa
 // whose Done channel receives the error once the proposal is flushed.
 func (b *proposalBatcher) propose(data []byte) *proposalResult {
 	r := &proposalResult{Done: make(chan error, 1)}
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if b.closed {
+		r.complete(errPeerStopped)
+		return r
+	}
 	b.ch <- &proposalItem{data: data, result: r}
 	return r
 }
@@ -68,10 +74,19 @@ func (r *proposalResult) Wait() error {
 	return <-r.Done
 }
 
+func (r *proposalResult) complete(err error) {
+	r.Done <- err
+}
+
 // close signals the batcher goroutine to stop and waits for it to drain
 // all pending proposals.
 func (b *proposalBatcher) close() {
-	close(b.stopCh)
+	b.mu.Lock()
+	if !b.closed {
+		b.closed = true
+		close(b.ch)
+	}
+	b.mu.Unlock()
 	b.wg.Wait()
 }
 
@@ -79,41 +94,65 @@ func (b *proposalBatcher) run() {
 	defer b.wg.Done()
 	batch := make([]*proposalItem, 0, b.maxSize)
 	timer := time.NewTimer(b.maxWait)
-	defer timer.Stop()
+	if !timer.Stop() {
+		<-timer.C
+	}
+	timerActive := false
+	defer func() {
+		if timerActive {
+			timer.Stop()
+		}
+	}()
+	resetTimer := func() {
+		if timerActive {
+			if !timer.Stop() {
+				select {
+				case <-timer.C:
+				default:
+				}
+			}
+		}
+		timer.Reset(b.maxWait)
+		timerActive = true
+	}
+	stopTimer := func() {
+		if !timerActive {
+			return
+		}
+		if !timer.Stop() {
+			select {
+			case <-timer.C:
+			default:
+			}
+		}
+		timerActive = false
+	}
 
 	for {
 		select {
-		case item := <-b.ch:
+		case item, ok := <-b.ch:
+			if !ok {
+				stopTimer()
+				if len(batch) > 0 {
+					b.flush(batch)
+				}
+				return
+			}
 			batch = append(batch, item)
 			if len(batch) >= b.maxSize {
+				stopTimer()
 				b.flush(batch)
 				batch = batch[:0]
-				timer.Reset(b.maxWait)
 			} else if len(batch) == 1 {
 				// First item: start the wait timer.
-				timer.Reset(b.maxWait)
+				resetTimer()
 			}
 
 		case <-timer.C:
+			timerActive = false
 			if len(batch) > 0 {
 				b.flush(batch)
 				batch = batch[:0]
-			}
-			timer.Reset(b.maxWait)
-
-		case <-b.stopCh:
-			// Flush any partial batch that was already collected.
-			if len(batch) > 0 {
-				b.flush(batch)
-			}
-			// Drain any remaining items in the channel.
-			for {
-				select {
-				case item := <-b.ch:
-					b.flush([]*proposalItem{item})
-				default:
-					return
-				}
 			}
 		}
 	}
@@ -121,30 +160,33 @@ func (b *proposalBatcher) run() {
 
 func (b *proposalBatcher) flush(batch []*proposalItem) {
 	p := b.peer
+	succeeded := make([]*proposalItem, 0, len(batch))
 	p.mu.Lock()
 	// Propose all items under a single lock hold. node.Propose only
 	// appends to the pending list, so this is safe.
 	for _, item := range batch {
 		if err := p.node.Propose(item.data); err != nil {
-			item.result.Done <- err
+			item.result.complete(err)
+			continue
 		}
+		succeeded = append(succeeded, item)
 	}
 	p.mu.Unlock()
+	if len(succeeded) == 0 {
+		return
+	}
 
 	// Process Ready once for the entire batch. If this fails, propagate
 	// the error to any item that hasn't already received a per-propose error.
 	if err := p.processReady(); err != nil {
-		for _, item := range batch {
-			select {
-			case item.result.Done <- err:
-			default:
-			}
+		for _, item := range succeeded {
+			item.result.complete(err)
 		}
 		return
 	}
 
-	for _, item := range batch {
-		item.result.Done <- nil
+	for _, item := range succeeded {
+		item.result.complete(nil)
 	}
 }
 

--- a/raftstore/peer/proposal_batcher_test.go
+++ b/raftstore/peer/proposal_batcher_test.go
@@ -1,0 +1,64 @@
+package peer
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	myraft "github.com/feichai0017/NoKV/raft"
+	"github.com/stretchr/testify/require"
+)
+
+func TestProposalBatcherRejectsAfterClose(t *testing.T) {
+	p := newTestPeer(t, newPayloadTestStorage(), nil)
+	require.NoError(t, p.Close())
+
+	done := make(chan error, 1)
+	go func() {
+		done <- p.Propose([]byte("after-close"))
+	}()
+
+	select {
+	case err := <-done:
+		require.ErrorIs(t, err, errPeerStopped)
+	case <-time.After(time.Second):
+		t.Fatal("proposal after close blocked")
+	}
+}
+
+func TestProposalBatcherCompletesDroppedProposalOnce(t *testing.T) {
+	storage := myraft.NewMemoryStorage()
+	p, err := NewPeer(&Config{
+		RaftConfig: myraft.Config{
+			ID:                        11,
+			ElectionTick:              5,
+			HeartbeatTick:             1,
+			MaxSizePerMsg:             1 << 20,
+			MaxInflightMsgs:           256,
+			MaxUncommittedEntriesSize: 1,
+			PreVote:                   true,
+		},
+		Transport:    noopPayloadTransport{},
+		Apply:        func([]myraft.Entry) error { return nil },
+		Storage:      storage,
+		GroupID:      1,
+		BatchMaxSize: 1,
+		BatchMaxWait: time.Hour,
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = p.Close() })
+	result := p.batcher.propose([]byte("larger-than-one-byte"))
+	select {
+	case err := <-result.Done:
+		require.Error(t, err)
+		require.False(t, errors.Is(err, errPeerStopped))
+	case <-time.After(time.Second):
+		t.Fatal("dropped proposal did not complete")
+	}
+
+	select {
+	case err := <-result.Done:
+		t.Fatalf("proposal completed more than once: %v", err)
+	case <-time.After(25 * time.Millisecond):
+	}
+}


### PR DESCRIPTION
## Summary

  Adds a proposal batcher as the single proposal submission path for Peer. Instead of calling node.Propose + processReady per proposal, the batcher collects proposals up to BatchMaxSize (default 64)
  or BatchMaxWait (default 1ms), then flushes the entire batch under one lock acquisition + one processReady call.

## Impact

  Proposal throughput improves by amortizing the cost of raft Ready processing across multiple proposals. Under I/O-bound workloads (WAL fsync), the improvement is 2–26x depending on concurrency. On
  local SSD with YCSB, write-heavy workloads (A/F) show +7–14% throughput gain. The batcher goroutine and channel introduce minimal overhead on low-latency paths.

## Validation
```bash
  go test ./raftstore/peer -count=1
  cd benchmark/ycsb && NOKV_RUN_BENCHMARKS=1 go test -run=TestBenchmarkYCSB -count=1 -ycsb_workloads=A,F -ycsb_engines=nokv -ycsb_records=1000000 -ycsb_ops=1000000 -ycsb_conc=16 -benchdir=/tmp/bench
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable proposal batching with tunable batch size and wait time parameters to optimize throughput.

* **Tests**
  * Introduced benchmark tests to evaluate peer proposal performance under various load conditions and simulated latency scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->