### PR TITLE
Split ephemeral fsmeta read versions from durable snapshots

### DIFF
--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -136,7 +136,7 @@ cd benchmark
 NOKV_FSMETA_BENCH=1 go test ./fsmeta -run TestBenchmarkFSMeta -count=1 -v -args \
   -fsmeta_addr 127.0.0.1:8090 \
   -fsmeta_coordinator_addr 127.0.0.1:2390,127.0.0.1:2391,127.0.0.1:2392 \
-  -fsmeta_workloads mixed,checkpoint-storm,hotspot-fanin,watch-subtree,negative-lookup \
+  -fsmeta_workloads mixed,durable-snapshot,checkpoint-storm,hotspot-fanin,watch-subtree,negative-lookup \
   -fsmeta_readdirplus=true
 ```
 

--- a/benchmark/fsmeta/fsmeta_bench_test.go
+++ b/benchmark/fsmeta/fsmeta_bench_test.go
@@ -27,7 +27,7 @@ const benchEnvKey = "NOKV_FSMETA_BENCH"
 var (
 	fsmetaAddr            = flag.String("fsmeta_addr", "127.0.0.1:8090", "FSMetadata gRPC endpoint")
 	fsmetaCoordAddr       = flag.String("fsmeta_coordinator_addr", "127.0.0.1:2379", "Coordinator gRPC endpoint for mount bootstrap")
-	fsmetaWorkloads       = flag.String("fsmeta_workloads", "mixed,checkpoint-storm,hotspot-fanin,watch-subtree,negative-lookup", "comma-separated workloads: mixed,checkpoint-storm,hotspot-fanin,watch-subtree,negative-lookup")
+	fsmetaWorkloads       = flag.String("fsmeta_workloads", "mixed,durable-snapshot,checkpoint-storm,hotspot-fanin,watch-subtree,negative-lookup", "comma-separated workloads: mixed,durable-snapshot,checkpoint-storm,hotspot-fanin,watch-subtree,negative-lookup")
 	fsmetaMount           = flag.String("fsmeta_mount", "fsmeta-bench", "fsmeta mount id")
 	fsmetaClients         = flag.Int("fsmeta_clients", 8, "concurrent clients")
 	fsmetaDirs            = flag.Int("fsmeta_dirs", 16, "checkpoint-storm directory count")
@@ -199,6 +199,14 @@ func runBenchmarkWorkload(ctx context.Context, cli workload.Client, workloadName
 			Clients:            *fsmetaClients,
 			Files:              *fsmetaFiles,
 			BackPressureWindow: uint32(*fsmetaWatchWindow),
+		})
+	case workload.DurableSnapshot:
+		result, err = workload.RunDurableSnapshot(ctx, cli, workload.DurableSnapshotConfig{
+			Mount:     fsmeta.MountID(*fsmetaMount),
+			RunID:     runID,
+			Files:     *fsmetaFilesPerDir,
+			Snapshots: *fsmetaEntriesPerGroup,
+			PageLimit: uint32(*fsmetaPageLimit),
 		})
 	case workload.NegativeLookup:
 		result, err = workload.RunNegativeLookup(ctx, cli, workload.NegativeLookupConfig{

--- a/benchmark/fsmeta/workload/mixed.go
+++ b/benchmark/fsmeta/workload/mixed.go
@@ -18,6 +18,7 @@ const Mixed = "mixed"
 type MixedClient interface {
 	WatchClient
 	UpdateInode(ctx context.Context, req fsmeta.UpdateInodeRequest) (fsmeta.InodeRecord, error)
+	GetReadVersion(ctx context.Context, req fsmeta.ReadVersionRequest) (uint64, error)
 	SnapshotSubtree(ctx context.Context, req fsmeta.SnapshotSubtreeRequest) (fsmeta.SnapshotSubtreeToken, error)
 	RetireSnapshotSubtree(ctx context.Context, token fsmeta.SnapshotSubtreeToken) error
 	GetQuotaUsage(ctx context.Context, req fsmeta.QuotaUsageRequest) (fsmeta.UsageRecord, error)
@@ -451,24 +452,21 @@ func runWriterSessionLifecycle(ctx context.Context, cli MixedClient, cfg MixedCo
 }
 
 func runSnapshotLifecycle(ctx context.Context, cli MixedClient, cfg MixedConfig, root fsmeta.InodeID, rec *recorder) {
-	var token fsmeta.SnapshotSubtreeToken
-	rec.recordCall("snapshot_subtree", func() error {
+	var readVersion uint64
+	rec.recordCall("get_read_version", func() error {
 		var err error
-		token, err = cli.SnapshotSubtree(ctx, fsmeta.SnapshotSubtreeRequest{Mount: cfg.Mount, RootInode: root})
+		readVersion, err = cli.GetReadVersion(ctx, fsmeta.ReadVersionRequest{Mount: cfg.Mount})
 		return err
 	})
-	if token.ReadVersion != 0 {
+	if readVersion != 0 {
 		rec.recordCall("snapshot_readdirplus", func() error {
 			_, err := cli.ReadDirPlus(ctx, fsmeta.ReadDirRequest{
 				Mount:           cfg.Mount,
 				Parent:          root,
 				Limit:           cfg.PageLimit,
-				SnapshotVersion: token.ReadVersion,
+				SnapshotVersion: readVersion,
 			})
 			return err
-		})
-		rec.recordCall("retire_snapshot_subtree", func() error {
-			return cli.RetireSnapshotSubtree(ctx, token)
 		})
 	}
 }

--- a/benchmark/fsmeta/workload/mixed.go
+++ b/benchmark/fsmeta/workload/mixed.go
@@ -453,22 +453,25 @@ func runWriterSessionLifecycle(ctx context.Context, cli MixedClient, cfg MixedCo
 
 func runSnapshotLifecycle(ctx context.Context, cli MixedClient, cfg MixedConfig, root fsmeta.InodeID, rec *recorder) {
 	var readVersion uint64
-	rec.recordCall("get_read_version", func() error {
+	if err := recordCall(rec, "get_read_version", func() error {
 		var err error
 		readVersion, err = cli.GetReadVersion(ctx, fsmeta.ReadVersionRequest{Mount: cfg.Mount})
 		return err
-	})
-	if readVersion != 0 {
-		rec.recordCall("snapshot_readdirplus", func() error {
-			_, err := cli.ReadDirPlus(ctx, fsmeta.ReadDirRequest{
-				Mount:           cfg.Mount,
-				Parent:          root,
-				Limit:           cfg.PageLimit,
-				SnapshotVersion: readVersion,
-			})
-			return err
-		})
+	}); err != nil {
+		return
 	}
+	rec.recordCall("snapshot_readdirplus", func() error {
+		if readVersion == 0 {
+			return fmt.Errorf("zero read version from GetReadVersion")
+		}
+		_, err := cli.ReadDirPlus(ctx, fsmeta.ReadDirRequest{
+			Mount:           cfg.Mount,
+			Parent:          root,
+			Limit:           cfg.PageLimit,
+			SnapshotVersion: readVersion,
+		})
+		return err
+	})
 }
 
 func runStaleSessionCleanup(ctx context.Context, cli MixedClient, cfg MixedConfig, parent fsmeta.InodeID, rec *recorder) {

--- a/benchmark/fsmeta/workload/mixed_test.go
+++ b/benchmark/fsmeta/workload/mixed_test.go
@@ -19,6 +19,8 @@ type fakeMixedClient struct {
 	inodes    map[fsmeta.InodeID]fsmeta.InodeRecord
 	sessions  map[fsmeta.SessionID]fsmeta.SessionRecord
 	snapshots map[uint64]fsmeta.SnapshotSubtreeToken
+	versions  map[uint64]struct{}
+	reads     []fsmeta.ReadDirRequest
 	next      fsmeta.InodeID
 	version   uint64
 	stream    *fakeWatchStream
@@ -30,6 +32,7 @@ func newFakeMixedClient() *fakeMixedClient {
 		inodes:    make(map[fsmeta.InodeID]fsmeta.InodeRecord),
 		sessions:  make(map[fsmeta.SessionID]fsmeta.SessionRecord),
 		snapshots: make(map[uint64]fsmeta.SnapshotSubtreeToken),
+		versions:  make(map[uint64]struct{}),
 		next:      100,
 		version:   1,
 		stream:    &fakeWatchStream{events: make(chan fsmeta.WatchEvent, 1024)},
@@ -97,6 +100,7 @@ func (c *fakeMixedClient) Lookup(_ context.Context, req fsmeta.LookupRequest) (f
 func (c *fakeMixedClient) ReadDir(_ context.Context, req fsmeta.ReadDirRequest) ([]fsmeta.DentryRecord, error) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
+	c.reads = append(c.reads, req)
 	out := make([]fsmeta.DentryRecord, 0)
 	for _, entry := range c.dentries {
 		if entry.Parent == req.Parent {
@@ -109,6 +113,7 @@ func (c *fakeMixedClient) ReadDir(_ context.Context, req fsmeta.ReadDirRequest) 
 func (c *fakeMixedClient) ReadDirPlus(_ context.Context, req fsmeta.ReadDirRequest) ([]fsmeta.DentryAttrPair, error) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
+	c.reads = append(c.reads, req)
 	out := make([]fsmeta.DentryAttrPair, 0)
 	for _, entry := range c.dentries {
 		if entry.Parent != req.Parent {
@@ -150,6 +155,7 @@ func (c *fakeMixedClient) GetReadVersion(context.Context, fsmeta.ReadVersionRequ
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	c.version++
+	c.versions[c.version] = struct{}{}
 	return c.version, nil
 }
 
@@ -304,7 +310,8 @@ func (c *fakeMixedClient) emitDentryEventLocked(mount fsmeta.MountID, entry fsme
 }
 
 func TestRunMixedCoversFullSurface(t *testing.T) {
-	result, err := RunMixed(context.Background(), newFakeMixedClient(), MixedConfig{
+	cli := newFakeMixedClient()
+	result, err := RunMixed(context.Background(), cli, MixedConfig{
 		Mount:           "vol",
 		RunID:           "test",
 		Clients:         2,
@@ -352,6 +359,23 @@ func TestRunMixedCoversFullSurface(t *testing.T) {
 		"expire_write_sessions",
 	} {
 		require.True(t, ops[op], fmt.Sprintf("missing operation %s", op))
+	}
+	cli.mu.Lock()
+	versions := make(map[uint64]struct{}, len(cli.versions))
+	for version := range cli.versions {
+		versions[version] = struct{}{}
+	}
+	reads := append([]fsmeta.ReadDirRequest(nil), cli.reads...)
+	cli.mu.Unlock()
+	seen := make(map[uint64]struct{})
+	for _, req := range reads {
+		if req.SnapshotVersion != 0 {
+			seen[req.SnapshotVersion] = struct{}{}
+		}
+	}
+	require.NotEmpty(t, versions)
+	for version := range versions {
+		require.Contains(t, seen, version)
 	}
 }
 

--- a/benchmark/fsmeta/workload/mixed_test.go
+++ b/benchmark/fsmeta/workload/mixed_test.go
@@ -146,6 +146,13 @@ func (c *fakeMixedClient) RetireSnapshotSubtree(_ context.Context, token fsmeta.
 	return nil
 }
 
+func (c *fakeMixedClient) GetReadVersion(context.Context, fsmeta.ReadVersionRequest) (uint64, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.version++
+	return c.version, nil
+}
+
 func (c *fakeMixedClient) GetQuotaUsage(context.Context, fsmeta.QuotaUsageRequest) (fsmeta.UsageRecord, error) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
@@ -338,9 +345,8 @@ func TestRunMixedCoversFullSurface(t *testing.T) {
 		"unlink_temp",
 		"readdir",
 		"readdirplus",
-		"snapshot_subtree",
+		"get_read_version",
 		"snapshot_readdirplus",
-		"retire_snapshot_subtree",
 		"get_quota_usage",
 		"open_stale_write_session",
 		"expire_write_sessions",

--- a/benchmark/fsmeta/workload/workload.go
+++ b/benchmark/fsmeta/workload/workload.go
@@ -429,23 +429,25 @@ func RunDurableSnapshot(ctx context.Context, cli Client, cfg DurableSnapshotConf
 	}
 	for i := 0; i < cfg.Snapshots; i++ {
 		var token fsmeta.SnapshotSubtreeToken
+		var snapshotErr error
 		rec.recordCall("snapshot_subtree", func() error {
-			var err error
-			token, err = snapshotCli.SnapshotSubtree(ctx, fsmeta.SnapshotSubtreeRequest{Mount: cfg.Mount, RootInode: root})
-			return err
+			token, snapshotErr = snapshotCli.SnapshotSubtree(ctx, fsmeta.SnapshotSubtreeRequest{Mount: cfg.Mount, RootInode: root})
+			return snapshotErr
 		})
-		if token.ReadVersion == 0 {
+		if snapshotErr != nil {
 			continue
 		}
-		rec.recordCall("snapshot_readdirplus", func() error {
-			_, err := cli.ReadDirPlus(ctx, fsmeta.ReadDirRequest{
-				Mount:           cfg.Mount,
-				Parent:          root,
-				Limit:           cfg.PageLimit,
-				SnapshotVersion: token.ReadVersion,
+		if token.ReadVersion != 0 {
+			rec.recordCall("snapshot_readdirplus", func() error {
+				_, err := cli.ReadDirPlus(ctx, fsmeta.ReadDirRequest{
+					Mount:           cfg.Mount,
+					Parent:          root,
+					Limit:           cfg.PageLimit,
+					SnapshotVersion: token.ReadVersion,
+				})
+				return err
 			})
-			return err
-		})
+		}
 		rec.recordCall("retire_snapshot_subtree", func() error {
 			return snapshotCli.RetireSnapshotSubtree(ctx, token)
 		})

--- a/benchmark/fsmeta/workload/workload.go
+++ b/benchmark/fsmeta/workload/workload.go
@@ -19,6 +19,7 @@ import (
 
 const (
 	CheckpointStorm = "checkpoint-storm"
+	DurableSnapshot = "durable-snapshot"
 	HotspotFanIn    = "hotspot-fanin"
 	WatchSubtree    = "watch-subtree"
 	NegativeLookup  = "negative-lookup"
@@ -63,6 +64,14 @@ type WatchSubtreeConfig struct {
 	BackPressureWindow uint32
 }
 
+type DurableSnapshotConfig struct {
+	Mount     fsmeta.MountID
+	RunID     string
+	Files     int
+	Snapshots int
+	PageLimit uint32
+}
+
 type NegativeLookupConfig struct {
 	Mount          fsmeta.MountID
 	RunID          string
@@ -86,6 +95,12 @@ type Result struct {
 type WatchClient interface {
 	Client
 	WatchSubtree(ctx context.Context, req fsmeta.WatchRequest) (fsmetaclient.WatchSubscription, error)
+}
+
+type DurableSnapshotClient interface {
+	Client
+	SnapshotSubtree(ctx context.Context, req fsmeta.SnapshotSubtreeRequest) (fsmeta.SnapshotSubtreeToken, error)
+	RetireSnapshotSubtree(ctx context.Context, token fsmeta.SnapshotSubtreeToken) error
 }
 
 type Sample struct {
@@ -375,6 +390,68 @@ func RunNegativeLookup(ctx context.Context, cli Client, cfg NegativeLookupConfig
 	wg.Wait()
 
 	return finishResult(NegativeLookup, cfg.RunID, started, rec.snapshot())
+}
+
+func RunDurableSnapshot(ctx context.Context, cli Client, cfg DurableSnapshotConfig) (Result, error) {
+	snapshotCli, ok := cli.(DurableSnapshotClient)
+	if !ok {
+		return Result{}, fmt.Errorf("durable-snapshot requires native fsmeta snapshot client")
+	}
+	cfg = normalizeDurableSnapshotConfig(cfg)
+	started := time.Now()
+	rec := newRecorder()
+
+	dirName := fmt.Sprintf("durable-snapshot-%s", cfg.RunID)
+	var root fsmeta.InodeID
+	rec.recordCall("mkdir", func() error {
+		result, err := cli.Create(ctx, fsmeta.CreateRequest{
+			Mount:  cfg.Mount,
+			Parent: fsmeta.RootInode,
+			Name:   dirName,
+			Attrs:  fsmeta.CreateAttrs{Type: fsmeta.InodeTypeDirectory, Mode: 0o755},
+		})
+		if err == nil {
+			root = result.Inode.Inode
+		}
+		return err
+	})
+	for i := 0; i < cfg.Files; i++ {
+		name := fmt.Sprintf("snapshot-%s-file-%08d", cfg.RunID, i)
+		rec.recordCall("seed_create", func() error {
+			_, err := cli.Create(ctx, fsmeta.CreateRequest{
+				Mount:  cfg.Mount,
+				Parent: root,
+				Name:   name,
+				Attrs:  fsmeta.CreateAttrs{Type: fsmeta.InodeTypeFile, Mode: 0o644},
+			})
+			return err
+		})
+	}
+	for i := 0; i < cfg.Snapshots; i++ {
+		var token fsmeta.SnapshotSubtreeToken
+		rec.recordCall("snapshot_subtree", func() error {
+			var err error
+			token, err = snapshotCli.SnapshotSubtree(ctx, fsmeta.SnapshotSubtreeRequest{Mount: cfg.Mount, RootInode: root})
+			return err
+		})
+		if token.ReadVersion == 0 {
+			continue
+		}
+		rec.recordCall("snapshot_readdirplus", func() error {
+			_, err := cli.ReadDirPlus(ctx, fsmeta.ReadDirRequest{
+				Mount:           cfg.Mount,
+				Parent:          root,
+				Limit:           cfg.PageLimit,
+				SnapshotVersion: token.ReadVersion,
+			})
+			return err
+		})
+		rec.recordCall("retire_snapshot_subtree", func() error {
+			return snapshotCli.RetireSnapshotSubtree(ctx, token)
+		})
+	}
+
+	return finishResult(DurableSnapshot, cfg.RunID, started, rec.snapshot())
 }
 
 func SummaryRows(result Result) []SummaryRow {
@@ -697,6 +774,28 @@ func normalizeNegativeLookupConfig(cfg NegativeLookupConfig) NegativeLookupConfi
 	}
 	if cfg.Parent == 0 {
 		cfg.Parent = fsmeta.RootInode
+	}
+	return cfg
+}
+
+func normalizeDurableSnapshotConfig(cfg DurableSnapshotConfig) DurableSnapshotConfig {
+	if cfg.Mount == "" {
+		cfg.Mount = "fsmeta-workload"
+	}
+	if cfg.RunID == "" {
+		cfg.RunID = NewRunID()
+	}
+	if cfg.Files <= 0 {
+		cfg.Files = 128
+	}
+	if cfg.Snapshots <= 0 {
+		cfg.Snapshots = 16
+	}
+	if cfg.PageLimit == 0 {
+		cfg.PageLimit = uint32(cfg.Files)
+	}
+	if cfg.PageLimit > fsmeta.MaxReadDirLimit {
+		cfg.PageLimit = fsmeta.MaxReadDirLimit
 	}
 	return cfg
 }

--- a/benchmark/fsmeta/workload/workload_test.go
+++ b/benchmark/fsmeta/workload/workload_test.go
@@ -155,7 +155,8 @@ func TestRunNegativeLookup(t *testing.T) {
 }
 
 func TestRunDurableSnapshot(t *testing.T) {
-	result, err := RunDurableSnapshot(context.Background(), newFakeSnapshotClient(), DurableSnapshotConfig{
+	cli := newFakeSnapshotClient()
+	result, err := RunDurableSnapshot(context.Background(), cli, DurableSnapshotConfig{
 		Mount:     "vol",
 		RunID:     "test",
 		Files:     3,
@@ -175,6 +176,21 @@ func TestRunDurableSnapshot(t *testing.T) {
 	require.Equal(t, 2, ops["snapshot_subtree"])
 	require.Equal(t, 2, ops["snapshot_readdirplus"])
 	require.Equal(t, 2, ops["retire_snapshot_subtree"])
+	cli.mu.RLock()
+	snapshots := len(cli.snapshots)
+	retired := make(map[uint64]fsmeta.SnapshotSubtreeToken, len(cli.retired))
+	for version, token := range cli.retired {
+		retired[version] = token
+	}
+	readVersions := append([]uint64(nil), cli.readVersions...)
+	cli.mu.RUnlock()
+	require.Zero(t, snapshots)
+	require.Len(t, retired, 2)
+	require.Len(t, readVersions, 2)
+	for _, version := range readVersions {
+		require.NotZero(t, version)
+		require.Contains(t, retired, version)
+	}
 }
 
 func TestWriteSummaryCSVIncludesDriver(t *testing.T) {
@@ -238,8 +254,10 @@ func (c *fakeWatchClient) WatchSubtree(_ context.Context, req fsmeta.WatchReques
 
 type fakeSnapshotClient struct {
 	*fakeClient
-	nextVersion uint64
-	snapshots   map[uint64]fsmeta.SnapshotSubtreeToken
+	nextVersion  uint64
+	snapshots    map[uint64]fsmeta.SnapshotSubtreeToken
+	retired      map[uint64]fsmeta.SnapshotSubtreeToken
+	readVersions []uint64
 }
 
 func newFakeSnapshotClient() *fakeSnapshotClient {
@@ -247,7 +265,15 @@ func newFakeSnapshotClient() *fakeSnapshotClient {
 		fakeClient:  newFakeClient(),
 		nextVersion: 1,
 		snapshots:   make(map[uint64]fsmeta.SnapshotSubtreeToken),
+		retired:     make(map[uint64]fsmeta.SnapshotSubtreeToken),
 	}
+}
+
+func (c *fakeSnapshotClient) ReadDirPlus(ctx context.Context, req fsmeta.ReadDirRequest) ([]fsmeta.DentryAttrPair, error) {
+	c.mu.Lock()
+	c.readVersions = append(c.readVersions, req.SnapshotVersion)
+	c.mu.Unlock()
+	return c.fakeClient.ReadDirPlus(ctx, req)
 }
 
 func (c *fakeSnapshotClient) SnapshotSubtree(_ context.Context, req fsmeta.SnapshotSubtreeRequest) (fsmeta.SnapshotSubtreeToken, error) {
@@ -263,6 +289,7 @@ func (c *fakeSnapshotClient) RetireSnapshotSubtree(_ context.Context, token fsme
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	delete(c.snapshots, token.ReadVersion)
+	c.retired[token.ReadVersion] = token
 	return nil
 }
 

--- a/benchmark/fsmeta/workload/workload_test.go
+++ b/benchmark/fsmeta/workload/workload_test.go
@@ -154,6 +154,29 @@ func TestRunNegativeLookup(t *testing.T) {
 	require.Equal(t, "lookup_missing", rows[0].Operation)
 }
 
+func TestRunDurableSnapshot(t *testing.T) {
+	result, err := RunDurableSnapshot(context.Background(), newFakeSnapshotClient(), DurableSnapshotConfig{
+		Mount:     "vol",
+		RunID:     "test",
+		Files:     3,
+		Snapshots: 2,
+		PageLimit: 8,
+	})
+	require.NoError(t, err)
+	require.Equal(t, DurableSnapshot, result.Name)
+	require.Zero(t, result.Errors)
+	rows := SummaryRows(result)
+	ops := make(map[string]int, len(rows))
+	for _, row := range rows {
+		ops[row.Operation] = row.Count
+	}
+	require.Equal(t, 1, ops["mkdir"])
+	require.Equal(t, 3, ops["seed_create"])
+	require.Equal(t, 2, ops["snapshot_subtree"])
+	require.Equal(t, 2, ops["snapshot_readdirplus"])
+	require.Equal(t, 2, ops["retire_snapshot_subtree"])
+}
+
 func TestWriteSummaryCSVIncludesDriver(t *testing.T) {
 	var buf bytes.Buffer
 	err := WriteSummaryCSV(&buf, []SummaryRow{{
@@ -211,6 +234,36 @@ func (c *fakeWatchClient) Create(ctx context.Context, req fsmeta.CreateRequest) 
 func (c *fakeWatchClient) WatchSubtree(_ context.Context, req fsmeta.WatchRequest) (fsmetaclient.WatchSubscription, error) {
 	c.stream.prefix = append([]byte(nil), req.KeyPrefix...)
 	return c.stream, nil
+}
+
+type fakeSnapshotClient struct {
+	*fakeClient
+	nextVersion uint64
+	snapshots   map[uint64]fsmeta.SnapshotSubtreeToken
+}
+
+func newFakeSnapshotClient() *fakeSnapshotClient {
+	return &fakeSnapshotClient{
+		fakeClient:  newFakeClient(),
+		nextVersion: 1,
+		snapshots:   make(map[uint64]fsmeta.SnapshotSubtreeToken),
+	}
+}
+
+func (c *fakeSnapshotClient) SnapshotSubtree(_ context.Context, req fsmeta.SnapshotSubtreeRequest) (fsmeta.SnapshotSubtreeToken, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.nextVersion++
+	token := fsmeta.SnapshotSubtreeToken{Mount: req.Mount, RootInode: req.RootInode, ReadVersion: c.nextVersion}
+	c.snapshots[token.ReadVersion] = token
+	return token, nil
+}
+
+func (c *fakeSnapshotClient) RetireSnapshotSubtree(_ context.Context, token fsmeta.SnapshotSubtreeToken) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	delete(c.snapshots, token.ReadVersion)
+	return nil
 }
 
 type fakeWatchStream struct {

--- a/cmd/nokv-fsmeta/main.go
+++ b/cmd/nokv-fsmeta/main.go
@@ -38,10 +38,15 @@ func main() {
 		negCacheDir            = flag.String("negative-cache-dir", "", "optional slab directory for persistent negative dentry cache")
 		dirPageDir             = flag.String("dirpage-cache-dir", "", "optional slab directory for ReadDirPlus page cache")
 		inodeAffinityShards    = flag.Int("inode-affinity-shards", 4, "local LSM shard count used to choose Create inode IDs that match dentry shard placement")
+		lockTTL                = flag.Duration("lock-ttl", 0, "Percolator primary-lock TTL for fsmeta mutations; zero uses the fsmeta default")
 		sessionCleanupInterval = flag.Duration("session-cleanup-interval", 30*time.Second, "interval for expired write-session cleanup; choose about half the smallest expected session TTL; negative disables")
 		sessionCleanupLimit    = flag.Uint("session-cleanup-limit", 0, "maximum session records scanned per mount per cleanup pass; zero uses fsmeta default")
 	)
 	flag.Parse()
+	if *lockTTL < 0 {
+		fatalf("lock-ttl must be non-negative")
+		return
+	}
 	if *sessionCleanupLimit > uint(fsmeta.MaxSessionExpireLimit) {
 		fatalf("session-cleanup-limit exceeds maximum %d", fsmeta.MaxSessionExpireLimit)
 		return
@@ -55,6 +60,7 @@ func main() {
 		NegativeCacheDir:       *negCacheDir,
 		DirPageCacheDir:        *dirPageDir,
 		InodeAffinityShards:    *inodeAffinityShards,
+		LockTTL:                *lockTTL,
 		SessionCleanupInterval: *sessionCleanupInterval,
 		SessionCleanupLimit:    uint32(*sessionCleanupLimit),
 	})

--- a/fsmeta/client/client.go
+++ b/fsmeta/client/client.go
@@ -23,6 +23,17 @@ const (
 	reasonMountNotRegistered   = "mount_not_registered"
 	reasonMountRetired         = "mount_retired"
 	reasonCrossAuthorityRename = "cross_authority_rename"
+	reasonInvalidFSMetaInput   = "invalid_fsmeta_input"
+	reasonInvalidMountID       = "invalid_mount_id"
+	reasonInvalidInodeID       = "invalid_inode_id"
+	reasonInvalidName          = "invalid_name"
+	reasonInvalidSession       = "invalid_session"
+	reasonInvalidRequest       = "invalid_request"
+	reasonInvalidKey           = "invalid_key"
+	reasonInvalidKeyKind       = "invalid_key_kind"
+	reasonInvalidValue         = "invalid_value"
+	reasonInvalidValueKind     = "invalid_value_kind"
+	reasonInvalidPageSize      = "invalid_page_size"
 )
 
 // Client is the typed fsmeta client surface consumed by demos and benchmarks.
@@ -387,6 +398,11 @@ func translateRPCError(err error) error {
 		return nil
 	}
 	switch status.Code(err) {
+	case codes.InvalidArgument:
+		if sentinel := invalidReasonSentinel(fsmetaReason(err)); sentinel != nil {
+			return fmt.Errorf("%w: %v", sentinel, err)
+		}
+		return err
 	case codes.AlreadyExists:
 		return fmt.Errorf("%w: %v", fsmeta.ErrExists, err)
 	case codes.NotFound:
@@ -414,6 +430,33 @@ func translateRPCError(err error) error {
 		return err
 	default:
 		return err
+	}
+}
+
+func invalidReasonSentinel(reason string) error {
+	switch reason {
+	case reasonInvalidMountID:
+		return fsmeta.ErrInvalidMountID
+	case reasonInvalidInodeID:
+		return fsmeta.ErrInvalidInodeID
+	case reasonInvalidName:
+		return fsmeta.ErrInvalidName
+	case reasonInvalidSession:
+		return fsmeta.ErrInvalidSession
+	case reasonInvalidRequest, reasonInvalidFSMetaInput:
+		return fsmeta.ErrInvalidRequest
+	case reasonInvalidKey:
+		return fsmeta.ErrInvalidKey
+	case reasonInvalidKeyKind:
+		return fsmeta.ErrInvalidKeyKind
+	case reasonInvalidValue:
+		return fsmeta.ErrInvalidValue
+	case reasonInvalidValueKind:
+		return fsmeta.ErrInvalidValueKind
+	case reasonInvalidPageSize:
+		return fsmeta.ErrInvalidPageSize
+	default:
+		return nil
 	}
 }
 

--- a/fsmeta/client/client.go
+++ b/fsmeta/client/client.go
@@ -33,6 +33,7 @@ type Client interface {
 	ReadDir(ctx context.Context, req fsmeta.ReadDirRequest) ([]fsmeta.DentryRecord, error)
 	ReadDirPlus(ctx context.Context, req fsmeta.ReadDirRequest) ([]fsmeta.DentryAttrPair, error)
 	WatchSubtree(ctx context.Context, req fsmeta.WatchRequest) (WatchSubscription, error)
+	GetReadVersion(ctx context.Context, req fsmeta.ReadVersionRequest) (uint64, error)
 	SnapshotSubtree(ctx context.Context, req fsmeta.SnapshotSubtreeRequest) (fsmeta.SnapshotSubtreeToken, error)
 	RetireSnapshotSubtree(ctx context.Context, token fsmeta.SnapshotSubtreeToken) error
 	GetQuotaUsage(ctx context.Context, req fsmeta.QuotaUsageRequest) (fsmeta.UsageRecord, error)
@@ -166,6 +167,17 @@ func (c *GRPCClient) WatchSubtree(ctx context.Context, req fsmeta.WatchRequest) 
 		return nil, err
 	}
 	return &WatchStream{stream: stream, ready: ready}, nil
+}
+
+func (c *GRPCClient) GetReadVersion(ctx context.Context, req fsmeta.ReadVersionRequest) (uint64, error) {
+	if err := c.requireRPC(); err != nil {
+		return 0, err
+	}
+	resp, err := c.rpc.GetReadVersion(ctx, getReadVersionRequestToProto(req))
+	if err != nil {
+		return 0, translateRPCError(err)
+	}
+	return resp.GetReadVersion(), nil
 }
 
 func (c *GRPCClient) SnapshotSubtree(ctx context.Context, req fsmeta.SnapshotSubtreeRequest) (fsmeta.SnapshotSubtreeToken, error) {

--- a/fsmeta/client/client_test.go
+++ b/fsmeta/client/client_test.go
@@ -309,6 +309,16 @@ func TestTypedClientErrorTranslation(t *testing.T) {
 	err = cli.Rename(context.Background(), fsmeta.RenameRequest{Mount: "vol", FromParent: 1, FromName: "a", ToParent: 2, ToName: "b"})
 	require.ErrorIs(t, err, fsmeta.ErrCrossAuthorityRename)
 
+	cli, cleanup = openBufconnClient(t, &fakeExecutor{err: fsmeta.ErrInvalidRequest})
+	defer cleanup()
+	err = cli.RenameSubtree(context.Background(), fsmeta.RenameSubtreeRequest{Mount: "vol", FromParent: 1, FromName: "a", ToParent: 1, ToName: "a"})
+	require.ErrorIs(t, err, fsmeta.ErrInvalidRequest)
+
+	cli, cleanup = openBufconnClient(t, &fakeExecutor{err: fsmeta.ErrInvalidName})
+	defer cleanup()
+	_, err = cli.Lookup(context.Background(), fsmeta.LookupRequest{Mount: "vol", Parent: fsmeta.RootInode, Name: ""})
+	require.ErrorIs(t, err, fsmeta.ErrInvalidName)
+
 	cli, cleanup = openBufconnClient(t, &fakeExecutor{err: fsmeta.ErrQuotaExceeded})
 	defer cleanup()
 	_, err = cli.GetQuotaUsage(context.Background(), fsmeta.QuotaUsageRequest{Mount: "vol"})

--- a/fsmeta/client/client_test.go
+++ b/fsmeta/client/client_test.go
@@ -79,6 +79,13 @@ func (e *fakeExecutor) ReadDirPlus(context.Context, fsmeta.ReadDirRequest) ([]fs
 	}}, nil
 }
 
+func (e *fakeExecutor) GetReadVersion(context.Context, fsmeta.ReadVersionRequest) (uint64, error) {
+	if e.err != nil {
+		return 0, e.err
+	}
+	return 5678, nil
+}
+
 func (e *fakeExecutor) SnapshotSubtree(_ context.Context, req fsmeta.SnapshotSubtreeRequest) (fsmeta.SnapshotSubtreeToken, error) {
 	if e.err != nil {
 		return fsmeta.SnapshotSubtreeToken{}, e.err
@@ -399,6 +406,15 @@ func TestTypedClientSnapshotSubtree(t *testing.T) {
 	require.Equal(t, fsmeta.SnapshotSubtreeToken{Mount: "vol", RootInode: 42, ReadVersion: 5678}, token)
 	require.NoError(t, cli.RetireSnapshotSubtree(context.Background(), token))
 	require.Equal(t, token, publisher.retired)
+}
+
+func TestTypedClientGetReadVersion(t *testing.T) {
+	cli, cleanup := openBufconnClient(t, &fakeExecutor{})
+	defer cleanup()
+
+	version, err := cli.GetReadVersion(context.Background(), fsmeta.ReadVersionRequest{Mount: "vol"})
+	require.NoError(t, err)
+	require.Equal(t, uint64(5678), version)
 }
 
 func TestTypedClientGetQuotaUsage(t *testing.T) {

--- a/fsmeta/client/wire.go
+++ b/fsmeta/client/wire.go
@@ -60,6 +60,10 @@ func readDirRequestToProto(req fsmeta.ReadDirRequest) *fsmetapb.ReadDirRequest {
 	}
 }
 
+func getReadVersionRequestToProto(req fsmeta.ReadVersionRequest) *fsmetapb.GetReadVersionRequest {
+	return &fsmetapb.GetReadVersionRequest{Mount: string(req.Mount)}
+}
+
 func snapshotSubtreeRequestToProto(req fsmeta.SnapshotSubtreeRequest) *fsmetapb.SnapshotSubtreeRequest {
 	return &fsmetapb.SnapshotSubtreeRequest{
 		Mount:     string(req.Mount),

--- a/fsmeta/exec/runner.go
+++ b/fsmeta/exec/runner.go
@@ -710,17 +710,27 @@ func decodeDirPageEntries(key dirpage.PageKey, entries []dirpage.Entry) ([]fsmet
 	return out, nil
 }
 
-// SnapshotSubtree publishes a stable MVCC read version for one direct subtree
-// root. The returned token is consumed by ReadDir / ReadDirPlus through
-// ReadDirRequest.SnapshotVersion.
+// GetReadVersion returns an ephemeral MVCC read version. It is intentionally
+// cheaper than SnapshotSubtree: no root event is published and no GC-retention
+// promise is made.
+func (e *Executor) GetReadVersion(ctx context.Context, req fsmeta.ReadVersionRequest) (uint64, error) {
+	if req.Mount == "" {
+		return 0, fsmeta.ErrInvalidMountID
+	}
+	if err := e.requireActiveMount(ctx, req.Mount); err != nil {
+		return 0, err
+	}
+	return e.reserveReadVersion(ctx)
+}
+
+// SnapshotSubtree reserves a durable MVCC read version for one direct subtree
+// root. The service boundary publishes the returned token into rooted truth so
+// GC can treat it as a retained snapshot until RetireSnapshotSubtree.
 func (e *Executor) SnapshotSubtree(ctx context.Context, req fsmeta.SnapshotSubtreeRequest) (fsmeta.SnapshotSubtreeToken, error) {
 	if _, err := fsmeta.PlanSnapshotSubtree(req); err != nil {
 		return fsmeta.SnapshotSubtreeToken{}, err
 	}
-	if err := e.requireActiveMount(ctx, req.Mount); err != nil {
-		return fsmeta.SnapshotSubtreeToken{}, err
-	}
-	version, err := e.reserveReadVersion(ctx)
+	version, err := e.GetReadVersion(ctx, fsmeta.ReadVersionRequest{Mount: req.Mount})
 	if err != nil {
 		return fsmeta.SnapshotSubtreeToken{}, err
 	}

--- a/fsmeta/exec/runner.go
+++ b/fsmeta/exec/runner.go
@@ -16,10 +16,17 @@ import (
 	kvrpcpb "github.com/feichai0017/NoKV/pb/kv"
 )
 
-const defaultLockTTL uint64 = 3000
-const maxTxnContentionRetries = 3
-const maxReadContentionRetries = 3
-const txnContentionRetryBackoff = time.Millisecond
+const (
+	// Percolator TTLs are encoded in milliseconds. fsmeta mutations cross the
+	// coordinator TSO path plus raft apply queues, so the default must cover
+	// short commit stalls instead of letting read-side lock resolution roll
+	// back a live metadata transaction.
+	defaultLockTTL uint64 = uint64(30 * time.Second / time.Millisecond)
+
+	maxTxnContentionRetries   = 3
+	maxReadContentionRetries  = 3
+	txnContentionRetryBackoff = time.Millisecond
+)
 
 // KV is the minimal key/value tuple the fsmeta executor consumes from scans.
 type KV struct {

--- a/fsmeta/exec/runner_test.go
+++ b/fsmeta/exec/runner_test.go
@@ -279,6 +279,17 @@ func TestExecutorSnapshotSubtreeTokenDrivesReadVersion(t *testing.T) {
 	require.Equal(t, []uint64{token.ReadVersion}, runner.batchVersions)
 }
 
+func TestExecutorGetReadVersionReservesEphemeralTimestamp(t *testing.T) {
+	runner := newFakeRunner()
+	executor, err := New(runner)
+	require.NoError(t, err)
+
+	version, err := executor.GetReadVersion(context.Background(), fsmeta.ReadVersionRequest{Mount: "vol"})
+	require.NoError(t, err)
+	require.Equal(t, uint64(1), version)
+	require.Equal(t, uint64(2), runner.nextTS)
+}
+
 func TestExecutorGetQuotaUsage(t *testing.T) {
 	runner := newFakeRunner()
 	key, err := fsmeta.EncodeUsageKey("vol", 7)

--- a/fsmeta/runtime/raftstore/errors.go
+++ b/fsmeta/runtime/raftstore/errors.go
@@ -10,6 +10,7 @@ import (
 var (
 	errCoordinatorAddrRequired     = nokverrors.New(nokverrors.KindInvalidArgument, "fsmeta/runtime/raftstore: coordinator addr is required")
 	errSessionCleanupLimitExceeded = nokverrors.New(nokverrors.KindInvalidArgument, "fsmeta/runtime/raftstore: session cleanup limit exceeds maximum")
+	errLockTTLInvalid              = nokverrors.New(nokverrors.KindInvalidArgument, "fsmeta/runtime/raftstore: lock ttl must be non-negative")
 	errMountCacheNotConfigured     = nokverrors.New(nokverrors.KindInvalidArgument, "fsmeta/runtime/raftstore: mount cache is not configured")
 	errRootPublisherNotConfigured  = nokverrors.New(nokverrors.KindInvalidArgument, "fsmeta/runtime/raftstore: root publisher is not configured")
 	errStoreListerRequired         = nokverrors.New(nokverrors.KindInvalidArgument, "fsmeta/runtime/raftstore: store lister is required")

--- a/fsmeta/runtime/raftstore/open.go
+++ b/fsmeta/runtime/raftstore/open.go
@@ -42,6 +42,12 @@ type Options struct {
 	// uses fsmeta.DefaultSessionExpireLimit.
 	SessionCleanupLimit uint32
 
+	// LockTTL bounds Percolator primary-lock liveness for fsmeta mutations.
+	// Zero uses fsmeta/exec's default. Set this above the p99 raft apply and
+	// coordinator TSO window; otherwise read-side lock resolution can roll back
+	// a live transaction that is only delayed in the commit path.
+	LockTTL time.Duration
+
 	// NegativeCacheDir enables the slab-backed negative dentry cache. Empty
 	// disables it. This is a Derived cache: authoritative reads still fall
 	// back to raftstore plus txn/percolator on miss or invalidation.
@@ -94,6 +100,9 @@ func Open(ctx context.Context, opts Options) (*Runtime, error) {
 	}
 	if opts.SessionCleanupLimit > fsmeta.MaxSessionExpireLimit {
 		return nil, errSessionCleanupLimitExceeded
+	}
+	if opts.LockTTL < 0 {
+		return nil, errLockTTLInvalid
 	}
 	if ctx == nil {
 		ctx = context.Background()
@@ -154,6 +163,9 @@ func Open(ctx context.Context, opts Options) (*Runtime, error) {
 		fsmetaexec.WithSubtreeAuthorityResolver(mounts),
 		fsmetaexec.WithQuotaResolver(quotas),
 		fsmetaexec.WithSubtreeHandoffPublisher(pub),
+	}
+	if opts.LockTTL > 0 {
+		execOpts = append(execOpts, fsmetaexec.WithLockTTL(uint64((opts.LockTTL+time.Millisecond-1)/time.Millisecond)))
 	}
 	var negPersist *negativecache.Persistence
 	if opts.NegativeCacheDir != "" {

--- a/fsmeta/runtime/raftstore/open_test.go
+++ b/fsmeta/runtime/raftstore/open_test.go
@@ -3,6 +3,7 @@ package raftstore
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/feichai0017/NoKV/fsmeta"
 	"github.com/stretchr/testify/require"
@@ -14,4 +15,12 @@ func TestOpenRejectsInvalidSessionCleanupLimit(t *testing.T) {
 		SessionCleanupLimit: fsmeta.MaxSessionExpireLimit + 1,
 	})
 	require.ErrorContains(t, err, "session cleanup limit exceeds maximum")
+}
+
+func TestOpenRejectsNegativeLockTTL(t *testing.T) {
+	_, err := Open(context.Background(), Options{
+		CoordinatorAddr: "127.0.0.1:1",
+		LockTTL:         -time.Millisecond,
+	})
+	require.ErrorIs(t, err, errLockTTLInvalid)
 }

--- a/fsmeta/server/errors.go
+++ b/fsmeta/server/errors.go
@@ -21,6 +21,16 @@ const (
 	reasonNamespaceExists      = "entry_exists"
 	reasonNamespaceNotFound    = "entry_not_found"
 	reasonInvalidFSMetaInput   = "invalid_fsmeta_input"
+	reasonInvalidMountID       = "invalid_mount_id"
+	reasonInvalidInodeID       = "invalid_inode_id"
+	reasonInvalidName          = "invalid_name"
+	reasonInvalidSession       = "invalid_session"
+	reasonInvalidRequest       = "invalid_request"
+	reasonInvalidKey           = "invalid_key"
+	reasonInvalidKeyKind       = "invalid_key_kind"
+	reasonInvalidValue         = "invalid_value"
+	reasonInvalidValueKind     = "invalid_value_kind"
+	reasonInvalidPageSize      = "invalid_page_size"
 	reasonServiceUnavailable   = "service_unavailable"
 	reasonContextCanceled      = "context_canceled"
 	reasonContextDeadline      = "context_deadline"
@@ -79,12 +89,26 @@ func fsmetaErrorMetadata(err error) map[string]string {
 		reason = reasonNamespaceExists
 	case errors.Is(err, fsmeta.ErrNotFound):
 		reason = reasonNamespaceNotFound
-	case errors.Is(err, fsmeta.ErrInvalidMountID), errors.Is(err, fsmeta.ErrInvalidInodeID),
-		errors.Is(err, fsmeta.ErrInvalidName), errors.Is(err, fsmeta.ErrInvalidSession),
-		errors.Is(err, fsmeta.ErrInvalidRequest), errors.Is(err, fsmeta.ErrInvalidKey),
-		errors.Is(err, fsmeta.ErrInvalidKeyKind), errors.Is(err, fsmeta.ErrInvalidValue),
-		errors.Is(err, fsmeta.ErrInvalidValueKind), errors.Is(err, fsmeta.ErrInvalidPageSize):
-		reason = reasonInvalidFSMetaInput
+	case errors.Is(err, fsmeta.ErrInvalidMountID):
+		reason = reasonInvalidMountID
+	case errors.Is(err, fsmeta.ErrInvalidInodeID):
+		reason = reasonInvalidInodeID
+	case errors.Is(err, fsmeta.ErrInvalidName):
+		reason = reasonInvalidName
+	case errors.Is(err, fsmeta.ErrInvalidSession):
+		reason = reasonInvalidSession
+	case errors.Is(err, fsmeta.ErrInvalidRequest):
+		reason = reasonInvalidRequest
+	case errors.Is(err, fsmeta.ErrInvalidKey):
+		reason = reasonInvalidKey
+	case errors.Is(err, fsmeta.ErrInvalidKeyKind):
+		reason = reasonInvalidKeyKind
+	case errors.Is(err, fsmeta.ErrInvalidValue):
+		reason = reasonInvalidValue
+	case errors.Is(err, fsmeta.ErrInvalidValueKind):
+		reason = reasonInvalidValueKind
+	case errors.Is(err, fsmeta.ErrInvalidPageSize):
+		reason = reasonInvalidPageSize
 	}
 	if reason == "" {
 		return nil

--- a/fsmeta/server/service.go
+++ b/fsmeta/server/service.go
@@ -19,6 +19,7 @@ type Executor interface {
 	Lookup(ctx context.Context, req fsmeta.LookupRequest) (fsmeta.DentryRecord, error)
 	ReadDir(ctx context.Context, req fsmeta.ReadDirRequest) ([]fsmeta.DentryRecord, error)
 	ReadDirPlus(ctx context.Context, req fsmeta.ReadDirRequest) ([]fsmeta.DentryAttrPair, error)
+	GetReadVersion(ctx context.Context, req fsmeta.ReadVersionRequest) (uint64, error)
 	SnapshotSubtree(ctx context.Context, req fsmeta.SnapshotSubtreeRequest) (fsmeta.SnapshotSubtreeToken, error)
 	GetQuotaUsage(ctx context.Context, req fsmeta.QuotaUsageRequest) (fsmeta.UsageRecord, error)
 	Rename(ctx context.Context, req fsmeta.RenameRequest) error
@@ -216,6 +217,20 @@ func (s *Service) WatchSubtree(stream fsmetapb.FSMetadata_WatchSubtreeServer) er
 			}
 		}
 	}
+}
+
+func (s *Service) GetReadVersion(ctx context.Context, req *fsmetapb.GetReadVersionRequest) (*fsmetapb.GetReadVersionResponse, error) {
+	if err := s.requireExecutor(); err != nil {
+		return nil, err
+	}
+	if req == nil {
+		return nil, rpcInvalidArgument("fsmeta get read version request is required")
+	}
+	version, err := s.executor.GetReadVersion(ctx, getReadVersionRequestFromProto(req))
+	if err != nil {
+		return nil, rpcError(err)
+	}
+	return &fsmetapb.GetReadVersionResponse{ReadVersion: version}, nil
 }
 
 func (s *Service) SnapshotSubtree(ctx context.Context, req *fsmetapb.SnapshotSubtreeRequest) (*fsmetapb.SnapshotSubtreeResponse, error) {

--- a/fsmeta/server/service_test.go
+++ b/fsmeta/server/service_test.go
@@ -23,6 +23,7 @@ type fakeExecutor struct {
 	createInode      fsmeta.InodeRecord
 	updateReq        fsmeta.UpdateInodeRequest
 	readDirReq       fsmeta.ReadDirRequest
+	readVersionReq   fsmeta.ReadVersionRequest
 	snapshotReq      fsmeta.SnapshotSubtreeRequest
 	quotaReq         fsmeta.QuotaUsageRequest
 	renameReq        fsmeta.RenameRequest
@@ -110,6 +111,14 @@ func (e *fakeExecutor) ReadDirPlus(_ context.Context, req fsmeta.ReadDirRequest)
 			LinkCount: 1,
 		},
 	}}, nil
+}
+
+func (e *fakeExecutor) GetReadVersion(_ context.Context, req fsmeta.ReadVersionRequest) (uint64, error) {
+	e.readVersionReq = req
+	if e.err != nil {
+		return 0, e.err
+	}
+	return 1234, nil
 }
 
 func (e *fakeExecutor) SnapshotSubtree(_ context.Context, req fsmeta.SnapshotSubtreeRequest) (fsmeta.SnapshotSubtreeToken, error) {
@@ -472,6 +481,20 @@ func TestGRPCServiceSnapshotSubtreePublishesToken(t *testing.T) {
 	require.Equal(t, fsmeta.SnapshotSubtreeRequest{Mount: "vol", RootInode: 42}, executor.snapshotReq)
 	require.Equal(t, uint64(1234), resp.GetReadVersion())
 	require.Equal(t, fsmeta.SnapshotSubtreeToken{Mount: "vol", RootInode: 42, ReadVersion: 1234}, publisher.token)
+}
+
+func TestGRPCServiceGetReadVersionDoesNotPublishSnapshot(t *testing.T) {
+	executor := &fakeExecutor{}
+	publisher := &fakeSnapshotPublisher{}
+	client, cleanup := openBufconnClient(t, executor, WithSnapshotPublisher(publisher))
+	defer cleanup()
+
+	resp, err := client.GetReadVersion(context.Background(), &fsmetapb.GetReadVersionRequest{Mount: "vol"})
+	require.NoError(t, err)
+	require.Equal(t, fsmeta.ReadVersionRequest{Mount: "vol"}, executor.readVersionReq)
+	require.Equal(t, uint64(1234), resp.GetReadVersion())
+	require.Zero(t, publisher.token)
+	require.Zero(t, publisher.retired)
 }
 
 func TestGRPCServiceSnapshotSubtreeRetiresTokenAfterPublishFailure(t *testing.T) {

--- a/fsmeta/server/service_test.go
+++ b/fsmeta/server/service_test.go
@@ -395,7 +395,7 @@ func TestGRPCServiceErrorMapping(t *testing.T) {
 	}{
 		{name: "exists", err: fsmeta.ErrExists, code: codes.AlreadyExists, reason: reasonNamespaceExists},
 		{name: "not found", err: fsmeta.ErrNotFound, code: codes.NotFound, reason: reasonNamespaceNotFound},
-		{name: "invalid", err: fsmeta.ErrInvalidName, code: codes.InvalidArgument, reason: reasonInvalidFSMetaInput},
+		{name: "invalid", err: fsmeta.ErrInvalidName, code: codes.InvalidArgument, reason: reasonInvalidName},
 		{name: "quota exceeded", err: fsmeta.ErrQuotaExceeded, code: codes.ResourceExhausted, reason: reasonQuotaExceeded},
 		{name: "watch overflow", err: fsmeta.ErrWatchOverflow, code: codes.ResourceExhausted, reason: reasonWatchOverflow},
 		{name: "watch cursor expired", err: fsmeta.ErrWatchCursorExpired, code: codes.OutOfRange, reason: reasonWatchCursorExpired},

--- a/fsmeta/server/wire.go
+++ b/fsmeta/server/wire.go
@@ -66,6 +66,13 @@ func readDirRequestFromProto(req *fsmetapb.ReadDirRequest) fsmeta.ReadDirRequest
 	}
 }
 
+func getReadVersionRequestFromProto(req *fsmetapb.GetReadVersionRequest) fsmeta.ReadVersionRequest {
+	if req == nil {
+		return fsmeta.ReadVersionRequest{}
+	}
+	return fsmeta.ReadVersionRequest{Mount: fsmeta.MountID(req.GetMount())}
+}
+
 func snapshotSubtreeRequestFromProto(req *fsmetapb.SnapshotSubtreeRequest) fsmeta.SnapshotSubtreeRequest {
 	if req == nil {
 		return fsmeta.SnapshotSubtreeRequest{}

--- a/fsmeta/types.go
+++ b/fsmeta/types.go
@@ -40,9 +40,16 @@ type DentryAttrPair struct {
 	Inode  InodeRecord
 }
 
-// SnapshotSubtreeToken identifies one MVCC read epoch for a direct subtree
-// page. V0 uses the token as a stable read version; recursive subtree
-// materialization and GC retention enforcement are later layers.
+// ReadVersionRequest asks for an ephemeral MVCC read version. It provides a
+// consistent read timestamp only; it does not publish a snapshot epoch or pin
+// GC state.
+type ReadVersionRequest struct {
+	Mount MountID
+}
+
+// SnapshotSubtreeToken identifies a durable subtree snapshot epoch. The token
+// is published into rooted truth by the fsmeta service boundary and must be
+// retired by callers when its GC-retention contract is no longer needed.
 type SnapshotSubtreeToken struct {
 	Mount       MountID
 	RootInode   InodeID

--- a/pb/fsmeta/fsmeta.pb.go
+++ b/pb/fsmeta/fsmeta.pb.go
@@ -1649,6 +1649,94 @@ func (*WatchAckOrSubscribe_Subscribe) isWatchAckOrSubscribe_Body() {}
 
 func (*WatchAckOrSubscribe_Ack) isWatchAckOrSubscribe_Body() {}
 
+type GetReadVersionRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Mount         string                 `protobuf:"bytes,1,opt,name=mount,proto3" json:"mount,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *GetReadVersionRequest) Reset() {
+	*x = GetReadVersionRequest{}
+	mi := &file_fsmeta_fsmeta_proto_msgTypes[23]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *GetReadVersionRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*GetReadVersionRequest) ProtoMessage() {}
+
+func (x *GetReadVersionRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_fsmeta_fsmeta_proto_msgTypes[23]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use GetReadVersionRequest.ProtoReflect.Descriptor instead.
+func (*GetReadVersionRequest) Descriptor() ([]byte, []int) {
+	return file_fsmeta_fsmeta_proto_rawDescGZIP(), []int{23}
+}
+
+func (x *GetReadVersionRequest) GetMount() string {
+	if x != nil {
+		return x.Mount
+	}
+	return ""
+}
+
+type GetReadVersionResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	ReadVersion   uint64                 `protobuf:"varint,1,opt,name=read_version,json=readVersion,proto3" json:"read_version,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *GetReadVersionResponse) Reset() {
+	*x = GetReadVersionResponse{}
+	mi := &file_fsmeta_fsmeta_proto_msgTypes[24]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *GetReadVersionResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*GetReadVersionResponse) ProtoMessage() {}
+
+func (x *GetReadVersionResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_fsmeta_fsmeta_proto_msgTypes[24]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use GetReadVersionResponse.ProtoReflect.Descriptor instead.
+func (*GetReadVersionResponse) Descriptor() ([]byte, []int) {
+	return file_fsmeta_fsmeta_proto_rawDescGZIP(), []int{24}
+}
+
+func (x *GetReadVersionResponse) GetReadVersion() uint64 {
+	if x != nil {
+		return x.ReadVersion
+	}
+	return 0
+}
+
 type SnapshotSubtreeRequest struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	Mount         string                 `protobuf:"bytes,1,opt,name=mount,proto3" json:"mount,omitempty"`
@@ -1659,7 +1747,7 @@ type SnapshotSubtreeRequest struct {
 
 func (x *SnapshotSubtreeRequest) Reset() {
 	*x = SnapshotSubtreeRequest{}
-	mi := &file_fsmeta_fsmeta_proto_msgTypes[23]
+	mi := &file_fsmeta_fsmeta_proto_msgTypes[25]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1671,7 +1759,7 @@ func (x *SnapshotSubtreeRequest) String() string {
 func (*SnapshotSubtreeRequest) ProtoMessage() {}
 
 func (x *SnapshotSubtreeRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_fsmeta_fsmeta_proto_msgTypes[23]
+	mi := &file_fsmeta_fsmeta_proto_msgTypes[25]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1684,7 +1772,7 @@ func (x *SnapshotSubtreeRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SnapshotSubtreeRequest.ProtoReflect.Descriptor instead.
 func (*SnapshotSubtreeRequest) Descriptor() ([]byte, []int) {
-	return file_fsmeta_fsmeta_proto_rawDescGZIP(), []int{23}
+	return file_fsmeta_fsmeta_proto_rawDescGZIP(), []int{25}
 }
 
 func (x *SnapshotSubtreeRequest) GetMount() string {
@@ -1712,7 +1800,7 @@ type SnapshotSubtreeResponse struct {
 
 func (x *SnapshotSubtreeResponse) Reset() {
 	*x = SnapshotSubtreeResponse{}
-	mi := &file_fsmeta_fsmeta_proto_msgTypes[24]
+	mi := &file_fsmeta_fsmeta_proto_msgTypes[26]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1724,7 +1812,7 @@ func (x *SnapshotSubtreeResponse) String() string {
 func (*SnapshotSubtreeResponse) ProtoMessage() {}
 
 func (x *SnapshotSubtreeResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_fsmeta_fsmeta_proto_msgTypes[24]
+	mi := &file_fsmeta_fsmeta_proto_msgTypes[26]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1737,7 +1825,7 @@ func (x *SnapshotSubtreeResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SnapshotSubtreeResponse.ProtoReflect.Descriptor instead.
 func (*SnapshotSubtreeResponse) Descriptor() ([]byte, []int) {
-	return file_fsmeta_fsmeta_proto_rawDescGZIP(), []int{24}
+	return file_fsmeta_fsmeta_proto_rawDescGZIP(), []int{26}
 }
 
 func (x *SnapshotSubtreeResponse) GetMount() string {
@@ -1772,7 +1860,7 @@ type RetireSnapshotSubtreeRequest struct {
 
 func (x *RetireSnapshotSubtreeRequest) Reset() {
 	*x = RetireSnapshotSubtreeRequest{}
-	mi := &file_fsmeta_fsmeta_proto_msgTypes[25]
+	mi := &file_fsmeta_fsmeta_proto_msgTypes[27]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1784,7 +1872,7 @@ func (x *RetireSnapshotSubtreeRequest) String() string {
 func (*RetireSnapshotSubtreeRequest) ProtoMessage() {}
 
 func (x *RetireSnapshotSubtreeRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_fsmeta_fsmeta_proto_msgTypes[25]
+	mi := &file_fsmeta_fsmeta_proto_msgTypes[27]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1797,7 +1885,7 @@ func (x *RetireSnapshotSubtreeRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RetireSnapshotSubtreeRequest.ProtoReflect.Descriptor instead.
 func (*RetireSnapshotSubtreeRequest) Descriptor() ([]byte, []int) {
-	return file_fsmeta_fsmeta_proto_rawDescGZIP(), []int{25}
+	return file_fsmeta_fsmeta_proto_rawDescGZIP(), []int{27}
 }
 
 func (x *RetireSnapshotSubtreeRequest) GetMount() string {
@@ -1829,7 +1917,7 @@ type RetireSnapshotSubtreeResponse struct {
 
 func (x *RetireSnapshotSubtreeResponse) Reset() {
 	*x = RetireSnapshotSubtreeResponse{}
-	mi := &file_fsmeta_fsmeta_proto_msgTypes[26]
+	mi := &file_fsmeta_fsmeta_proto_msgTypes[28]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1841,7 +1929,7 @@ func (x *RetireSnapshotSubtreeResponse) String() string {
 func (*RetireSnapshotSubtreeResponse) ProtoMessage() {}
 
 func (x *RetireSnapshotSubtreeResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_fsmeta_fsmeta_proto_msgTypes[26]
+	mi := &file_fsmeta_fsmeta_proto_msgTypes[28]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1854,7 +1942,7 @@ func (x *RetireSnapshotSubtreeResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RetireSnapshotSubtreeResponse.ProtoReflect.Descriptor instead.
 func (*RetireSnapshotSubtreeResponse) Descriptor() ([]byte, []int) {
-	return file_fsmeta_fsmeta_proto_rawDescGZIP(), []int{26}
+	return file_fsmeta_fsmeta_proto_rawDescGZIP(), []int{28}
 }
 
 type QuotaUsageRequest struct {
@@ -1869,7 +1957,7 @@ type QuotaUsageRequest struct {
 
 func (x *QuotaUsageRequest) Reset() {
 	*x = QuotaUsageRequest{}
-	mi := &file_fsmeta_fsmeta_proto_msgTypes[27]
+	mi := &file_fsmeta_fsmeta_proto_msgTypes[29]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1881,7 +1969,7 @@ func (x *QuotaUsageRequest) String() string {
 func (*QuotaUsageRequest) ProtoMessage() {}
 
 func (x *QuotaUsageRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_fsmeta_fsmeta_proto_msgTypes[27]
+	mi := &file_fsmeta_fsmeta_proto_msgTypes[29]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1894,7 +1982,7 @@ func (x *QuotaUsageRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use QuotaUsageRequest.ProtoReflect.Descriptor instead.
 func (*QuotaUsageRequest) Descriptor() ([]byte, []int) {
-	return file_fsmeta_fsmeta_proto_rawDescGZIP(), []int{27}
+	return file_fsmeta_fsmeta_proto_rawDescGZIP(), []int{29}
 }
 
 func (x *QuotaUsageRequest) GetMount() string {
@@ -1921,7 +2009,7 @@ type QuotaUsageResponse struct {
 
 func (x *QuotaUsageResponse) Reset() {
 	*x = QuotaUsageResponse{}
-	mi := &file_fsmeta_fsmeta_proto_msgTypes[28]
+	mi := &file_fsmeta_fsmeta_proto_msgTypes[30]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1933,7 +2021,7 @@ func (x *QuotaUsageResponse) String() string {
 func (*QuotaUsageResponse) ProtoMessage() {}
 
 func (x *QuotaUsageResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_fsmeta_fsmeta_proto_msgTypes[28]
+	mi := &file_fsmeta_fsmeta_proto_msgTypes[30]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1946,7 +2034,7 @@ func (x *QuotaUsageResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use QuotaUsageResponse.ProtoReflect.Descriptor instead.
 func (*QuotaUsageResponse) Descriptor() ([]byte, []int) {
-	return file_fsmeta_fsmeta_proto_rawDescGZIP(), []int{28}
+	return file_fsmeta_fsmeta_proto_rawDescGZIP(), []int{30}
 }
 
 func (x *QuotaUsageResponse) GetBytes() uint64 {
@@ -1976,7 +2064,7 @@ type RenameRequest struct {
 
 func (x *RenameRequest) Reset() {
 	*x = RenameRequest{}
-	mi := &file_fsmeta_fsmeta_proto_msgTypes[29]
+	mi := &file_fsmeta_fsmeta_proto_msgTypes[31]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1988,7 +2076,7 @@ func (x *RenameRequest) String() string {
 func (*RenameRequest) ProtoMessage() {}
 
 func (x *RenameRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_fsmeta_fsmeta_proto_msgTypes[29]
+	mi := &file_fsmeta_fsmeta_proto_msgTypes[31]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2001,7 +2089,7 @@ func (x *RenameRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RenameRequest.ProtoReflect.Descriptor instead.
 func (*RenameRequest) Descriptor() ([]byte, []int) {
-	return file_fsmeta_fsmeta_proto_rawDescGZIP(), []int{29}
+	return file_fsmeta_fsmeta_proto_rawDescGZIP(), []int{31}
 }
 
 func (x *RenameRequest) GetMount() string {
@@ -2047,7 +2135,7 @@ type RenameResponse struct {
 
 func (x *RenameResponse) Reset() {
 	*x = RenameResponse{}
-	mi := &file_fsmeta_fsmeta_proto_msgTypes[30]
+	mi := &file_fsmeta_fsmeta_proto_msgTypes[32]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2059,7 +2147,7 @@ func (x *RenameResponse) String() string {
 func (*RenameResponse) ProtoMessage() {}
 
 func (x *RenameResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_fsmeta_fsmeta_proto_msgTypes[30]
+	mi := &file_fsmeta_fsmeta_proto_msgTypes[32]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2072,7 +2160,7 @@ func (x *RenameResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RenameResponse.ProtoReflect.Descriptor instead.
 func (*RenameResponse) Descriptor() ([]byte, []int) {
-	return file_fsmeta_fsmeta_proto_rawDescGZIP(), []int{30}
+	return file_fsmeta_fsmeta_proto_rawDescGZIP(), []int{32}
 }
 
 type RenameSubtreeRequest struct {
@@ -2088,7 +2176,7 @@ type RenameSubtreeRequest struct {
 
 func (x *RenameSubtreeRequest) Reset() {
 	*x = RenameSubtreeRequest{}
-	mi := &file_fsmeta_fsmeta_proto_msgTypes[31]
+	mi := &file_fsmeta_fsmeta_proto_msgTypes[33]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2100,7 +2188,7 @@ func (x *RenameSubtreeRequest) String() string {
 func (*RenameSubtreeRequest) ProtoMessage() {}
 
 func (x *RenameSubtreeRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_fsmeta_fsmeta_proto_msgTypes[31]
+	mi := &file_fsmeta_fsmeta_proto_msgTypes[33]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2113,7 +2201,7 @@ func (x *RenameSubtreeRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RenameSubtreeRequest.ProtoReflect.Descriptor instead.
 func (*RenameSubtreeRequest) Descriptor() ([]byte, []int) {
-	return file_fsmeta_fsmeta_proto_rawDescGZIP(), []int{31}
+	return file_fsmeta_fsmeta_proto_rawDescGZIP(), []int{33}
 }
 
 func (x *RenameSubtreeRequest) GetMount() string {
@@ -2159,7 +2247,7 @@ type RenameSubtreeResponse struct {
 
 func (x *RenameSubtreeResponse) Reset() {
 	*x = RenameSubtreeResponse{}
-	mi := &file_fsmeta_fsmeta_proto_msgTypes[32]
+	mi := &file_fsmeta_fsmeta_proto_msgTypes[34]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2171,7 +2259,7 @@ func (x *RenameSubtreeResponse) String() string {
 func (*RenameSubtreeResponse) ProtoMessage() {}
 
 func (x *RenameSubtreeResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_fsmeta_fsmeta_proto_msgTypes[32]
+	mi := &file_fsmeta_fsmeta_proto_msgTypes[34]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2184,7 +2272,7 @@ func (x *RenameSubtreeResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RenameSubtreeResponse.ProtoReflect.Descriptor instead.
 func (*RenameSubtreeResponse) Descriptor() ([]byte, []int) {
-	return file_fsmeta_fsmeta_proto_rawDescGZIP(), []int{32}
+	return file_fsmeta_fsmeta_proto_rawDescGZIP(), []int{34}
 }
 
 type LinkRequest struct {
@@ -2200,7 +2288,7 @@ type LinkRequest struct {
 
 func (x *LinkRequest) Reset() {
 	*x = LinkRequest{}
-	mi := &file_fsmeta_fsmeta_proto_msgTypes[33]
+	mi := &file_fsmeta_fsmeta_proto_msgTypes[35]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2212,7 +2300,7 @@ func (x *LinkRequest) String() string {
 func (*LinkRequest) ProtoMessage() {}
 
 func (x *LinkRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_fsmeta_fsmeta_proto_msgTypes[33]
+	mi := &file_fsmeta_fsmeta_proto_msgTypes[35]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2225,7 +2313,7 @@ func (x *LinkRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use LinkRequest.ProtoReflect.Descriptor instead.
 func (*LinkRequest) Descriptor() ([]byte, []int) {
-	return file_fsmeta_fsmeta_proto_rawDescGZIP(), []int{33}
+	return file_fsmeta_fsmeta_proto_rawDescGZIP(), []int{35}
 }
 
 func (x *LinkRequest) GetMount() string {
@@ -2271,7 +2359,7 @@ type LinkResponse struct {
 
 func (x *LinkResponse) Reset() {
 	*x = LinkResponse{}
-	mi := &file_fsmeta_fsmeta_proto_msgTypes[34]
+	mi := &file_fsmeta_fsmeta_proto_msgTypes[36]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2283,7 +2371,7 @@ func (x *LinkResponse) String() string {
 func (*LinkResponse) ProtoMessage() {}
 
 func (x *LinkResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_fsmeta_fsmeta_proto_msgTypes[34]
+	mi := &file_fsmeta_fsmeta_proto_msgTypes[36]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2296,7 +2384,7 @@ func (x *LinkResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use LinkResponse.ProtoReflect.Descriptor instead.
 func (*LinkResponse) Descriptor() ([]byte, []int) {
-	return file_fsmeta_fsmeta_proto_rawDescGZIP(), []int{34}
+	return file_fsmeta_fsmeta_proto_rawDescGZIP(), []int{36}
 }
 
 type UnlinkRequest struct {
@@ -2310,7 +2398,7 @@ type UnlinkRequest struct {
 
 func (x *UnlinkRequest) Reset() {
 	*x = UnlinkRequest{}
-	mi := &file_fsmeta_fsmeta_proto_msgTypes[35]
+	mi := &file_fsmeta_fsmeta_proto_msgTypes[37]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2322,7 +2410,7 @@ func (x *UnlinkRequest) String() string {
 func (*UnlinkRequest) ProtoMessage() {}
 
 func (x *UnlinkRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_fsmeta_fsmeta_proto_msgTypes[35]
+	mi := &file_fsmeta_fsmeta_proto_msgTypes[37]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2335,7 +2423,7 @@ func (x *UnlinkRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UnlinkRequest.ProtoReflect.Descriptor instead.
 func (*UnlinkRequest) Descriptor() ([]byte, []int) {
-	return file_fsmeta_fsmeta_proto_rawDescGZIP(), []int{35}
+	return file_fsmeta_fsmeta_proto_rawDescGZIP(), []int{37}
 }
 
 func (x *UnlinkRequest) GetMount() string {
@@ -2367,7 +2455,7 @@ type UnlinkResponse struct {
 
 func (x *UnlinkResponse) Reset() {
 	*x = UnlinkResponse{}
-	mi := &file_fsmeta_fsmeta_proto_msgTypes[36]
+	mi := &file_fsmeta_fsmeta_proto_msgTypes[38]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2379,7 +2467,7 @@ func (x *UnlinkResponse) String() string {
 func (*UnlinkResponse) ProtoMessage() {}
 
 func (x *UnlinkResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_fsmeta_fsmeta_proto_msgTypes[36]
+	mi := &file_fsmeta_fsmeta_proto_msgTypes[38]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2392,7 +2480,7 @@ func (x *UnlinkResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UnlinkResponse.ProtoReflect.Descriptor instead.
 func (*UnlinkResponse) Descriptor() ([]byte, []int) {
-	return file_fsmeta_fsmeta_proto_rawDescGZIP(), []int{36}
+	return file_fsmeta_fsmeta_proto_rawDescGZIP(), []int{38}
 }
 
 type OpenWriteSessionRequest struct {
@@ -2407,7 +2495,7 @@ type OpenWriteSessionRequest struct {
 
 func (x *OpenWriteSessionRequest) Reset() {
 	*x = OpenWriteSessionRequest{}
-	mi := &file_fsmeta_fsmeta_proto_msgTypes[37]
+	mi := &file_fsmeta_fsmeta_proto_msgTypes[39]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2419,7 +2507,7 @@ func (x *OpenWriteSessionRequest) String() string {
 func (*OpenWriteSessionRequest) ProtoMessage() {}
 
 func (x *OpenWriteSessionRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_fsmeta_fsmeta_proto_msgTypes[37]
+	mi := &file_fsmeta_fsmeta_proto_msgTypes[39]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2432,7 +2520,7 @@ func (x *OpenWriteSessionRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use OpenWriteSessionRequest.ProtoReflect.Descriptor instead.
 func (*OpenWriteSessionRequest) Descriptor() ([]byte, []int) {
-	return file_fsmeta_fsmeta_proto_rawDescGZIP(), []int{37}
+	return file_fsmeta_fsmeta_proto_rawDescGZIP(), []int{39}
 }
 
 func (x *OpenWriteSessionRequest) GetMount() string {
@@ -2472,7 +2560,7 @@ type OpenWriteSessionResponse struct {
 
 func (x *OpenWriteSessionResponse) Reset() {
 	*x = OpenWriteSessionResponse{}
-	mi := &file_fsmeta_fsmeta_proto_msgTypes[38]
+	mi := &file_fsmeta_fsmeta_proto_msgTypes[40]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2484,7 +2572,7 @@ func (x *OpenWriteSessionResponse) String() string {
 func (*OpenWriteSessionResponse) ProtoMessage() {}
 
 func (x *OpenWriteSessionResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_fsmeta_fsmeta_proto_msgTypes[38]
+	mi := &file_fsmeta_fsmeta_proto_msgTypes[40]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2497,7 +2585,7 @@ func (x *OpenWriteSessionResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use OpenWriteSessionResponse.ProtoReflect.Descriptor instead.
 func (*OpenWriteSessionResponse) Descriptor() ([]byte, []int) {
-	return file_fsmeta_fsmeta_proto_rawDescGZIP(), []int{38}
+	return file_fsmeta_fsmeta_proto_rawDescGZIP(), []int{40}
 }
 
 func (x *OpenWriteSessionResponse) GetSession() *SessionRecord {
@@ -2519,7 +2607,7 @@ type HeartbeatWriteSessionRequest struct {
 
 func (x *HeartbeatWriteSessionRequest) Reset() {
 	*x = HeartbeatWriteSessionRequest{}
-	mi := &file_fsmeta_fsmeta_proto_msgTypes[39]
+	mi := &file_fsmeta_fsmeta_proto_msgTypes[41]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2531,7 +2619,7 @@ func (x *HeartbeatWriteSessionRequest) String() string {
 func (*HeartbeatWriteSessionRequest) ProtoMessage() {}
 
 func (x *HeartbeatWriteSessionRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_fsmeta_fsmeta_proto_msgTypes[39]
+	mi := &file_fsmeta_fsmeta_proto_msgTypes[41]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2544,7 +2632,7 @@ func (x *HeartbeatWriteSessionRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use HeartbeatWriteSessionRequest.ProtoReflect.Descriptor instead.
 func (*HeartbeatWriteSessionRequest) Descriptor() ([]byte, []int) {
-	return file_fsmeta_fsmeta_proto_rawDescGZIP(), []int{39}
+	return file_fsmeta_fsmeta_proto_rawDescGZIP(), []int{41}
 }
 
 func (x *HeartbeatWriteSessionRequest) GetMount() string {
@@ -2584,7 +2672,7 @@ type HeartbeatWriteSessionResponse struct {
 
 func (x *HeartbeatWriteSessionResponse) Reset() {
 	*x = HeartbeatWriteSessionResponse{}
-	mi := &file_fsmeta_fsmeta_proto_msgTypes[40]
+	mi := &file_fsmeta_fsmeta_proto_msgTypes[42]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2596,7 +2684,7 @@ func (x *HeartbeatWriteSessionResponse) String() string {
 func (*HeartbeatWriteSessionResponse) ProtoMessage() {}
 
 func (x *HeartbeatWriteSessionResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_fsmeta_fsmeta_proto_msgTypes[40]
+	mi := &file_fsmeta_fsmeta_proto_msgTypes[42]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2609,7 +2697,7 @@ func (x *HeartbeatWriteSessionResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use HeartbeatWriteSessionResponse.ProtoReflect.Descriptor instead.
 func (*HeartbeatWriteSessionResponse) Descriptor() ([]byte, []int) {
-	return file_fsmeta_fsmeta_proto_rawDescGZIP(), []int{40}
+	return file_fsmeta_fsmeta_proto_rawDescGZIP(), []int{42}
 }
 
 func (x *HeartbeatWriteSessionResponse) GetSession() *SessionRecord {
@@ -2629,7 +2717,7 @@ type CloseWriteSessionRequest struct {
 
 func (x *CloseWriteSessionRequest) Reset() {
 	*x = CloseWriteSessionRequest{}
-	mi := &file_fsmeta_fsmeta_proto_msgTypes[41]
+	mi := &file_fsmeta_fsmeta_proto_msgTypes[43]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2641,7 +2729,7 @@ func (x *CloseWriteSessionRequest) String() string {
 func (*CloseWriteSessionRequest) ProtoMessage() {}
 
 func (x *CloseWriteSessionRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_fsmeta_fsmeta_proto_msgTypes[41]
+	mi := &file_fsmeta_fsmeta_proto_msgTypes[43]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2654,7 +2742,7 @@ func (x *CloseWriteSessionRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CloseWriteSessionRequest.ProtoReflect.Descriptor instead.
 func (*CloseWriteSessionRequest) Descriptor() ([]byte, []int) {
-	return file_fsmeta_fsmeta_proto_rawDescGZIP(), []int{41}
+	return file_fsmeta_fsmeta_proto_rawDescGZIP(), []int{43}
 }
 
 func (x *CloseWriteSessionRequest) GetMount() string {
@@ -2679,7 +2767,7 @@ type CloseWriteSessionResponse struct {
 
 func (x *CloseWriteSessionResponse) Reset() {
 	*x = CloseWriteSessionResponse{}
-	mi := &file_fsmeta_fsmeta_proto_msgTypes[42]
+	mi := &file_fsmeta_fsmeta_proto_msgTypes[44]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2691,7 +2779,7 @@ func (x *CloseWriteSessionResponse) String() string {
 func (*CloseWriteSessionResponse) ProtoMessage() {}
 
 func (x *CloseWriteSessionResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_fsmeta_fsmeta_proto_msgTypes[42]
+	mi := &file_fsmeta_fsmeta_proto_msgTypes[44]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2704,7 +2792,7 @@ func (x *CloseWriteSessionResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CloseWriteSessionResponse.ProtoReflect.Descriptor instead.
 func (*CloseWriteSessionResponse) Descriptor() ([]byte, []int) {
-	return file_fsmeta_fsmeta_proto_rawDescGZIP(), []int{42}
+	return file_fsmeta_fsmeta_proto_rawDescGZIP(), []int{44}
 }
 
 type ExpireWriteSessionsRequest struct {
@@ -2717,7 +2805,7 @@ type ExpireWriteSessionsRequest struct {
 
 func (x *ExpireWriteSessionsRequest) Reset() {
 	*x = ExpireWriteSessionsRequest{}
-	mi := &file_fsmeta_fsmeta_proto_msgTypes[43]
+	mi := &file_fsmeta_fsmeta_proto_msgTypes[45]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2729,7 +2817,7 @@ func (x *ExpireWriteSessionsRequest) String() string {
 func (*ExpireWriteSessionsRequest) ProtoMessage() {}
 
 func (x *ExpireWriteSessionsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_fsmeta_fsmeta_proto_msgTypes[43]
+	mi := &file_fsmeta_fsmeta_proto_msgTypes[45]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2742,7 +2830,7 @@ func (x *ExpireWriteSessionsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ExpireWriteSessionsRequest.ProtoReflect.Descriptor instead.
 func (*ExpireWriteSessionsRequest) Descriptor() ([]byte, []int) {
-	return file_fsmeta_fsmeta_proto_rawDescGZIP(), []int{43}
+	return file_fsmeta_fsmeta_proto_rawDescGZIP(), []int{45}
 }
 
 func (x *ExpireWriteSessionsRequest) GetMount() string {
@@ -2768,7 +2856,7 @@ type ExpireWriteSessionsResponse struct {
 
 func (x *ExpireWriteSessionsResponse) Reset() {
 	*x = ExpireWriteSessionsResponse{}
-	mi := &file_fsmeta_fsmeta_proto_msgTypes[44]
+	mi := &file_fsmeta_fsmeta_proto_msgTypes[46]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2780,7 +2868,7 @@ func (x *ExpireWriteSessionsResponse) String() string {
 func (*ExpireWriteSessionsResponse) ProtoMessage() {}
 
 func (x *ExpireWriteSessionsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_fsmeta_fsmeta_proto_msgTypes[44]
+	mi := &file_fsmeta_fsmeta_proto_msgTypes[46]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2793,7 +2881,7 @@ func (x *ExpireWriteSessionsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ExpireWriteSessionsResponse.ProtoReflect.Descriptor instead.
 func (*ExpireWriteSessionsResponse) Descriptor() ([]byte, []int) {
-	return file_fsmeta_fsmeta_proto_rawDescGZIP(), []int{44}
+	return file_fsmeta_fsmeta_proto_rawDescGZIP(), []int{46}
 }
 
 func (x *ExpireWriteSessionsResponse) GetExpired() uint64 {
@@ -2918,7 +3006,11 @@ const file_fsmeta_fsmeta_proto_rawDesc = "" +
 	"\x13WatchAckOrSubscribe\x12C\n" +
 	"\tsubscribe\x18\x01 \x01(\v2#.nokv.fsmeta.v1.WatchSubtreeRequestH\x00R\tsubscribe\x12,\n" +
 	"\x03ack\x18\x02 \x01(\v2\x18.nokv.fsmeta.v1.WatchAckH\x00R\x03ackB\x06\n" +
-	"\x04body\"M\n" +
+	"\x04body\"-\n" +
+	"\x15GetReadVersionRequest\x12\x14\n" +
+	"\x05mount\x18\x01 \x01(\tR\x05mount\";\n" +
+	"\x16GetReadVersionResponse\x12!\n" +
+	"\fread_version\x18\x01 \x01(\x04R\vreadVersion\"M\n" +
 	"\x16SnapshotSubtreeRequest\x12\x14\n" +
 	"\x05mount\x18\x01 \x01(\tR\x05mount\x12\x1d\n" +
 	"\n" +
@@ -2999,7 +3091,7 @@ const file_fsmeta_fsmeta_proto_rawDesc = "" +
 	"\x10WatchEventSource\x12\"\n" +
 	"\x1eWATCH_EVENT_SOURCE_UNSPECIFIED\x10\x00\x12\x1d\n" +
 	"\x19WATCH_EVENT_SOURCE_COMMIT\x10\x01\x12#\n" +
-	"\x1fWATCH_EVENT_SOURCE_RESOLVE_LOCK\x10\x022\x91\f\n" +
+	"\x1fWATCH_EVENT_SOURCE_RESOLVE_LOCK\x10\x022\xf2\f\n" +
 	"\n" +
 	"FSMetadata\x12G\n" +
 	"\x06Create\x12\x1d.nokv.fsmeta.v1.CreateRequest\x1a\x1e.nokv.fsmeta.v1.CreateResponse\x12V\n" +
@@ -3007,7 +3099,8 @@ const file_fsmeta_fsmeta_proto_rawDesc = "" +
 	"\x06Lookup\x12\x1d.nokv.fsmeta.v1.LookupRequest\x1a\x1e.nokv.fsmeta.v1.LookupResponse\x12J\n" +
 	"\aReadDir\x12\x1e.nokv.fsmeta.v1.ReadDirRequest\x1a\x1f.nokv.fsmeta.v1.ReadDirResponse\x12R\n" +
 	"\vReadDirPlus\x12\x1e.nokv.fsmeta.v1.ReadDirRequest\x1a#.nokv.fsmeta.v1.ReadDirPlusResponse\x12]\n" +
-	"\fWatchSubtree\x12#.nokv.fsmeta.v1.WatchAckOrSubscribe\x1a$.nokv.fsmeta.v1.WatchSubtreeResponse(\x010\x01\x12b\n" +
+	"\fWatchSubtree\x12#.nokv.fsmeta.v1.WatchAckOrSubscribe\x1a$.nokv.fsmeta.v1.WatchSubtreeResponse(\x010\x01\x12_\n" +
+	"\x0eGetReadVersion\x12%.nokv.fsmeta.v1.GetReadVersionRequest\x1a&.nokv.fsmeta.v1.GetReadVersionResponse\x12b\n" +
 	"\x0fSnapshotSubtree\x12&.nokv.fsmeta.v1.SnapshotSubtreeRequest\x1a'.nokv.fsmeta.v1.SnapshotSubtreeResponse\x12t\n" +
 	"\x15RetireSnapshotSubtree\x12,.nokv.fsmeta.v1.RetireSnapshotSubtreeRequest\x1a-.nokv.fsmeta.v1.RetireSnapshotSubtreeResponse\x12V\n" +
 	"\rGetQuotaUsage\x12!.nokv.fsmeta.v1.QuotaUsageRequest\x1a\".nokv.fsmeta.v1.QuotaUsageResponse\x12G\n" +
@@ -3033,7 +3126,7 @@ func file_fsmeta_fsmeta_proto_rawDescGZIP() []byte {
 }
 
 var file_fsmeta_fsmeta_proto_enumTypes = make([]protoimpl.EnumInfo, 2)
-var file_fsmeta_fsmeta_proto_msgTypes = make([]protoimpl.MessageInfo, 45)
+var file_fsmeta_fsmeta_proto_msgTypes = make([]protoimpl.MessageInfo, 47)
 var file_fsmeta_fsmeta_proto_goTypes = []any{
 	(InodeType)(0),                        // 0: nokv.fsmeta.v1.InodeType
 	(WatchEventSource)(0),                 // 1: nokv.fsmeta.v1.WatchEventSource
@@ -3060,28 +3153,30 @@ var file_fsmeta_fsmeta_proto_goTypes = []any{
 	(*WatchThrottle)(nil),                 // 22: nokv.fsmeta.v1.WatchThrottle
 	(*WatchSubtreeResponse)(nil),          // 23: nokv.fsmeta.v1.WatchSubtreeResponse
 	(*WatchAckOrSubscribe)(nil),           // 24: nokv.fsmeta.v1.WatchAckOrSubscribe
-	(*SnapshotSubtreeRequest)(nil),        // 25: nokv.fsmeta.v1.SnapshotSubtreeRequest
-	(*SnapshotSubtreeResponse)(nil),       // 26: nokv.fsmeta.v1.SnapshotSubtreeResponse
-	(*RetireSnapshotSubtreeRequest)(nil),  // 27: nokv.fsmeta.v1.RetireSnapshotSubtreeRequest
-	(*RetireSnapshotSubtreeResponse)(nil), // 28: nokv.fsmeta.v1.RetireSnapshotSubtreeResponse
-	(*QuotaUsageRequest)(nil),             // 29: nokv.fsmeta.v1.QuotaUsageRequest
-	(*QuotaUsageResponse)(nil),            // 30: nokv.fsmeta.v1.QuotaUsageResponse
-	(*RenameRequest)(nil),                 // 31: nokv.fsmeta.v1.RenameRequest
-	(*RenameResponse)(nil),                // 32: nokv.fsmeta.v1.RenameResponse
-	(*RenameSubtreeRequest)(nil),          // 33: nokv.fsmeta.v1.RenameSubtreeRequest
-	(*RenameSubtreeResponse)(nil),         // 34: nokv.fsmeta.v1.RenameSubtreeResponse
-	(*LinkRequest)(nil),                   // 35: nokv.fsmeta.v1.LinkRequest
-	(*LinkResponse)(nil),                  // 36: nokv.fsmeta.v1.LinkResponse
-	(*UnlinkRequest)(nil),                 // 37: nokv.fsmeta.v1.UnlinkRequest
-	(*UnlinkResponse)(nil),                // 38: nokv.fsmeta.v1.UnlinkResponse
-	(*OpenWriteSessionRequest)(nil),       // 39: nokv.fsmeta.v1.OpenWriteSessionRequest
-	(*OpenWriteSessionResponse)(nil),      // 40: nokv.fsmeta.v1.OpenWriteSessionResponse
-	(*HeartbeatWriteSessionRequest)(nil),  // 41: nokv.fsmeta.v1.HeartbeatWriteSessionRequest
-	(*HeartbeatWriteSessionResponse)(nil), // 42: nokv.fsmeta.v1.HeartbeatWriteSessionResponse
-	(*CloseWriteSessionRequest)(nil),      // 43: nokv.fsmeta.v1.CloseWriteSessionRequest
-	(*CloseWriteSessionResponse)(nil),     // 44: nokv.fsmeta.v1.CloseWriteSessionResponse
-	(*ExpireWriteSessionsRequest)(nil),    // 45: nokv.fsmeta.v1.ExpireWriteSessionsRequest
-	(*ExpireWriteSessionsResponse)(nil),   // 46: nokv.fsmeta.v1.ExpireWriteSessionsResponse
+	(*GetReadVersionRequest)(nil),         // 25: nokv.fsmeta.v1.GetReadVersionRequest
+	(*GetReadVersionResponse)(nil),        // 26: nokv.fsmeta.v1.GetReadVersionResponse
+	(*SnapshotSubtreeRequest)(nil),        // 27: nokv.fsmeta.v1.SnapshotSubtreeRequest
+	(*SnapshotSubtreeResponse)(nil),       // 28: nokv.fsmeta.v1.SnapshotSubtreeResponse
+	(*RetireSnapshotSubtreeRequest)(nil),  // 29: nokv.fsmeta.v1.RetireSnapshotSubtreeRequest
+	(*RetireSnapshotSubtreeResponse)(nil), // 30: nokv.fsmeta.v1.RetireSnapshotSubtreeResponse
+	(*QuotaUsageRequest)(nil),             // 31: nokv.fsmeta.v1.QuotaUsageRequest
+	(*QuotaUsageResponse)(nil),            // 32: nokv.fsmeta.v1.QuotaUsageResponse
+	(*RenameRequest)(nil),                 // 33: nokv.fsmeta.v1.RenameRequest
+	(*RenameResponse)(nil),                // 34: nokv.fsmeta.v1.RenameResponse
+	(*RenameSubtreeRequest)(nil),          // 35: nokv.fsmeta.v1.RenameSubtreeRequest
+	(*RenameSubtreeResponse)(nil),         // 36: nokv.fsmeta.v1.RenameSubtreeResponse
+	(*LinkRequest)(nil),                   // 37: nokv.fsmeta.v1.LinkRequest
+	(*LinkResponse)(nil),                  // 38: nokv.fsmeta.v1.LinkResponse
+	(*UnlinkRequest)(nil),                 // 39: nokv.fsmeta.v1.UnlinkRequest
+	(*UnlinkResponse)(nil),                // 40: nokv.fsmeta.v1.UnlinkResponse
+	(*OpenWriteSessionRequest)(nil),       // 41: nokv.fsmeta.v1.OpenWriteSessionRequest
+	(*OpenWriteSessionResponse)(nil),      // 42: nokv.fsmeta.v1.OpenWriteSessionResponse
+	(*HeartbeatWriteSessionRequest)(nil),  // 43: nokv.fsmeta.v1.HeartbeatWriteSessionRequest
+	(*HeartbeatWriteSessionResponse)(nil), // 44: nokv.fsmeta.v1.HeartbeatWriteSessionResponse
+	(*CloseWriteSessionRequest)(nil),      // 45: nokv.fsmeta.v1.CloseWriteSessionRequest
+	(*CloseWriteSessionResponse)(nil),     // 46: nokv.fsmeta.v1.CloseWriteSessionResponse
+	(*ExpireWriteSessionsRequest)(nil),    // 47: nokv.fsmeta.v1.ExpireWriteSessionsRequest
+	(*ExpireWriteSessionsResponse)(nil),   // 48: nokv.fsmeta.v1.ExpireWriteSessionsResponse
 }
 var file_fsmeta_fsmeta_proto_depIdxs = []int32{
 	0,  // 0: nokv.fsmeta.v1.InodeRecord.type:type_name -> nokv.fsmeta.v1.InodeType
@@ -3116,36 +3211,38 @@ var file_fsmeta_fsmeta_proto_depIdxs = []int32{
 	13, // 29: nokv.fsmeta.v1.FSMetadata.ReadDir:input_type -> nokv.fsmeta.v1.ReadDirRequest
 	13, // 30: nokv.fsmeta.v1.FSMetadata.ReadDirPlus:input_type -> nokv.fsmeta.v1.ReadDirRequest
 	24, // 31: nokv.fsmeta.v1.FSMetadata.WatchSubtree:input_type -> nokv.fsmeta.v1.WatchAckOrSubscribe
-	25, // 32: nokv.fsmeta.v1.FSMetadata.SnapshotSubtree:input_type -> nokv.fsmeta.v1.SnapshotSubtreeRequest
-	27, // 33: nokv.fsmeta.v1.FSMetadata.RetireSnapshotSubtree:input_type -> nokv.fsmeta.v1.RetireSnapshotSubtreeRequest
-	29, // 34: nokv.fsmeta.v1.FSMetadata.GetQuotaUsage:input_type -> nokv.fsmeta.v1.QuotaUsageRequest
-	31, // 35: nokv.fsmeta.v1.FSMetadata.Rename:input_type -> nokv.fsmeta.v1.RenameRequest
-	33, // 36: nokv.fsmeta.v1.FSMetadata.RenameSubtree:input_type -> nokv.fsmeta.v1.RenameSubtreeRequest
-	35, // 37: nokv.fsmeta.v1.FSMetadata.Link:input_type -> nokv.fsmeta.v1.LinkRequest
-	37, // 38: nokv.fsmeta.v1.FSMetadata.Unlink:input_type -> nokv.fsmeta.v1.UnlinkRequest
-	39, // 39: nokv.fsmeta.v1.FSMetadata.OpenWriteSession:input_type -> nokv.fsmeta.v1.OpenWriteSessionRequest
-	41, // 40: nokv.fsmeta.v1.FSMetadata.HeartbeatWriteSession:input_type -> nokv.fsmeta.v1.HeartbeatWriteSessionRequest
-	43, // 41: nokv.fsmeta.v1.FSMetadata.CloseWriteSession:input_type -> nokv.fsmeta.v1.CloseWriteSessionRequest
-	45, // 42: nokv.fsmeta.v1.FSMetadata.ExpireWriteSessions:input_type -> nokv.fsmeta.v1.ExpireWriteSessionsRequest
-	8,  // 43: nokv.fsmeta.v1.FSMetadata.Create:output_type -> nokv.fsmeta.v1.CreateResponse
-	10, // 44: nokv.fsmeta.v1.FSMetadata.UpdateInode:output_type -> nokv.fsmeta.v1.UpdateInodeResponse
-	12, // 45: nokv.fsmeta.v1.FSMetadata.Lookup:output_type -> nokv.fsmeta.v1.LookupResponse
-	14, // 46: nokv.fsmeta.v1.FSMetadata.ReadDir:output_type -> nokv.fsmeta.v1.ReadDirResponse
-	15, // 47: nokv.fsmeta.v1.FSMetadata.ReadDirPlus:output_type -> nokv.fsmeta.v1.ReadDirPlusResponse
-	23, // 48: nokv.fsmeta.v1.FSMetadata.WatchSubtree:output_type -> nokv.fsmeta.v1.WatchSubtreeResponse
-	26, // 49: nokv.fsmeta.v1.FSMetadata.SnapshotSubtree:output_type -> nokv.fsmeta.v1.SnapshotSubtreeResponse
-	28, // 50: nokv.fsmeta.v1.FSMetadata.RetireSnapshotSubtree:output_type -> nokv.fsmeta.v1.RetireSnapshotSubtreeResponse
-	30, // 51: nokv.fsmeta.v1.FSMetadata.GetQuotaUsage:output_type -> nokv.fsmeta.v1.QuotaUsageResponse
-	32, // 52: nokv.fsmeta.v1.FSMetadata.Rename:output_type -> nokv.fsmeta.v1.RenameResponse
-	34, // 53: nokv.fsmeta.v1.FSMetadata.RenameSubtree:output_type -> nokv.fsmeta.v1.RenameSubtreeResponse
-	36, // 54: nokv.fsmeta.v1.FSMetadata.Link:output_type -> nokv.fsmeta.v1.LinkResponse
-	38, // 55: nokv.fsmeta.v1.FSMetadata.Unlink:output_type -> nokv.fsmeta.v1.UnlinkResponse
-	40, // 56: nokv.fsmeta.v1.FSMetadata.OpenWriteSession:output_type -> nokv.fsmeta.v1.OpenWriteSessionResponse
-	42, // 57: nokv.fsmeta.v1.FSMetadata.HeartbeatWriteSession:output_type -> nokv.fsmeta.v1.HeartbeatWriteSessionResponse
-	44, // 58: nokv.fsmeta.v1.FSMetadata.CloseWriteSession:output_type -> nokv.fsmeta.v1.CloseWriteSessionResponse
-	46, // 59: nokv.fsmeta.v1.FSMetadata.ExpireWriteSessions:output_type -> nokv.fsmeta.v1.ExpireWriteSessionsResponse
-	43, // [43:60] is the sub-list for method output_type
-	26, // [26:43] is the sub-list for method input_type
+	25, // 32: nokv.fsmeta.v1.FSMetadata.GetReadVersion:input_type -> nokv.fsmeta.v1.GetReadVersionRequest
+	27, // 33: nokv.fsmeta.v1.FSMetadata.SnapshotSubtree:input_type -> nokv.fsmeta.v1.SnapshotSubtreeRequest
+	29, // 34: nokv.fsmeta.v1.FSMetadata.RetireSnapshotSubtree:input_type -> nokv.fsmeta.v1.RetireSnapshotSubtreeRequest
+	31, // 35: nokv.fsmeta.v1.FSMetadata.GetQuotaUsage:input_type -> nokv.fsmeta.v1.QuotaUsageRequest
+	33, // 36: nokv.fsmeta.v1.FSMetadata.Rename:input_type -> nokv.fsmeta.v1.RenameRequest
+	35, // 37: nokv.fsmeta.v1.FSMetadata.RenameSubtree:input_type -> nokv.fsmeta.v1.RenameSubtreeRequest
+	37, // 38: nokv.fsmeta.v1.FSMetadata.Link:input_type -> nokv.fsmeta.v1.LinkRequest
+	39, // 39: nokv.fsmeta.v1.FSMetadata.Unlink:input_type -> nokv.fsmeta.v1.UnlinkRequest
+	41, // 40: nokv.fsmeta.v1.FSMetadata.OpenWriteSession:input_type -> nokv.fsmeta.v1.OpenWriteSessionRequest
+	43, // 41: nokv.fsmeta.v1.FSMetadata.HeartbeatWriteSession:input_type -> nokv.fsmeta.v1.HeartbeatWriteSessionRequest
+	45, // 42: nokv.fsmeta.v1.FSMetadata.CloseWriteSession:input_type -> nokv.fsmeta.v1.CloseWriteSessionRequest
+	47, // 43: nokv.fsmeta.v1.FSMetadata.ExpireWriteSessions:input_type -> nokv.fsmeta.v1.ExpireWriteSessionsRequest
+	8,  // 44: nokv.fsmeta.v1.FSMetadata.Create:output_type -> nokv.fsmeta.v1.CreateResponse
+	10, // 45: nokv.fsmeta.v1.FSMetadata.UpdateInode:output_type -> nokv.fsmeta.v1.UpdateInodeResponse
+	12, // 46: nokv.fsmeta.v1.FSMetadata.Lookup:output_type -> nokv.fsmeta.v1.LookupResponse
+	14, // 47: nokv.fsmeta.v1.FSMetadata.ReadDir:output_type -> nokv.fsmeta.v1.ReadDirResponse
+	15, // 48: nokv.fsmeta.v1.FSMetadata.ReadDirPlus:output_type -> nokv.fsmeta.v1.ReadDirPlusResponse
+	23, // 49: nokv.fsmeta.v1.FSMetadata.WatchSubtree:output_type -> nokv.fsmeta.v1.WatchSubtreeResponse
+	26, // 50: nokv.fsmeta.v1.FSMetadata.GetReadVersion:output_type -> nokv.fsmeta.v1.GetReadVersionResponse
+	28, // 51: nokv.fsmeta.v1.FSMetadata.SnapshotSubtree:output_type -> nokv.fsmeta.v1.SnapshotSubtreeResponse
+	30, // 52: nokv.fsmeta.v1.FSMetadata.RetireSnapshotSubtree:output_type -> nokv.fsmeta.v1.RetireSnapshotSubtreeResponse
+	32, // 53: nokv.fsmeta.v1.FSMetadata.GetQuotaUsage:output_type -> nokv.fsmeta.v1.QuotaUsageResponse
+	34, // 54: nokv.fsmeta.v1.FSMetadata.Rename:output_type -> nokv.fsmeta.v1.RenameResponse
+	36, // 55: nokv.fsmeta.v1.FSMetadata.RenameSubtree:output_type -> nokv.fsmeta.v1.RenameSubtreeResponse
+	38, // 56: nokv.fsmeta.v1.FSMetadata.Link:output_type -> nokv.fsmeta.v1.LinkResponse
+	40, // 57: nokv.fsmeta.v1.FSMetadata.Unlink:output_type -> nokv.fsmeta.v1.UnlinkResponse
+	42, // 58: nokv.fsmeta.v1.FSMetadata.OpenWriteSession:output_type -> nokv.fsmeta.v1.OpenWriteSessionResponse
+	44, // 59: nokv.fsmeta.v1.FSMetadata.HeartbeatWriteSession:output_type -> nokv.fsmeta.v1.HeartbeatWriteSessionResponse
+	46, // 60: nokv.fsmeta.v1.FSMetadata.CloseWriteSession:output_type -> nokv.fsmeta.v1.CloseWriteSessionResponse
+	48, // 61: nokv.fsmeta.v1.FSMetadata.ExpireWriteSessions:output_type -> nokv.fsmeta.v1.ExpireWriteSessionsResponse
+	44, // [44:62] is the sub-list for method output_type
+	26, // [26:44] is the sub-list for method input_type
 	26, // [26:26] is the sub-list for extension type_name
 	26, // [26:26] is the sub-list for extension extendee
 	0,  // [0:26] is the sub-list for field type_name
@@ -3172,7 +3269,7 @@ func file_fsmeta_fsmeta_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_fsmeta_fsmeta_proto_rawDesc), len(file_fsmeta_fsmeta_proto_rawDesc)),
 			NumEnums:      2,
-			NumMessages:   45,
+			NumMessages:   47,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/pb/fsmeta/fsmeta.proto
+++ b/pb/fsmeta/fsmeta.proto
@@ -168,6 +168,14 @@ message WatchAckOrSubscribe {
   }
 }
 
+message GetReadVersionRequest {
+  string mount = 1;
+}
+
+message GetReadVersionResponse {
+  uint64 read_version = 1;
+}
+
 message SnapshotSubtreeRequest {
   string mount = 1;
   uint64 root_inode = 2;
@@ -282,6 +290,7 @@ service FSMetadata {
   rpc ReadDir(ReadDirRequest) returns (ReadDirResponse);
   rpc ReadDirPlus(ReadDirRequest) returns (ReadDirPlusResponse);
   rpc WatchSubtree(stream WatchAckOrSubscribe) returns (stream WatchSubtreeResponse);
+  rpc GetReadVersion(GetReadVersionRequest) returns (GetReadVersionResponse);
   rpc SnapshotSubtree(SnapshotSubtreeRequest) returns (SnapshotSubtreeResponse);
   rpc RetireSnapshotSubtree(RetireSnapshotSubtreeRequest) returns (RetireSnapshotSubtreeResponse);
   rpc GetQuotaUsage(QuotaUsageRequest) returns (QuotaUsageResponse);

--- a/pb/fsmeta/fsmeta_grpc.pb.go
+++ b/pb/fsmeta/fsmeta_grpc.pb.go
@@ -27,6 +27,7 @@ const (
 	FSMetadata_ReadDir_FullMethodName               = "/nokv.fsmeta.v1.FSMetadata/ReadDir"
 	FSMetadata_ReadDirPlus_FullMethodName           = "/nokv.fsmeta.v1.FSMetadata/ReadDirPlus"
 	FSMetadata_WatchSubtree_FullMethodName          = "/nokv.fsmeta.v1.FSMetadata/WatchSubtree"
+	FSMetadata_GetReadVersion_FullMethodName        = "/nokv.fsmeta.v1.FSMetadata/GetReadVersion"
 	FSMetadata_SnapshotSubtree_FullMethodName       = "/nokv.fsmeta.v1.FSMetadata/SnapshotSubtree"
 	FSMetadata_RetireSnapshotSubtree_FullMethodName = "/nokv.fsmeta.v1.FSMetadata/RetireSnapshotSubtree"
 	FSMetadata_GetQuotaUsage_FullMethodName         = "/nokv.fsmeta.v1.FSMetadata/GetQuotaUsage"
@@ -50,6 +51,7 @@ type FSMetadataClient interface {
 	ReadDir(ctx context.Context, in *ReadDirRequest, opts ...grpc.CallOption) (*ReadDirResponse, error)
 	ReadDirPlus(ctx context.Context, in *ReadDirRequest, opts ...grpc.CallOption) (*ReadDirPlusResponse, error)
 	WatchSubtree(ctx context.Context, opts ...grpc.CallOption) (grpc.BidiStreamingClient[WatchAckOrSubscribe, WatchSubtreeResponse], error)
+	GetReadVersion(ctx context.Context, in *GetReadVersionRequest, opts ...grpc.CallOption) (*GetReadVersionResponse, error)
 	SnapshotSubtree(ctx context.Context, in *SnapshotSubtreeRequest, opts ...grpc.CallOption) (*SnapshotSubtreeResponse, error)
 	RetireSnapshotSubtree(ctx context.Context, in *RetireSnapshotSubtreeRequest, opts ...grpc.CallOption) (*RetireSnapshotSubtreeResponse, error)
 	GetQuotaUsage(ctx context.Context, in *QuotaUsageRequest, opts ...grpc.CallOption) (*QuotaUsageResponse, error)
@@ -133,6 +135,16 @@ func (c *fSMetadataClient) WatchSubtree(ctx context.Context, opts ...grpc.CallOp
 
 // This type alias is provided for backwards compatibility with existing code that references the prior non-generic stream type by name.
 type FSMetadata_WatchSubtreeClient = grpc.BidiStreamingClient[WatchAckOrSubscribe, WatchSubtreeResponse]
+
+func (c *fSMetadataClient) GetReadVersion(ctx context.Context, in *GetReadVersionRequest, opts ...grpc.CallOption) (*GetReadVersionResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(GetReadVersionResponse)
+	err := c.cc.Invoke(ctx, FSMetadata_GetReadVersion_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
 
 func (c *fSMetadataClient) SnapshotSubtree(ctx context.Context, in *SnapshotSubtreeRequest, opts ...grpc.CallOption) (*SnapshotSubtreeResponse, error) {
 	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
@@ -254,6 +266,7 @@ type FSMetadataServer interface {
 	ReadDir(context.Context, *ReadDirRequest) (*ReadDirResponse, error)
 	ReadDirPlus(context.Context, *ReadDirRequest) (*ReadDirPlusResponse, error)
 	WatchSubtree(grpc.BidiStreamingServer[WatchAckOrSubscribe, WatchSubtreeResponse]) error
+	GetReadVersion(context.Context, *GetReadVersionRequest) (*GetReadVersionResponse, error)
 	SnapshotSubtree(context.Context, *SnapshotSubtreeRequest) (*SnapshotSubtreeResponse, error)
 	RetireSnapshotSubtree(context.Context, *RetireSnapshotSubtreeRequest) (*RetireSnapshotSubtreeResponse, error)
 	GetQuotaUsage(context.Context, *QuotaUsageRequest) (*QuotaUsageResponse, error)
@@ -291,6 +304,9 @@ func (UnimplementedFSMetadataServer) ReadDirPlus(context.Context, *ReadDirReques
 }
 func (UnimplementedFSMetadataServer) WatchSubtree(grpc.BidiStreamingServer[WatchAckOrSubscribe, WatchSubtreeResponse]) error {
 	return status.Error(codes.Unimplemented, "method WatchSubtree not implemented")
+}
+func (UnimplementedFSMetadataServer) GetReadVersion(context.Context, *GetReadVersionRequest) (*GetReadVersionResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method GetReadVersion not implemented")
 }
 func (UnimplementedFSMetadataServer) SnapshotSubtree(context.Context, *SnapshotSubtreeRequest) (*SnapshotSubtreeResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method SnapshotSubtree not implemented")
@@ -441,6 +457,24 @@ func _FSMetadata_WatchSubtree_Handler(srv interface{}, stream grpc.ServerStream)
 
 // This type alias is provided for backwards compatibility with existing code that references the prior non-generic stream type by name.
 type FSMetadata_WatchSubtreeServer = grpc.BidiStreamingServer[WatchAckOrSubscribe, WatchSubtreeResponse]
+
+func _FSMetadata_GetReadVersion_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(GetReadVersionRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(FSMetadataServer).GetReadVersion(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: FSMetadata_GetReadVersion_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(FSMetadataServer).GetReadVersion(ctx, req.(*GetReadVersionRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
 
 func _FSMetadata_SnapshotSubtree_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
 	in := new(SnapshotSubtreeRequest)
@@ -666,6 +700,10 @@ var FSMetadata_ServiceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "ReadDirPlus",
 			Handler:    _FSMetadata_ReadDirPlus_Handler,
+		},
+		{
+			MethodName: "GetReadVersion",
+			Handler:    _FSMetadata_GetReadVersion_Handler,
 		},
 		{
 			MethodName: "SnapshotSubtree",

--- a/scripts/run_fsmeta_benchmarks.sh
+++ b/scripts/run_fsmeta_benchmarks.sh
@@ -219,7 +219,7 @@ print_bench_summary() {
 }
 
 run_compose_benchmarks() {
-	local workloads="${NOKV_FSMETA_WORKLOADS:-mixed,checkpoint-storm,hotspot-fanin,watch-subtree,negative-lookup}"
+	local workloads="${NOKV_FSMETA_WORKLOADS:-mixed,durable-snapshot,checkpoint-storm,hotspot-fanin,watch-subtree,negative-lookup}"
 	local output="${NOKV_FSMETA_OUTPUT:-$output_dir/fsmeta_compose_${profile}_${run_id}.csv}"
 	if [[ "${NOKV_FSMETA_COMPOSE:-1}" == "1" ]]; then
 		if [[ "${NOKV_FSMETA_COMPOSE_BUILD:-1}" == "1" ]]; then


### PR DESCRIPTION
## Summary
- add fsmeta GetReadVersion for ephemeral MVCC read timestamps without root snapshot publication
- keep SnapshotSubtree as the durable root-published snapshot API with explicit retire semantics
- move mixed workload short snapshot reads to GetReadVersion + ReadDirPlus(SnapshotVersion)
- add a separate durable-snapshot benchmark workload for SnapshotSubtree/RetireSnapshotSubtree coverage

## Tests
- make fmt
- make lint
- make proto-check
- go test ./fsmeta/... ./raftstore/client ./raftstore/kv ./txn/percolator ./coordinator/...
- go test ./...
- cd benchmark && go test ./fsmeta ./fsmeta/workload

## Benchmark Evidence
- scripts/run_fsmeta_benchmarks.sh with NOKV_FSMETA_PROFILE=median against Docker Compose
- CSV: benchmark/data/fsmeta/results/fsmeta_compose_median_20260508T004410Z.csv
- Result: mixed,durable-snapshot,checkpoint-storm,hotspot-fanin,watch-subtree,negative-lookup all completed with 0 errors
- Mixed get_read_version: 512 ops, avg 1035.541 us, p95 1711 us
- Prior mixed durable snapshot pair was snapshot_subtree avg 34012.244 us plus retire_snapshot_subtree avg 32559.938 us, so the ephemeral acquisition path removes root publication and retire from mixed short reads

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `durable-snapshot` benchmark workload for expanded performance testing scenarios
  * Introduced new RPC method for retrieving ephemeral MVCC read versions

* **Improvements**
  * Enhanced snapshot lifecycle handling with optimized version retrieval mechanism
  * Updated snapshot documentation to clarify token lifecycle and GC requirements

* **Documentation**
  * Updated benchmark examples to include new workload in default test configuration

<!-- end of auto-generated comment: release notes by coderabbit.ai -->