### PR TITLE
Unify stable error boundaries

### DIFF
--- a/.github/workflows/fsmeta-benchmark.yml
+++ b/.github/workflows/fsmeta-benchmark.yml
@@ -35,7 +35,7 @@ on:
         required: true
         default: "long"
         options:
-          - medium
+          - median
           - long
   schedule:
     - cron: "19 17 * * 0"
@@ -44,10 +44,11 @@ permissions:
   contents: read
 
 jobs:
-  fsmeta-medium:
-    if: github.event_name == 'push' || github.event_name == 'pull_request' || (github.event_name == 'workflow_dispatch' && github.event.inputs.profile == 'medium')
+  fsmeta-median:
+    name: Benchmark / fsmeta median
+    if: github.event_name == 'push' || github.event_name == 'pull_request' || (github.event_name == 'workflow_dispatch' && github.event.inputs.profile == 'median')
     runs-on: ubuntu-latest
-    timeout-minutes: 45
+    timeout-minutes: 60
     steps:
       - uses: actions/checkout@v6
 
@@ -56,9 +57,9 @@ jobs:
         with:
           go-version: "1.26.2"
 
-      - name: Run medium fsmeta workload matrix
+      - name: Run median fsmeta workload matrix
         env:
-          NOKV_FSMETA_PROFILE: medium
+          NOKV_FSMETA_PROFILE: median
           NOKV_FSMETA_OUTPUT_DIR: benchmark/data/fsmeta/results
         run: make fsmeta-bench
 
