### PR TITLE
Keep 2PC primary locks alive during commit

### DIFF
--- a/raftstore/client/client_kv.go
+++ b/raftstore/client/client_kv.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"time"
 
 	nokverrors "github.com/feichai0017/NoKV/errors"
 	errorpb "github.com/feichai0017/NoKV/pb/error"
@@ -582,6 +583,12 @@ func (c *Client) twoPhaseCommit(ctx context.Context, primary []byte, mutations [
 	if err != nil {
 		return 0, err
 	}
+	// Read-side lock resolution is allowed to roll back an expired primary
+	// lock. Keep the primary alive while secondary prewrites and commit RPCs
+	// wait behind raft/store work, otherwise a live long transaction can lose
+	// its own lock and surface as retryable "lock not found".
+	stopHeartbeat := c.startTxnHeartbeat(ctx, primary, startVersion, lockTTL)
+	defer stopHeartbeat()
 	secondaryMutations := make([]*kvrpcpb.Mutation, 0, len(cleaned)-1)
 	primarySkipped := false
 	for _, mut := range cleaned {
@@ -720,6 +727,58 @@ func shouldRollbackAfterPrimaryCommitFailure(err error) bool {
 		}
 	}
 	return false
+}
+
+func txnHeartbeatInterval(lockTTL uint64) time.Duration {
+	if lockTTL == 0 {
+		return 0
+	}
+	interval := time.Duration(lockTTL) * time.Millisecond / 3
+	if interval <= 0 {
+		return time.Millisecond
+	}
+	return interval
+}
+
+// startTxnHeartbeat is best-effort liveness maintenance for a prewritten
+// primary. It deliberately does not turn transient heartbeat RPC failures into
+// transaction failures: commit remains the authority for the final outcome, and
+// heartbeat only prevents healthy long 2PC windows from expiring early.
+func (c *Client) startTxnHeartbeat(ctx context.Context, primary []byte, startVersion, lockTTL uint64) func() {
+	interval := txnHeartbeatInterval(lockTTL)
+	if interval <= 0 {
+		return func() {}
+	}
+	heartbeatCtx, cancel := context.WithCancel(ctx)
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		ticker := time.NewTicker(interval)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-heartbeatCtx.Done():
+				return
+			case <-ticker.C:
+			}
+			resp, err := c.TxnHeartBeat(heartbeatCtx, primary, startVersion, lockTTL)
+			if err != nil {
+				continue
+			}
+			if resp.GetError() != nil || resp.GetCommitVersion() != 0 {
+				return
+			}
+			switch resp.GetAction() {
+			case kvrpcpb.TxnHeartBeatAction_TxnHeartBeatTTLExpireRollback,
+				kvrpcpb.TxnHeartBeatAction_TxnHeartBeatLockNotExistRollback:
+				return
+			}
+		}
+	}()
+	return func() {
+		cancel()
+		<-done
+	}
 }
 
 func (c *Client) prewriteRegionOnce(ctx context.Context, region regionSnapshot, primary []byte, startVersion, ttl uint64, muts []*kvrpcpb.Mutation) (*kvrpcpb.PrewriteResponse, *errorpb.RegionError, error) {

--- a/raftstore/client/client_kv_test.go
+++ b/raftstore/client/client_kv_test.go
@@ -893,6 +893,73 @@ func TestClientTxnHeartBeatRoutesPrimaryAndDelegatesPhysicalTime(t *testing.T) {
 	require.Equal(t, 1, calls)
 }
 
+func TestClientTwoPhaseCommitHeartbeatsPrimaryWhileCommitWaits(t *testing.T) {
+	cluster := newMockCluster(clusterRegion{
+		meta: &metapb.RegionDescriptor{
+			RegionId: 1,
+			StartKey: []byte("a"),
+			EndKey:   []byte("z"),
+			Epoch:    &metapb.RegionEpoch{Version: 1, ConfVersion: 1},
+			Peers: []*metapb.RegionPeer{
+				{StoreId: 1, PeerId: 101},
+			},
+		},
+		leaderStore: 1,
+	})
+
+	heartbeatChecked := make(chan error, 1)
+	svc := &scriptedKVService{mockService: mockService{storeID: 1, cluster: cluster}}
+	svc.commitFn = func(ctx context.Context, req *kvrpcpb.KvCommitRequest) (*kvrpcpb.KvCommitResponse, error) {
+		select {
+		case err := <-heartbeatChecked:
+			if err != nil {
+				return nil, err
+			}
+		case <-time.After(time.Second):
+			return nil, fmt.Errorf("timed out waiting for transaction heartbeat")
+		}
+		return svc.mockService.Commit(ctx, req)
+	}
+	svc.txnHeartBeatFn = func(_ context.Context, req *kvrpcpb.KvTxnHeartBeatRequest) (*kvrpcpb.KvTxnHeartBeatResponse, error) {
+		var err error
+		if req.GetContext().GetRegionId() != 1 {
+			err = fmt.Errorf("heartbeat routed to region %d", req.GetContext().GetRegionId())
+		} else if string(req.GetRequest().GetPrimaryKey()) != "alfa" {
+			err = fmt.Errorf("heartbeat primary = %q", req.GetRequest().GetPrimaryKey())
+		} else if req.GetRequest().GetStartVersion() != 100 {
+			err = fmt.Errorf("heartbeat start version = %d", req.GetRequest().GetStartVersion())
+		} else if req.GetRequest().GetTtlExtension() != 30 {
+			err = fmt.Errorf("heartbeat ttl extension = %d", req.GetRequest().GetTtlExtension())
+		}
+		select {
+		case heartbeatChecked <- err:
+		default:
+		}
+		return &kvrpcpb.KvTxnHeartBeatResponse{
+			Response: &kvrpcpb.TxnHeartBeatResponse{
+				Action:  kvrpcpb.TxnHeartBeatAction_TxnHeartBeatTTLExtended,
+				LockTtl: 60,
+			},
+		}, nil
+	}
+	addr, stop := startBlockingStore(t, svc)
+	defer stop()
+
+	cli, err := New(Config{
+		StoreResolver:  staticStoreResolver{{StoreID: 1, Addr: addr}},
+		RegionResolver: resolverFromCluster(cluster),
+		DialOptions:    []grpc.DialOption{grpc.WithTransportCredentials(insecure.NewCredentials())},
+		Retry:          RetryPolicy{MaxAttempts: 2, RegionErrorBackoff: 0},
+	})
+	require.NoError(t, err)
+	defer func() { _ = cli.Close() }()
+
+	err = cli.TwoPhaseCommit(context.Background(), []byte("alfa"), []*kvrpcpb.Mutation{
+		{Op: kvrpcpb.Mutation_Put, Key: []byte("alfa"), Value: []byte("value")},
+	}, 100, 150, 30)
+	require.NoError(t, err)
+}
+
 func TestClientResolveLocksReturnsKeyError(t *testing.T) {
 	cluster := newMockCluster(clusterRegion{
 		meta: &metapb.RegionDescriptor{


### PR DESCRIPTION
## Summary
- start a best-effort primary-lock heartbeat after 2PC primary prewrite succeeds
- keep long transactions from being rolled back by read-side lock resolution while secondary prewrites or commit RPCs wait behind raft/store work
- add a StoreKV client regression test that blocks commit until a heartbeat is observed

## Root cause
The failed main run was `Benchmark / fsmeta long` (run 25489367774). The long `mixed` workload had 1/63513 operation errors: `unlink_temp` surfaced `retryable:"percolator: lock not found"`. The artifact counters showed Create 1PC was fully healthy, but fsmeta ordinary transaction retry exhausted once. The missing piece was that StoreKV already exposed TxnHeartBeat, but the 2PC client did not use it, so a live transaction could let its 3s primary lock expire under long commit windows and then be rolled back by read-side lock resolution.

## Validation
- make fmt
- make lint
- go test ./fsmeta/... ./raftstore/client ./raftstore/kv ./txn/percolator
- cd benchmark && go test ./fsmeta ./fsmeta/workload
- go test ./...
- bash -n scripts/run_fsmeta_benchmarks.sh && git diff --check

Note: I started a tiny local Docker Compose fsmeta smoke, but local Docker/buildx stalled before service creation while resolving the Dockerfile frontend image. No NoKV service reached startup in that local smoke; GitHub CI should exercise the Compose path on the runner.