### PR TITLE
Add DCO contributor sign-off policy

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,11 @@
+## Summary
+
+- 
+
+## Validation
+
+- 
+
+## Contributor Sign-off
+
+- [ ] Every commit in this PR includes a DCO `Signed-off-by` trailer.

--- a/.github/workflows/dco.yml
+++ b/.github/workflows/dco.yml
@@ -27,7 +27,7 @@ jobs:
           else
             before="${{ github.event.before }}"
             if [[ "$before" =~ ^0+$ ]]; then
-              range="${{ github.sha }}"
+              range="${{ github.sha }}^..${{ github.sha }}"
             else
               range="$before..${{ github.sha }}"
             fi

--- a/.github/workflows/dco.yml
+++ b/.github/workflows/dco.yml
@@ -1,0 +1,74 @@
+name: DCO
+
+on:
+  pull_request:
+    branches: [ "main" ]
+  push:
+    branches: [ "main" ]
+
+permissions:
+  contents: read
+
+jobs:
+  signoff:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Check commit sign-offs
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+            range="${{ github.event.pull_request.base.sha }}..HEAD"
+          else
+            before="${{ github.event.before }}"
+            if [[ "$before" =~ ^0+$ ]]; then
+              range="${{ github.sha }}"
+            else
+              range="$before..${{ github.sha }}"
+            fi
+          fi
+
+          if ! commits="$(git rev-list --no-merges "$range")"; then
+            echo "::error title=Invalid DCO commit range::Unable to resolve commit range $range."
+            exit 1
+          fi
+          if [[ -z "$commits" ]]; then
+            echo "No non-merge commits to check."
+            exit 0
+          fi
+
+          missing=0
+          while IFS= read -r commit; do
+            trailers="$(git show -s --format=%B "$commit" | git interpret-trailers --parse)"
+            if ! grep -Eiq '^Signed-off-by: .+ <[^>]+>$' <<<"$trailers"; then
+              echo "::error title=Missing DCO sign-off::Commit $commit is missing a Signed-off-by trailer."
+              git show -s --format='%h %s' "$commit"
+              missing=1
+            fi
+          done <<<"$commits"
+
+          if [[ "$missing" -ne 0 ]]; then
+            cat <<'EOF'
+
+          Add a Developer Certificate of Origin sign-off to every commit:
+
+            git commit -s -m "type: subject"
+
+          If the latest commit is missing a sign-off:
+
+            git commit --amend -s --no-edit
+
+          For a local branch with multiple commits:
+
+            git rebase --signoff origin/main
+
+          EOF
+            exit 1
+          fi
+
+          echo "All checked commits include Signed-off-by trailers."

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,6 +35,18 @@ Use these branch prefixes:
 - Commit format: `<type>: <subject>`
 - Common types: `feat`, `fix`, `refactor`, `docs`, `test`, `chore`
 - Keep each commit focused on one logical change.
+- Sign every commit with the Developer Certificate of Origin trailer:
+
+```bash
+git commit -s -m "feat: add feature"
+```
+
+If a local commit is missing the trailer, amend or rebase before opening the PR:
+
+```bash
+git commit --amend -s --no-edit
+git rebase --signoff origin/main
+```
 
 ## Local Validation
 
@@ -65,6 +77,7 @@ make bench
 - Link related issue(s).
 - Include docs updates when behavior/config/CLI changes.
 - Keep PRs small enough for focused review.
+- Every non-merge commit must include a `Signed-off-by` trailer matching the Developer Certificate of Origin in [`DCO`](./DCO).
 
 ## Code Guidelines
 

--- a/DCO
+++ b/DCO
@@ -1,0 +1,33 @@
+Developer Certificate of Origin
+Version 1.1
+
+Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
+
+Everyone is permitted to copy and distribute verbatim copies of this
+license document, but changing it is not allowed.
+
+Developer's Certificate of Origin 1.1
+
+By making a contribution to this project, I certify that:
+
+(a) The contribution was created in whole or in part by me and I
+    have the right to submit it under the open source license
+    indicated in the file; or
+
+(b) The contribution is based upon previous work that, to the best
+    of my knowledge, is covered under an appropriate open source
+    license and I have the right under that license to submit that
+    work with modifications, whether created in whole or in part
+    by me, under the same open source license (unless I am
+    permitted to submit under a different license), as indicated
+    in the file; or
+
+(c) The contribution was provided directly to me by some other
+    person who certified (a), (b) or (c) and I have not modified
+    it.
+
+(d) I understand and agree that this project and the contribution
+    are public and that a record of the contribution (including all
+    personal information I submit with it, including my sign-off) is
+    maintained indefinitely and may be redistributed consistent with
+    this project or the open source license(s) involved.


### PR DESCRIPTION
## Summary
- add the Developer Certificate of Origin text at the repository root
- document `git commit -s` and sign-off repair commands in CONTRIBUTING.md
- add a PR template sign-off checklist and a DCO workflow that checks every non-merge PR/push commit

## Validation
- git diff --check
- bash -n extracted DCO workflow shell block
- actionlint .github/workflows/dco.yml (when available locally)
- make fmt
- make lint
- local DCO check over origin/main..HEAD


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated contribution guidelines with new commit-signing requirements using the Developer Certificate of Origin.
  * Enhanced pull request template with summary and validation sections.

* **Chores**
  * Added automated enforcement for Developer Certificate of Origin on contributions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->