### PR TITLE
Add fsmeta benchmark profile bundles

### DIFF
--- a/.github/workflows/fsmeta-benchmark.yml
+++ b/.github/workflows/fsmeta-benchmark.yml
@@ -20,6 +20,7 @@ on:
       - "go.sum"
       - "local/**"
       - "Makefile"
+      - "metrics/**"
       - "meta/**"
       - "pb/**"
       - "proto/**"
@@ -78,6 +79,7 @@ jobs:
           name: fsmeta-median-${{ github.run_id }}
           path: |
             benchmark/data/fsmeta/results/*.csv
+            benchmark/data/fsmeta/profiles/**
             benchmark/data/fsmeta/ci/*.txt
             benchmark/data/fsmeta/ci/*.log
           if-no-files-found: ignore
@@ -102,6 +104,8 @@ jobs:
       - name: Run long fsmeta workload matrix
         env:
           NOKV_FSMETA_PROFILE: long
+          NOKV_FSMETA_CAPTURE_PROFILES: "1"
+          NOKV_FSMETA_PROFILE_SECONDS: "60"
           NOKV_FSMETA_OUTPUT_DIR: benchmark/data/fsmeta/results
         run: make fsmeta-bench
 
@@ -120,6 +124,7 @@ jobs:
           name: fsmeta-long-${{ github.run_id }}
           path: |
             benchmark/data/fsmeta/results/*.csv
+            benchmark/data/fsmeta/profiles/**
             benchmark/data/fsmeta/ci/*.txt
             benchmark/data/fsmeta/ci/*.log
           if-no-files-found: ignore

--- a/Makefile
+++ b/Makefile
@@ -359,6 +359,7 @@ clean:
 	rm -rf ./testdata
 	rm -f coverage.out
 	rm -f *.pprof
+	rm -rf benchmark/data/fsmeta/profiles
 	rm -f benchmark.test
 	@echo "✓ Clean complete"
 

--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -119,6 +119,16 @@ temporary fsmeta gateways.
 mixed workload always creates `prompt.md`, `plan.json`, `state.bin`, and
 `checkpoint.tmp` to exercise update, writer-session, and unlink paths.
 
+For server-side profiling, set `NOKV_FSMETA_CAPTURE_PROFILES=1`. The helper
+captures concurrent CPU profiles from fsmeta, stores, coordinators, and
+meta-root processes through their diagnostics ports, then packages CPU, heap,
+allocs, goroutine, and expvar snapshots under
+`benchmark/data/fsmeta/profiles/`. Main-push and scheduled long fsmeta CI runs
+enable this automatically; PR median runs keep it disabled to avoid adding
+diagnostic overhead to the gating path. Override capture length with
+`NOKV_FSMETA_PROFILE_SECONDS` or endpoints with `NOKV_FSMETA_PROFILE_TARGETS`
+using `name=host:port` comma-separated entries.
+
 Direct run from inside the `benchmark/` Go module:
 
 ```bash

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,6 @@
 # NoKV HA deployment: 3 meta-root + 3 coordinators + 3 stores + 1 fsmeta gateway.
-# Every running service exposes a /debug/vars expvar endpoint for dashboards.
+# Every running service exposes /debug/vars and /debug/pprof on its diagnostics
+# port for dashboards and benchmark profiling.
 #
 # Usage:
 #   docker compose up -d
@@ -23,8 +24,8 @@
 # write retries and lands on whichever standby has grabbed the grant.
 #
 # Every runtime binary (coordinator, store, fsmeta, meta-root) exposes expvar
-# at /debug/vars via its own --metrics-addr flag; ports 9380-9382 belong to
-# the three meta-root peers.
+# at /debug/vars and pprof at /debug/pprof via its own --metrics-addr flag;
+# ports 9380-9382 belong to the three meta-root peers.
 
 x-nokv-image: &nokv-image
   build: .

--- a/metrics/expvar.go
+++ b/metrics/expvar.go
@@ -5,9 +5,13 @@ import (
 	"log"
 	"net"
 	"net/http"
+	"net/http/pprof"
 )
 
-// StartExpvarServer starts an optional HTTP endpoint exposing /debug/vars.
+// StartExpvarServer starts an optional HTTP endpoint exposing /debug/vars and
+// /debug/pprof. The pprof surface is intentionally tied to the same opt-in
+// diagnostics listener as expvar so production deployments can keep both
+// disabled by leaving --metrics-addr empty.
 // An empty address disables the server and returns nil.
 //
 // CORS is permissive so a browser-based dashboard served from a different
@@ -27,12 +31,24 @@ func StartExpvarServer(addr string) (net.Listener, error) {
 	}
 	mux := http.NewServeMux()
 	mux.Handle("/debug/vars", corsReadOnly(expvar.Handler()))
+	registerPprofHandlers(mux)
 	go func() {
 		if err := http.Serve(ln, mux); err != nil && err != http.ErrServerClosed {
 			log.Printf("expvar metrics server error: %v", err)
 		}
 	}()
 	return ln, nil
+}
+
+func registerPprofHandlers(mux *http.ServeMux) {
+	mux.HandleFunc("/debug/pprof/", corsReadOnlyFunc(pprof.Index))
+	mux.HandleFunc("/debug/pprof/cmdline", corsReadOnlyFunc(pprof.Cmdline))
+	mux.HandleFunc("/debug/pprof/profile", corsReadOnlyFunc(pprof.Profile))
+	mux.HandleFunc("/debug/pprof/symbol", corsReadOnlyFunc(pprof.Symbol))
+	mux.HandleFunc("/debug/pprof/trace", corsReadOnlyFunc(pprof.Trace))
+	for _, name := range []string{"allocs", "block", "goroutine", "heap", "mutex", "threadcreate"} {
+		mux.Handle("/debug/pprof/"+name, corsReadOnly(pprof.Handler(name)))
+	}
 }
 
 // corsReadOnly allows cross-origin GETs. Writes are not exposed on this
@@ -48,4 +64,8 @@ func corsReadOnly(next http.Handler) http.Handler {
 		}
 		next.ServeHTTP(w, r)
 	})
+}
+
+func corsReadOnlyFunc(next func(http.ResponseWriter, *http.Request)) http.HandlerFunc {
+	return corsReadOnly(http.HandlerFunc(next)).ServeHTTP
 }

--- a/metrics/expvar_test.go
+++ b/metrics/expvar_test.go
@@ -1,0 +1,33 @@
+package metrics
+
+import (
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+)
+
+func TestStartExpvarServerExposesPprof(t *testing.T) {
+	ln, err := StartExpvarServer("127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("StartExpvarServer: %v", err)
+	}
+	defer func() { _ = ln.Close() }()
+
+	baseURL := "http://" + ln.Addr().String()
+	resp, err := http.Get(baseURL + "/debug/pprof/goroutine?debug=1")
+	if err != nil {
+		t.Fatalf("GET pprof goroutine: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("pprof goroutine status = %s", resp.Status)
+	}
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("read pprof goroutine: %v", err)
+	}
+	if !strings.Contains(string(body), "goroutine profile:") {
+		t.Fatalf("pprof goroutine response missing profile header: %q", string(body))
+	}
+}

--- a/scripts/run_fsmeta_benchmarks.sh
+++ b/scripts/run_fsmeta_benchmarks.sh
@@ -13,9 +13,14 @@ mount="${NOKV_FSMETA_MOUNT:-fsmeta-bench}"
 wait_attempts="${NOKV_FSMETA_WAIT_ATTEMPTS:-180}"
 wait_interval="${NOKV_FSMETA_WAIT_INTERVAL:-1}"
 output_dir="${NOKV_FSMETA_OUTPUT_DIR:-$ROOT/benchmark/data/fsmeta/results}"
+capture_profiles="${NOKV_FSMETA_CAPTURE_PROFILES:-0}"
+profile_seconds="${NOKV_FSMETA_PROFILE_SECONDS:-30}"
+profile_dir="${NOKV_FSMETA_PROFILE_DIR:-$ROOT/benchmark/data/fsmeta/profiles/fsmeta_${profile}_${run_id}}"
+profile_targets="${NOKV_FSMETA_PROFILE_TARGETS:-fsmeta=127.0.0.1:9400,store1=127.0.0.1:9200,store2=127.0.0.1:9201,store3=127.0.0.1:9202,coord1=127.0.0.1:9100,coord2=127.0.0.1:9101,coord3=127.0.0.1:9102,root1=127.0.0.1:9380,root2=127.0.0.1:9381,root3=127.0.0.1:9382}"
 cache_tmp_dir=""
 plain_pid=""
 cached_pid=""
+profile_pids=()
 
 case "$profile" in
 	median)
@@ -68,6 +73,11 @@ case "$output_dir" in
 esac
 mkdir -p "$output_dir"
 
+case "$profile_dir" in
+	/*) ;;
+	*) profile_dir="$ROOT/$profile_dir" ;;
+esac
+
 wait_port() {
 	local addr="$1"
 	local host="${addr%:*}"
@@ -108,6 +118,97 @@ run_bench() {
 	)
 }
 
+profiles_enabled() {
+	case "$capture_profiles" in
+		1|true|TRUE|yes|YES) return 0 ;;
+		*) return 1 ;;
+	esac
+}
+
+write_profile_manifest() {
+	local workloads="$1"
+	cat >"$profile_dir/manifest.txt" <<EOF
+run_id=$run_id
+benchmark_profile=$profile
+workloads=$workloads
+clients=$clients
+dirs=$dirs
+files_per_dir=$files_per_dir
+files=$files
+reads_per_client=$reads
+groups=$groups
+entries_per_group=$entries_per_group
+artifacts_per_entry=$artifacts_per_entry
+session_ttl=$session_ttl
+profile_seconds=$profile_seconds
+targets=$profile_targets
+EOF
+}
+
+start_profile_capture() {
+	local workloads="$1"
+	if ! profiles_enabled; then
+		return
+	fi
+	mkdir -p "$profile_dir"
+	write_profile_manifest "$workloads"
+	echo "capturing fsmeta profile bundle in $profile_dir"
+	IFS=',' read -r -a targets <<<"$profile_targets"
+	for target in "${targets[@]}"; do
+		local name="${target%%=*}"
+		local addr="${target#*=}"
+		if [[ -z "$name" || -z "$addr" || "$name" == "$addr" ]]; then
+			echo "skip malformed profile target: $target" >&2
+			continue
+		fi
+		(
+			curl -fsS --max-time "$((profile_seconds + 15))" \
+				"http://$addr/debug/pprof/profile?seconds=$profile_seconds" \
+				-o "$profile_dir/${name}.cpu.pprof" \
+				>"$profile_dir/${name}.cpu.log" 2>&1 || \
+				echo "cpu profile capture failed for $name at $addr" >>"$profile_dir/${name}.cpu.log"
+		) &
+		profile_pids+=("$!")
+	done
+}
+
+fetch_profile_file() {
+	local url="$1"
+	local output="$2"
+	curl -fsS --max-time 15 "$url" -o "$output" >/dev/null 2>&1 || \
+		echo "profile fetch failed: $url" >"$output.error"
+}
+
+collect_profile_snapshots() {
+	if ! profiles_enabled; then
+		return
+	fi
+	IFS=',' read -r -a targets <<<"$profile_targets"
+	for target in "${targets[@]}"; do
+		local name="${target%%=*}"
+		local addr="${target#*=}"
+		if [[ -z "$name" || -z "$addr" || "$name" == "$addr" ]]; then
+			continue
+		fi
+		fetch_profile_file "http://$addr/debug/vars" "$profile_dir/${name}.vars.json"
+		fetch_profile_file "http://$addr/debug/pprof/goroutine?debug=2" "$profile_dir/${name}.goroutine.txt"
+		fetch_profile_file "http://$addr/debug/pprof/heap" "$profile_dir/${name}.heap.pprof"
+		fetch_profile_file "http://$addr/debug/pprof/allocs" "$profile_dir/${name}.allocs.pprof"
+	done
+}
+
+finish_profile_capture() {
+	if ! profiles_enabled; then
+		return
+	fi
+	for pid in "${profile_pids[@]}"; do
+		wait "$pid" || true
+	done
+	collect_profile_snapshots
+	tar -C "$(dirname "$profile_dir")" -czf "$profile_dir.tar.gz" "$(basename "$profile_dir")"
+	echo "wrote fsmeta profile bundle: $profile_dir.tar.gz"
+}
+
 print_bench_summary() {
 	local output="$1"
 	if [[ ! -f "$output" ]]; then
@@ -138,7 +239,15 @@ run_compose_benchmarks() {
 			sleep "$stabilize_seconds"
 		fi
 	fi
+	start_profile_capture "$workloads"
+	set +e
 	run_bench "$fsmeta_addr" "$workloads" "$output"
+	local bench_status=$?
+	set -e
+	finish_profile_capture
+	if [[ "$bench_status" -ne 0 ]]; then
+		exit "$bench_status"
+	fi
 	print_bench_summary "$output"
 	echo "wrote fsmeta benchmark summary: $output"
 	if [[ "${NOKV_FSMETA_COMPOSE_DOWN:-0}" == "1" ]]; then


### PR DESCRIPTION
## Summary
- expose pprof on the existing opt-in diagnostics listener alongside expvar
- add optional fsmeta benchmark profile bundle capture for fsmeta, store, coordinator, and meta-root processes
- upload fsmeta profile artifacts from long benchmark CI and document local usage

## Validation
- bash -n scripts/run_fsmeta_benchmarks.sh
- go test ./metrics
- go test ./metrics ./cmd/nokv ./cmd/nokv-fsmeta
- cd benchmark && go test ./fsmeta ./fsmeta/workload
- make fmt
- make lint
- make test


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional server-side profiling capability for benchmarks to capture CPU, memory, and goroutine profiles during benchmark runs.
  * Profiling can be controlled via configuration flags with configurable capture duration.

* **Documentation**
  * Updated benchmark documentation to explain profiling setup and usage.
  * Clarified diagnostics endpoint availability across all runtime components.

* **Chores**
  * Enhanced CI workflow and build configuration to support profile data collection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->