@@ -74,7 +75,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: fsmeta-medium-${{ github.run_id }}
+          name: fsmeta-median-${{ github.run_id }}
           path: |
             benchmark/data/fsmeta/results/*.csv
             benchmark/data/fsmeta/ci/*.txt
@@ -86,6 +87,7 @@ jobs:
         run: docker compose down -v || true
 
   fsmeta-long:
+    name: Benchmark / fsmeta long
     if: github.event_name == 'push' || github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && github.event.inputs.profile == 'long')
     runs-on: ubuntu-latest
     timeout-minutes: 180

--- a/.github/workflows/project-automation.yml
+++ b/.github/workflows/project-automation.yml
@@ -105,6 +105,21 @@ jobs:
                 return message.includes(`Could not resolve to a ${kind}`);
               }
 
+              function isTransientGitHubError(err) {
+                const status = Number(err && err.status);
+                const message = String(err && err.message ? err.message : err).toLowerCase();
+                return (
+                  status === 502 ||
+                  status === 503 ||
+                  status === 504 ||
+                  message.includes("couldn't respond to your request in time") ||
+                  message.includes('timeout') ||
+                  message.includes('timed out') ||
+                  message.includes('econnreset') ||
+                  message.includes('etimedout')
+                );
+              }
+
               async function resolveProjectForUser(owner, number) {
                 const res = await github.graphql(
                   `
@@ -345,26 +360,35 @@ jobs:
                 const ids = [];
                 let cursor = null;
                 while (true) {
-                  const res = await github.graphql(
-                    `
-                    query($owner: String!, $repo: String!, $number: Int!, $cursor: String) {
-                      repository(owner: $owner, name: $repo) {
-                        pullRequest(number: $number) {
-                          closingIssuesReferences(first: 50, after: $cursor) {
-                            nodes {
-                              id
-                            }
-                            pageInfo {
-                              hasNextPage
-                              endCursor
+                  let res;
+                  try {
+                    res = await github.graphql(
+                      `
+                      query($owner: String!, $repo: String!, $number: Int!, $cursor: String) {
+                        repository(owner: $owner, name: $repo) {
+                          pullRequest(number: $number) {
+                            closingIssuesReferences(first: 50, after: $cursor) {
+                              nodes {
+                                id
+                              }
+                              pageInfo {
+                                hasNextPage
+                                endCursor
+                              }
                             }
                           }
                         }
                       }
+                      `,
+                      { owner, repo, number: prNumber, cursor }
+                    );
+                  } catch (err) {
+                    if (isTransientGitHubError(err)) {
+                      core.warning(`Project linked-issue sync skipped due to transient GitHub API error: ${err.message}`);
+                      return [];
                     }
-                    `,
-                    { owner, repo, number: prNumber, cursor }
-                  );
+                    throw err;
+                  }
 
                   const page = res?.repository?.pullRequest?.closingIssuesReferences;
                   if (!page) {
@@ -427,12 +451,27 @@ jobs:
 
             await main().catch((err) => {
               const message = String(err && err.message ? err.message : err);
+              const lowerMessage = message.toLowerCase();
+              const status = Number(err && err.status);
               if (
                 message.includes('Could not resolve to a node') ||
                 message.includes('Resource not accessible by integration') ||
                 message.includes('insufficient scopes')
               ) {
                 core.warning(`Project automation skipped due to token scope: ${message}`);
+                return;
+              }
+              if (
+                status === 502 ||
+                status === 503 ||
+                status === 504 ||
+                lowerMessage.includes("couldn't respond to your request in time") ||
+                lowerMessage.includes('timeout') ||
+                lowerMessage.includes('timed out') ||
+                lowerMessage.includes('econnreset') ||
+                lowerMessage.includes('etimedout')
+              ) {
+                core.warning(`Project automation skipped due to transient GitHub API error: ${message}`);
                 return;
               }
               throw err;

--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -103,12 +103,12 @@ make fsmeta-bench
 The helper starts Docker Compose with a local image build, waits for fsmeta and
 coordinator ports, then writes a CSV under `benchmark/data/fsmeta/results/`.
 Compose enables both `--negative-cache-dir` and `--dirpage-cache-dir` on the
-fsmeta gateway. Default scale is a medium service run: 8 clients, 8 checkpoint
-directories × 128 files, 1024 hotspot/watch/negative keys, and a mixed workload
-with 4 groups × 16 entries × 6 artifacts. Override scale with environment
+fsmeta gateway. Default scale is the PR-oriented median service run: 12 clients,
+16 checkpoint directories x 256 files, 4096 hotspot/watch/negative keys, and a
+mixed workload with 8 groups x 64 entries x 8 artifacts. Override scale with environment
 variables such as `NOKV_FSMETA_CLIENTS`, `NOKV_FSMETA_GROUPS`,
 `NOKV_FSMETA_ENTRIES_PER_GROUP`, `NOKV_FSMETA_ARTIFACTS_PER_ENTRY`, and
-`NOKV_FSMETA_WORKLOADS`. The script also waits 15 seconds after ports open so a
+`NOKV_FSMETA_WORKLOADS`. The script also waits 20 seconds after ports open so a
 fresh Compose cluster can finish Raft leader election and coordinator grant
 publication; set `NOKV_FSMETA_STABILIZE_SECONDS=0` for an already-warm cluster.
 The underlying script is `scripts/run_fsmeta_benchmarks.sh`; set
@@ -165,8 +165,8 @@ It writes two CSV files named `fsmeta_derived_cache_off_*` and
 
 The summary CSV is written under `data/fsmeta/results/` unless
 `-fsmeta_output` is set. Rows include a `driver` column with the fixed value
-`native-fsmeta` so old plotting tools can keep the same schema. CI uploads these
-runtime outputs as artifacts instead of committing benchmark result packages.
+`native-fsmeta` to identify the service driver. CI uploads these runtime outputs
+as artifacts instead of committing benchmark result packages.
 
 ## Research Plotting
 
@@ -320,5 +320,5 @@ Run:
 
 ```bash
 cd benchmark
-go test ./namespace -bench . -benchmem
+go test ./plot ./fsmeta ./fsmeta/workload
 ```

--- a/benchmark/fsmeta/fsmeta_bench_test.go
+++ b/benchmark/fsmeta/fsmeta_bench_test.go
@@ -165,14 +165,7 @@ func waitForFSMetaMount(t *testing.T, ctx context.Context, cli workload.Client) 
 }
 
 func isMountVisibilityPending(err error) bool {
-	if errors.Is(err, fsmeta.ErrMountNotRegistered) {
-		return true
-	}
-	// The gRPC client preserves the global NotFound kind, but the concrete
-	// fsmeta sentinel can be lost when the gateway has not observed the mount
-	// root event yet. Treat only that exact mount-registration message as the
-	// Compose bootstrap propagation window.
-	return strings.Contains(err.Error(), fsmeta.ErrMountNotRegistered.Error())
+	return errors.Is(err, fsmeta.ErrMountNotRegistered)
 }
 
 func runBenchmarkWorkload(ctx context.Context, cli workload.Client, workloadName, runID string) (workload.Result, error) {

--- a/coordinator/client/client_test.go
+++ b/coordinator/client/client_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 	"time"
 
+	nokverrors "github.com/feichai0017/NoKV/errors"
 	rootevent "github.com/feichai0017/NoKV/meta/root/event"
 	rootproto "github.com/feichai0017/NoKV/meta/root/protocol"
 	rootstate "github.com/feichai0017/NoKV/meta/root/state"
@@ -34,6 +35,20 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )
+
+func notLeaderErrorForTest(leaderID uint64) error {
+	metadata := map[string]string{coordinatorReasonMetadata: reasonNotLeader}
+	if leaderID != 0 {
+		metadata[leaderIDMetadata] = fmt.Sprintf("%d", leaderID)
+	}
+	return nokverrors.RPCStatusError(nokverrors.KindNotLeader, codes.FailedPrecondition, "coordinator test not leader", metadata)
+}
+
+func grantNotHeldErrorForTest() error {
+	return nokverrors.RPCStatusError(nokverrors.KindNotLeader, codes.FailedPrecondition, "coordinator test grant not held", map[string]string{
+		coordinatorReasonMetadata: reasonGrantNotHeld,
+	})
+}
 
 func TestNewGRPCClientEmptyAddress(t *testing.T) {
 	cli, err := NewGRPCClient(context.Background(), "")
@@ -393,7 +408,7 @@ func clientDutyGrantsFromUsages(usages []rootproto.AuthorityUsage) []rootproto.D
 }
 
 func TestGRPCClientDoesNotRetryReadOnNotLeaderWriteError(t *testing.T) {
-	err := status.Error(codes.FailedPrecondition, errNotLeaderPrefix+" (leader_id=2)")
+	err := notLeaderErrorForTest(2)
 	require.True(t, retryableWrite(err))
 	require.False(t, retryableRead(err))
 	require.True(t, IsNotLeader(err))
@@ -415,7 +430,7 @@ func TestCoordinatorClientErrorHelpers(t *testing.T) {
 }
 
 func TestGRPCClientRetriesWriteOnGrantNotHeld(t *testing.T) {
-	err := status.Error(codes.FailedPrecondition, errGrantNotHeldPrefix+": meta/root/state: coordinator grant held")
+	err := grantNotHeldErrorForTest()
 	require.True(t, IsGrantNotHeld(err))
 	require.True(t, retryableWrite(err))
 	require.False(t, retryableRead(err))
@@ -423,7 +438,7 @@ func TestGRPCClientRetriesWriteOnGrantNotHeld(t *testing.T) {
 }
 
 func TestGRPCClientRetriesTSOAcrossGrantNotHeldEndpoint(t *testing.T) {
-	grantErr := status.Error(codes.FailedPrecondition, errGrantNotHeldPrefix+": "+rootstate.ErrPrimacy.Error())
+	grantErr := grantNotHeldErrorForTest()
 	servers := map[string]*scriptedCoordinatorServer{
 		"standby": {
 			tsoErrors: []error{grantErr},
@@ -449,7 +464,7 @@ func TestGRPCClientRetriesTSOAcrossGrantNotHeldEndpoint(t *testing.T) {
 }
 
 func TestGRPCClientRetriesAllocIDAcrossGrantNotHeldEndpoint(t *testing.T) {
-	grantErr := status.Error(codes.FailedPrecondition, errGrantNotHeldPrefix+": "+rootstate.ErrPrimacy.Error())
+	grantErr := grantNotHeldErrorForTest()
 	servers := map[string]*scriptedCoordinatorServer{
 		"standby": {
 			allocErrors: []error{grantErr},
@@ -475,7 +490,7 @@ func TestGRPCClientRetriesAllocIDAcrossGrantNotHeldEndpoint(t *testing.T) {
 }
 
 func TestGRPCClientRetriesGetRegionByKeyAcrossGrantNotHeldEndpoint(t *testing.T) {
-	grantErr := status.Error(codes.FailedPrecondition, errGrantNotHeldPrefix+": "+rootstate.ErrPrimacy.Error())
+	grantErr := grantNotHeldErrorForTest()
 	servers := map[string]*scriptedCoordinatorServer{
 		"standby": {
 			getErrors: []error{grantErr},
@@ -515,7 +530,7 @@ func TestGRPCClientRetriesGetRegionByKeyAcrossGrantNotHeldEndpoint(t *testing.T)
 }
 
 func TestGRPCClientRetriesTSOAfterFullGrantMissRound(t *testing.T) {
-	grantErr := status.Error(codes.FailedPrecondition, errGrantNotHeldPrefix+": "+rootstate.ErrPrimacy.Error())
+	grantErr := grantNotHeldErrorForTest()
 	servers := map[string]*scriptedCoordinatorServer{
 		"standby": {
 			tsoErrors: []error{grantErr, grantErr},

--- a/coordinator/client/errors.go
+++ b/coordinator/client/errors.go
@@ -3,11 +3,8 @@ package client
 import (
 	"errors"
 	"strconv"
-	"strings"
 
 	nokverrors "github.com/feichai0017/NoKV/errors"
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
 )
 
 var (
@@ -25,8 +22,12 @@ var (
 	errInvalidWitness = nokverrors.New(nokverrors.KindProtocolViolation, "coordinator client: invalid witness")
 )
 
-const errNotLeaderPrefix = "coordinator not leader"
-const errGrantNotHeldPrefix = "coordinator grant not held"
+const (
+	coordinatorReasonMetadata = "coordinator_reason"
+	leaderIDMetadata          = "leader_id"
+	reasonNotLeader           = "not_leader"
+	reasonGrantNotHeld        = "grant_not_held"
+)
 
 // IsEmptyAddress reports whether err represents an empty coordinator address set.
 func IsEmptyAddress(err error) bool {
@@ -57,7 +58,7 @@ func IsInvalidWitness(err error) bool {
 
 // IsNotLeader reports whether err is a coordinator not-leader write rejection.
 func IsNotLeader(err error) bool {
-	return status.Code(err) == codes.FailedPrecondition && strings.Contains(err.Error(), errNotLeaderPrefix)
+	return nokverrors.KindOf(err) == nokverrors.KindNotLeader && coordinatorReason(err) == reasonNotLeader
 }
 
 // IsGrantNotHeld reports whether err is a coordinator rejecting a
@@ -65,33 +66,34 @@ func IsNotLeader(err error) bool {
 // Treated as retryable: another endpoint in the client's pool may hold the
 // grant.
 func IsGrantNotHeld(err error) bool {
-	return status.Code(err) == codes.FailedPrecondition && strings.Contains(err.Error(), errGrantNotHeldPrefix)
+	return nokverrors.KindOf(err) == nokverrors.KindNotLeader && coordinatorReason(err) == reasonGrantNotHeld
 }
 
-// LeaderHint extracts leader_id=N from not-leader coordinator errors when present.
+// LeaderHint extracts the stable leader_id metadata from not-leader coordinator
+// errors when present. The diagnostic error string is intentionally ignored.
 func LeaderHint(err error) (uint64, bool) {
 	if !IsNotLeader(err) {
 		return 0, false
 	}
-	msg := err.Error()
-	_, after, ok := strings.Cut(msg, "leader_id=")
+	_, metadata, ok := nokverrors.RPCErrorInfo(err)
 	if !ok {
 		return 0, false
 	}
-	raw := after
-	end := len(raw)
-	for i, r := range raw {
-		if r < '0' || r > '9' {
-			end = i
-			break
-		}
-	}
-	if end == 0 {
+	raw := metadata[leaderIDMetadata]
+	if raw == "" {
 		return 0, false
 	}
-	id, parseErr := strconv.ParseUint(raw[:end], 10, 64)
+	id, parseErr := strconv.ParseUint(raw, 10, 64)
 	if parseErr != nil || id == 0 {
 		return 0, false
 	}
 	return id, true
+}
+
+func coordinatorReason(err error) string {
+	_, metadata, ok := nokverrors.RPCErrorInfo(err)
+	if !ok {
+		return ""
+	}
+	return metadata[coordinatorReasonMetadata]
 }

--- a/coordinator/client/errors_test.go
+++ b/coordinator/client/errors_test.go
@@ -6,7 +6,6 @@ import (
 	nokverrors "github.com/feichai0017/NoKV/errors"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
 )
 
 func TestCoordinatorClientErrorsExposeStableKinds(t *testing.T) {
@@ -18,15 +17,27 @@ func TestCoordinatorClientErrorsExposeStableKinds(t *testing.T) {
 	require.True(t, nokverrors.Retryable(errStaleWitnessEra))
 	require.False(t, nokverrors.Retryable(errInvalidWitness))
 
-	notLeader := status.Error(codes.FailedPrecondition, errNotLeaderPrefix+" (leader_id=2)")
+	notLeader := nokverrors.RPCStatusError(nokverrors.KindNotLeader, codes.FailedPrecondition, "coordinator not leader", map[string]string{
+		coordinatorReasonMetadata: reasonNotLeader,
+		leaderIDMetadata:          "2",
+	})
 	require.Equal(t, nokverrors.KindNotLeader, nokverrors.KindOf(notLeader))
 	require.True(t, nokverrors.Retryable(notLeader))
+	require.True(t, IsNotLeader(notLeader))
+	leaderID, ok := LeaderHint(notLeader)
+	require.True(t, ok)
+	require.Equal(t, uint64(2), leaderID)
 
-	grantNotHeld := status.Error(codes.FailedPrecondition, errGrantNotHeldPrefix)
+	grantNotHeld := nokverrors.RPCStatusError(nokverrors.KindNotLeader, codes.FailedPrecondition, "coordinator grant not held", map[string]string{
+		coordinatorReasonMetadata: reasonGrantNotHeld,
+	})
 	require.Equal(t, nokverrors.KindNotLeader, nokverrors.KindOf(grantNotHeld))
 	require.True(t, nokverrors.Retryable(grantNotHeld))
+	require.True(t, IsGrantNotHeld(grantNotHeld))
 
-	grantExpired := status.Error(codes.FailedPrecondition, errGrantNotHeldPrefix+": "+nokverrors.New(nokverrors.KindInvalidArgument, "meta/root/state: invalid grant: rooted grant expired era=7").Error())
+	grantExpired := nokverrors.RPCStatusError(nokverrors.KindNotLeader, codes.FailedPrecondition, nokverrors.New(nokverrors.KindInvalidArgument, "meta/root/state: invalid grant: rooted grant expired era=7").Error(), map[string]string{
+		coordinatorReasonMetadata: reasonGrantNotHeld,
+	})
 	require.Equal(t, nokverrors.KindNotLeader, nokverrors.KindOf(grantExpired))
 	require.True(t, nokverrors.Retryable(grantExpired))
 }

--- a/coordinator/integration/control_plane_test.go
+++ b/coordinator/integration/control_plane_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 	"time"
 
+	coordclient "github.com/feichai0017/NoKV/coordinator/client"
 	coordserver "github.com/feichai0017/NoKV/coordinator/server"
 	pdtestcluster "github.com/feichai0017/NoKV/coordinator/testcluster"
 	metaregion "github.com/feichai0017/NoKV/meta/region"
@@ -84,7 +85,7 @@ func TestControlPlaneFollowerRejectsLeaderOnlyWrites(t *testing.T) {
 	})
 	require.Error(t, err)
 	require.Equal(t, codes.FailedPrecondition, status.Code(err))
-	require.Contains(t, status.Convert(err).Message(), "coordinator not leader")
+	require.True(t, coordclient.IsNotLeader(err), "error = %v", err)
 
 	_, err = leader.PublishRootEvent(context.Background(), &coordpb.PublishRootEventRequest{
 		Event: metawire.RootEventToProto(rootevent.RegionBootstrapped(controlPlaneDescriptor(195, []byte("b"), []byte("c")))),
@@ -114,12 +115,12 @@ func TestControlPlaneLeaderOnlyAllocatorsRejectFollowerWrites(t *testing.T) {
 	_, err = follower.AllocID(context.Background(), &coordpb.AllocIDRequest{Count: 1})
 	require.Error(t, err)
 	require.Equal(t, codes.FailedPrecondition, status.Code(err))
-	require.Contains(t, status.Convert(err).Message(), "coordinator not leader")
+	require.True(t, coordclient.IsNotLeader(err), "error = %v", err)
 
 	_, err = follower.Tso(context.Background(), &coordpb.TsoRequest{Count: 1})
 	require.Error(t, err)
 	require.Equal(t, codes.FailedPrecondition, status.Code(err))
-	require.Contains(t, status.Convert(err).Message(), "coordinator not leader")
+	require.True(t, coordclient.IsNotLeader(err), "error = %v", err)
 }
 
 func publishControlPlaneDescriptorEvent(svc *coordserver.Service, desc topology.Descriptor) error {

--- a/coordinator/integration/separated_mode_test.go
+++ b/coordinator/integration/separated_mode_test.go
@@ -4,11 +4,11 @@ import (
 	"context"
 	"net"
 	"slices"
-	"strings"
 	"testing"
 	"time"
 
 	"github.com/feichai0017/NoKV/coordinator/catalog"
+	coordclient "github.com/feichai0017/NoKV/coordinator/client"
 	"github.com/feichai0017/NoKV/coordinator/idalloc"
 	"github.com/feichai0017/NoKV/coordinator/rootview"
 	coordserver "github.com/feichai0017/NoKV/coordinator/server"
@@ -136,17 +136,17 @@ func TestSeparatedModeRoutingAuthorityStaysWithGrantHolder(t *testing.T) {
 				return false
 			}
 			_, getErr := svc.GetRegionByKey(context.Background(), &coordpb.GetRegionByKeyRequest{Key: []byte("m")})
-			return getErr != nil && strings.Contains(getErr.Error(), "coordinator grant not held")
+			return getErr != nil && coordclient.IsGrantNotHeld(getErr)
 		}, 8*time.Second, 50*time.Millisecond)
 	}
 
 	_, err = readOnlyA.AllocID(context.Background(), &coordpb.AllocIDRequest{Count: 1})
 	require.Error(t, err)
-	require.Contains(t, err.Error(), "coordinator grant not held")
+	require.True(t, coordclient.IsGrantNotHeld(err), "error = %v", err)
 
 	_, err = readOnlyB.AllocID(context.Background(), &coordpb.AllocIDRequest{Count: 1})
 	require.Error(t, err)
-	require.Contains(t, err.Error(), "coordinator grant not held")
+	require.True(t, coordclient.IsGrantNotHeld(err), "error = %v", err)
 }
 
 func separatedModeDescriptor(id uint64, start, end []byte) topology.Descriptor {
@@ -180,7 +180,7 @@ func TestSeparatedModeCoordinatorContestedFailoverPreservesAllocatorFence(t *tes
 
 	_, err = second.AllocID(context.Background(), &coordpb.AllocIDRequest{Count: 1})
 	require.Error(t, err)
-	require.Contains(t, err.Error(), "coordinator grant not held")
+	require.True(t, coordclient.IsGrantNotHeld(err), "error = %v", err)
 
 	var next *coordpb.AllocIDResponse
 	require.Eventually(t, func() bool {

--- a/coordinator/rootview/errors.go
+++ b/coordinator/rootview/errors.go
@@ -1,0 +1,5 @@
+package rootview
+
+import "errors"
+
+var errGrantCommandUnsupported = errors.New("coordinator/rootview: coordinator grant command unsupported")

--- a/coordinator/rootview/root.go
+++ b/coordinator/rootview/root.go
@@ -7,7 +7,6 @@ package rootview
 
 import (
 	"context"
-	"errors"
 	"sync"
 	"time"
 
@@ -18,8 +17,6 @@ import (
 	rootstorage "github.com/feichai0017/NoKV/meta/root/storage"
 	"github.com/feichai0017/NoKV/meta/topology"
 )
-
-var errGrantCommandUnsupported = errors.New("coordinator/rootview: coordinator grant command unsupported")
 
 // RootStorage persists control-plane mutations into durable metadata truth and
 // exposes the reconstructed rooted snapshot back to Coordinator.

--- a/coordinator/server/errors.go
+++ b/coordinator/server/errors.go
@@ -1,16 +1,19 @@
 package server
 
 import (
+	"context"
+	stderrors "errors"
 	"fmt"
+	"strconv"
 
+	nokverrors "github.com/feichai0017/NoKV/errors"
 	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
 )
 
 const (
-	errNotLeaderPrefix                 = "coordinator not leader"
-	errRootUnavailable                 = "coordinator root unavailable"
-	errGrantPrefix                     = "coordinator grant not held"
+	diagnosticNotLeader                = "coordinator not leader"
+	diagnosticRootUnavailable          = "coordinator root unavailable"
+	diagnosticGrantNotHeld             = "coordinator grant not held"
 	errRootLagExceedsStrongFreshness   = "root lag exceeds strong freshness"
 	errBootstrapRequiredBeforeBounded  = "bootstrap required before bounded freshness"
 	errRequiredRootedTokenNotSatisfied = "required rooted token not satisfied"
@@ -19,13 +22,97 @@ const (
 	errRangeChangePending              = "rooted range change still pending"
 )
 
-func statusNotLeader(leaderID uint64) error {
-	if leaderID == 0 {
-		return status.Error(codes.FailedPrecondition, errNotLeaderPrefix)
+const (
+	coordinatorReasonMetadata = "coordinator_reason"
+	leaderIDMetadata          = "leader_id"
+
+	reasonNotLeader              = "not_leader"
+	reasonGrantNotHeld           = "grant_not_held"
+	reasonRootUnavailable        = "root_unavailable"
+	reasonRootLagExceeded        = "root_lag_exceeded"
+	reasonRequiredRootedToken    = "required_rooted_token"
+	reasonRequiredDescriptor     = "required_descriptor"
+	reasonRangeChangePending     = "range_change_pending"
+	reasonBootstrapRequired      = "bootstrap_required"
+	reasonCatalogInvalid         = "catalog_invalid"
+	reasonCatalogPrecondition    = "catalog_precondition"
+	reasonCatalogInternal        = "catalog_internal"
+	reasonClusterEraMismatch     = "cluster_era_mismatch"
+	reasonRootStorageUnavailable = "root_storage_unavailable"
+	reasonInvalidRequest         = "invalid_request"
+	reasonContextCanceled        = "context_canceled"
+	reasonContextDeadline        = "context_deadline"
+	reasonInternal               = "internal"
+)
+
+func statusContext(err error) error {
+	reason := reasonContextCanceled
+	code := codes.Canceled
+	kind := nokverrors.KindAborted
+	if stderrors.Is(err, context.DeadlineExceeded) {
+		reason = reasonContextDeadline
+		code = codes.DeadlineExceeded
+		kind = nokverrors.KindUnavailable
 	}
-	return status.Error(codes.FailedPrecondition, fmt.Sprintf("%s (leader_id=%d)", errNotLeaderPrefix, leaderID))
+	return nokverrors.RPCStatusError(kind, code, err.Error(), map[string]string{
+		coordinatorReasonMetadata: reason,
+	})
+}
+
+func statusInvalidArgument(message string) error {
+	return nokverrors.RPCStatusError(nokverrors.KindInvalidArgument, codes.InvalidArgument, message, map[string]string{
+		coordinatorReasonMetadata: reasonInvalidRequest,
+	})
+}
+
+func statusInternal(message string) error {
+	return nokverrors.RPCStatusError(nokverrors.KindUnavailable, codes.Internal, message, map[string]string{
+		coordinatorReasonMetadata: reasonInternal,
+	})
+}
+
+func statusInternalf(format string, args ...any) error {
+	return statusInternal(fmt.Sprintf(format, args...))
+}
+
+func statusNotLeader(leaderID uint64) error {
+	metadata := map[string]string{coordinatorReasonMetadata: reasonNotLeader}
+	if leaderID == 0 {
+		return nokverrors.RPCStatusError(nokverrors.KindNotLeader, codes.FailedPrecondition, diagnosticNotLeader, metadata)
+	}
+	metadata[leaderIDMetadata] = strconv.FormatUint(leaderID, 10)
+	return nokverrors.RPCStatusError(nokverrors.KindNotLeader, codes.FailedPrecondition, fmt.Sprintf("%s (leader_id=%d)", diagnosticNotLeader, leaderID), metadata)
 }
 
 func statusGrant(err error) error {
-	return status.Error(codes.FailedPrecondition, fmt.Sprintf("%s: %v", errGrantPrefix, err))
+	return nokverrors.RPCStatusError(nokverrors.KindNotLeader, codes.FailedPrecondition, fmt.Sprintf("%s: %v", diagnosticGrantNotHeld, err), map[string]string{
+		coordinatorReasonMetadata: reasonGrantNotHeld,
+	})
+}
+
+func statusRootUnavailable() error {
+	return nokverrors.RPCStatusError(nokverrors.KindUnavailable, codes.FailedPrecondition, diagnosticRootUnavailable, map[string]string{
+		coordinatorReasonMetadata: reasonRootUnavailable,
+	})
+}
+
+func statusStaleEpoch(message, reason string) error {
+	return nokverrors.RPCStatusError(nokverrors.KindStaleEpoch, codes.FailedPrecondition, message, map[string]string{
+		coordinatorReasonMetadata: reason,
+	})
+}
+
+func statusProtocol(message, reason string) error {
+	return nokverrors.RPCStatusError(nokverrors.KindProtocolViolation, codes.FailedPrecondition, message, map[string]string{
+		coordinatorReasonMetadata: reason,
+	})
+}
+
+func statusCatalog(kind nokverrors.Kind, code codes.Code, err error, reason string) error {
+	if kind == nokverrors.KindUnknown {
+		kind = nokverrors.KindProtocolViolation
+	}
+	return nokverrors.RPCStatusError(kind, code, err.Error(), map[string]string{
+		coordinatorReasonMetadata: reason,
+	})
 }

--- a/coordinator/server/service_admission.go
+++ b/coordinator/server/service_admission.go
@@ -8,8 +8,6 @@ import (
 
 	rootproto "github.com/feichai0017/NoKV/meta/root/protocol"
 	rootstate "github.com/feichai0017/NoKV/meta/root/state"
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
 )
 
 type dutyAdmission struct {
@@ -71,7 +69,7 @@ func (s *Service) beginAuthorityServing(ctx context.Context, duty rootproto.Duty
 	}
 	if ctx != nil {
 		if err := ctx.Err(); err != nil {
-			return nil, status.FromContextError(err).Err()
+			return nil, statusContext(err)
 		}
 	}
 	s.authorityMu.Lock()
@@ -115,12 +113,12 @@ func (s *Service) requireExpectedClusterEpoch(expected uint64) error {
 	}
 	current, err := s.currentClusterEpoch()
 	if err != nil {
-		return status.Error(codes.Internal, "load current cluster era: "+err.Error())
+		return statusInternalf("load current cluster era: %v", err)
 	}
 	if current == expected {
 		return nil
 	}
-	return status.Error(codes.FailedPrecondition, fmt.Sprintf("pd/meta cluster era mismatch (expected=%d current=%d)", expected, current))
+	return statusProtocol(fmt.Sprintf("pd/meta cluster era mismatch (expected=%d current=%d)", expected, current), reasonClusterEraMismatch)
 }
 
 func (s *Service) currentClusterEpoch() (uint64, error) {

--- a/coordinator/server/service_alloc.go
+++ b/coordinator/server/service_alloc.go
@@ -6,12 +6,12 @@ import (
 	"fmt"
 
 	"github.com/feichai0017/NoKV/coordinator/idalloc"
+	nokverrors "github.com/feichai0017/NoKV/errors"
 	rootevent "github.com/feichai0017/NoKV/meta/root/event"
 	rootproto "github.com/feichai0017/NoKV/meta/root/protocol"
 	"github.com/feichai0017/NoKV/meta/topology"
 	coordpb "github.com/feichai0017/NoKV/pb/coordinator"
 	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
 )
 
 func (s *Service) normalizeRootEvent(event rootevent.Event) (rootevent.Event, error) {
@@ -262,10 +262,10 @@ func maxUint64(a, b uint64) uint64 {
 // AllocID allocates one or more globally unique ids.
 func (s *Service) AllocID(ctx context.Context, req *coordpb.AllocIDRequest) (*coordpb.AllocIDResponse, error) {
 	if err := ctx.Err(); err != nil {
-		return nil, status.FromContextError(err).Err()
+		return nil, statusContext(err)
 	}
 	if req == nil {
-		return nil, status.Error(codes.InvalidArgument, "alloc id request is nil")
+		return nil, statusInvalidArgument("alloc id request is nil")
 	}
 	count := req.GetCount()
 	if count == 0 {
@@ -282,9 +282,9 @@ func (s *Service) AllocID(ctx context.Context, req *coordpb.AllocIDRequest) (*co
 	first, err := s.reserveIDs(ctx, count)
 	if err != nil {
 		if errors.Is(err, idalloc.ErrInvalidBatch) {
-			return nil, status.Error(codes.InvalidArgument, err.Error())
+			return nil, statusCatalog(nokverrors.KindInvalidArgument, codes.InvalidArgument, err, reasonInvalidRequest)
 		}
-		return nil, status.Error(codes.Internal, "persist allocator state: "+err.Error())
+		return nil, statusInternalf("persist allocator state: %v", err)
 	}
 	consumedFrontier := allocationConsumedFrontier(first, count)
 	proof, err := admission.authorityEvidence(rootproto.DutyBound{Kind: rootproto.DutyBoundMonotone, MonotoneUpper: consumedFrontier})
@@ -304,10 +304,10 @@ func (s *Service) AllocID(ctx context.Context, req *coordpb.AllocIDRequest) (*co
 // Tso allocates one or more timestamps.
 func (s *Service) Tso(ctx context.Context, req *coordpb.TsoRequest) (*coordpb.TsoResponse, error) {
 	if err := ctx.Err(); err != nil {
-		return nil, status.FromContextError(err).Err()
+		return nil, statusContext(err)
 	}
 	if req == nil {
-		return nil, status.Error(codes.InvalidArgument, "tso request is nil")
+		return nil, statusInvalidArgument("tso request is nil")
 	}
 	count := req.GetCount()
 	if count == 0 {
@@ -324,9 +324,9 @@ func (s *Service) Tso(ctx context.Context, req *coordpb.TsoRequest) (*coordpb.Ts
 	first, got, err := s.reserveTSO(ctx, count)
 	if err != nil {
 		if errors.Is(err, idalloc.ErrInvalidBatch) {
-			return nil, status.Error(codes.InvalidArgument, err.Error())
+			return nil, statusCatalog(nokverrors.KindInvalidArgument, codes.InvalidArgument, err, reasonInvalidRequest)
 		}
-		return nil, status.Error(codes.Internal, "persist allocator state: "+err.Error())
+		return nil, statusInternalf("persist allocator state: %v", err)
 	}
 	consumedFrontier := allocationConsumedFrontier(first, got)
 	proof, err := admission.authorityEvidence(rootproto.DutyBound{Kind: rootproto.DutyBoundMonotone, MonotoneUpper: consumedFrontier})

--- a/coordinator/server/service_certificate.go
+++ b/coordinator/server/service_certificate.go
@@ -1,13 +1,12 @@
 package server
 
 import (
+	"fmt"
 	"reflect"
 
 	rootproto "github.com/feichai0017/NoKV/meta/root/protocol"
 	metawire "github.com/feichai0017/NoKV/meta/wire"
 	metapb "github.com/feichai0017/NoKV/pb/meta"
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
 )
 
 type authorityProof struct {
@@ -21,15 +20,15 @@ func (a dutyAdmission) authorityEvidence(usage rootproto.DutyBound) (authorityPr
 		return authorityProof{}, nil
 	}
 	if !grantCertificateMatches(a.certificate, a.grant) {
-		return authorityProof{}, status.Error(codes.Internal, "root-issued grant certificate is missing or stale")
+		return authorityProof{}, statusProtocol("root-issued grant certificate is missing or stale", reasonGrantNotHeld)
 	}
 	if a.grant.ExpiresUnixNano <= a.servedUnixNano {
-		return authorityProof{}, status.Error(codes.FailedPrecondition, "admitted grant expired before evidence generation")
+		return authorityProof{}, statusGrant(fmt.Errorf("admitted grant expired before evidence generation"))
 	}
 	scope := rootproto.DutyScope{Kind: rootproto.DutyScopeGlobal}
 	dutyGrant, ok := a.grant.DutyFor(a.duty, scope)
 	if !ok || !rootproto.DutyBoundCovers(dutyGrant.Bound, usage) {
-		return authorityProof{}, status.Errorf(codes.FailedPrecondition, "admitted grant does not cover duty=%s grant_id=%s era=%d", rootproto.DutyName(a.duty), a.grant.GrantID, a.grant.Era)
+		return authorityProof{}, statusGrant(fmt.Errorf("admitted grant does not cover duty=%s grant_id=%s era=%d", rootproto.DutyName(a.duty), a.grant.GrantID, a.grant.Era))
 	}
 	evidence := metawire.RootAuthorityEvidenceToProto(rootproto.AuthorityEvidence{
 		Certificate: a.certificate,

--- a/coordinator/server/service_gateway.go
+++ b/coordinator/server/service_gateway.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/feichai0017/NoKV/coordinator/catalog"
+	nokverrors "github.com/feichai0017/NoKV/errors"
 	rootevent "github.com/feichai0017/NoKV/meta/root/event"
 	rootstate "github.com/feichai0017/NoKV/meta/root/state"
 	rootstorage "github.com/feichai0017/NoKV/meta/root/storage"
@@ -14,7 +15,6 @@ import (
 	coordpb "github.com/feichai0017/NoKV/pb/coordinator"
 	metapb "github.com/feichai0017/NoKV/pb/meta"
 	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
 )
 
 type rootedTailSubscriber interface {
@@ -24,10 +24,10 @@ type rootedTailSubscriber interface {
 // StoreHeartbeat records store-level stats.
 func (s *Service) StoreHeartbeat(ctx context.Context, req *coordpb.StoreHeartbeatRequest) (*coordpb.StoreHeartbeatResponse, error) {
 	if err := ctx.Err(); err != nil {
-		return nil, status.Error(codes.Canceled, err.Error())
+		return nil, statusContext(err)
 	}
 	if req == nil {
-		return nil, status.Error(codes.InvalidArgument, "store heartbeat request is nil")
+		return nil, statusInvalidArgument("store heartbeat request is nil")
 	}
 	err := s.cluster.UpsertStoreHeartbeat(catalog.StoreStats{
 		StoreID:           req.GetStoreId(),
@@ -41,12 +41,12 @@ func (s *Service) StoreHeartbeat(ctx context.Context, req *coordpb.StoreHeartbea
 	})
 	if err != nil {
 		if errors.Is(err, catalog.ErrInvalidStoreID) {
-			return nil, status.Error(codes.InvalidArgument, err.Error())
+			return nil, statusCatalog(nokverrors.KindInvalidArgument, codes.InvalidArgument, err, reasonCatalogInvalid)
 		}
 		if errors.Is(err, catalog.ErrStoreNotJoined) || errors.Is(err, catalog.ErrStoreRetired) {
-			return nil, status.Error(codes.FailedPrecondition, err.Error())
+			return nil, statusCatalog(nokverrors.KindProtocolViolation, codes.FailedPrecondition, err, reasonCatalogPrecondition)
 		}
-		return nil, status.Error(codes.Internal, err.Error())
+		return nil, statusCatalog(nokverrors.KindUnknown, codes.Internal, err, reasonCatalogInternal)
 	}
 	// Record which regions this store claims raft leadership of. If the
 	// store previously claimed leaders it no longer owns (e.g. raft
@@ -63,10 +63,10 @@ func (s *Service) StoreHeartbeat(ctx context.Context, req *coordpb.StoreHeartbea
 // GetStore returns the current runtime endpoint for one store.
 func (s *Service) GetStore(ctx context.Context, req *coordpb.GetStoreRequest) (*coordpb.GetStoreResponse, error) {
 	if err := ctx.Err(); err != nil {
-		return nil, status.Error(codes.Canceled, err.Error())
+		return nil, statusContext(err)
 	}
 	if req == nil || req.GetStoreId() == 0 {
-		return nil, status.Error(codes.InvalidArgument, "get store request missing store_id")
+		return nil, statusInvalidArgument("get store request missing store_id")
 	}
 	info, ok := s.cluster.StoreInfoByID(req.GetStoreId())
 	if !ok {
@@ -78,7 +78,7 @@ func (s *Service) GetStore(ctx context.Context, req *coordpb.GetStoreRequest) (*
 // ListStores returns the current runtime store registry.
 func (s *Service) ListStores(ctx context.Context, _ *coordpb.ListStoresRequest) (*coordpb.ListStoresResponse, error) {
 	if err := ctx.Err(); err != nil {
-		return nil, status.Error(codes.Canceled, err.Error())
+		return nil, statusContext(err)
 	}
 	stores := s.cluster.StoreInfos()
 	out := make([]*coordpb.StoreInfo, 0, len(stores))
@@ -90,10 +90,10 @@ func (s *Service) ListStores(ctx context.Context, _ *coordpb.ListStoresRequest) 
 
 func (s *Service) GetMount(ctx context.Context, req *coordpb.GetMountRequest) (*coordpb.GetMountResponse, error) {
 	if err := ctx.Err(); err != nil {
-		return nil, status.Error(codes.Canceled, err.Error())
+		return nil, statusContext(err)
 	}
 	if req == nil || req.GetMountId() == "" {
-		return nil, status.Error(codes.InvalidArgument, "get mount request missing mount_id")
+		return nil, statusInvalidArgument("get mount request missing mount_id")
 	}
 	mount, ok := s.cluster.MountByID(req.GetMountId())
 	if !ok {
@@ -104,7 +104,7 @@ func (s *Service) GetMount(ctx context.Context, req *coordpb.GetMountRequest) (*
 
 func (s *Service) ListMounts(ctx context.Context, _ *coordpb.ListMountsRequest) (*coordpb.ListMountsResponse, error) {
 	if err := ctx.Err(); err != nil {
-		return nil, status.Error(codes.Canceled, err.Error())
+		return nil, statusContext(err)
 	}
 	mounts := s.cluster.MountSnapshot()
 	out := make([]*coordpb.MountInfo, 0, len(mounts))
@@ -116,7 +116,7 @@ func (s *Service) ListMounts(ctx context.Context, _ *coordpb.ListMountsRequest) 
 
 func (s *Service) ListSubtreeAuthorities(ctx context.Context, _ *coordpb.ListSubtreeAuthoritiesRequest) (*coordpb.ListSubtreeAuthoritiesResponse, error) {
 	if err := ctx.Err(); err != nil {
-		return nil, status.Error(codes.Canceled, err.Error())
+		return nil, statusContext(err)
 	}
 	subtrees := s.cluster.SubtreeAuthoritySnapshot()
 	out := make([]*coordpb.SubtreeAuthorityInfo, 0, len(subtrees))
@@ -128,14 +128,14 @@ func (s *Service) ListSubtreeAuthorities(ctx context.Context, _ *coordpb.ListSub
 
 func (s *Service) GetQuotaFence(ctx context.Context, req *coordpb.GetQuotaFenceRequest) (*coordpb.GetQuotaFenceResponse, error) {
 	if err := ctx.Err(); err != nil {
-		return nil, status.Error(codes.Canceled, err.Error())
+		return nil, statusContext(err)
 	}
 	if req == nil {
-		return nil, status.Error(codes.InvalidArgument, "get quota fence request missing subject")
+		return nil, statusInvalidArgument("get quota fence request missing subject")
 	}
 	subject := req.GetSubject()
 	if subject == nil || subject.GetMountId() == "" {
-		return nil, status.Error(codes.InvalidArgument, "get quota fence request missing subject")
+		return nil, statusInvalidArgument("get quota fence request missing subject")
 	}
 	fence, ok := s.cluster.QuotaFenceBySubject(subject.GetMountId(), subject.GetSubtreeRoot())
 	if !ok {
@@ -146,7 +146,7 @@ func (s *Service) GetQuotaFence(ctx context.Context, req *coordpb.GetQuotaFenceR
 
 func (s *Service) ListQuotaFences(ctx context.Context, _ *coordpb.ListQuotaFencesRequest) (*coordpb.ListQuotaFencesResponse, error) {
 	if err := ctx.Err(); err != nil {
-		return nil, status.Error(codes.Canceled, err.Error())
+		return nil, statusContext(err)
 	}
 	quotas := s.cluster.QuotaFenceSnapshot()
 	out := make([]*coordpb.QuotaFenceInfo, 0, len(quotas))
@@ -158,14 +158,14 @@ func (s *Service) ListQuotaFences(ctx context.Context, _ *coordpb.ListQuotaFence
 
 func (s *Service) WatchRootEvents(req *coordpb.WatchRootEventsRequest, stream coordpb.Coordinator_WatchRootEventsServer) error {
 	if stream == nil {
-		return status.Error(codes.InvalidArgument, "watch root events stream is nil")
+		return statusInvalidArgument("watch root events stream is nil")
 	}
 	if s == nil || s.storage == nil {
-		return status.Error(codes.FailedPrecondition, "root storage is not configured")
+		return statusProtocol("root storage is not configured", reasonRootStorageUnavailable)
 	}
 	subscriber, ok := s.storage.(rootedTailSubscriber)
 	if !ok {
-		return status.Error(codes.FailedPrecondition, "root storage does not support tail subscriptions")
+		return statusProtocol("root storage does not support tail subscriptions", reasonRootStorageUnavailable)
 	}
 	var after rootstorage.TailToken
 	if req != nil {
@@ -173,16 +173,16 @@ func (s *Service) WatchRootEvents(req *coordpb.WatchRootEventsRequest, stream co
 	}
 	sub := subscriber.SubscribeTail(after)
 	if sub == nil {
-		return status.Error(codes.FailedPrecondition, "root tail subscription is not available")
+		return statusProtocol("root tail subscription is not available", reasonRootStorageUnavailable)
 	}
 	ctx := stream.Context()
 	for {
 		advance, err := sub.Next(ctx, 30*time.Second)
 		if err != nil {
 			if errors.Is(err, context.Canceled) {
-				return status.Error(codes.Canceled, err.Error())
+				return statusContext(err)
 			}
-			return status.Error(codes.Internal, err.Error())
+			return statusInternal(err.Error())
 		}
 		if !advance.Advanced() {
 			continue
@@ -335,10 +335,10 @@ func (s *Service) storeState(info catalog.StoreInfo) coordpb.StoreState {
 // RegionLiveness records one runtime heartbeat without mutating rooted truth.
 func (s *Service) RegionLiveness(ctx context.Context, req *coordpb.RegionLivenessRequest) (*coordpb.RegionLivenessResponse, error) {
 	if err := ctx.Err(); err != nil {
-		return nil, status.Error(codes.Canceled, err.Error())
+		return nil, statusContext(err)
 	}
 	if req == nil || req.GetRegionId() == 0 {
-		return nil, status.Error(codes.InvalidArgument, "region liveness request missing region_id")
+		return nil, statusInvalidArgument("region liveness request missing region_id")
 	}
 	accepted := s.cluster.TouchRegionHeartbeat(req.GetRegionId())
 	return &coordpb.RegionLivenessResponse{Accepted: accepted}, nil
@@ -347,18 +347,18 @@ func (s *Service) RegionLiveness(ctx context.Context, req *coordpb.RegionLivenes
 // PublishRootEvent records one explicit rooted topology truth event.
 func (s *Service) PublishRootEvent(ctx context.Context, req *coordpb.PublishRootEventRequest) (*coordpb.PublishRootEventResponse, error) {
 	if err := ctx.Err(); err != nil {
-		return nil, status.Error(codes.Canceled, err.Error())
+		return nil, statusContext(err)
 	}
 	if req == nil || req.GetEvent() == nil {
-		return nil, status.Error(codes.InvalidArgument, "publish root event request missing event")
+		return nil, statusInvalidArgument("publish root event request missing event")
 	}
 	event := metawire.RootEventFromProto(req.GetEvent())
 	if event.Kind == rootevent.KindUnknown {
-		return nil, status.Error(codes.InvalidArgument, "publish root event requires known kind")
+		return nil, statusInvalidArgument("publish root event requires known kind")
 	}
 	event, err := s.normalizeRootEvent(event)
 	if err != nil {
-		return nil, status.Error(codes.Internal, "normalize root event: "+err.Error())
+		return nil, statusInternalf("normalize root event: %v", err)
 	}
 	if err := s.requireRootWriteAccess(); err != nil {
 		return nil, err
@@ -370,7 +370,7 @@ func (s *Service) PublishRootEvent(ctx context.Context, req *coordpb.PublishRoot
 	}
 	assessment, validationSnapshot, storageBacked, err := s.assessRootEventLifecycle(event)
 	if err != nil {
-		return nil, status.Error(codes.FailedPrecondition, err.Error())
+		return nil, statusCatalog(nokverrors.KindOf(err), codes.FailedPrecondition, err, reasonCatalogPrecondition)
 	}
 	resp := &coordpb.PublishRootEventResponse{
 		Assessment: transitionAssessmentToProto(assessment),
@@ -392,29 +392,29 @@ func (s *Service) PublishRootEvent(ctx context.Context, req *coordpb.PublishRoot
 	if err := validationErr; err != nil {
 		switch {
 		case errors.Is(err, catalog.ErrInvalidRegionID), errors.Is(err, catalog.ErrInvalidMountID):
-			return nil, status.Error(codes.InvalidArgument, err.Error())
+			return nil, statusCatalog(nokverrors.KindInvalidArgument, codes.InvalidArgument, err, reasonCatalogInvalid)
 		case errors.Is(err, catalog.ErrRegionHeartbeatStale), errors.Is(err, catalog.ErrRegionRangeOverlap),
 			errors.Is(err, catalog.ErrMountNotFound), errors.Is(err, catalog.ErrMountRetired), errors.Is(err, catalog.ErrMountConflict),
 			errors.Is(err, catalog.ErrSubtreeAuthorityNotFound), errors.Is(err, catalog.ErrSubtreeAuthorityConflict),
 			errors.Is(err, catalog.ErrSubtreeAuthorityHandoff), errors.Is(err, catalog.ErrQuotaFenceNotFound),
 			errors.Is(err, catalog.ErrQuotaFenceConflict):
-			return nil, status.Error(codes.FailedPrecondition, err.Error())
+			return nil, statusCatalog(nokverrors.KindOf(err), codes.FailedPrecondition, err, reasonCatalogPrecondition)
 		default:
-			return nil, status.Error(codes.Internal, err.Error())
+			return nil, statusCatalog(nokverrors.KindProtocolViolation, codes.Internal, err, reasonCatalogInternal)
 		}
 	}
 	if s.storage != nil {
 		if err := s.storage.AppendRootEvent(ctx, event); err != nil {
-			return nil, status.Error(codes.Internal, "persist root event: "+err.Error())
+			return nil, statusInternalf("persist root event: %v", err)
 		}
 		if _, err := s.reloadRootedView(false); err != nil {
-			return nil, status.Error(codes.Internal, "reload rooted view: "+err.Error())
+			return nil, statusInternalf("reload rooted view: %v", err)
 		}
 		resp.Accepted = true
 		return resp, nil
 	}
 	if err := s.cluster.PublishRootEvent(event); err != nil {
-		return nil, status.Error(codes.Internal, "apply root event after persist: "+err.Error())
+		return nil, statusInternalf("apply root event after persist: %v", err)
 	}
 	resp.Accepted = true
 	return resp, nil
@@ -448,14 +448,14 @@ func (s *Service) assessRootEventLifecycle(event rootevent.Event) (rootstate.Tra
 // RemoveRegion deletes region metadata from the Coordinator in-memory catalog.
 func (s *Service) RemoveRegion(ctx context.Context, req *coordpb.RemoveRegionRequest) (*coordpb.RemoveRegionResponse, error) {
 	if err := ctx.Err(); err != nil {
-		return nil, status.Error(codes.Canceled, err.Error())
+		return nil, statusContext(err)
 	}
 	if req == nil {
-		return nil, status.Error(codes.InvalidArgument, "remove region request is nil")
+		return nil, statusInvalidArgument("remove region request is nil")
 	}
 	regionID := req.GetRegionId()
 	if regionID == 0 {
-		return nil, status.Error(codes.InvalidArgument, "remove region requires region_id > 0")
+		return nil, statusInvalidArgument("remove region requires region_id > 0")
 	}
 	if err := s.requireRootWriteAccess(); err != nil {
 		return nil, err

--- a/coordinator/server/service_grant.go
+++ b/coordinator/server/service_grant.go
@@ -229,11 +229,11 @@ func (s *Service) sealGrant(ctx context.Context) error {
 	consumedTSOFrontier := s.tso.Current()
 	s.allocMu.Unlock()
 	if err := rootfailpoints.InjectBeforeGrantStorageRead(); err != nil {
-		return status.Error(codes.Internal, err.Error())
+		return statusInternal(err.Error())
 	}
 	snapshot, err := s.storage.Load()
 	if err != nil {
-		return status.Error(codes.Internal, "load rooted snapshot: "+err.Error())
+		return statusInternalf("load rooted snapshot: %v", err)
 	}
 	s.refreshCurrentRootSnapshot(snapshot)
 	grant := snapshot.ActiveGrant
@@ -601,13 +601,13 @@ func translateGrantError(err error) error {
 		return nil
 	}
 	if errors.Is(err, context.Canceled) {
-		return status.Error(codes.Canceled, err.Error())
+		return statusContext(err)
 	}
 	if errors.Is(err, context.DeadlineExceeded) {
-		return status.Error(codes.DeadlineExceeded, err.Error())
+		return statusContext(err)
 	}
 	if errors.Is(err, rootstate.ErrPrimacy) || errors.Is(err, rootstate.ErrInheritance) {
 		return statusGrant(err)
 	}
-	return status.Error(codes.Internal, "campaign coordinator grant: "+err.Error())
+	return statusInternalf("campaign coordinator grant: %v", err)
 }

--- a/coordinator/server/service_metadata.go
+++ b/coordinator/server/service_metadata.go
@@ -14,17 +14,15 @@ import (
 	rootstorage "github.com/feichai0017/NoKV/meta/root/storage"
 	metawire "github.com/feichai0017/NoKV/meta/wire"
 	coordpb "github.com/feichai0017/NoKV/pb/coordinator"
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
 )
 
 // GetRegionByKey returns region metadata for the specified key.
 func (s *Service) GetRegionByKey(ctx context.Context, req *coordpb.GetRegionByKeyRequest) (*coordpb.GetRegionByKeyResponse, error) {
 	if err := ctx.Err(); err != nil {
-		return nil, status.FromContextError(err).Err()
+		return nil, statusContext(err)
 	}
 	if req == nil {
-		return nil, status.Error(codes.InvalidArgument, "get region by key request is nil")
+		return nil, statusInvalidArgument("get region by key request is nil")
 	}
 	if err := s.rejectIfAuthorityClosed(); err != nil {
 		return nil, err
@@ -64,7 +62,7 @@ func (s *Service) GetRegionByKey(ctx context.Context, req *coordpb.GetRegionByKe
 		return resp, nil
 	}
 	if pending, ok := s.cluster.PendingRangeChangeForDescriptor(desc.RegionID); ok {
-		return nil, status.Error(codes.FailedPrecondition, pendingRangeChangeError(pending))
+		return nil, statusStaleEpoch(pendingRangeChangeError(pending), reasonRangeChangePending)
 	}
 	if err := admission.admitDescriptorRevision(desc.RootEpoch); err != nil {
 		return nil, err
@@ -117,7 +115,7 @@ type metadataAnswerability struct {
 
 func (a metadataAnswerability) admitDescriptorRevision(revision uint64) error {
 	if revision < a.requiredDescriptorRevision {
-		return status.Error(codes.FailedPrecondition, errRequiredDescriptorNotSatisfied)
+		return statusStaleEpoch(errRequiredDescriptorNotSatisfied, reasonRequiredDescriptor)
 	}
 	return nil
 }
@@ -167,7 +165,7 @@ func (s *Service) admitMetadataAnswerability(req *coordpb.GetRegionByKeyRequest,
 	}
 	if loadErr != nil {
 		if admission.freshness == coordpb.Freshness_FRESHNESS_STRONG || admission.freshness == coordpb.Freshness_FRESHNESS_BOUNDED {
-			return metadataAnswerability{}, status.Error(codes.FailedPrecondition, errRootUnavailable)
+			return metadataAnswerability{}, statusRootUnavailable()
 		}
 		admission.state.degraded = coordpb.DegradedMode_DEGRADED_MODE_ROOT_UNAVAILABLE
 	}
@@ -186,12 +184,12 @@ func (s *Service) admitMetadataAnswerability(req *coordpb.GetRegionByKeyRequest,
 		}
 	}
 	if !rootTokenSatisfied(admission.state.servedToken, admission.requiredRootToken) {
-		return metadataAnswerability{}, status.Error(codes.FailedPrecondition, errRequiredRootedTokenNotSatisfied)
+		return metadataAnswerability{}, statusStaleEpoch(errRequiredRootedTokenNotSatisfied, reasonRequiredRootedToken)
 	}
 	if admission.freshness == coordpb.Freshness_FRESHNESS_BOUNDED &&
 		admission.maxRootLag != nil &&
 		!boundedLagSatisfied(admission.state.rootLag, *admission.maxRootLag) {
-		return metadataAnswerability{}, status.Error(codes.FailedPrecondition, errRootLagExceedsBound)
+		return metadataAnswerability{}, statusStaleEpoch(errRootLagExceedsBound, reasonRootLagExceeded)
 	}
 	servingClass, syncHealth, err := s.admitReadServing(admission.freshness, admission.state)
 	if err != nil {
@@ -417,15 +415,15 @@ func (s *Service) admitReadServing(freshness coordpb.Freshness, state readState)
 			if !state.servedByLeader {
 				return servingClass, syncHealth, s.notLeaderError()
 			}
-			return servingClass, syncHealth, status.Error(codes.FailedPrecondition, errRootLagExceedsStrongFreshness)
+			return servingClass, syncHealth, statusStaleEpoch(errRootLagExceedsStrongFreshness, reasonRootLagExceeded)
 		}
 	case coordpb.Freshness_FRESHNESS_BOUNDED:
 		if servingClass == coordpb.ServingClass_SERVING_CLASS_DEGRADED {
 			switch syncHealth {
 			case coordpb.SyncHealth_SYNC_HEALTH_ROOT_UNAVAILABLE:
-				return servingClass, syncHealth, status.Error(codes.FailedPrecondition, errRootUnavailable)
+				return servingClass, syncHealth, statusRootUnavailable()
 			case coordpb.SyncHealth_SYNC_HEALTH_BOOTSTRAP_REQUIRED:
-				return servingClass, syncHealth, status.Error(codes.FailedPrecondition, errBootstrapRequiredBeforeBounded)
+				return servingClass, syncHealth, statusProtocol(errBootstrapRequiredBeforeBounded, reasonBootstrapRequired)
 			}
 		}
 	}

--- a/coordinator/server/service_test.go
+++ b/coordinator/server/service_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/feichai0017/NoKV/coordinator/rootview"
+	nokverrors "github.com/feichai0017/NoKV/errors"
 	metaregion "github.com/feichai0017/NoKV/meta/region"
 	rootevent "github.com/feichai0017/NoKV/meta/root/event"
 	rootproto "github.com/feichai0017/NoKV/meta/root/protocol"
@@ -69,8 +70,12 @@ func TestTranslateGrantErrorsAsGrantNotHeld(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			require.Equal(t, codes.FailedPrecondition, status.Code(tc.err))
 			message := status.Convert(tc.err).Message()
-			require.Contains(t, message, errGrantPrefix)
+			require.Contains(t, message, diagnosticGrantNotHeld)
 			require.Contains(t, message, tc.contains)
+			require.Equal(t, nokverrors.KindNotLeader, nokverrors.KindOf(tc.err))
+			_, metadata, ok := nokverrors.RPCErrorInfo(tc.err)
+			require.True(t, ok)
+			require.Equal(t, reasonGrantNotHeld, metadata[coordinatorReasonMetadata])
 		})
 	}
 }
@@ -744,7 +749,10 @@ func TestServiceGetRegionByKeyStrongReadRejectsFollower(t *testing.T) {
 	})
 	require.Error(t, err)
 	require.Equal(t, codes.FailedPrecondition, status.Code(err))
-	require.Contains(t, err.Error(), errNotLeaderPrefix)
+	require.Equal(t, nokverrors.KindNotLeader, nokverrors.KindOf(err))
+	_, metadata, ok := nokverrors.RPCErrorInfo(err)
+	require.True(t, ok)
+	require.Equal(t, reasonNotLeader, metadata[coordinatorReasonMetadata])
 }
 
 func TestServiceGetRegionByKeyGrantModeIssuesLookupGrant(t *testing.T) {
@@ -1094,7 +1102,10 @@ func TestServiceGetRegionByKeyBestEffortWithUnavailableRoot(t *testing.T) {
 	})
 	require.Error(t, err)
 	require.Equal(t, codes.FailedPrecondition, status.Code(err))
-	require.Contains(t, err.Error(), errRootUnavailable)
+	require.Equal(t, nokverrors.KindUnavailable, nokverrors.KindOf(err))
+	_, metadata, ok := nokverrors.RPCErrorInfo(err)
+	require.True(t, ok)
+	require.Equal(t, reasonRootUnavailable, metadata[coordinatorReasonMetadata])
 }
 
 func TestServiceGetRegionByKeyReportsRootLagging(t *testing.T) {
@@ -2362,7 +2373,10 @@ func TestServiceDrainAndSealBlocksNewAuthorityRequests(t *testing.T) {
 	_, err = svc.AllocID(context.Background(), &coordpb.AllocIDRequest{Count: 1})
 	require.Error(t, err)
 	require.Equal(t, codes.FailedPrecondition, status.Code(err))
-	require.Contains(t, status.Convert(err).Message(), "authority is draining")
+	require.Equal(t, nokverrors.KindNotLeader, nokverrors.KindOf(err))
+	_, metadata, ok := nokverrors.RPCErrorInfo(err)
+	require.True(t, ok)
+	require.Equal(t, reasonGrantNotHeld, metadata[coordinatorReasonMetadata])
 
 	doneAdmission.Done()
 	require.NoError(t, <-drainDone)
@@ -2399,7 +2413,10 @@ func TestServiceRejectsDrainingAdmissionBeforeGrantRenewal(t *testing.T) {
 	_, err := svc.beginDutyAdmission(context.Background(), rootproto.DutyAllocID)
 	require.Error(t, err)
 	require.Equal(t, codes.FailedPrecondition, status.Code(err))
-	require.Contains(t, status.Convert(err).Message(), "authority is draining")
+	require.Equal(t, nokverrors.KindNotLeader, nokverrors.KindOf(err))
+	_, metadata, ok := nokverrors.RPCErrorInfo(err)
+	require.True(t, ok)
+	require.Equal(t, reasonGrantNotHeld, metadata[coordinatorReasonMetadata])
 	require.Zero(t, store.campaignCalls)
 }
 
@@ -2431,7 +2448,10 @@ func TestServiceRejectsDrainingMetadataBeforeGrantRenewal(t *testing.T) {
 	})
 	require.Error(t, err)
 	require.Equal(t, codes.FailedPrecondition, status.Code(err))
-	require.Contains(t, status.Convert(err).Message(), "authority is draining")
+	require.Equal(t, nokverrors.KindNotLeader, nokverrors.KindOf(err))
+	_, metadata, ok := nokverrors.RPCErrorInfo(err)
+	require.True(t, ok)
+	require.Equal(t, reasonGrantNotHeld, metadata[coordinatorReasonMetadata])
 	require.Zero(t, store.campaignCalls)
 }
 
@@ -2602,7 +2622,10 @@ func TestServiceSealGrantRejectsOtherHolder(t *testing.T) {
 	err := svc.SealGrant()
 	require.Error(t, err)
 	require.Equal(t, codes.FailedPrecondition, status.Code(err))
-	require.Contains(t, err.Error(), errGrantPrefix)
+	require.Equal(t, nokverrors.KindNotLeader, nokverrors.KindOf(err))
+	_, metadata, ok := nokverrors.RPCErrorInfo(err)
+	require.True(t, ok)
+	require.Equal(t, reasonGrantNotHeld, metadata[coordinatorReasonMetadata])
 	require.Equal(t, 0, store.sealCalls)
 	require.Equal(t, "c2/2", store.snapshot.ActiveGrant.GrantID)
 }
@@ -2627,7 +2650,10 @@ func TestServiceDutyAdmissionRejectsOtherActiveGrant(t *testing.T) {
 	_, err := svc.AllocID(context.Background(), &coordpb.AllocIDRequest{Count: 1})
 	require.Error(t, err)
 	require.Equal(t, codes.FailedPrecondition, status.Code(err))
-	require.Contains(t, status.Convert(err).Message(), errGrantPrefix)
+	require.Equal(t, nokverrors.KindNotLeader, nokverrors.KindOf(err))
+	_, metadata, ok := nokverrors.RPCErrorInfo(err)
+	require.True(t, ok)
+	require.Equal(t, reasonGrantNotHeld, metadata[coordinatorReasonMetadata])
 	require.Equal(t, 0, store.campaignCalls)
 }
 
@@ -2789,7 +2815,10 @@ func TestServiceRejectsWritesOnFollower(t *testing.T) {
 	err := publishDescriptorEvent(t, svc, testDescriptor(8, []byte("a"), []byte("m"), metaregion.Epoch{Version: 1, ConfVersion: 1}, nil), 0)
 	require.Error(t, err)
 	require.Equal(t, codes.FailedPrecondition, status.Code(err))
-	require.True(t, strings.Contains(err.Error(), errNotLeaderPrefix))
+	require.Equal(t, nokverrors.KindNotLeader, nokverrors.KindOf(err))
+	_, metadata, ok := nokverrors.RPCErrorInfo(err)
+	require.True(t, ok)
+	require.Equal(t, reasonNotLeader, metadata[coordinatorReasonMetadata])
 
 	_, err = svc.PublishRootEvent(context.Background(), &coordpb.PublishRootEventRequest{
 		Event: metawire.RootEventToProto(rootevent.RegionTombstoned(8)),

--- a/coordinator/server/transition_service.go
+++ b/coordinator/server/transition_service.go
@@ -3,12 +3,12 @@ package server
 import (
 	"context"
 
+	nokverrors "github.com/feichai0017/NoKV/errors"
 	rootevent "github.com/feichai0017/NoKV/meta/root/event"
 	rootstate "github.com/feichai0017/NoKV/meta/root/state"
 	metawire "github.com/feichai0017/NoKV/meta/wire"
 	coordpb "github.com/feichai0017/NoKV/pb/coordinator"
 	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
 )
 
 // ListTransitions returns the rooted transition view currently materialized
@@ -33,19 +33,19 @@ func (s *Service) ListTransitions(_ context.Context, _ *coordpb.ListTransitionsR
 // rooted view without mutating truth.
 func (s *Service) AssessRootEvent(_ context.Context, req *coordpb.AssessRootEventRequest) (*coordpb.AssessRootEventResponse, error) {
 	if req == nil || req.GetEvent() == nil {
-		return nil, status.Error(codes.InvalidArgument, "assess root event request missing event")
+		return nil, statusInvalidArgument("assess root event request missing event")
 	}
 	event := metawire.RootEventFromProto(req.GetEvent())
 	if event.Kind == rootevent.KindUnknown {
-		return nil, status.Error(codes.InvalidArgument, "assess root event requires known kind")
+		return nil, statusInvalidArgument("assess root event requires known kind")
 	}
 	event, err := s.normalizeRootEvent(event)
 	if err != nil {
-		return nil, status.Error(codes.Internal, "normalize root event: "+err.Error())
+		return nil, statusInternalf("normalize root event: %v", err)
 	}
 	assessment, _, _, err := s.assessRootEventLifecycle(event)
 	if err != nil {
-		return nil, status.Error(codes.FailedPrecondition, err.Error())
+		return nil, statusCatalog(nokverrors.KindOf(err), codes.FailedPrecondition, err, reasonCatalogPrecondition)
 	}
 	return &coordpb.AssessRootEventResponse{
 		Assessment: transitionAssessmentToProto(assessment),

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -232,7 +232,7 @@ Nightly policy:
 
 1. PR CI runs bounded smoke through `make test-correctness-smoke`, including
    `make test-history-smoke` and `make test-model-smoke`.
-2. PR benchmark CI also runs the medium `make fsmeta-bench` profile across all
+2. PR benchmark CI also runs the median `make fsmeta-bench` profile across all
    fsmeta workloads: mixed, checkpoint-storm, hotspot-fanin, watch-subtree, and
    negative-lookup. It uploads CSVs and Docker diagnostics as workflow artifacts.
 3. Nightly CI runs `make test-correctness-nightly`, which raises model seeds

--- a/engine/slab/dirpage/codec.go
+++ b/engine/slab/dirpage/codec.go
@@ -26,7 +26,6 @@ package dirpage
 
 import (
 	"encoding/binary"
-	"errors"
 	"fmt"
 	"hash/crc32"
 )
@@ -37,7 +36,7 @@ const dirPageMagic uint32 = 0x4c535044
 
 // dirPageVersion is the current dirpage slab format. NoKV has not shipped a
 // stable dirpage cache format yet, so development-time incompatible changes
-// keep the clean v1 format instead of carrying migration branches.
+// update this format directly instead of carrying migration branches.
 const dirPageVersion uint16 = 1
 
 // recordHeaderFixed is the size of the magic + version prefix we read
@@ -148,13 +147,6 @@ func encodePage(dst []byte, hdr pageHeader, entries []Entry) []byte {
 	dst = append(dst, crcBuf[:]...)
 	return dst
 }
-
-var (
-	errPageTruncated   = errors.New("dirpage: record truncated")
-	errPageBadMagic    = errors.New("dirpage: bad magic")
-	errPageBadVersion  = errors.New("dirpage: unsupported version")
-	errPageBadChecksum = errors.New("dirpage: checksum mismatch")
-)
 
 // decodePage parses one page from buf. Returns the header, decoded
 // entries, and the number of bytes consumed (so callers iterating over

--- a/engine/slab/dirpage/errors.go
+++ b/engine/slab/dirpage/errors.go
@@ -1,0 +1,10 @@
+package dirpage
+
+import "errors"
+
+var (
+	errPageTruncated   = errors.New("dirpage: record truncated")
+	errPageBadMagic    = errors.New("dirpage: bad magic")
+	errPageBadVersion  = errors.New("dirpage: unsupported version")
+	errPageBadChecksum = errors.New("dirpage: checksum mismatch")
+)

--- a/engine/slab/negativecache/cache_test.go
+++ b/engine/slab/negativecache/cache_test.go
@@ -43,7 +43,7 @@ func TestCacheRememberHasInvalidate(t *testing.T) {
 	require.False(t, c.Has(versionedKey("beta", 1)))
 
 	// Invalidating any version of "alpha" bumps the group's generation,
-	// so the previously-remembered alpha@v1 becomes stale.
+	// so the previously-remembered alpha entry becomes stale.
 	c.Invalidate(versionedKey("alpha", 5))
 	require.False(t, c.Has(k), "Invalidate must stale every entry in the group")
 

--- a/engine/slab/segment.go
+++ b/engine/slab/segment.go
@@ -72,7 +72,7 @@ func (s *Segment) Open(opt *file.Options) error {
 // Returns io.EOF when the range falls outside the mapped region or beyond
 // the high-water mark. The high-water guarantee depends on the upper-layer
 // publish discipline: callers must not surface an offset to readers until
-// the corresponding Write has returned (Invariant V1 in slab-substrate note
+// the corresponding Write has returned (slab-substrate publish invariant in
 // §4.4). Within the high-water mark there can be holes (reserved-but-not-
 // yet-written ranges); the publish discipline is what keeps readers from
 // observing them.

--- a/engine/wal/catalog.go
+++ b/engine/wal/catalog.go
@@ -13,7 +13,6 @@ import (
 )
 
 var catalogMagic = [8]byte{'N', 'O', 'K', 'V', 'I', 'D', 'X', 1}
-var errStaleCatalog = errors.New("wal: stale catalog")
 
 type catalogEntry struct {
 	Type   RecordType

--- a/engine/wal/errors.go
+++ b/engine/wal/errors.go
@@ -11,4 +11,6 @@ var (
 	ErrSegmentRetained = errors.New("wal: segment retained")
 	// ErrWALBackpressure indicates the WAL reached its configured hard cap.
 	ErrWALBackpressure = errors.New("wal: backpressure")
+
+	errStaleCatalog = errors.New("wal: stale catalog")
 )

--- a/errors/errors.go
+++ b/errors/errors.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	kvrpcpb "github.com/feichai0017/NoKV/pb/kv"
+	errdetails "google.golang.org/genproto/googleapis/rpc/errdetails"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )
@@ -36,6 +37,12 @@ const (
 	KindProtocolViolation
 	KindCorruption
 	KindAborted
+)
+
+const (
+	RPCErrorInfoDomain   = "nokv"
+	RPCErrorInfoReason   = "nokv_error"
+	RPCErrorKindMetadata = "nokv_kind"
 )
 
 func (k Kind) String() string {
@@ -240,22 +247,12 @@ func KindOfGRPCStatus(err error) Kind {
 	if code == codes.OK || code == codes.Unknown {
 		return KindUnknown
 	}
+	if kind, _, ok := RPCErrorInfo(err); ok && kind != KindUnknown {
+		return kind
+	}
 	message := status.Convert(err).Message()
 	if kind := kindFromMessage(message); kind != KindUnknown {
 		return kind
-	}
-	if strings.Contains(message, "not leader") ||
-		strings.Contains(message, "grant not held") ||
-		strings.Contains(message, "lease not held") {
-		return KindNotLeader
-	}
-	if strings.Contains(message, "root unavailable") {
-		return KindUnavailable
-	}
-	if strings.Contains(message, "root lag") ||
-		strings.Contains(message, "required rooted token") ||
-		strings.Contains(message, "required descriptor") {
-		return KindStaleEpoch
 	}
 	switch code {
 	case codes.InvalidArgument, codes.OutOfRange:
@@ -277,6 +274,49 @@ func KindOfGRPCStatus(err error) Kind {
 	default:
 		return KindUnknown
 	}
+}
+
+// RPCStatusError returns a gRPC status error with stable machine-readable NoKV
+// error metadata. The status message remains diagnostic; clients must branch on
+// the ErrorInfo metadata or KindOf rather than matching message text.
+func RPCStatusError(kind Kind, code codes.Code, message string, metadata map[string]string) error {
+	md := cloneStringMap(metadata)
+	md[RPCErrorKindMetadata] = kind.String()
+	st := status.New(code, message)
+	withDetails, err := st.WithDetails(&errdetails.ErrorInfo{
+		Reason:   RPCErrorInfoReason,
+		Domain:   RPCErrorInfoDomain,
+		Metadata: md,
+	})
+	if err != nil {
+		return st.Err()
+	}
+	return withDetails.Err()
+}
+
+// RPCErrorInfo extracts NoKV's stable gRPC ErrorInfo metadata when present.
+func RPCErrorInfo(err error) (Kind, map[string]string, bool) {
+	st, ok := status.FromError(err)
+	if !ok {
+		return KindUnknown, nil, false
+	}
+	for _, detail := range st.Details() {
+		info, ok := detail.(*errdetails.ErrorInfo)
+		if !ok || info.GetDomain() != RPCErrorInfoDomain || info.GetReason() != RPCErrorInfoReason {
+			continue
+		}
+		md := cloneStringMap(info.GetMetadata())
+		return ParseKind(md[RPCErrorKindMetadata]), md, true
+	}
+	return KindUnknown, nil, false
+}
+
+func cloneStringMap(in map[string]string) map[string]string {
+	out := make(map[string]string, len(in)+1)
+	for k := range in {
+		out[k] = in[k]
+	}
+	return out
 }
 
 func kindFromMessage(message string) Kind {

--- a/errors/errors_test.go
+++ b/errors/errors_test.go
@@ -81,16 +81,23 @@ func TestContextAndGRPCStatusKinds(t *testing.T) {
 	require.Equal(t, KindAborted, KindOf(status.Error(codes.Canceled, "client canceled")))
 	require.Equal(t, KindResourceExhausted, KindOf(status.Error(codes.ResourceExhausted, "quota")))
 	require.Equal(t, KindUnavailable, KindOf(status.Error(codes.Unavailable, "down")))
-	require.Equal(t, KindUnavailable, KindOf(status.Error(codes.FailedPrecondition, "coordinator root unavailable")))
-	require.Equal(t, KindStaleEpoch, KindOf(status.Error(codes.FailedPrecondition, "root lag exceeds bound")))
-	require.Equal(t, KindNotLeader, KindOf(status.Error(codes.FailedPrecondition, "coordinator not leader (leader_id=2)")))
-	require.Equal(t, KindNotLeader, KindOf(status.Error(codes.FailedPrecondition, "coordinator grant not held")))
-	require.Equal(t, KindNotLeader, KindOf(status.Error(codes.FailedPrecondition, "coordinator lease not held")))
 	require.Equal(t, KindProtocolViolation, KindOf(status.Error(codes.FailedPrecondition, "invalid protocol state")))
 	require.Equal(t, KindAborted, KindOf(status.Error(codes.FailedPrecondition, New(KindAborted, "fsmeta: mount is retired").Error())))
 	require.Equal(t, KindResourceExhausted, KindOf(status.Error(codes.ResourceExhausted, New(KindResourceExhausted, "fsmeta: quota exceeded").Error())))
 
-	require.True(t, Retryable(status.Error(codes.FailedPrecondition, "coordinator not leader (leader_id=2)")))
-	require.True(t, Retryable(status.Error(codes.FailedPrecondition, "root lag exceeds bound")))
+	notLeader := RPCStatusError(KindNotLeader, codes.FailedPrecondition, "diagnostic not leader text", map[string]string{"leader_id": "2"})
+	require.Equal(t, KindNotLeader, KindOf(notLeader))
+	require.True(t, Retryable(notLeader))
+
+	stale := RPCStatusError(KindStaleEpoch, codes.FailedPrecondition, "diagnostic stale root text", nil)
+	require.Equal(t, KindStaleEpoch, KindOf(stale))
+	require.True(t, Retryable(stale))
+
+	unavailable := RPCStatusError(KindUnavailable, codes.FailedPrecondition, "diagnostic root unavailable text", nil)
+	require.Equal(t, KindUnavailable, KindOf(unavailable))
+	require.True(t, Retryable(unavailable))
+
+	require.Equal(t, KindProtocolViolation, KindOf(status.Error(codes.FailedPrecondition, "coordinator not leader")))
+	require.False(t, Retryable(status.Error(codes.FailedPrecondition, "root lag exceeds bound")))
 	require.False(t, Retryable(status.Error(codes.ResourceExhausted, "quota")))
 }

--- a/fsmeta/client/client.go
+++ b/fsmeta/client/client.go
@@ -3,8 +3,8 @@ package client
 import (
 	"context"
 	"fmt"
-	"strings"
 
+	nokverrors "github.com/feichai0017/NoKV/errors"
 	"github.com/feichai0017/NoKV/fsmeta"
 	fsmetapb "github.com/feichai0017/NoKV/pb/fsmeta"
 	"google.golang.org/grpc"
@@ -12,6 +12,16 @@ import (
 	"google.golang.org/grpc/connectivity"
 	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/status"
+)
+
+const (
+	fsmetaReasonMetadata = "fsmeta_reason"
+
+	reasonQuotaExceeded      = "quota_exceeded"
+	reasonWatchOverflow      = "watch_overflow"
+	reasonWatchCursorExpired = "watch_cursor_expired"
+	reasonMountNotRegistered = "mount_not_registered"
+	reasonMountRetired       = "mount_retired"
 )
 
 // Client is the typed fsmeta client surface consumed by demos and benchmarks.
@@ -358,21 +368,36 @@ func translateRPCError(err error) error {
 	case codes.AlreadyExists:
 		return fmt.Errorf("%w: %v", fsmeta.ErrExists, err)
 	case codes.NotFound:
+		if fsmetaReason(err) == reasonMountNotRegistered {
+			return fmt.Errorf("%w: %v", fsmeta.ErrMountNotRegistered, err)
+		}
 		return fmt.Errorf("%w: %v", fsmeta.ErrNotFound, err)
 	case codes.OutOfRange:
 		return fmt.Errorf("%w: %v", fsmeta.ErrWatchCursorExpired, err)
-	case codes.ResourceExhausted:
-		msg := status.Convert(err).Message()
-		if strings.Contains(msg, fsmeta.ErrQuotaExceeded.Error()) {
-			return fmt.Errorf("%w: %v", fsmeta.ErrQuotaExceeded, err)
+	case codes.FailedPrecondition:
+		if fsmetaReason(err) == reasonMountRetired {
+			return fmt.Errorf("%w: %v", fsmeta.ErrMountRetired, err)
 		}
-		if strings.Contains(msg, fsmeta.ErrWatchOverflow.Error()) {
+		return err
+	case codes.ResourceExhausted:
+		switch fsmetaReason(err) {
+		case reasonQuotaExceeded:
+			return fmt.Errorf("%w: %v", fsmeta.ErrQuotaExceeded, err)
+		case reasonWatchOverflow:
 			return fmt.Errorf("%w: %v", fsmeta.ErrWatchOverflow, err)
 		}
 		return err
 	default:
 		return err
 	}
+}
+
+func fsmetaReason(err error) string {
+	_, metadata, ok := nokverrors.RPCErrorInfo(err)
+	if !ok {
+		return ""
+	}
+	return metadata[fsmetaReasonMetadata]
 }
 
 // WatchSession wraps a WatchSubscription with event-based ack helpers.

--- a/fsmeta/client/client_test.go
+++ b/fsmeta/client/client_test.go
@@ -282,6 +282,26 @@ func TestTypedClientErrorTranslation(t *testing.T) {
 		Name:   "missing",
 	})
 	require.ErrorIs(t, err, fsmeta.ErrNotFound)
+
+	cli, cleanup = openBufconnClient(t, &fakeExecutor{err: fsmeta.ErrMountNotRegistered})
+	defer cleanup()
+	_, err = cli.Lookup(context.Background(), fsmeta.LookupRequest{Mount: "missing", Parent: fsmeta.RootInode, Name: "x"})
+	require.ErrorIs(t, err, fsmeta.ErrMountNotRegistered)
+
+	cli, cleanup = openBufconnClient(t, &fakeExecutor{err: fsmeta.ErrMountRetired})
+	defer cleanup()
+	_, err = cli.Lookup(context.Background(), fsmeta.LookupRequest{Mount: "retired", Parent: fsmeta.RootInode, Name: "x"})
+	require.ErrorIs(t, err, fsmeta.ErrMountRetired)
+
+	cli, cleanup = openBufconnClient(t, &fakeExecutor{err: fsmeta.ErrQuotaExceeded})
+	defer cleanup()
+	_, err = cli.GetQuotaUsage(context.Background(), fsmeta.QuotaUsageRequest{Mount: "vol"})
+	require.ErrorIs(t, err, fsmeta.ErrQuotaExceeded)
+
+	cli, cleanup = openBufconnClient(t, &fakeExecutor{err: fsmeta.ErrWatchOverflow})
+	defer cleanup()
+	_, err = cli.ReadDir(context.Background(), fsmeta.ReadDirRequest{Mount: "vol", Parent: fsmeta.RootInode})
+	require.ErrorIs(t, err, fsmeta.ErrWatchOverflow)
 }
 
 func TestTypedClientPreservesUnknownStatus(t *testing.T) {

--- a/fsmeta/exec/runner.go
+++ b/fsmeta/exec/runner.go
@@ -374,7 +374,7 @@ func (e *Executor) Create(ctx context.Context, req fsmeta.CreateRequest) (fsmeta
 
 // UpdateInode updates mutable inode attributes and applies the size quota delta
 // in the same transaction. The parent field is required because quota and
-// DirPage invalidation are directory-scoped in fsmeta v1.
+// DirPage invalidation are directory-scoped by parent inode and page token.
 func (e *Executor) UpdateInode(ctx context.Context, req fsmeta.UpdateInodeRequest) (fsmeta.InodeRecord, error) {
 	plan, err := fsmeta.PlanUpdateInode(req)
 	if err != nil {
@@ -405,7 +405,7 @@ func (e *Executor) UpdateInode(ctx context.Context, req fsmeta.UpdateInodeReques
 		if dentry.Type != inode.Type {
 			return fsmeta.ErrInvalidValue
 		}
-		// v1 does not maintain an inode->parents reverse index. Updating a
+		// fsmeta does not maintain an inode->parents reverse index. Updating a
 		// hard-linked inode would require invalidating and quota-adjusting every
 		// parent, so reject it rather than silently corrupting accounting.
 		if inode.LinkCount != 1 {

--- a/fsmeta/keys.go
+++ b/fsmeta/keys.go
@@ -5,6 +5,24 @@ import (
 	"fmt"
 )
 
+// fsmeta key layout:
+//
+//	common prefix:
+//	  magic[4] = "fsm\0"
+//	  version  = 0x01
+//	  mount_len uvarint
+//	  mount bytes
+//	  kind byte
+//
+//	kind bodies:
+//	  mount   'm' : empty
+//	  inode   'i' : inode be64
+//	  dentry  'd' : parent inode be64 | name bytes
+//	  chunk   'c' : inode be64 | chunk index be64
+//	  session 's' : session bytes, or 0x00 | inode be64 for writer ownership
+//	  usage   'u' : quota scope inode be64; scope 0 is mount-wide usage
+//
+// Big-endian integer fields preserve numeric order inside each key family.
 var keyMagic = []byte{'f', 's', 'm', 0}
 
 const keySchemaVersion byte = 1

--- a/fsmeta/plan.go
+++ b/fsmeta/plan.go
@@ -1,12 +1,11 @@
 package fsmeta
 
-// V0 scope:
-//   - PlanRenameSubtree v0 only moves the subtree root dentry. Descendants refer
-//     to parent inode IDs, so they follow the moved root without key rewrites.
-//     POSIX overwrite and file-type checks belong to the executor that
-//     interprets current values.
-//   - mkdir and setxattr are left for later slices after the base
-//     transaction contract is stable.
+// fsmeta operation plans define semantic key boundaries only. The executor
+// owns value interpretation, conflict handling, and operation-specific checks;
+// the transaction runner owns timestamps, retries, and MVCC mutation encoding.
+//
+// RenameSubtree moves only the subtree-root dentry. Descendants reference
+// parent inode IDs, so they remain reachable without descendant key rewrites.
 
 // OperationKind identifies one metadata operation contract.
 type OperationKind string

--- a/fsmeta/server/errors.go
+++ b/fsmeta/server/errors.go
@@ -5,8 +5,24 @@ import (
 	"errors"
 
 	nokverrors "github.com/feichai0017/NoKV/errors"
+	"github.com/feichai0017/NoKV/fsmeta"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+)
+
+const (
+	fsmetaReasonMetadata     = "fsmeta_reason"
+	reasonQuotaExceeded      = "quota_exceeded"
+	reasonWatchOverflow      = "watch_overflow"
+	reasonWatchCursorExpired = "watch_cursor_expired"
+	reasonMountNotRegistered = "mount_not_registered"
+	reasonMountRetired       = "mount_retired"
+	reasonNamespaceExists    = "entry_exists"
+	reasonNamespaceNotFound  = "entry_not_found"
+	reasonInvalidFSMetaInput = "invalid_fsmeta_input"
+	reasonServiceUnavailable = "service_unavailable"
+	reasonContextCanceled    = "context_canceled"
+	reasonContextDeadline    = "context_deadline"
 )
 
 func rpcError(err error) error {
@@ -18,12 +34,59 @@ func rpcError(err error) error {
 	}
 	switch {
 	case errors.Is(err, context.Canceled):
-		return status.Error(codes.Canceled, err.Error())
+		return nokverrors.RPCStatusError(nokverrors.KindAborted, codes.Canceled, err.Error(), map[string]string{
+			fsmetaReasonMetadata: reasonContextCanceled,
+		})
 	case errors.Is(err, context.DeadlineExceeded):
-		return status.Error(codes.DeadlineExceeded, err.Error())
+		return nokverrors.RPCStatusError(nokverrors.KindUnavailable, codes.DeadlineExceeded, err.Error(), map[string]string{
+			fsmetaReasonMetadata: reasonContextDeadline,
+		})
 	default:
-		return status.Error(rpcCodeForKind(nokverrors.KindOf(err)), err.Error())
+		kind := nokverrors.KindOf(err)
+		return nokverrors.RPCStatusError(kind, rpcCodeForKind(kind), err.Error(), fsmetaErrorMetadata(err))
 	}
+}
+
+func rpcInvalidArgument(message string) error {
+	return nokverrors.RPCStatusError(nokverrors.KindInvalidArgument, codes.InvalidArgument, message, map[string]string{
+		fsmetaReasonMetadata: reasonInvalidFSMetaInput,
+	})
+}
+
+func rpcServiceUnavailable(message string) error {
+	return nokverrors.RPCStatusError(nokverrors.KindProtocolViolation, codes.FailedPrecondition, message, map[string]string{
+		fsmetaReasonMetadata: reasonServiceUnavailable,
+	})
+}
+
+func fsmetaErrorMetadata(err error) map[string]string {
+	reason := ""
+	switch {
+	case errors.Is(err, fsmeta.ErrQuotaExceeded):
+		reason = reasonQuotaExceeded
+	case errors.Is(err, fsmeta.ErrWatchOverflow):
+		reason = reasonWatchOverflow
+	case errors.Is(err, fsmeta.ErrWatchCursorExpired):
+		reason = reasonWatchCursorExpired
+	case errors.Is(err, fsmeta.ErrMountNotRegistered):
+		reason = reasonMountNotRegistered
+	case errors.Is(err, fsmeta.ErrMountRetired):
+		reason = reasonMountRetired
+	case errors.Is(err, fsmeta.ErrExists):
+		reason = reasonNamespaceExists
+	case errors.Is(err, fsmeta.ErrNotFound):
+		reason = reasonNamespaceNotFound
+	case errors.Is(err, fsmeta.ErrInvalidMountID), errors.Is(err, fsmeta.ErrInvalidInodeID),
+		errors.Is(err, fsmeta.ErrInvalidName), errors.Is(err, fsmeta.ErrInvalidSession),
+		errors.Is(err, fsmeta.ErrInvalidRequest), errors.Is(err, fsmeta.ErrInvalidKey),
+		errors.Is(err, fsmeta.ErrInvalidKeyKind), errors.Is(err, fsmeta.ErrInvalidValue),
+		errors.Is(err, fsmeta.ErrInvalidValueKind), errors.Is(err, fsmeta.ErrInvalidPageSize):
+		reason = reasonInvalidFSMetaInput
+	}
+	if reason == "" {
+		return nil
+	}
+	return map[string]string{fsmetaReasonMetadata: reason}
 }
 
 func rpcCodeForKind(kind nokverrors.Kind) codes.Code {

--- a/fsmeta/server/service.go
+++ b/fsmeta/server/service.go
@@ -9,8 +9,6 @@ import (
 	"github.com/feichai0017/NoKV/fsmeta"
 	fsmetapb "github.com/feichai0017/NoKV/pb/fsmeta"
 	"google.golang.org/grpc"
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
 )
 
 // Executor is the fsmeta operation surface exported by the gRPC service.
@@ -81,7 +79,7 @@ func (s *Service) Create(ctx context.Context, req *fsmetapb.CreateRequest) (*fsm
 		return nil, err
 	}
 	if req == nil {
-		return nil, status.Error(codes.InvalidArgument, "fsmeta create request is required")
+		return nil, rpcInvalidArgument("fsmeta create request is required")
 	}
 	result, err := s.executor.Create(ctx, createRequestFromProto(req))
 	if err != nil {
@@ -98,7 +96,7 @@ func (s *Service) UpdateInode(ctx context.Context, req *fsmetapb.UpdateInodeRequ
 		return nil, err
 	}
 	if req == nil {
-		return nil, status.Error(codes.InvalidArgument, "fsmeta update inode request is required")
+		return nil, rpcInvalidArgument("fsmeta update inode request is required")
 	}
 	inode, err := s.executor.UpdateInode(ctx, updateInodeRequestFromProto(req))
 	if err != nil {
@@ -112,7 +110,7 @@ func (s *Service) Lookup(ctx context.Context, req *fsmetapb.LookupRequest) (*fsm
 		return nil, err
 	}
 	if req == nil {
-		return nil, status.Error(codes.InvalidArgument, "fsmeta lookup request is required")
+		return nil, rpcInvalidArgument("fsmeta lookup request is required")
 	}
 	record, err := s.executor.Lookup(ctx, lookupRequestFromProto(req))
 	if err != nil {
@@ -126,7 +124,7 @@ func (s *Service) ReadDir(ctx context.Context, req *fsmetapb.ReadDirRequest) (*f
 		return nil, err
 	}
 	if req == nil {
-		return nil, status.Error(codes.InvalidArgument, "fsmeta readdir request is required")
+		return nil, rpcInvalidArgument("fsmeta readdir request is required")
 	}
 	entries, err := s.executor.ReadDir(ctx, readDirRequestFromProto(req))
 	if err != nil {
@@ -144,7 +142,7 @@ func (s *Service) ReadDirPlus(ctx context.Context, req *fsmetapb.ReadDirRequest)
 		return nil, err
 	}
 	if req == nil {
-		return nil, status.Error(codes.InvalidArgument, "fsmeta readdirplus request is required")
+		return nil, rpcInvalidArgument("fsmeta readdirplus request is required")
 	}
 	entries, err := s.executor.ReadDirPlus(ctx, readDirRequestFromProto(req))
 	if err != nil {
@@ -167,7 +165,7 @@ func (s *Service) WatchSubtree(stream fsmetapb.FSMetadata_WatchSubtreeServer) er
 	}
 	subscribe := first.GetSubscribe()
 	if subscribe == nil {
-		return status.Error(codes.InvalidArgument, "fsmeta watch first message must subscribe")
+		return rpcInvalidArgument("fsmeta watch first message must subscribe")
 	}
 	watchReq := watchRequestFromProto(subscribe)
 	sub, err := s.watcher.Subscribe(stream.Context(), watchReq)
@@ -195,7 +193,7 @@ func (s *Service) WatchSubtree(stream fsmetapb.FSMetadata_WatchSubtreeServer) er
 				sub.Ack(watchCursorFromProto(ack.GetCursor()))
 				continue
 			}
-			recvErr <- status.Error(codes.InvalidArgument, "fsmeta watch stream only accepts ack after subscribe")
+			recvErr <- rpcInvalidArgument("fsmeta watch stream only accepts ack after subscribe")
 			return
 		}
 	}()
@@ -224,7 +222,7 @@ func (s *Service) SnapshotSubtree(ctx context.Context, req *fsmetapb.SnapshotSub
 		return nil, err
 	}
 	if req == nil {
-		return nil, status.Error(codes.InvalidArgument, "fsmeta snapshot subtree request is required")
+		return nil, rpcInvalidArgument("fsmeta snapshot subtree request is required")
 	}
 	token, err := s.executor.SnapshotSubtree(ctx, snapshotSubtreeRequestFromProto(req))
 	if err != nil {
@@ -243,10 +241,10 @@ func (s *Service) SnapshotSubtree(ctx context.Context, req *fsmetapb.SnapshotSub
 
 func (s *Service) RetireSnapshotSubtree(ctx context.Context, req *fsmetapb.RetireSnapshotSubtreeRequest) (*fsmetapb.RetireSnapshotSubtreeResponse, error) {
 	if s == nil || s.snapshot == nil {
-		return nil, status.Error(codes.FailedPrecondition, "fsmeta snapshot publisher is not configured")
+		return nil, rpcServiceUnavailable("fsmeta snapshot publisher is not configured")
 	}
 	if req == nil {
-		return nil, status.Error(codes.InvalidArgument, "fsmeta retire snapshot subtree request is required")
+		return nil, rpcInvalidArgument("fsmeta retire snapshot subtree request is required")
 	}
 	if err := s.snapshot.RetireSnapshotSubtree(ctx, retireSnapshotSubtreeRequestFromProto(req)); err != nil {
 		return nil, rpcError(err)
@@ -259,7 +257,7 @@ func (s *Service) GetQuotaUsage(ctx context.Context, req *fsmetapb.QuotaUsageReq
 		return nil, err
 	}
 	if req == nil {
-		return nil, status.Error(codes.InvalidArgument, "fsmeta quota usage request is required")
+		return nil, rpcInvalidArgument("fsmeta quota usage request is required")
 	}
 	usage, err := s.executor.GetQuotaUsage(ctx, quotaUsageRequestFromProto(req))
 	if err != nil {
@@ -273,7 +271,7 @@ func (s *Service) RenameSubtree(ctx context.Context, req *fsmetapb.RenameSubtree
 		return nil, err
 	}
 	if req == nil {
-		return nil, status.Error(codes.InvalidArgument, "fsmeta rename subtree request is required")
+		return nil, rpcInvalidArgument("fsmeta rename subtree request is required")
 	}
 	if err := s.executor.RenameSubtree(ctx, renameSubtreeRequestFromProto(req)); err != nil {
 		return nil, rpcError(err)
@@ -286,7 +284,7 @@ func (s *Service) Link(ctx context.Context, req *fsmetapb.LinkRequest) (*fsmetap
 		return nil, err
 	}
 	if req == nil {
-		return nil, status.Error(codes.InvalidArgument, "fsmeta link request is required")
+		return nil, rpcInvalidArgument("fsmeta link request is required")
 	}
 	if err := s.executor.Link(ctx, linkRequestFromProto(req)); err != nil {
 		return nil, rpcError(err)
@@ -299,7 +297,7 @@ func (s *Service) Unlink(ctx context.Context, req *fsmetapb.UnlinkRequest) (*fsm
 		return nil, err
 	}
 	if req == nil {
-		return nil, status.Error(codes.InvalidArgument, "fsmeta unlink request is required")
+		return nil, rpcInvalidArgument("fsmeta unlink request is required")
 	}
 	if err := s.executor.Unlink(ctx, unlinkRequestFromProto(req)); err != nil {
 		return nil, rpcError(err)
@@ -312,7 +310,7 @@ func (s *Service) OpenWriteSession(ctx context.Context, req *fsmetapb.OpenWriteS
 		return nil, err
 	}
 	if req == nil {
-		return nil, status.Error(codes.InvalidArgument, "fsmeta open write session request is required")
+		return nil, rpcInvalidArgument("fsmeta open write session request is required")
 	}
 	record, err := s.executor.OpenWriteSession(ctx, openWriteSessionRequestFromProto(req))
 	if err != nil {
@@ -326,7 +324,7 @@ func (s *Service) HeartbeatWriteSession(ctx context.Context, req *fsmetapb.Heart
 		return nil, err
 	}
 	if req == nil {
-		return nil, status.Error(codes.InvalidArgument, "fsmeta heartbeat write session request is required")
+		return nil, rpcInvalidArgument("fsmeta heartbeat write session request is required")
 	}
 	record, err := s.executor.HeartbeatWriteSession(ctx, heartbeatWriteSessionRequestFromProto(req))
 	if err != nil {
@@ -340,7 +338,7 @@ func (s *Service) CloseWriteSession(ctx context.Context, req *fsmetapb.CloseWrit
 		return nil, err
 	}
 	if req == nil {
-		return nil, status.Error(codes.InvalidArgument, "fsmeta close write session request is required")
+		return nil, rpcInvalidArgument("fsmeta close write session request is required")
 	}
 	if err := s.executor.CloseWriteSession(ctx, closeWriteSessionRequestFromProto(req)); err != nil {
 		return nil, rpcError(err)
@@ -353,7 +351,7 @@ func (s *Service) ExpireWriteSessions(ctx context.Context, req *fsmetapb.ExpireW
 		return nil, err
 	}
 	if req == nil {
-		return nil, status.Error(codes.InvalidArgument, "fsmeta expire write sessions request is required")
+		return nil, rpcInvalidArgument("fsmeta expire write sessions request is required")
 	}
 	result, err := s.executor.ExpireWriteSessions(ctx, expireWriteSessionsRequestFromProto(req))
 	if err != nil {
@@ -364,14 +362,14 @@ func (s *Service) ExpireWriteSessions(ctx context.Context, req *fsmetapb.ExpireW
 
 func (s *Service) requireExecutor() error {
 	if s == nil || s.executor == nil {
-		return status.Error(codes.FailedPrecondition, "fsmeta executor is not configured")
+		return rpcServiceUnavailable("fsmeta executor is not configured")
 	}
 	return nil
 }
 
 func (s *Service) requireWatcher() error {
 	if s == nil || s.watcher == nil {
-		return status.Error(codes.FailedPrecondition, "fsmeta watcher is not configured")
+		return rpcServiceUnavailable("fsmeta watcher is not configured")
 	}
 	return nil
 }

--- a/fsmeta/server/service_test.go
+++ b/fsmeta/server/service_test.go
@@ -357,17 +357,18 @@ func TestGRPCServiceReadDirAndMutationRPCs(t *testing.T) {
 
 func TestGRPCServiceErrorMapping(t *testing.T) {
 	tests := []struct {
-		name string
-		err  error
-		code codes.Code
+		name   string
+		err    error
+		code   codes.Code
+		reason string
 	}{
-		{name: "exists", err: fsmeta.ErrExists, code: codes.AlreadyExists},
-		{name: "not found", err: fsmeta.ErrNotFound, code: codes.NotFound},
-		{name: "invalid", err: fsmeta.ErrInvalidName, code: codes.InvalidArgument},
-		{name: "quota exceeded", err: fsmeta.ErrQuotaExceeded, code: codes.ResourceExhausted},
-		{name: "watch overflow", err: fsmeta.ErrWatchOverflow, code: codes.ResourceExhausted},
-		{name: "watch cursor expired", err: fsmeta.ErrWatchCursorExpired, code: codes.OutOfRange},
-		{name: "mount retired", err: fsmeta.ErrMountRetired, code: codes.FailedPrecondition},
+		{name: "exists", err: fsmeta.ErrExists, code: codes.AlreadyExists, reason: reasonNamespaceExists},
+		{name: "not found", err: fsmeta.ErrNotFound, code: codes.NotFound, reason: reasonNamespaceNotFound},
+		{name: "invalid", err: fsmeta.ErrInvalidName, code: codes.InvalidArgument, reason: reasonInvalidFSMetaInput},
+		{name: "quota exceeded", err: fsmeta.ErrQuotaExceeded, code: codes.ResourceExhausted, reason: reasonQuotaExceeded},
+		{name: "watch overflow", err: fsmeta.ErrWatchOverflow, code: codes.ResourceExhausted, reason: reasonWatchOverflow},
+		{name: "watch cursor expired", err: fsmeta.ErrWatchCursorExpired, code: codes.OutOfRange, reason: reasonWatchCursorExpired},
+		{name: "mount retired", err: fsmeta.ErrMountRetired, code: codes.FailedPrecondition, reason: reasonMountRetired},
 		{name: "retry exhausted", err: nokverrors.New(nokverrors.KindRetryExhausted, "fsmeta: retry exhausted"), code: codes.Unavailable},
 		{name: "internal", err: errors.New("boom"), code: codes.Internal},
 	}
@@ -382,6 +383,12 @@ func TestGRPCServiceErrorMapping(t *testing.T) {
 			})
 			require.Error(t, err)
 			require.Equal(t, tt.code, status.Code(err))
+			if tt.reason != "" {
+				kind, metadata, ok := nokverrors.RPCErrorInfo(err)
+				require.True(t, ok)
+				require.Equal(t, nokverrors.KindOf(tt.err), kind)
+				require.Equal(t, tt.reason, metadata[fsmetaReasonMetadata])
+			}
 		})
 	}
 }

--- a/fsmeta/value.go
+++ b/fsmeta/value.go
@@ -5,6 +5,25 @@ import (
 	"fmt"
 )
 
+// fsmeta value layout:
+//
+//	common prefix:
+//	  magic[4] = "fsv\0"
+//	  version  = 0x01
+//	  kind byte
+//
+//	kind bodies:
+//	  inode   'i' : inode be64 | type byte | size be64 | mode be32 |
+//	                link_count be32 | created_unix_ns be64 |
+//	                updated_unix_ns be64 | opaque_len uvarint | opaque bytes
+//	  dentry  'd' : parent inode be64 | name_len uvarint | name bytes |
+//	                inode be64 | type byte
+//	  session 's' : session_len uvarint | session bytes | inode be64 |
+//	                expires_unix_ns be64
+//	  usage   'u' : bytes be64 | inodes be64
+//
+// Decode rejects unsupported versions and wrong value families at the public
+// decode entry points, keeping namespace corruption visible to callers.
 var valueMagic = []byte{'f', 's', 'v', 0}
 
 const valueSchemaVersion byte = 1

--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/stretchr/testify v1.11.1
 	go.etcd.io/raft/v3 v3.6.0
 	golang.org/x/sys v0.43.0
+	google.golang.org/genproto/googleapis/rpc v0.0.0-20260226221140-a57be14db171
 	google.golang.org/grpc v1.81.0
 	google.golang.org/protobuf v1.36.11
 )
@@ -27,7 +28,6 @@ require (
 	golang.org/x/net v0.51.0 // indirect
 	golang.org/x/sync v0.20.0 // indirect
 	golang.org/x/text v0.34.0 // indirect
-	google.golang.org/genproto/googleapis/rpc v0.0.0-20260226221140-a57be14db171 // indirect
 	gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/local/errkind/classify.go
+++ b/local/errkind/classify.go
@@ -13,8 +13,10 @@ import (
 
 // Classify maps local DB and embedded-engine errors to the stable
 // cross-boundary error taxonomy. Engine and utils packages intentionally keep
-// their local sentinels and do not import the root errors package; callers
-// should use this at DB, RPC, or fsmeta/runtime/local boundaries.
+// their local sentinels and do not import the root errors package; public DB,
+// runtime, or RPC boundaries should classify them here before deciding retry,
+// abort, or corruption handling. Package-private control-flow sentinels stay
+// Unknown and must not escape as public API decisions.
 func Classify(err error) nokverrors.Kind {
 	if err == nil {
 		return nokverrors.KindUnknown

--- a/meta/root/client/client.go
+++ b/meta/root/client/client.go
@@ -8,6 +8,7 @@ package client
 
 import (
 	"context"
+	"errors"
 	"slices"
 	"strconv"
 	"strings"
@@ -29,7 +30,12 @@ import (
 const defaultCallTimeout = 3 * time.Second
 
 const errMetadataRootNotLeader = "metadata root not leader"
-const errClientConnectionClosing = "grpc: the client connection is closing"
+
+const (
+	metaRootReasonMetadata = "meta_root_reason"
+	leaderIDMetadata       = "leader_id"
+	reasonNotLeader        = "not_leader"
+)
 
 // Client is a remote metadata-root backend client. It implements the same
 // authority surface consumed by coordinator/rootview.OpenRootRemoteStore.
@@ -447,24 +453,24 @@ func retryableRemoteError(err error, write bool) bool {
 }
 
 func transientConnectionClosing(err error) bool {
-	return err != nil && strings.Contains(err.Error(), errClientConnectionClosing)
+	// gRPC does not expose a non-deprecated replacement that distinguishes a
+	// local ClientConn shutdown from ordinary application-level Canceled. The
+	// retry path needs that distinction, so keep the transport sentinel here and
+	// keep protocol errors on nokverrors.Kind/RPC metadata elsewhere.
+	//nolint:staticcheck
+	return errors.Is(err, grpc.ErrClientConnClosing)
 }
 
 func leaderHint(err error) (uint64, bool) {
-	msg := err.Error()
-	idx := strings.Index(msg, "leader_id=")
-	if idx < 0 {
+	kind, metadata, ok := nokverrors.RPCErrorInfo(err)
+	if !ok || kind != nokverrors.KindNotLeader || metadata[metaRootReasonMetadata] != reasonNotLeader {
 		return 0, false
 	}
-	start := idx + len("leader_id=")
-	end := start
-	for end < len(msg) && msg[end] >= '0' && msg[end] <= '9' {
-		end++
-	}
-	if end == start {
+	raw := metadata[leaderIDMetadata]
+	if raw == "" {
 		return 0, false
 	}
-	id, parseErr := strconv.ParseUint(msg[start:end], 10, 64)
+	id, parseErr := strconv.ParseUint(raw, 10, 64)
 	if parseErr != nil || id == 0 {
 		return 0, false
 	}

--- a/meta/root/client/client_test.go
+++ b/meta/root/client/client_test.go
@@ -2,9 +2,12 @@ package client
 
 import (
 	"context"
+	stderrors "errors"
+	"strconv"
 	"testing"
 	"time"
 
+	nokverrors "github.com/feichai0017/NoKV/errors"
 	metapb "github.com/feichai0017/NoKV/pb/meta"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
@@ -13,20 +16,24 @@ import (
 )
 
 func TestRetryableRemoteErrorConnectionClosing(t *testing.T) {
-	err := status.Error(codes.Canceled, errClientConnectionClosing)
+	err := clientConnClosingErrForTest()
 	require.True(t, retryableRemoteError(err, false))
 	require.True(t, retryableRemoteError(err, true))
 }
 
 func TestRetryableRemoteErrorWrappedConnectionClosing(t *testing.T) {
-	inner := status.Error(codes.Canceled, errClientConnectionClosing)
-	err := status.Error(codes.Internal, inner.Error())
+	err := stderrors.Join(clientConnClosingErrForTest(), status.Error(codes.Internal, "transport closing"))
 	require.True(t, retryableRemoteError(err, false))
 	require.True(t, retryableRemoteError(err, true))
 }
 
+func clientConnClosingErrForTest() error {
+	//nolint:staticcheck
+	return grpc.ErrClientConnClosing
+}
+
 func TestRetryableRemoteErrorMetadataRootNotLeaderIsWriteOnly(t *testing.T) {
-	err := status.Error(codes.FailedPrecondition, errMetadataRootNotLeader+" (leader_id=2)")
+	err := metadataRootNotLeaderErrorForTest(2)
 	require.False(t, retryableRemoteError(err, false))
 	require.True(t, retryableRemoteError(err, true))
 }
@@ -109,13 +116,23 @@ func TestClientHelpersAndOrdering(t *testing.T) {
 	require.True(t, validGrantAct(1))
 	require.False(t, validGrantAct(99))
 
-	leaderID, ok := leaderHint(status.Error(codes.FailedPrecondition, errMetadataRootNotLeader+" (leader_id=23)"))
+	leaderID, ok := leaderHint(metadataRootNotLeaderErrorForTest(23))
 	require.True(t, ok)
 	require.Equal(t, uint64(23), leaderID)
-	_, ok = leaderHint(status.Error(codes.FailedPrecondition, "metadata root not leader"))
+	_, ok = leaderHint(nokverrors.RPCStatusError(nokverrors.KindNotLeader, codes.FailedPrecondition, errMetadataRootNotLeader, map[string]string{
+		metaRootReasonMetadata: reasonNotLeader,
+	}))
 	require.False(t, ok)
 
 	require.NoError(t, waitForReady(context.Background(), nil))
+}
+
+func metadataRootNotLeaderErrorForTest(leaderID uint64) error {
+	metadata := map[string]string{metaRootReasonMetadata: reasonNotLeader}
+	if leaderID != 0 {
+		metadata[leaderIDMetadata] = strconv.FormatUint(leaderID, 10)
+	}
+	return nokverrors.RPCStatusError(nokverrors.KindNotLeader, codes.FailedPrecondition, errMetadataRootNotLeader, metadata)
 }
 
 func TestInvokeRejectsNilCanceledAndEmptyClients(t *testing.T) {
@@ -147,7 +164,7 @@ func TestInvokeWriteRetriesToLeaderHint(t *testing.T) {
 				rpc: &fakeMetadataRootClient{
 					statusFunc: func(context.Context, *metapb.MetadataRootStatusRequest, ...grpc.CallOption) (*metapb.MetadataRootStatusResponse, error) {
 						followerCalls++
-						return nil, status.Error(codes.FailedPrecondition, errMetadataRootNotLeader+" (leader_id=2)")
+						return nil, metadataRootNotLeaderErrorForTest(2)
 					},
 				},
 			},
@@ -184,7 +201,7 @@ func TestInvokeReadDoesNotRetryNotLeaderHint(t *testing.T) {
 				rpc: &fakeMetadataRootClient{
 					statusFunc: func(context.Context, *metapb.MetadataRootStatusRequest, ...grpc.CallOption) (*metapb.MetadataRootStatusResponse, error) {
 						followerCalls++
-						return nil, status.Error(codes.FailedPrecondition, errMetadataRootNotLeader+" (leader_id=2)")
+						return nil, metadataRootNotLeaderErrorForTest(2)
 					},
 				},
 			},
@@ -205,7 +222,7 @@ func TestInvokeReadDoesNotRetryNotLeaderHint(t *testing.T) {
 		return rpc.Status(ctx, &metapb.MetadataRootStatusRequest{})
 	})
 	require.Error(t, err)
-	require.Contains(t, err.Error(), errMetadataRootNotLeader)
+	require.Equal(t, nokverrors.KindNotLeader, nokverrors.KindOf(err))
 	require.Equal(t, 1, followerCalls)
 	require.Zero(t, leaderCalls)
 }

--- a/meta/root/client/errors_test.go
+++ b/meta/root/client/errors_test.go
@@ -6,7 +6,6 @@ import (
 	nokverrors "github.com/feichai0017/NoKV/errors"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
 )
 
 func TestMetadataRootClientErrorsExposeStableKinds(t *testing.T) {
@@ -17,7 +16,10 @@ func TestMetadataRootClientErrorsExposeStableKinds(t *testing.T) {
 	require.Equal(t, nokverrors.KindUnavailable, nokverrors.KindOf(errNoReachableEndpoint))
 	require.True(t, nokverrors.Retryable(errNoReachableEndpoint))
 
-	notLeader := status.Error(codes.FailedPrecondition, errMetadataRootNotLeader+" (leader_id=2)")
+	notLeader := nokverrors.RPCStatusError(nokverrors.KindNotLeader, codes.FailedPrecondition, errMetadataRootNotLeader, map[string]string{
+		metaRootReasonMetadata: reasonNotLeader,
+		leaderIDMetadata:       "2",
+	})
 	require.Equal(t, nokverrors.KindNotLeader, nokverrors.KindOf(notLeader))
 	require.True(t, nokverrors.Retryable(notLeader))
 }

--- a/meta/root/replicated/errors.go
+++ b/meta/root/replicated/errors.go
@@ -1,8 +1,13 @@
 package replicated
 
 import (
+	"context"
 	"errors"
 	"fmt"
+
+	nokverrors "github.com/feichai0017/NoKV/errors"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 var (
@@ -17,6 +22,37 @@ var (
 	errCommittedEventPayloadTooLarge  = errors.New("meta/root/replicated: committed event payload too large")
 	errInvalidCommittedEntryPayload   = errors.New("meta/root/replicated: invalid committed entry payload")
 )
+
+const (
+	rootTransportReasonMetadata = "meta_root_transport_reason"
+
+	reasonContextCanceled = "context_canceled"
+	reasonContextDeadline = "context_deadline"
+	reasonInternal        = "internal"
+)
+
+func rpcTransportStatus(err error) error {
+	if err == nil {
+		return nil
+	}
+	if _, ok := status.FromError(err); ok {
+		return err
+	}
+	switch {
+	case errors.Is(err, context.Canceled):
+		return rpcTransportError(nokverrors.KindAborted, codes.Canceled, err.Error(), reasonContextCanceled)
+	case errors.Is(err, context.DeadlineExceeded):
+		return rpcTransportError(nokverrors.KindUnavailable, codes.DeadlineExceeded, err.Error(), reasonContextDeadline)
+	default:
+		return rpcTransportError(nokverrors.KindUnavailable, codes.Internal, err.Error(), reasonInternal)
+	}
+}
+
+func rpcTransportError(kind nokverrors.Kind, code codes.Code, message, reason string) error {
+	return nokverrors.RPCStatusError(kind, code, message, map[string]string{
+		rootTransportReasonMetadata: reason,
+	})
+}
 
 func errPeerAddressUnknown(id uint64) error {
 	return fmt.Errorf("meta/root/replicated: peer %d address unknown", id)

--- a/meta/root/replicated/grpc_transport.go
+++ b/meta/root/replicated/grpc_transport.go
@@ -10,10 +10,8 @@ import (
 	myraft "github.com/feichai0017/NoKV/raft"
 	raftpb "go.etcd.io/raft/v3/raftpb"
 	"google.golang.org/grpc"
-	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/connectivity"
 	"google.golang.org/grpc/credentials/insecure"
-	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/types/known/emptypb"
 )
 
@@ -58,13 +56,7 @@ func (s *grpcTransportService) Step(ctx context.Context, msg *raftpb.Message) (*
 		return &emptypb.Empty{}, nil
 	}
 	if err := handler(myraft.Message(*msg)); err != nil {
-		if st, ok := status.FromError(err); ok {
-			return nil, st.Err()
-		}
-		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
-			return nil, status.FromContextError(err).Err()
-		}
-		return nil, status.Error(codes.Internal, err.Error())
+		return nil, rpcTransportStatus(err)
 	}
 	return &emptypb.Empty{}, nil
 }

--- a/meta/root/server/errors.go
+++ b/meta/root/server/errors.go
@@ -10,6 +10,18 @@ import (
 	"google.golang.org/grpc/status"
 )
 
+const (
+	metaRootReasonMetadata = "meta_root_reason"
+	leaderIDMetadata       = "leader_id"
+	reasonNotLeader        = "not_leader"
+	reasonInvalidArgument  = "invalid_argument"
+	reasonPrecondition     = "failed_precondition"
+	reasonInternal         = "internal"
+	reasonContextCanceled  = "context_canceled"
+	reasonContextDeadline  = "context_deadline"
+	reasonUnimplemented    = "unimplemented"
+)
+
 func rpcError(err error) error {
 	if err == nil {
 		return nil
@@ -19,11 +31,18 @@ func rpcError(err error) error {
 	}
 	switch {
 	case stderrors.Is(err, context.Canceled):
-		return status.Error(codes.Canceled, err.Error())
+		return nokverrors.RPCStatusError(nokverrors.KindAborted, codes.Canceled, err.Error(), map[string]string{
+			metaRootReasonMetadata: reasonContextCanceled,
+		})
 	case stderrors.Is(err, context.DeadlineExceeded):
-		return status.Error(codes.DeadlineExceeded, err.Error())
+		return nokverrors.RPCStatusError(nokverrors.KindUnavailable, codes.DeadlineExceeded, err.Error(), map[string]string{
+			metaRootReasonMetadata: reasonContextDeadline,
+		})
 	default:
-		return status.Error(rpcCodeForKind(nokverrors.KindOf(err)), err.Error())
+		kind := nokverrors.KindOf(err)
+		return nokverrors.RPCStatusError(kind, rpcCodeForKind(kind), err.Error(), map[string]string{
+			metaRootReasonMetadata: reasonInternal,
+		})
 	}
 }
 
@@ -55,24 +74,36 @@ func rpcCodeForKind(kind nokverrors.Kind) codes.Code {
 }
 
 func statusInvalidArgument(message string) error {
-	return status.Error(codes.InvalidArgument, nokverrors.New(nokverrors.KindInvalidArgument, message).Error())
+	return nokverrors.RPCStatusError(nokverrors.KindInvalidArgument, codes.InvalidArgument, message, map[string]string{
+		metaRootReasonMetadata: reasonInvalidArgument,
+	})
 }
 
 func statusFailedPrecondition(err error) error {
 	if err == nil {
 		return nil
 	}
-	return status.Error(codes.FailedPrecondition, err.Error())
+	kind := nokverrors.KindOf(err)
+	if kind == nokverrors.KindUnknown {
+		kind = nokverrors.KindProtocolViolation
+	}
+	return nokverrors.RPCStatusError(kind, codes.FailedPrecondition, err.Error(), map[string]string{
+		metaRootReasonMetadata: reasonPrecondition,
+	})
 }
 
 func statusUnimplemented(message string) error {
-	return status.Error(codes.Unimplemented, message)
+	return nokverrors.RPCStatusError(nokverrors.KindProtocolViolation, codes.Unimplemented, message, map[string]string{
+		metaRootReasonMetadata: reasonUnimplemented,
+	})
 }
 
 func statusNotLeader(leaderID uint64) error {
 	message := "metadata root not leader"
+	metadata := map[string]string{metaRootReasonMetadata: reasonNotLeader}
 	if leaderID != 0 {
 		message = fmt.Sprintf("%s (leader_id=%d)", message, leaderID)
+		metadata[leaderIDMetadata] = fmt.Sprintf("%d", leaderID)
 	}
-	return status.Error(codes.FailedPrecondition, nokverrors.New(nokverrors.KindNotLeader, message).Error())
+	return nokverrors.RPCStatusError(nokverrors.KindNotLeader, codes.FailedPrecondition, message, metadata)
 }

--- a/meta/root/server/errors_test.go
+++ b/meta/root/server/errors_test.go
@@ -77,5 +77,8 @@ func TestStatusHelpersExposeKinds(t *testing.T) {
 	notLeader := statusNotLeader(23)
 	require.Equal(t, codes.FailedPrecondition, status.Code(notLeader))
 	require.Equal(t, nokverrors.KindNotLeader, nokverrors.KindOf(notLeader))
-	require.Contains(t, notLeader.Error(), "leader_id=23")
+	_, metadata, ok := nokverrors.RPCErrorInfo(notLeader)
+	require.True(t, ok)
+	require.Equal(t, reasonNotLeader, metadata[metaRootReasonMetadata])
+	require.Equal(t, "23", metadata[leaderIDMetadata])
 }

--- a/meta/root/server/service_test.go
+++ b/meta/root/server/service_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	nokverrors "github.com/feichai0017/NoKV/errors"
 	metaregion "github.com/feichai0017/NoKV/meta/region"
 	rootevent "github.com/feichai0017/NoKV/meta/root/event"
 	rootproto "github.com/feichai0017/NoKV/meta/root/protocol"
@@ -218,14 +219,22 @@ func TestServiceAppendPaths(t *testing.T) {
 		svc := NewService(&fakeServiceBackend{isLeader: false, leaderID: 9})
 		_, err := svc.Append(context.Background(), &metapb.MetadataRootAppendRequest{})
 		require.Equal(t, codes.FailedPrecondition, status.Code(err))
-		require.Contains(t, err.Error(), "leader_id=9")
+		require.Equal(t, nokverrors.KindNotLeader, nokverrors.KindOf(err))
+		_, metadata, ok := nokverrors.RPCErrorInfo(err)
+		require.True(t, ok)
+		require.Equal(t, reasonNotLeader, metadata[metaRootReasonMetadata])
+		require.Equal(t, "9", metadata[leaderIDMetadata])
 	})
 
 	t.Run("non leader without leader id", func(t *testing.T) {
 		svc := NewService(&fakeServiceBackend{isLeader: false})
 		_, err := svc.Append(context.Background(), &metapb.MetadataRootAppendRequest{})
 		require.Equal(t, codes.FailedPrecondition, status.Code(err))
-		require.Contains(t, err.Error(), "metadata root not leader")
+		require.Equal(t, nokverrors.KindNotLeader, nokverrors.KindOf(err))
+		_, metadata, ok := nokverrors.RPCErrorInfo(err)
+		require.True(t, ok)
+		require.Equal(t, reasonNotLeader, metadata[metaRootReasonMetadata])
+		require.Empty(t, metadata[leaderIDMetadata])
 	})
 
 	t.Run("invalid event kind", func(t *testing.T) {

--- a/raftstore/admin/errors.go
+++ b/raftstore/admin/errors.go
@@ -1,0 +1,71 @@
+package admin
+
+import (
+	"fmt"
+
+	nokverrors "github.com/feichai0017/NoKV/errors"
+	"google.golang.org/grpc/codes"
+)
+
+const (
+	adminReasonMetadata = "raft_admin_reason"
+
+	reasonCanceled              = "canceled"
+	reasonInvalidRequest        = "invalid_request"
+	reasonServiceNotConfigured  = "service_not_configured"
+	reasonSnapshotNotConfigured = "snapshot_not_configured"
+	reasonRegionNotHosted       = "region_not_hosted"
+	reasonRegionNotLeader       = "region_not_leader"
+	reasonPrecondition          = "failed_precondition"
+	reasonInternal              = "internal"
+)
+
+func rpcCanceled(err error) error {
+	return rpcAdminError(nokverrors.KindAborted, codes.Canceled, err.Error(), reasonCanceled)
+}
+
+func rpcInvalidArgument(message string) error {
+	return rpcAdminError(nokverrors.KindInvalidArgument, codes.InvalidArgument, message, reasonInvalidRequest)
+}
+
+func rpcInvalidArgumentf(format string, args ...any) error {
+	return rpcInvalidArgument(fmt.Sprintf(format, args...))
+}
+
+func rpcServiceNotConfigured(message string) error {
+	return rpcAdminError(nokverrors.KindProtocolViolation, codes.FailedPrecondition, message, reasonServiceNotConfigured)
+}
+
+func rpcSnapshotNotConfigured(message string) error {
+	return rpcAdminError(nokverrors.KindProtocolViolation, codes.FailedPrecondition, message, reasonSnapshotNotConfigured)
+}
+
+func rpcPrecondition(err error) error {
+	kind := nokverrors.KindOf(err)
+	if kind == nokverrors.KindUnknown {
+		kind = nokverrors.KindProtocolViolation
+	}
+	return rpcAdminError(kind, codes.FailedPrecondition, err.Error(), reasonPrecondition)
+}
+
+func rpcPreconditionf(format string, args ...any) error {
+	return rpcAdminError(nokverrors.KindProtocolViolation, codes.FailedPrecondition, fmt.Sprintf(format, args...), reasonPrecondition)
+}
+
+func rpcNotFoundf(format string, args ...any) error {
+	return rpcAdminError(nokverrors.KindNotFound, codes.NotFound, fmt.Sprintf(format, args...), reasonRegionNotHosted)
+}
+
+func rpcNotLeaderf(format string, args ...any) error {
+	return rpcAdminError(nokverrors.KindNotLeader, codes.FailedPrecondition, fmt.Sprintf(format, args...), reasonRegionNotLeader)
+}
+
+func rpcInternalf(format string, args ...any) error {
+	return rpcAdminError(nokverrors.KindProtocolViolation, codes.Internal, fmt.Sprintf(format, args...), reasonInternal)
+}
+
+func rpcAdminError(kind nokverrors.Kind, code codes.Code, message, reason string) error {
+	return nokverrors.RPCStatusError(kind, code, message, map[string]string{
+		adminReasonMetadata: reason,
+	})
+}

--- a/raftstore/admin/service.go
+++ b/raftstore/admin/service.go
@@ -12,8 +12,6 @@ import (
 	snapshotpkg "github.com/feichai0017/NoKV/raftstore/snapshot"
 	"github.com/feichai0017/NoKV/raftstore/store"
 	raftpb "go.etcd.io/raft/v3/raftpb"
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
 )
 
 const snapshotStreamChunkSize = 64 << 10
@@ -40,13 +38,13 @@ func NewServiceWithSnapshot(st *store.Store, snapshot snapshotpkg.SnapshotStore)
 // AddPeer issues one raft configuration change on the region leader.
 func (s *Service) AddPeer(_ context.Context, req *adminpb.AddPeerRequest) (*adminpb.AddPeerResponse, error) {
 	if s == nil || s.store == nil {
-		return nil, status.Error(codes.FailedPrecondition, "raft admin service not configured")
+		return nil, rpcServiceNotConfigured("raft admin service not configured")
 	}
 	if req.GetRegionId() == 0 || req.GetStoreId() == 0 || req.GetPeerId() == 0 {
-		return nil, status.Error(codes.InvalidArgument, "region_id, store_id, and peer_id are required")
+		return nil, rpcInvalidArgument("region_id, store_id, and peer_id are required")
 	}
 	if err := s.store.AddPeer(req.GetRegionId(), metaregion.Peer{StoreID: req.GetStoreId(), PeerID: req.GetPeerId()}); err != nil {
-		return nil, status.Errorf(codes.FailedPrecondition, "%v", err)
+		return nil, rpcPrecondition(err)
 	}
 	runtime, ok := s.store.RegionRuntimeStatus(req.GetRegionId())
 	if !ok {
@@ -58,13 +56,13 @@ func (s *Service) AddPeer(_ context.Context, req *adminpb.AddPeerRequest) (*admi
 // RemovePeer issues one raft configuration change removing the specified peer.
 func (s *Service) RemovePeer(_ context.Context, req *adminpb.RemovePeerRequest) (*adminpb.RemovePeerResponse, error) {
 	if s == nil || s.store == nil {
-		return nil, status.Error(codes.FailedPrecondition, "raft admin service not configured")
+		return nil, rpcServiceNotConfigured("raft admin service not configured")
 	}
 	if req.GetRegionId() == 0 || req.GetPeerId() == 0 {
-		return nil, status.Error(codes.InvalidArgument, "region_id and peer_id are required")
+		return nil, rpcInvalidArgument("region_id and peer_id are required")
 	}
 	if err := s.store.RemovePeer(req.GetRegionId(), req.GetPeerId()); err != nil {
-		return nil, status.Errorf(codes.FailedPrecondition, "%v", err)
+		return nil, rpcPrecondition(err)
 	}
 	runtime, ok := s.store.RegionRuntimeStatus(req.GetRegionId())
 	if !ok {
@@ -76,16 +74,16 @@ func (s *Service) RemovePeer(_ context.Context, req *adminpb.RemovePeerRequest) 
 // TransferLeader requests leader transfer on the specified region.
 func (s *Service) TransferLeader(ctx context.Context, req *adminpb.TransferLeaderRequest) (*adminpb.TransferLeaderResponse, error) {
 	if err := ctx.Err(); err != nil {
-		return nil, status.Error(codes.Canceled, err.Error())
+		return nil, rpcCanceled(err)
 	}
 	if s == nil || s.store == nil {
-		return nil, status.Error(codes.FailedPrecondition, "raft admin service not configured")
+		return nil, rpcServiceNotConfigured("raft admin service not configured")
 	}
 	if req.GetRegionId() == 0 || req.GetPeerId() == 0 {
-		return nil, status.Error(codes.InvalidArgument, "region_id and peer_id are required")
+		return nil, rpcInvalidArgument("region_id and peer_id are required")
 	}
 	if err := s.store.TransferLeader(req.GetRegionId(), req.GetPeerId()); err != nil {
-		return nil, status.Errorf(codes.FailedPrecondition, "%v", err)
+		return nil, rpcPrecondition(err)
 	}
 	runtime, ok := s.store.RegionRuntimeStatus(req.GetRegionId())
 	if !ok {
@@ -98,7 +96,7 @@ func (s *Service) TransferLeader(ctx context.Context, req *adminpb.TransferLeade
 // encoded as one migration-only SST snapshot payload.
 func (s *Service) ExportRegionSnapshot(ctx context.Context, req *adminpb.ExportRegionSnapshotRequest) (*adminpb.ExportRegionSnapshotResponse, error) {
 	if err := ctx.Err(); err != nil {
-		return nil, status.Error(codes.Canceled, err.Error())
+		return nil, rpcCanceled(err)
 	}
 	region, header, reader, waitExport, err := s.startExportRegionSnapshot(ctx, req.GetRegionId())
 	if err != nil {
@@ -107,22 +105,22 @@ func (s *Service) ExportRegionSnapshot(ctx context.Context, req *adminpb.ExportR
 	defer func() { _ = reader.Close() }()
 	payload, err := io.ReadAll(reader)
 	if err != nil {
-		return nil, status.Errorf(codes.Internal, "export region snapshot payload: %v", err)
+		return nil, rpcInternalf("export region snapshot payload: %v", err)
 	}
 	if err := ctx.Err(); err != nil {
-		return nil, status.Error(codes.Canceled, err.Error())
+		return nil, rpcCanceled(err)
 	}
 	if err := waitExport(); err != nil {
-		return nil, status.Errorf(codes.Internal, "export sst region snapshot: %v", err)
+		return nil, rpcInternalf("export sst region snapshot: %v", err)
 	}
 	var snap raftpb.Snapshot
 	if err := snap.Unmarshal(header); err != nil {
-		return nil, status.Errorf(codes.Internal, "unmarshal region snapshot header: %v", err)
+		return nil, rpcInternalf("unmarshal region snapshot header: %v", err)
 	}
 	snap.Data = payload
 	data, err := (&snap).Marshal()
 	if err != nil {
-		return nil, status.Errorf(codes.Internal, "marshal region snapshot: %v", err)
+		return nil, rpcInternalf("marshal region snapshot: %v", err)
 	}
 	return &adminpb.ExportRegionSnapshotResponse{Snapshot: data, Region: localmeta.DescriptorToProto(region)}, nil
 }
@@ -132,7 +130,7 @@ func (s *Service) ExportRegionSnapshot(ctx context.Context, req *adminpb.ExportR
 func (s *Service) ExportRegionSnapshotStream(req *adminpb.ExportRegionSnapshotStreamRequest, stream adminpb.RaftAdmin_ExportRegionSnapshotStreamServer) error {
 	ctx := stream.Context()
 	if err := ctx.Err(); err != nil {
-		return status.Error(codes.Canceled, err.Error())
+		return rpcCanceled(err)
 	}
 	region, header, reader, waitExport, err := s.startExportRegionSnapshot(ctx, req.GetRegionId())
 	if err != nil {
@@ -143,7 +141,7 @@ func (s *Service) ExportRegionSnapshotStream(req *adminpb.ExportRegionSnapshotSt
 	first := true
 	for {
 		if err := ctx.Err(); err != nil {
-			return status.Error(codes.Canceled, err.Error())
+			return rpcCanceled(err)
 		}
 		n, readErr := reader.Read(buf)
 		if n > 0 || first {
@@ -161,11 +159,11 @@ func (s *Service) ExportRegionSnapshotStream(req *adminpb.ExportRegionSnapshotSt
 			break
 		}
 		if readErr != nil {
-			return status.Errorf(codes.Internal, "export region snapshot stream: %v", readErr)
+			return rpcInternalf("export region snapshot stream: %v", readErr)
 		}
 	}
 	if err := waitExport(); err != nil {
-		return status.Errorf(codes.Internal, "export sst region snapshot stream: %v", err)
+		return rpcInternalf("export sst region snapshot stream: %v", err)
 	}
 	return nil
 }
@@ -174,17 +172,17 @@ func (s *Service) ExportRegionSnapshotStream(req *adminpb.ExportRegionSnapshotSt
 // store. The local peer is bootstrapped on demand from the payload.
 func (s *Service) ImportRegionSnapshot(ctx context.Context, req *adminpb.ImportRegionSnapshotRequest) (*adminpb.ImportRegionSnapshotResponse, error) {
 	if err := ctx.Err(); err != nil {
-		return nil, status.Error(codes.Canceled, err.Error())
+		return nil, rpcCanceled(err)
 	}
 	if s == nil || s.store == nil {
-		return nil, status.Error(codes.FailedPrecondition, "raft admin service not configured")
+		return nil, rpcServiceNotConfigured("raft admin service not configured")
 	}
 	if len(req.GetSnapshot()) == 0 {
-		return nil, status.Error(codes.InvalidArgument, "snapshot is required")
+		return nil, rpcInvalidArgument("snapshot is required")
 	}
 	var snap raftpb.Snapshot
 	if err := snap.Unmarshal(req.GetSnapshot()); err != nil {
-		return nil, status.Errorf(codes.InvalidArgument, "unmarshal region snapshot: %v", err)
+		return nil, rpcInvalidArgumentf("unmarshal region snapshot: %v", err)
 	}
 	meta, err := s.importRegionSnapshot(ctx, snap, nil)
 	if err != nil {
@@ -199,34 +197,34 @@ func (s *Service) ImportRegionSnapshot(ctx context.Context, req *adminpb.ImportR
 func (s *Service) ImportRegionSnapshotStream(stream adminpb.RaftAdmin_ImportRegionSnapshotStreamServer) error {
 	ctx := stream.Context()
 	if err := ctx.Err(); err != nil {
-		return status.Error(codes.Canceled, err.Error())
+		return rpcCanceled(err)
 	}
 	if s == nil || s.store == nil {
-		return status.Error(codes.FailedPrecondition, "raft admin service not configured")
+		return rpcServiceNotConfigured("raft admin service not configured")
 	}
 	if s.snapshot == nil {
-		return status.Error(codes.FailedPrecondition, "sst snapshot import is not configured")
+		return rpcSnapshotNotConfigured("sst snapshot import is not configured")
 	}
 	first, err := stream.Recv()
 	if err == io.EOF {
-		return status.Error(codes.InvalidArgument, "snapshot stream is empty")
+		return rpcInvalidArgument("snapshot stream is empty")
 	}
 	if err != nil {
 		return err
 	}
 	if len(first.GetSnapshotHeader()) == 0 {
-		return status.Error(codes.InvalidArgument, "snapshot_header is required")
+		return rpcInvalidArgument("snapshot_header is required")
 	}
 	if first.GetRegion() == nil {
-		return status.Error(codes.InvalidArgument, "region is required")
+		return rpcInvalidArgument("region is required")
 	}
 	var snap raftpb.Snapshot
 	if err := snap.Unmarshal(first.GetSnapshotHeader()); err != nil {
-		return status.Errorf(codes.InvalidArgument, "unmarshal region snapshot header: %v", err)
+		return rpcInvalidArgumentf("unmarshal region snapshot header: %v", err)
 	}
 	meta, err := localmeta.FromDescriptorProto(first.GetRegion())
 	if err != nil {
-		return status.Errorf(codes.InvalidArgument, "decode region snapshot metadata: %v", err)
+		return rpcInvalidArgumentf("decode region snapshot metadata: %v", err)
 	}
 	pr, pw := io.Pipe()
 	resultCh := make(chan struct {
@@ -253,13 +251,13 @@ func (s *Service) ImportRegionSnapshotStream(stream adminpb.RaftAdmin_ImportRegi
 		if outcome.err != nil {
 			return outcome.err
 		}
-		return status.Errorf(codes.Internal, "write region snapshot stream: %v", err)
+		return rpcInternalf("write region snapshot stream: %v", err)
 	}
 	for {
 		if err := ctx.Err(); err != nil {
 			_ = pw.CloseWithError(err)
 			<-resultCh
-			return status.Error(codes.Canceled, err.Error())
+			return rpcCanceled(err)
 		}
 		req, recvErr := stream.Recv()
 		if recvErr == io.EOF {
@@ -278,7 +276,7 @@ func (s *Service) ImportRegionSnapshotStream(stream adminpb.RaftAdmin_ImportRegi
 			streamErr := fmt.Errorf("snapshot header repeated")
 			_ = pw.CloseWithError(streamErr)
 			<-resultCh
-			return status.Error(codes.InvalidArgument, "snapshot header may only appear in the first chunk")
+			return rpcInvalidArgument("snapshot header may only appear in the first chunk")
 		}
 		if err := writeChunk(req.GetChunk()); err != nil {
 			_ = pw.CloseWithError(err)
@@ -286,7 +284,7 @@ func (s *Service) ImportRegionSnapshotStream(stream adminpb.RaftAdmin_ImportRegi
 			if outcome.err != nil {
 				return outcome.err
 			}
-			return status.Errorf(codes.Internal, "write region snapshot stream: %v", err)
+			return rpcInternalf("write region snapshot stream: %v", err)
 		}
 	}
 	outcome := <-resultCh
@@ -299,13 +297,13 @@ func (s *Service) ImportRegionSnapshotStream(stream adminpb.RaftAdmin_ImportRegi
 // RegionRuntimeStatus returns store-local runtime information for one region.
 func (s *Service) RegionRuntimeStatus(ctx context.Context, req *adminpb.RegionRuntimeStatusRequest) (*adminpb.RegionRuntimeStatusResponse, error) {
 	if err := ctx.Err(); err != nil {
-		return nil, status.Error(codes.Canceled, err.Error())
+		return nil, rpcCanceled(err)
 	}
 	if s == nil || s.store == nil {
-		return nil, status.Error(codes.FailedPrecondition, "raft admin service not configured")
+		return nil, rpcServiceNotConfigured("raft admin service not configured")
 	}
 	if req.GetRegionId() == 0 {
-		return nil, status.Error(codes.InvalidArgument, "region_id is required")
+		return nil, rpcInvalidArgument("region_id is required")
 	}
 	runtime, ok := s.store.RegionRuntimeStatus(req.GetRegionId())
 	if !ok {
@@ -327,11 +325,11 @@ func (s *Service) RegionRuntimeStatus(ctx context.Context, req *adminpb.RegionRu
 // the store's admission, topology, and restart runtime state.
 func (s *Service) ExecutionStatus(ctx context.Context, req *adminpb.ExecutionStatusRequest) (*adminpb.ExecutionStatusResponse, error) {
 	if err := ctx.Err(); err != nil {
-		return nil, status.Error(codes.Canceled, err.Error())
+		return nil, rpcCanceled(err)
 	}
 	_ = req
 	if s == nil || s.store == nil {
-		return nil, status.Error(codes.FailedPrecondition, "raft admin service not configured")
+		return nil, rpcServiceNotConfigured("raft admin service not configured")
 	}
 	lastAdmission := s.store.LastAdmission()
 	topology := s.store.TopologyExecutions()
@@ -513,7 +511,7 @@ func (s *Service) prepareExportRegionSnapshot(regionID uint64) (localmeta.Region
 	headerSnap.Data = nil
 	header, err := (&headerSnap).Marshal()
 	if err != nil {
-		return localmeta.RegionMeta{}, nil, status.Errorf(codes.Internal, "marshal region snapshot header: %v", err)
+		return localmeta.RegionMeta{}, nil, rpcInternalf("marshal region snapshot header: %v", err)
 	}
 	return runtime.Meta, header, nil
 }
@@ -540,28 +538,28 @@ func (s *Service) startExportRegionSnapshot(ctx context.Context, regionID uint64
 
 func (s *Service) exportRegionSnapshot(regionID uint64) (store.RegionRuntimeStatus, raftpb.Snapshot, error) {
 	if s == nil || s.store == nil {
-		return store.RegionRuntimeStatus{}, raftpb.Snapshot{}, status.Error(codes.FailedPrecondition, "raft admin service not configured")
+		return store.RegionRuntimeStatus{}, raftpb.Snapshot{}, rpcServiceNotConfigured("raft admin service not configured")
 	}
 	if regionID == 0 {
-		return store.RegionRuntimeStatus{}, raftpb.Snapshot{}, status.Error(codes.InvalidArgument, "region_id is required")
+		return store.RegionRuntimeStatus{}, raftpb.Snapshot{}, rpcInvalidArgument("region_id is required")
 	}
 	runtime, ok := s.store.RegionRuntimeStatus(regionID)
 	if !ok || !runtime.Hosted {
-		return store.RegionRuntimeStatus{}, raftpb.Snapshot{}, status.Errorf(codes.NotFound, "region %d is not hosted on this store", regionID)
+		return store.RegionRuntimeStatus{}, raftpb.Snapshot{}, rpcNotFoundf("region %d is not hosted on this store", regionID)
 	}
 	if !runtime.Leader {
-		return store.RegionRuntimeStatus{}, raftpb.Snapshot{}, status.Errorf(codes.FailedPrecondition, "region %d is not led by this store", regionID)
+		return store.RegionRuntimeStatus{}, raftpb.Snapshot{}, rpcNotLeaderf("region %d is not led by this store", regionID)
 	}
 	peerRef, ok := s.store.Peer(runtime.LocalPeerID)
 	if !ok || peerRef == nil {
-		return store.RegionRuntimeStatus{}, raftpb.Snapshot{}, status.Errorf(codes.FailedPrecondition, "leader peer %d is not registered", runtime.LocalPeerID)
+		return store.RegionRuntimeStatus{}, raftpb.Snapshot{}, rpcPreconditionf("leader peer %d is not registered", runtime.LocalPeerID)
 	}
 	snap, err := peerRef.Snapshot()
 	if err != nil {
-		return store.RegionRuntimeStatus{}, raftpb.Snapshot{}, status.Errorf(codes.Internal, "export region snapshot: %v", err)
+		return store.RegionRuntimeStatus{}, raftpb.Snapshot{}, rpcInternalf("export region snapshot: %v", err)
 	}
 	if s.snapshot == nil {
-		return store.RegionRuntimeStatus{}, raftpb.Snapshot{}, status.Error(codes.FailedPrecondition, "sst snapshot export is not configured")
+		return store.RegionRuntimeStatus{}, raftpb.Snapshot{}, rpcSnapshotNotConfigured("sst snapshot export is not configured")
 	}
 	return runtime, raftpb.Snapshot(snap), nil
 }
@@ -598,16 +596,16 @@ func (s *Service) importRegionSnapshot(ctx context.Context, snap raftpb.Snapshot
 		ctx = context.Background()
 	}
 	if err := ctx.Err(); err != nil {
-		return localmeta.RegionMeta{}, status.Error(codes.Canceled, err.Error())
+		return localmeta.RegionMeta{}, rpcCanceled(err)
 	}
 	if s.snapshot == nil {
-		return localmeta.RegionMeta{}, status.Error(codes.FailedPrecondition, "sst snapshot import is not configured")
+		return localmeta.RegionMeta{}, rpcSnapshotNotConfigured("sst snapshot import is not configured")
 	}
 	var meta localmeta.RegionMeta
 	if streamed == nil {
 		metaFile, metaErr := snapshotpkg.ReadPayloadMeta(snap.Data)
 		if metaErr != nil {
-			return localmeta.RegionMeta{}, status.Errorf(codes.InvalidArgument, "decode sst snapshot payload: %v", metaErr)
+			return localmeta.RegionMeta{}, rpcInvalidArgumentf("decode sst snapshot payload: %v", metaErr)
 		}
 		meta = metaFile.Region
 	} else {
@@ -639,7 +637,7 @@ func (s *Service) importRegionSnapshot(ctx context.Context, snap raftpb.Snapshot
 		return result.Rollback, nil
 	})
 	if err != nil {
-		return localmeta.RegionMeta{}, status.Errorf(codes.FailedPrecondition, "%v", err)
+		return localmeta.RegionMeta{}, rpcPrecondition(err)
 	}
 	runtime, ok := s.store.RegionRuntimeStatus(installed.ID)
 	if !ok {

--- a/raftstore/admin/service_test.go
+++ b/raftstore/admin/service_test.go
@@ -3,12 +3,15 @@ package admin
 import (
 	"bytes"
 	"context"
+
+	nokverrors "github.com/feichai0017/NoKV/errors"
 	metaregion "github.com/feichai0017/NoKV/meta/region"
 	rootevent "github.com/feichai0017/NoKV/meta/root/event"
 	adminpb "github.com/feichai0017/NoKV/pb/admin"
 	kvrpcpb "github.com/feichai0017/NoKV/pb/kv"
 	metapb "github.com/feichai0017/NoKV/pb/meta"
 	raftcmdpb "github.com/feichai0017/NoKV/pb/raft"
+
 	"io"
 	"sync"
 	"testing"
@@ -26,7 +29,9 @@ import (
 	"github.com/feichai0017/NoKV/utils"
 	"github.com/stretchr/testify/require"
 	raftpb "go.etcd.io/raft/v3/raftpb"
+	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/status"
 )
 
 type noopTransport struct{}
@@ -300,28 +305,37 @@ func TestServiceValidationAndHelperMappings(t *testing.T) {
 	var nilSvc *Service
 	_, err := nilSvc.AddPeer(context.Background(), &adminpb.AddPeerRequest{})
 	require.ErrorContains(t, err, "raft admin service not configured")
+	requireAdminRPCError(t, err, codes.FailedPrecondition, nokverrors.KindProtocolViolation, reasonServiceNotConfigured)
 	_, err = nilSvc.RemovePeer(context.Background(), &adminpb.RemovePeerRequest{})
 	require.ErrorContains(t, err, "raft admin service not configured")
+	requireAdminRPCError(t, err, codes.FailedPrecondition, nokverrors.KindProtocolViolation, reasonServiceNotConfigured)
 
 	svc := &Service{store: new(store.Store)}
 	_, err = svc.AddPeer(context.Background(), &adminpb.AddPeerRequest{})
 	require.ErrorContains(t, err, "region_id, store_id, and peer_id are required")
+	requireAdminRPCError(t, err, codes.InvalidArgument, nokverrors.KindInvalidArgument, reasonInvalidRequest)
 	_, err = svc.RemovePeer(context.Background(), &adminpb.RemovePeerRequest{})
 	require.ErrorContains(t, err, "region_id and peer_id are required")
+	requireAdminRPCError(t, err, codes.InvalidArgument, nokverrors.KindInvalidArgument, reasonInvalidRequest)
 	_, err = svc.TransferLeader(context.Background(), &adminpb.TransferLeaderRequest{})
 	require.ErrorContains(t, err, "region_id and peer_id are required")
+	requireAdminRPCError(t, err, codes.InvalidArgument, nokverrors.KindInvalidArgument, reasonInvalidRequest)
 
 	canceled, cancel := context.WithCancel(context.Background())
 	cancel()
 	_, err = svc.TransferLeader(canceled, &adminpb.TransferLeaderRequest{RegionId: 1, PeerId: 2})
 	require.ErrorContains(t, err, context.Canceled.Error())
+	requireAdminRPCError(t, err, codes.Canceled, nokverrors.KindAborted, reasonCanceled)
 	_, err = svc.RegionRuntimeStatus(canceled, &adminpb.RegionRuntimeStatusRequest{RegionId: 1})
 	require.ErrorContains(t, err, context.Canceled.Error())
+	requireAdminRPCError(t, err, codes.Canceled, nokverrors.KindAborted, reasonCanceled)
 	_, err = svc.ExecutionStatus(canceled, &adminpb.ExecutionStatusRequest{})
 	require.ErrorContains(t, err, context.Canceled.Error())
+	requireAdminRPCError(t, err, codes.Canceled, nokverrors.KindAborted, reasonCanceled)
 
 	_, err = svc.RegionRuntimeStatus(context.Background(), &adminpb.RegionRuntimeStatusRequest{})
 	require.ErrorContains(t, err, "region_id is required")
+	requireAdminRPCError(t, err, codes.InvalidArgument, nokverrors.KindInvalidArgument, reasonInvalidRequest)
 
 	resp, err := svc.RegionRuntimeStatus(context.Background(), &adminpb.RegionRuntimeStatusRequest{RegionId: 99})
 	require.NoError(t, err)
@@ -388,6 +402,16 @@ func TestServiceValidationAndHelperMappings(t *testing.T) {
 	require.True(t, matchesSnapshotRegion(header, payload))
 	payload.Peers[0].PeerID = 202
 	require.False(t, matchesSnapshotRegion(header, payload))
+}
+
+func requireAdminRPCError(t *testing.T, err error, code codes.Code, kind nokverrors.Kind, reason string) {
+	t.Helper()
+	require.Equal(t, code, status.Code(err))
+	require.Equal(t, kind, nokverrors.KindOf(err))
+	gotKind, metadata, ok := nokverrors.RPCErrorInfo(err)
+	require.True(t, ok)
+	require.Equal(t, kind, gotKind)
+	require.Equal(t, reason, metadata[adminReasonMetadata])
 }
 
 func TestServiceExportsAndInstallsRegionSnapshot(t *testing.T) {

--- a/raftstore/kv/errors.go
+++ b/raftstore/kv/errors.go
@@ -1,11 +1,75 @@
 package kv
 
-import "errors"
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	nokverrors "github.com/feichai0017/NoKV/errors"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
 
 var (
 	errStoreNotInitialized = errors.New("raftstore: store not initialized")
 )
 
+const (
+	kvReasonMetadata = "raftstore_kv_reason"
+
+	reasonInvalidRequest        = "invalid_request"
+	reasonServiceNotInitialized = "service_not_initialized"
+	reasonUnsupportedOperation  = "unsupported_operation"
+	reasonProtocolViolation     = "protocol_violation"
+	reasonContextCanceled       = "context_canceled"
+	reasonContextDeadline       = "context_deadline"
+	reasonInternal              = "internal"
+)
+
 func IsStoreNotInitialized(err error) bool {
 	return errors.Is(err, errStoreNotInitialized)
+}
+
+func rpcInvalidArgument(message string) error {
+	return rpcKVError(nokverrors.KindInvalidArgument, codes.InvalidArgument, message, reasonInvalidRequest)
+}
+
+func rpcServiceNotInitialized() error {
+	return rpcKVError(nokverrors.KindProtocolViolation, codes.FailedPrecondition, errStoreNotInitialized.Error(), reasonServiceNotInitialized)
+}
+
+func rpcUnsupported(message string) error {
+	return rpcKVError(nokverrors.KindProtocolViolation, codes.Unimplemented, message, reasonUnsupportedOperation)
+}
+
+func rpcProtocolPrecondition(message string) error {
+	return rpcKVError(nokverrors.KindProtocolViolation, codes.FailedPrecondition, message, reasonProtocolViolation)
+}
+
+func raftPayloadError(op, detail string) error {
+	msg := fmt.Sprintf("raftstore/kv: %s response protocol violation: %s", op, detail)
+	return rpcProtocolPrecondition(msg)
+}
+
+func rpcStatus(err error) error {
+	if err == nil {
+		return nil
+	}
+	if _, ok := status.FromError(err); ok {
+		return err
+	}
+	switch {
+	case errors.Is(err, context.Canceled):
+		return rpcKVError(nokverrors.KindAborted, codes.Canceled, err.Error(), reasonContextCanceled)
+	case errors.Is(err, context.DeadlineExceeded):
+		return rpcKVError(nokverrors.KindUnavailable, codes.DeadlineExceeded, err.Error(), reasonContextDeadline)
+	default:
+		return rpcKVError(nokverrors.KindUnavailable, codes.Internal, err.Error(), reasonInternal)
+	}
+}
+
+func rpcKVError(kind nokverrors.Kind, code codes.Code, message, reason string) error {
+	return nokverrors.RPCStatusError(kind, code, message, map[string]string{
+		kvReasonMetadata: reason,
+	})
 }

--- a/raftstore/kv/service.go
+++ b/raftstore/kv/service.go
@@ -2,17 +2,13 @@ package kv
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"time"
 
-	nokverrors "github.com/feichai0017/NoKV/errors"
 	kvrpcpb "github.com/feichai0017/NoKV/pb/kv"
 	raftcmdpb "github.com/feichai0017/NoKV/pb/raft"
 
 	"github.com/feichai0017/NoKV/raftstore/store"
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
 )
 
 // Service exposes StoreKV gRPC handlers backed by a raftstore Store.
@@ -61,11 +57,11 @@ func txnHeartBeatRequestWithServiceTime(req *kvrpcpb.TxnHeartBeatRequest) *kvrpc
 func (s *Service) Get(ctx context.Context, req *kvrpcpb.KvGetRequest) (*kvrpcpb.KvGetResponse, error) {
 	header, err := buildHeader(req.GetContext())
 	if err != nil {
-		return nil, status.Errorf(codes.InvalidArgument, "%v", err)
+		return nil, rpcInvalidArgument(err.Error())
 	}
 	readReq := req.GetRequest()
 	if readReq == nil {
-		return nil, status.Error(codes.InvalidArgument, "get request missing payload")
+		return nil, rpcInvalidArgument("get request missing payload")
 	}
 	cmd := &raftcmdpb.RaftCmdRequest{
 		Header: header,
@@ -96,11 +92,11 @@ func (s *Service) Get(ctx context.Context, req *kvrpcpb.KvGetRequest) (*kvrpcpb.
 func (s *Service) BatchGet(ctx context.Context, req *kvrpcpb.KvBatchGetRequest) (*kvrpcpb.KvBatchGetResponse, error) {
 	header, err := buildHeader(req.GetContext())
 	if err != nil {
-		return nil, status.Errorf(codes.InvalidArgument, "%v", err)
+		return nil, rpcInvalidArgument(err.Error())
 	}
 	batch := req.GetRequest()
 	if batch == nil {
-		return nil, status.Error(codes.InvalidArgument, "batch get request missing payload")
+		return nil, rpcInvalidArgument("batch get request missing payload")
 	}
 	if len(batch.GetRequests()) == 0 {
 		return &kvrpcpb.KvBatchGetResponse{
@@ -145,14 +141,14 @@ func (s *Service) BatchGet(ctx context.Context, req *kvrpcpb.KvBatchGetRequest) 
 func (s *Service) Scan(ctx context.Context, req *kvrpcpb.KvScanRequest) (*kvrpcpb.KvScanResponse, error) {
 	header, err := buildHeader(req.GetContext())
 	if err != nil {
-		return nil, status.Errorf(codes.InvalidArgument, "%v", err)
+		return nil, rpcInvalidArgument(err.Error())
 	}
 	scanReq := req.GetRequest()
 	if scanReq == nil {
-		return nil, status.Error(codes.InvalidArgument, "scan request missing payload")
+		return nil, rpcInvalidArgument("scan request missing payload")
 	}
 	if scanReq.GetReverse() {
-		return nil, status.Error(codes.Unimplemented, "StoreKV Scan reverse scans are not supported yet")
+		return nil, rpcUnsupported("StoreKV Scan reverse scans are not supported yet")
 	}
 	cmd := &raftcmdpb.RaftCmdRequest{
 		Header: header,
@@ -183,10 +179,10 @@ func (s *Service) Scan(ctx context.Context, req *kvrpcpb.KvScanRequest) (*kvrpcp
 func (s *Service) Prewrite(ctx context.Context, req *kvrpcpb.KvPrewriteRequest) (*kvrpcpb.KvPrewriteResponse, error) {
 	header, err := buildHeader(req.GetContext())
 	if err != nil {
-		return nil, status.Errorf(codes.InvalidArgument, "%v", err)
+		return nil, rpcInvalidArgument(err.Error())
 	}
 	if req.GetRequest() == nil {
-		return nil, status.Error(codes.InvalidArgument, "prewrite request missing payload")
+		return nil, rpcInvalidArgument("prewrite request missing payload")
 	}
 	resp, err := s.propose(ctx, &raftcmdpb.RaftCmdRequest{
 		Header: header,
@@ -216,10 +212,10 @@ func (s *Service) Prewrite(ctx context.Context, req *kvrpcpb.KvPrewriteRequest) 
 func (s *Service) Commit(ctx context.Context, req *kvrpcpb.KvCommitRequest) (*kvrpcpb.KvCommitResponse, error) {
 	header, err := buildHeader(req.GetContext())
 	if err != nil {
-		return nil, status.Errorf(codes.InvalidArgument, "%v", err)
+		return nil, rpcInvalidArgument(err.Error())
 	}
 	if req.GetRequest() == nil {
-		return nil, status.Error(codes.InvalidArgument, "commit request missing payload")
+		return nil, rpcInvalidArgument("commit request missing payload")
 	}
 	resp, err := s.propose(ctx, &raftcmdpb.RaftCmdRequest{
 		Header: header,
@@ -249,10 +245,10 @@ func (s *Service) Commit(ctx context.Context, req *kvrpcpb.KvCommitRequest) (*kv
 func (s *Service) BatchRollback(ctx context.Context, req *kvrpcpb.KvBatchRollbackRequest) (*kvrpcpb.KvBatchRollbackResponse, error) {
 	header, err := buildHeader(req.GetContext())
 	if err != nil {
-		return nil, status.Errorf(codes.InvalidArgument, "%v", err)
+		return nil, rpcInvalidArgument(err.Error())
 	}
 	if req.GetRequest() == nil {
-		return nil, status.Error(codes.InvalidArgument, "rollback request missing payload")
+		return nil, rpcInvalidArgument("rollback request missing payload")
 	}
 	resp, err := s.propose(ctx, &raftcmdpb.RaftCmdRequest{
 		Header: header,
@@ -282,10 +278,10 @@ func (s *Service) BatchRollback(ctx context.Context, req *kvrpcpb.KvBatchRollbac
 func (s *Service) ResolveLock(ctx context.Context, req *kvrpcpb.KvResolveLockRequest) (*kvrpcpb.KvResolveLockResponse, error) {
 	header, err := buildHeader(req.GetContext())
 	if err != nil {
-		return nil, status.Errorf(codes.InvalidArgument, "%v", err)
+		return nil, rpcInvalidArgument(err.Error())
 	}
 	if req.GetRequest() == nil {
-		return nil, status.Error(codes.InvalidArgument, "resolve lock request missing payload")
+		return nil, rpcInvalidArgument("resolve lock request missing payload")
 	}
 	resp, err := s.propose(ctx, &raftcmdpb.RaftCmdRequest{
 		Header: header,
@@ -315,10 +311,10 @@ func (s *Service) ResolveLock(ctx context.Context, req *kvrpcpb.KvResolveLockReq
 func (s *Service) CheckTxnStatus(ctx context.Context, req *kvrpcpb.KvCheckTxnStatusRequest) (*kvrpcpb.KvCheckTxnStatusResponse, error) {
 	header, err := buildHeader(req.GetContext())
 	if err != nil {
-		return nil, status.Errorf(codes.InvalidArgument, "%v", err)
+		return nil, rpcInvalidArgument(err.Error())
 	}
 	if req.GetRequest() == nil {
-		return nil, status.Error(codes.InvalidArgument, "check txn status request missing payload")
+		return nil, rpcInvalidArgument("check txn status request missing payload")
 	}
 	checkReq := checkTxnStatusRequestWithServiceTime(req.GetRequest())
 	resp, err := s.propose(ctx, &raftcmdpb.RaftCmdRequest{
@@ -349,10 +345,10 @@ func (s *Service) CheckTxnStatus(ctx context.Context, req *kvrpcpb.KvCheckTxnSta
 func (s *Service) TxnHeartBeat(ctx context.Context, req *kvrpcpb.KvTxnHeartBeatRequest) (*kvrpcpb.KvTxnHeartBeatResponse, error) {
 	header, err := buildHeader(req.GetContext())
 	if err != nil {
-		return nil, status.Errorf(codes.InvalidArgument, "%v", err)
+		return nil, rpcInvalidArgument(err.Error())
 	}
 	if req.GetRequest() == nil {
-		return nil, status.Error(codes.InvalidArgument, "txn heartbeat request missing payload")
+		return nil, rpcInvalidArgument("txn heartbeat request missing payload")
 	}
 	heartBeatReq := txnHeartBeatRequestWithServiceTime(req.GetRequest())
 	resp, err := s.propose(ctx, &raftcmdpb.RaftCmdRequest{
@@ -383,10 +379,10 @@ func (s *Service) TxnHeartBeat(ctx context.Context, req *kvrpcpb.KvTxnHeartBeatR
 func (s *Service) TryAtomicMutate(ctx context.Context, req *kvrpcpb.KvTryAtomicMutateRequest) (*kvrpcpb.KvTryAtomicMutateResponse, error) {
 	header, err := buildHeader(req.GetContext())
 	if err != nil {
-		return nil, status.Errorf(codes.InvalidArgument, "%v", err)
+		return nil, rpcInvalidArgument(err.Error())
 	}
 	if req.GetRequest() == nil {
-		return nil, status.Error(codes.InvalidArgument, "atomic mutate request missing payload")
+		return nil, rpcInvalidArgument("atomic mutate request missing payload")
 	}
 	resp, err := s.propose(ctx, &raftcmdpb.RaftCmdRequest{
 		Header: header,
@@ -440,11 +436,6 @@ func singleRaftResponse(op string, resp *raftcmdpb.RaftCmdResponse) (*raftcmdpb.
 	return resp.GetResponses()[0], nil
 }
 
-func raftPayloadError(op, detail string) error {
-	msg := fmt.Sprintf("raftstore/kv: %s response protocol violation: %s", op, detail)
-	return status.Error(codes.FailedPrecondition, nokverrors.New(nokverrors.KindProtocolViolation, msg).Error())
-}
-
 func buildHeader(ctx *kvrpcpb.Context) (*raftcmdpb.CmdHeader, error) {
 	if ctx == nil {
 		return nil, fmt.Errorf("context is required")
@@ -458,21 +449,4 @@ func buildHeader(ctx *kvrpcpb.Context) (*raftcmdpb.CmdHeader, error) {
 		header.StoreId = peer.GetStoreId()
 	}
 	return header, nil
-}
-
-func rpcStatus(err error) error {
-	if err == nil {
-		return nil
-	}
-	if _, ok := status.FromError(err); ok {
-		return err
-	}
-	switch {
-	case errors.Is(err, context.Canceled):
-		return status.Error(codes.Canceled, err.Error())
-	case errors.Is(err, context.DeadlineExceeded):
-		return status.Error(codes.DeadlineExceeded, err.Error())
-	default:
-		return status.Error(codes.Internal, err.Error())
-	}
 }

--- a/raftstore/kv/watch.go
+++ b/raftstore/kv/watch.go
@@ -7,8 +7,6 @@ import (
 
 	kvrpcpb "github.com/feichai0017/NoKV/pb/kv"
 	storepkg "github.com/feichai0017/NoKV/raftstore/store"
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
 )
 
 const defaultApplyWatchBuffer = 256
@@ -58,15 +56,15 @@ func (o *applyWatchObserver) OnApply(evt storepkg.ApplyEvent) {
 
 func (s *Service) WatchApply(req *kvrpcpb.ApplyWatchRequest, stream kvrpcpb.StoreKV_WatchApplyServer) error {
 	if s == nil || s.store == nil {
-		return status.Error(codes.FailedPrecondition, "raftstore kv service is not initialized")
+		return rpcServiceNotInitialized()
 	}
 	if req == nil {
-		return status.Error(codes.InvalidArgument, "apply watch request is required")
+		return rpcInvalidArgument("apply watch request is required")
 	}
 	observer := newApplyWatchObserver(req)
 	reg, err := s.store.RegisterApplyObserver(observer, int(req.GetBuffer()))
 	if err != nil {
-		return status.Errorf(codes.FailedPrecondition, "%v", err)
+		return rpcProtocolPrecondition(err.Error())
 	}
 	defer reg.Close()
 

--- a/raftstore/mvcc/errors.go
+++ b/raftstore/mvcc/errors.go
@@ -10,6 +10,7 @@ var (
 	errNilMaintenanceProposer  = errors.New("raftstore/mvcc: nil maintenance proposer")
 	errNilLockResolver         = errors.New("raftstore/mvcc: nil lock resolver")
 	errNilCheckTxnStatusResult = errors.New("raftstore/mvcc: nil check txn status response")
+	errStop                    = errors.New("raftstore/mvcc: stop batch")
 )
 
 func errDecodeCFLock(key []byte, err error) error {

--- a/raftstore/mvcc/plan.go
+++ b/raftstore/mvcc/plan.go
@@ -14,8 +14,6 @@ import (
 
 const defaultApplyBatchEntries = 4096
 
-var errStop = errors.New("raftstore/mvcc: stop batch")
-
 // PlanStats summarizes a non-destructive MVCC GC planning pass.
 type PlanStats struct {
 	ScannedKeys           uint64

--- a/raftstore/transport/errors.go
+++ b/raftstore/transport/errors.go
@@ -1,6 +1,17 @@
 package transport
 
-import "errors"
+import (
+	"errors"
+
+	nokverrors "github.com/feichai0017/NoKV/errors"
+	"google.golang.org/grpc/codes"
+)
+
+const (
+	transportReasonMetadata = "raftstore_transport_reason"
+	reasonTransportInternal = "internal"
+	reasonTransportInjected = "failpoint_injected"
+)
 
 var (
 	// errPeerBlocked indicates that transport delivery to the target peer is currently blocked.
@@ -16,3 +27,19 @@ var (
 	// errNilTransport indicates that a nil transport was used.
 	errNilTransport = errors.New("raftstore: transport is nil")
 )
+
+func rpcTransportInternal(err error) error {
+	kind := nokverrors.KindOf(err)
+	if kind == nokverrors.KindUnknown {
+		kind = nokverrors.KindProtocolViolation
+	}
+	return nokverrors.RPCStatusError(kind, codes.Internal, err.Error(), map[string]string{
+		transportReasonMetadata: reasonTransportInternal,
+	})
+}
+
+func rpcTransportUnavailable(message string) error {
+	return nokverrors.RPCStatusError(nokverrors.KindUnavailable, codes.Unavailable, message, map[string]string{
+		transportReasonMetadata: reasonTransportInjected,
+	})
+}

--- a/raftstore/transport/grpc_transport.go
+++ b/raftstore/transport/grpc_transport.go
@@ -12,11 +12,9 @@ import (
 	"github.com/feichai0017/NoKV/raftstore/failpoints"
 	raftpb "go.etcd.io/raft/v3/raftpb"
 	"google.golang.org/grpc"
-	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/connectivity"
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/credentials/insecure"
-	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/types/known/emptypb"
 )
 
@@ -114,7 +112,7 @@ func (s *raftService) Step(ctx context.Context, msg *raftpb.Message) (*emptypb.E
 		return &emptypb.Empty{}, nil
 	}
 	if err := handler(myraft.Message(*msg)); err != nil {
-		return nil, status.Error(codes.Internal, err.Error())
+		return nil, rpcTransportInternal(err)
 	}
 	return &emptypb.Empty{}, nil
 }
@@ -438,7 +436,7 @@ func (t *GRPCTransport) Send(ctx context.Context, msg myraft.Message) {
 		pbMsg := raftpb.Message(msg)
 		if failpoints.ShouldFailBeforeTransportSendRPC() {
 			cancel()
-			err = status.Error(codes.Unavailable, "raftstore: failpoint before transport send rpc")
+			err = rpcTransportUnavailable("raftstore: failpoint before transport send rpc")
 			metrics.recordSendFailure(err, attempt == attempts-1)
 			if attempt == attempts-1 {
 				return

--- a/scripts/run_fsmeta_benchmarks.sh
+++ b/scripts/run_fsmeta_benchmarks.sh
@@ -5,7 +5,7 @@ ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$ROOT"
 
 mode="${NOKV_FSMETA_BENCH_MODE:-compose}"
-profile="${NOKV_FSMETA_PROFILE:-medium}"
+profile="${NOKV_FSMETA_PROFILE:-median}"
 run_id="$(date -u +%Y%m%dT%H%M%SZ)"
 coord_addr="${NOKV_FSMETA_COORDINATOR_ADDR:-127.0.0.1:2390,127.0.0.1:2391,127.0.0.1:2392}"
 fsmeta_addr="${NOKV_FSMETA_ADDR:-127.0.0.1:8090}"
@@ -18,34 +18,34 @@ plain_pid=""
 cached_pid=""
 
 case "$profile" in
-	medium)
-		default_clients=8
-		default_dirs=8
-		default_files_per_dir=128
-		default_files=1024
-		default_reads=128
-		default_groups=4
-		default_entries_per_group=16
-		default_artifacts_per_entry=6
-		default_session_ttl=2s
-		default_timeout=10m
-		default_stabilize_seconds=15
-		;;
-	long)
+	median)
 		default_clients=12
 		default_dirs=16
 		default_files_per_dir=256
 		default_files=4096
-		default_reads=256
+		default_reads=512
 		default_groups=8
-		default_entries_per_group=32
+		default_entries_per_group=64
 		default_artifacts_per_entry=8
 		default_session_ttl=2s
-		default_timeout=90m
-		default_stabilize_seconds=30
+		default_timeout=25m
+		default_stabilize_seconds=20
+		;;
+	long)
+		default_clients=16
+		default_dirs=32
+		default_files_per_dir=512
+		default_files=16384
+		default_reads=1024
+		default_groups=16
+		default_entries_per_group=128
+		default_artifacts_per_entry=10
+		default_session_ttl=2s
+		default_timeout=120m
+		default_stabilize_seconds=45
 		;;
 	*)
-		echo "unknown NOKV_FSMETA_PROFILE=$profile; use medium or long" >&2
+		echo "unknown NOKV_FSMETA_PROFILE=$profile; use median or long" >&2
 		exit 2
 		;;
 esac

--- a/txn/mvcc/codec.go
+++ b/txn/mvcc/codec.go
@@ -12,8 +12,19 @@ const (
 	writeCodecVersion byte = 1
 )
 
-// Readers reject unsupported codec versions. The current lock v1 layout is
-// allowed to change destructively before a production data-format guarantee.
+// Lock encoding layout:
+//
+//	version byte = 0x01
+//	primary_len uvarint
+//	primary key bytes
+//	start_ts uvarint
+//	start_time_unix_ms uvarint
+//	ttl_ms uvarint
+//	mutation_kind byte
+//	min_commit_ts uvarint
+//
+// TTL is measured from start_time_unix_ms. start_ts remains the MVCC logical
+// timestamp and must not be used as a physical clock.
 
 // Lock captures the metadata recorded in the lock column family during
 // prewrite.
@@ -106,6 +117,21 @@ type Write struct {
 	ExpiresAt  uint64
 }
 
+// Write encoding layout:
+//
+//	version byte = 0x01
+//	mutation_kind byte
+//	start_ts uvarint
+//	has_short_value byte
+//	if has_short_value == 1:
+//	  short_value_len uvarint
+//	  short_value bytes
+//	if short value or expires_at is present:
+//	  expires_at_unix_ms uvarint
+//
+// Missing expires_at means zero. That keeps ordinary non-TTL writes compact
+// while preserving TTL metadata for short-value writes.
+//
 // EncodeWrite serialises a write entry.
 func EncodeWrite(w Write) []byte {
 	buf := make([]byte, 0, 1+1+binary.MaxVarintLen64*3+len(w.ShortValue))
@@ -119,8 +145,6 @@ func EncodeWrite(w Write) []byte {
 	} else {
 		buf = append(buf, 0)
 	}
-	// Optional extension field used by short-value paths to preserve TTL metadata.
-	// Older decoders safely ignore trailing bytes.
 	if len(w.ShortValue) > 0 || w.ExpiresAt > 0 {
 		buf = binary.AppendUvarint(buf, w.ExpiresAt)
 	}

--- a/txn/mvcc/codec_test.go
+++ b/txn/mvcc/codec_test.go
@@ -67,8 +67,8 @@ func TestEncodeDecodeWriteRoundTrip(t *testing.T) {
 	require.Equal(t, write.ExpiresAt, got.ExpiresAt)
 }
 
-func TestDecodeWriteBackwardCompatibleWithoutExpiresAt(t *testing.T) {
-	// Old format: version, kind, startTs, hasShort, shortLen, shortValue.
+func TestDecodeWriteDefaultsMissingExpiresAtToZero(t *testing.T) {
+	// ExpiresAt is omitted when the write has no TTL metadata to preserve.
 	raw := make([]byte, 0, 32)
 	raw = append(raw, writeCodecVersion, byte(kvrpcpb.Mutation_Put))
 	raw = binary.AppendUvarint(raw, 7)


### PR DESCRIPTION
## Summary
- add stable RPC ErrorInfo metadata and switch coordinator, fsmeta, meta-root, raftstore KV/admin/transport boundaries away from message-based errors
- keep package-local sentinels in errors.go files and move local engine classification policy into local/errkind.Classify
- refresh fsmeta benchmark median/long naming, codec layout docs, and stale benchmark documentation

## Validation
- make fmt
- make lint
- go test ./...
- cd benchmark && go test ./fsmeta ./fsmeta/workload