### PR TITLE
Batch primary-region 2PC RPCs

### DIFF
--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -108,7 +108,10 @@ fsmeta gateway. Default scale is the PR-oriented median service run: 12 clients,
 mixed workload with 8 groups x 64 entries x 8 artifacts. Override scale with environment
 variables such as `NOKV_FSMETA_CLIENTS`, `NOKV_FSMETA_GROUPS`,
 `NOKV_FSMETA_ENTRIES_PER_GROUP`, `NOKV_FSMETA_ARTIFACTS_PER_ENTRY`, and
-`NOKV_FSMETA_WORKLOADS`. The script also waits 20 seconds after ports open so a
+`NOKV_FSMETA_WORKLOADS`. The default writer-session TTL is 10 seconds so
+session cleanup measures stale lease behavior without racing ordinary
+open/heartbeat/close tails on shared CI runners. The script also waits 20
+seconds after ports open so a
 fresh Compose cluster can finish Raft leader election and coordinator grant
 publication; set `NOKV_FSMETA_STABILIZE_SECONDS=0` for an already-warm cluster.
 The underlying script is `scripts/run_fsmeta_benchmarks.sh`; set

--- a/benchmark/fsmeta/fsmeta_bench_test.go
+++ b/benchmark/fsmeta/fsmeta_bench_test.go
@@ -41,7 +41,7 @@ var (
 	fsmetaGroups          = flag.Int("fsmeta_groups", 4, "mixed workload group directory count")
 	fsmetaEntriesPerGroup = flag.Int("fsmeta_entries_per_group", 8, "mixed workload published entry count per group")
 	fsmetaArtifactsPerRun = flag.Int("fsmeta_artifacts_per_entry", 4, "mixed workload artifact file count per entry; minimum 4")
-	fsmetaSessionTTL      = flag.Duration("fsmeta_session_ttl", 2*time.Second, "mixed writer session TTL")
+	fsmetaSessionTTL      = flag.Duration("fsmeta_session_ttl", 10*time.Second, "mixed writer session TTL")
 	fsmetaTimeout         = flag.Duration("fsmeta_timeout", 5*time.Minute, "overall benchmark timeout")
 	fsmetaOutput          = flag.String("fsmeta_output", "", "summary CSV output path")
 )

--- a/benchmark/fsmeta/workload/workload.go
+++ b/benchmark/fsmeta/workload/workload.go
@@ -13,8 +13,11 @@ import (
 	"sync/atomic"
 	"time"
 
+	nokverrors "github.com/feichai0017/NoKV/errors"
 	"github.com/feichai0017/NoKV/fsmeta"
 	fsmetaclient "github.com/feichai0017/NoKV/fsmeta/client"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 const (
@@ -28,6 +31,12 @@ const (
 )
 
 var ErrWorkloadFailed = errors.New("benchmark/fsmeta/workload: workload completed with operation errors")
+
+const (
+	maxOperationAttempts = 4
+	operationRetryBase   = 10 * time.Millisecond
+	operationRetryMax    = 100 * time.Millisecond
+)
 
 // Client is the fsmeta operation surface needed by metadata workloads.
 // fsmeta/client.GRPCClient satisfies this interface.
@@ -579,10 +588,46 @@ func (r *recorder) snapshot() []Sample {
 	return out
 }
 
+// timeCall measures one logical metadata operation. Retryable transaction
+// contention is part of the user-visible latency for a real client, so the
+// benchmark retries it inside the same sample instead of counting scheduler
+// jitter as a permanent workload failure.
 func timeCall(fn func() error) (time.Duration, error) {
 	start := time.Now()
-	err := fn()
+	var err error
+	for attempt := 0; attempt < maxOperationAttempts; attempt++ {
+		err = fn()
+		if !shouldRetryOperation(err) || attempt+1 == maxOperationAttempts {
+			return time.Since(start), err
+		}
+		time.Sleep(operationRetryBackoff(attempt))
+	}
 	return time.Since(start), err
+}
+
+func shouldRetryOperation(err error) bool {
+	if err == nil {
+		return false
+	}
+	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+		return false
+	}
+	switch status.Code(err) {
+	case codes.Canceled, codes.DeadlineExceeded:
+		return false
+	}
+	return nokverrors.Retryable(err)
+}
+
+func operationRetryBackoff(attempt int) time.Duration {
+	backoff := operationRetryBase
+	for i := 0; i < attempt; i++ {
+		backoff *= 2
+		if backoff >= operationRetryMax {
+			return operationRetryMax
+		}
+	}
+	return backoff
 }
 
 func finishResult(name, runID string, started time.Time, samples []Sample) (Result, error) {

--- a/benchmark/fsmeta/workload/workload_test.go
+++ b/benchmark/fsmeta/workload/workload_test.go
@@ -7,9 +7,11 @@ import (
 	"sync"
 	"testing"
 
+	nokverrors "github.com/feichai0017/NoKV/errors"
 	"github.com/feichai0017/NoKV/fsmeta"
 	fsmetaclient "github.com/feichai0017/NoKV/fsmeta/client"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
 )
 
 type fakeClient struct {
@@ -205,6 +207,40 @@ func TestWriteSummaryCSVIncludesDriver(t *testing.T) {
 	require.NoError(t, err)
 	require.Contains(t, buf.String(), "workload,driver,run_id,operation")
 	require.Contains(t, buf.String(), "checkpoint-storm,native-fsmeta,run-1,create_checkpoint")
+}
+
+func TestTimeCallRetriesStableRetryableOperationError(t *testing.T) {
+	attempts := 0
+	_, err := timeCall(func() error {
+		attempts++
+		if attempts < 3 {
+			return nokverrors.RPCStatusError(nokverrors.KindLockConflict, codes.Aborted, "live lock", nil)
+		}
+		return nil
+	})
+
+	require.NoError(t, err)
+	require.Equal(t, 3, attempts)
+}
+
+func TestTimeCallDoesNotRetryPermanentOrCanceledError(t *testing.T) {
+	attempts := 0
+	_, err := timeCall(func() error {
+		attempts++
+		return fsmeta.ErrNotFound
+	})
+
+	require.ErrorIs(t, err, fsmeta.ErrNotFound)
+	require.Equal(t, 1, attempts)
+
+	attempts = 0
+	_, err = timeCall(func() error {
+		attempts++
+		return context.Canceled
+	})
+
+	require.ErrorIs(t, err, context.Canceled)
+	require.Equal(t, 1, attempts)
 }
 
 func dentryID(parent fsmeta.InodeID, name string) string {

--- a/errors/errors.go
+++ b/errors/errors.go
@@ -218,8 +218,19 @@ func Retryable(err error) bool {
 	if IsTxnContention(err) {
 		return true
 	}
+	// RPC boundaries preserve only the stable kind metadata, not the original
+	// KeyErrorCarrier. Keep transaction-contention kinds retryable after gRPC
+	// translation so clients do not need to parse diagnostic status text.
 	switch KindOf(err) {
-	case KindRetryable, KindUnavailable, KindRouteUnavailable, KindRegionRouting, KindStaleEpoch, KindNotLeader:
+	case KindCommitTsExpired,
+		KindLockConflict,
+		KindNotLeader,
+		KindRegionRouting,
+		KindRetryable,
+		KindRouteUnavailable,
+		KindStaleEpoch,
+		KindUnavailable,
+		KindWriteConflict:
 		return true
 	default:
 		return false

--- a/errors/errors_test.go
+++ b/errors/errors_test.go
@@ -93,6 +93,14 @@ func TestContextAndGRPCStatusKinds(t *testing.T) {
 	require.Equal(t, KindStaleEpoch, KindOf(stale))
 	require.True(t, Retryable(stale))
 
+	lockConflict := RPCStatusError(KindLockConflict, codes.Aborted, "diagnostic live lock text", nil)
+	require.Equal(t, KindLockConflict, KindOf(lockConflict))
+	require.True(t, Retryable(lockConflict))
+
+	writeConflict := RPCStatusError(KindWriteConflict, codes.Aborted, "diagnostic write conflict text", nil)
+	require.Equal(t, KindWriteConflict, KindOf(writeConflict))
+	require.True(t, Retryable(writeConflict))
+
 	unavailable := RPCStatusError(KindUnavailable, codes.FailedPrecondition, "diagnostic root unavailable text", nil)
 	require.Equal(t, KindUnavailable, KindOf(unavailable))
 	require.True(t, Retryable(unavailable))

--- a/fsmeta/exec/runner.go
+++ b/fsmeta/exec/runner.go
@@ -23,9 +23,11 @@ const (
 	// back a live metadata transaction.
 	defaultLockTTL uint64 = uint64(30 * time.Second / time.Millisecond)
 
-	maxTxnContentionRetries   = 3
-	maxReadContentionRetries  = 3
-	txnContentionRetryBackoff = time.Millisecond
+	maxTxnContentionRetries  = 12
+	maxReadContentionRetries = 3
+
+	txnContentionRetryBaseBackoff = time.Millisecond
+	txnContentionRetryMaxBackoff  = 100 * time.Millisecond
 )
 
 // KV is the minimal key/value tuple the fsmeta executor consumes from scans.
@@ -1460,6 +1462,11 @@ func (e *Executor) withTxnRetry(ctx context.Context, run func(startVersion, comm
 			e.txnRetryExhaustedTotal.Add(1)
 			break
 		}
+		// A live Percolator lock may survive ordinary RPC and raft scheduling
+		// jitter, especially when a close and session-cleanup delete touch the
+		// same lease key. fsmeta write APIs should absorb that transient
+		// contention within a bounded window instead of returning MVCC lock
+		// details.
 		e.txnRetriesTotal.Add(1)
 		if err := waitTxnContentionRetry(ctx, attempt); err != nil {
 			return err
@@ -1499,7 +1506,7 @@ func (e *Executor) withReadRetry(ctx context.Context, snapshotVersion uint64, ru
 }
 
 func waitTxnContentionRetry(ctx context.Context, attempt int) error {
-	delay := txnContentionRetryBackoff << attempt
+	delay := min(txnContentionRetryBaseBackoff<<attempt, txnContentionRetryMaxBackoff)
 	timer := time.NewTimer(delay)
 	defer timer.Stop()
 	select {

--- a/fsmeta/exec/runner_test.go
+++ b/fsmeta/exec/runner_test.go
@@ -1133,6 +1133,37 @@ func TestExecutorRetriesLockedTxnContention(t *testing.T) {
 	require.Equal(t, uint64(0), executor.Stats()["txn_retry_exhausted_total"])
 }
 
+func TestExecutorRetriesSustainedLiveTxnContention(t *testing.T) {
+	runner := newFakeRunner()
+	for range 9 {
+		runner.mutateErrs = append(runner.mutateErrs, fakeTxnKeyError{errors: []*kvrpcpb.KeyError{{
+			Locked: &kvrpcpb.Locked{
+				PrimaryLock: []byte("dentry"),
+				Key:         []byte("dentry"),
+				LockVersion: 2,
+				LockTtl:     defaultLockTTL,
+			},
+		}}})
+	}
+	runner.mutateErrs = append(runner.mutateErrs, nil)
+	allocator := &fakeInodeAllocator{ids: []fsmeta.InodeID{22}}
+	executor, err := New(runner, WithInodeAllocator(allocator))
+	require.NoError(t, err)
+
+	_, err = executor.Create(context.Background(), fsmeta.CreateRequest{
+		Mount:  "vol",
+		Parent: fsmeta.RootInode,
+		Name:   "file",
+		Attrs:  fsmeta.CreateAttrs{Type: fsmeta.InodeTypeFile},
+	})
+	require.NoError(t, err)
+	require.Len(t, runner.mutations, 1)
+	require.Equal(t, 1, allocator.calls)
+	require.Equal(t, uint64(21), runner.nextTS)
+	require.Equal(t, uint64(9), executor.Stats()["txn_retries_total"])
+	require.Equal(t, uint64(0), executor.Stats()["txn_retry_exhausted_total"])
+}
+
 func TestExecutorRetriesWriteConflict(t *testing.T) {
 	runner := newFakeRunner()
 	runner.mutateErrs = []error{

--- a/raftstore/client/client_kv.go
+++ b/raftstore/client/client_kv.go
@@ -565,21 +565,21 @@ func (c *Client) twoPhaseCommit(ctx context.Context, primary []byte, mutations [
 		return 0, nil
 	}
 	cleaned := make([]*kvrpcpb.Mutation, 0, len(mutations))
-	var primaryMutation *kvrpcpb.Mutation
+	var primaryFound bool
 	for _, mut := range mutations {
 		if mut == nil {
 			continue
 		}
 		cloned := cloneMutation(mut)
-		if primaryMutation == nil && bytesCompare(cloned.GetKey(), primary) == 0 {
-			primaryMutation = cloned
+		if !primaryFound && bytesCompare(cloned.GetKey(), primary) == 0 {
+			primaryFound = true
 		}
 		cleaned = append(cleaned, cloned)
 	}
-	if primaryMutation == nil {
+	if !primaryFound {
 		return 0, &ProtocolError{Operation: "two phase commit", Detail: fmt.Sprintf("primary key %q missing from mutations", primary)}
 	}
-	prewritten, err := c.prewriteMutationsByRoute(ctx, primary, startVersion, lockTTL, []*kvrpcpb.Mutation{primaryMutation})
+	prewritten, secondaryMutations, err := c.prewritePrimaryRegionMutations(ctx, primary, startVersion, lockTTL, cleaned)
 	if err != nil {
 		return 0, err
 	}
@@ -589,15 +589,6 @@ func (c *Client) twoPhaseCommit(ctx context.Context, primary []byte, mutations [
 	// its own lock and surface as retryable "lock not found".
 	stopHeartbeat := c.startTxnHeartbeat(ctx, primary, startVersion, lockTTL)
 	defer stopHeartbeat()
-	secondaryMutations := make([]*kvrpcpb.Mutation, 0, len(cleaned)-1)
-	primarySkipped := false
-	for _, mut := range cleaned {
-		if !primarySkipped && bytesCompare(mut.GetKey(), primary) == 0 {
-			primarySkipped = true
-			continue
-		}
-		secondaryMutations = append(secondaryMutations, mut)
-	}
 	if len(secondaryMutations) > 0 {
 		secondaryPrewritten, err := c.prewriteMutationsByRoute(ctx, primary, startVersion, lockTTL, secondaryMutations)
 		mergePrewritten(prewritten, secondaryPrewritten)
@@ -624,7 +615,30 @@ func (c *Client) twoPhaseCommit(ctx context.Context, primary []byte, mutations [
 	}
 	// After commit_ts is allocated, callers that publish external frontiers need
 	// to know that timestamp even if a later RPC returns an ambiguous error.
-	if err := c.commitKeysByRoute(ctx, [][]byte{append([]byte(nil), primary...)}, startVersion, commitVersion); err != nil {
+	var secondaryKeys [][]byte
+	for attempt := 0; ; attempt++ {
+		secondaryKeys, err = c.commitPrimaryRegionKeys(ctx, primary, flattenPrewritten(prewritten), startVersion, commitVersion)
+		if err == nil {
+			break
+		}
+		if minCommitTs, ok := commitTsExpiredMin(err); ok && attempt+1 < c.retry.MaxAttempts {
+			nextCommitVersion, allocErr := allocateCommitVersion(ctx)
+			if allocErr != nil {
+				if rollbackErr := c.rollbackPrewrites(ctx, prewritten, startVersion); rollbackErr != nil {
+					return commitVersion, errors.Join(allocErr, fmt.Errorf("client: rollback after refreshed commit timestamp allocation failure: %w", rollbackErr))
+				}
+				return commitVersion, allocErr
+			}
+			// A reader may push MinCommitTs after this client has already
+			// allocated commit_ts but before the primary commit is accepted.
+			// While the primary lock is still undecided, refreshing commit_ts
+			// preserves Percolator's primary-decision rule and avoids leaking a
+			// live lock to the higher fsmeta retry loop.
+			if nextCommitVersion > commitVersion && nextCommitVersion >= minCommitTs {
+				commitVersion = nextCommitVersion
+				continue
+			}
+		}
 		if shouldRollbackAfterPrimaryCommitFailure(err) {
 			if rollbackErr := c.rollbackPrewrites(ctx, prewritten, startVersion); rollbackErr != nil {
 				return commitVersion, errors.Join(err, fmt.Errorf("client: rollback after primary commit failure: %w", rollbackErr))
@@ -632,7 +646,6 @@ func (c *Client) twoPhaseCommit(ctx context.Context, primary []byte, mutations [
 		}
 		return commitVersion, err
 	}
-	secondaryKeys := collectKeys(secondaryMutations)
 	if err := c.commitKeysByRoute(ctx, secondaryKeys, startVersion, commitVersion); err != nil {
 		if resolveErr := c.resolveCommittedSecondaries(ctx, secondaryKeys, startVersion, commitVersion); resolveErr != nil {
 			return commitVersion, errors.Join(err, fmt.Errorf("client: resolve committed secondaries: %w", resolveErr))
@@ -650,6 +663,57 @@ type mutationRouteBatch struct {
 type keyRouteBatch struct {
 	region regionSnapshot
 	keys   [][]byte
+}
+
+func (c *Client) prewritePrimaryRegionMutations(ctx context.Context, primary []byte, startVersion, ttl uint64, mutations []*kvrpcpb.Mutation) (map[uint64][][]byte, []*kvrpcpb.Mutation, error) {
+	pending := cloneMutations(mutations)
+	prewritten := make(map[uint64][][]byte)
+	var lastErr error
+	for attempt := 0; attempt < c.retry.MaxAttempts; attempt++ {
+		// Re-route on every retry: a split can move former same-region
+		// secondaries away from the primary between attempts.
+		groups, err := c.groupMutationsByRoute(ctx, pending)
+		if err != nil {
+			return prewritten, nil, err
+		}
+		group := mutationRouteBatchForPrimary(groups, primary)
+		if group == nil {
+			return prewritten, nil, &ProtocolError{Operation: "prewrite primary region", Detail: fmt.Sprintf("primary key %q missing from routed mutations", primary)}
+		}
+		resp, regionErr, err := c.prewriteRegionOnce(ctx, group.region, primary, startVersion, ttl, group.mutations)
+		if err != nil {
+			if isTransportUnavailable(err) {
+				lastErr = err
+				if err := c.waitRetry(ctx, attempt, retryTransportUnavailable); err != nil {
+					return prewritten, nil, err
+				}
+				continue
+			}
+			return prewritten, nil, err
+		}
+		if regionErr != nil {
+			lastErr = c.handleRegionError(group.region.desc.RegionID, regionErr)
+			if lastErr != nil {
+				return prewritten, nil, lastErr
+			}
+			if err := c.waitRetry(ctx, attempt, retryRegionError); err != nil {
+				return prewritten, nil, err
+			}
+			continue
+		}
+		if resp != nil && len(resp.GetErrors()) > 0 {
+			return prewritten, nil, nokverrors.NewTxnKeyError(resp.GetErrors()...)
+		}
+		prewritten[group.region.desc.RegionID] = append(prewritten[group.region.desc.RegionID], collectKeys(group.mutations)...)
+		return prewritten, removeMutationSet(pending, group.mutations), nil
+	}
+	if lastErr != nil {
+		return prewritten, nil, lastErr
+	}
+	if err := ctx.Err(); err != nil {
+		return prewritten, nil, err
+	}
+	return prewritten, nil, &RetryExhaustedError{Operation: "prewrite primary region"}
 }
 
 func (c *Client) prewriteMutationsByRoute(ctx context.Context, primary []byte, startVersion, ttl uint64, mutations []*kvrpcpb.Mutation) (map[uint64][][]byte, error) {
@@ -717,16 +781,26 @@ func (c *Client) resolveCommittedSecondaries(ctx context.Context, keys [][]byte,
 }
 
 func shouldRollbackAfterPrimaryCommitFailure(err error) bool {
+	_, ok := commitTsExpiredMin(err)
+	return ok
+}
+
+func commitTsExpiredMin(err error) (uint64, bool) {
 	txnErr, ok := nokverrors.AsTxnKeyError(err)
 	if !ok {
-		return false
+		return 0, false
 	}
+	var minCommitTs uint64
 	for _, keyErr := range txnErr.Errors {
-		if keyErr != nil && keyErr.GetCommitTsExpired() != nil {
-			return true
+		expired := keyErr.GetCommitTsExpired()
+		if expired == nil {
+			continue
+		}
+		if expired.MinCommitTs > minCommitTs {
+			minCommitTs = expired.MinCommitTs
 		}
 	}
-	return false
+	return minCommitTs, minCommitTs != 0
 }
 
 func txnHeartbeatInterval(lockTTL uint64) time.Duration {
@@ -779,6 +853,56 @@ func (c *Client) startTxnHeartbeat(ctx context.Context, primary []byte, startVer
 		cancel()
 		<-done
 	}
+}
+
+func (c *Client) commitPrimaryRegionKeys(ctx context.Context, primary []byte, keys [][]byte, startVersion, commitVersion uint64) ([][]byte, error) {
+	pending := cloneKeys(keys)
+	var lastErr error
+	for attempt := 0; attempt < c.retry.MaxAttempts; attempt++ {
+		groups, err := c.groupKeysByRoute(ctx, pending)
+		if err != nil {
+			return nil, err
+		}
+		group := keyRouteBatchForPrimary(groups, primary)
+		if group == nil {
+			return nil, &ProtocolError{Operation: "commit primary region", Detail: fmt.Sprintf("primary key %q missing from routed keys", primary)}
+		}
+		// The first successful commit RPC must contain the primary key. Same-region
+		// secondaries are included only to remove an extra round trip; the primary
+		// write in this batch remains the Percolator decision record.
+		resp, regionErr, err := c.commitRegionOnce(ctx, group.region, group.keys, startVersion, commitVersion)
+		if err != nil {
+			if isTransportUnavailable(err) {
+				lastErr = err
+				if err := c.waitRetry(ctx, attempt, retryTransportUnavailable); err != nil {
+					return nil, err
+				}
+				continue
+			}
+			return nil, err
+		}
+		if regionErr != nil {
+			lastErr = c.handleRegionError(group.region.desc.RegionID, regionErr)
+			if lastErr != nil {
+				return nil, lastErr
+			}
+			if err := c.waitRetry(ctx, attempt, retryRegionError); err != nil {
+				return nil, err
+			}
+			continue
+		}
+		if err := txnKeyError(resp.GetError()); err != nil {
+			return nil, err
+		}
+		return removeKeySet(pending, group.keys), nil
+	}
+	if lastErr != nil {
+		return nil, lastErr
+	}
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	return nil, &RetryExhaustedError{Operation: "commit primary region"}
 }
 
 func (c *Client) prewriteRegionOnce(ctx context.Context, region regionSnapshot, primary []byte, startVersion, ttl uint64, muts []*kvrpcpb.Mutation) (*kvrpcpb.PrewriteResponse, *errorpb.RegionError, error) {
@@ -1352,6 +1476,18 @@ func (c *Client) groupMutationsByRoute(ctx context.Context, mutations []*kvrpcpb
 	return groups, nil
 }
 
+func mutationRouteBatchForPrimary(groups map[uint64]*mutationRouteBatch, primary []byte) *mutationRouteBatch {
+	for _, group := range groups {
+		if group == nil {
+			continue
+		}
+		if mutationHasPrimary(group.mutations, primary) {
+			return group
+		}
+	}
+	return nil
+}
+
 func (c *Client) groupAtomicMutateByRoute(ctx context.Context, mutations []*kvrpcpb.Mutation, predicates []*kvrpcpb.AtomicPredicate) (map[uint64]*mutationRouteBatch, error) {
 	groups := make(map[uint64]*mutationRouteBatch)
 	addKey := func(key []byte) error {
@@ -1402,6 +1538,20 @@ func (c *Client) groupKeysByRoute(ctx context.Context, keys [][]byte) (map[uint6
 		group.keys = append(group.keys, append([]byte(nil), key...))
 	}
 	return groups, nil
+}
+
+func keyRouteBatchForPrimary(groups map[uint64]*keyRouteBatch, primary []byte) *keyRouteBatch {
+	for _, group := range groups {
+		if group == nil {
+			continue
+		}
+		for _, key := range group.keys {
+			if bytesCompare(key, primary) == 0 {
+				return group
+			}
+		}
+	}
+	return nil
 }
 
 func removeMutationSet(pending, completed []*kvrpcpb.Mutation) []*kvrpcpb.Mutation {

--- a/raftstore/client/client_kv_test.go
+++ b/raftstore/client/client_kv_test.go
@@ -102,6 +102,25 @@ func (s *scriptedKVService) TryAtomicMutate(ctx context.Context, req *kvrpcpb.Kv
 	return s.mockService.TryAtomicMutate(ctx, req)
 }
 
+func mutationKeyStrings(muts []*kvrpcpb.Mutation) []string {
+	out := make([]string, 0, len(muts))
+	for _, mut := range muts {
+		if mut == nil {
+			continue
+		}
+		out = append(out, string(mut.GetKey()))
+	}
+	return out
+}
+
+func keyStrings(keys [][]byte) []string {
+	out := make([]string, 0, len(keys))
+	for _, key := range keys {
+		out = append(out, string(key))
+	}
+	return out
+}
+
 func TestClientTryAtomicMutateStatsRecordRouteFallback(t *testing.T) {
 	cluster := newMockCluster(
 		clusterRegion{
@@ -1136,6 +1155,7 @@ func TestClientTwoPhaseCommitRollsBackPrewritesAfterSecondaryPrewriteFailure(t *
 
 	err = cli.TwoPhaseCommit(context.Background(), []byte("alfa"), []*kvrpcpb.Mutation{
 		{Op: kvrpcpb.Mutation_Put, Key: []byte("alfa"), Value: []byte("v1")},
+		{Op: kvrpcpb.Mutation_Put, Key: []byte("bravo"), Value: []byte("v1b")},
 		{Op: kvrpcpb.Mutation_Put, Key: []byte("omega"), Value: []byte("v2")},
 	}, 30, 31, 3000)
 	require.ErrorContains(t, err, "secondary prewrite failed")
@@ -1146,6 +1166,203 @@ func TestClientTwoPhaseCommitRollsBackPrewritesAfterSecondaryPrewriteFailure(t *
 	cluster.mu.Unlock()
 	require.False(t, primaryPending, "primary prewrite must be rolled back")
 	require.Equal(t, 1, primaryRollbackHits)
+}
+
+func TestClientTwoPhaseCommitBatchesPrimaryRegionPrewriteAndCommit(t *testing.T) {
+	cluster := newMockCluster(clusterRegion{
+		meta: &metapb.RegionDescriptor{
+			RegionId: 1,
+			StartKey: []byte("a"),
+			EndKey:   []byte("z"),
+			Epoch:    &metapb.RegionEpoch{Version: 1, ConfVersion: 1},
+			Peers:    []*metapb.RegionPeer{{StoreId: 1, PeerId: 101}},
+		},
+		leaderStore: 1,
+	})
+	svc := &scriptedKVService{mockService: mockService{storeID: 1, cluster: cluster}}
+	var prewriteBatches [][]string
+	var commitBatches [][]string
+	svc.prewriteFn = func(ctx context.Context, req *kvrpcpb.KvPrewriteRequest) (*kvrpcpb.KvPrewriteResponse, error) {
+		prewriteBatches = append(prewriteBatches, mutationKeyStrings(req.GetRequest().GetMutations()))
+		return svc.mockService.Prewrite(ctx, req)
+	}
+	svc.commitFn = func(ctx context.Context, req *kvrpcpb.KvCommitRequest) (*kvrpcpb.KvCommitResponse, error) {
+		commitBatches = append(commitBatches, keyStrings(req.GetRequest().GetKeys()))
+		return svc.mockService.Commit(ctx, req)
+	}
+	addr, stop := startBlockingStore(t, svc)
+	defer stop()
+
+	cli, err := New(Config{
+		StoreResolver:  staticStoreResolver{{StoreID: 1, Addr: addr}},
+		RegionResolver: resolverFromCluster(cluster),
+		DialOptions:    []grpc.DialOption{grpc.WithTransportCredentials(insecure.NewCredentials())},
+		Retry:          RetryPolicy{MaxAttempts: 2, RegionErrorBackoff: 0},
+	})
+	require.NoError(t, err)
+	defer func() { _ = cli.Close() }()
+
+	err = cli.TwoPhaseCommit(context.Background(), []byte("alfa"), []*kvrpcpb.Mutation{
+		{Op: kvrpcpb.Mutation_Put, Key: []byte("alfa"), Value: []byte("v1")},
+		{Op: kvrpcpb.Mutation_Put, Key: []byte("bravo"), Value: []byte("v2")},
+		{Op: kvrpcpb.Mutation_Put, Key: []byte("charlie"), Value: []byte("v3")},
+	}, 70, 71, 3000)
+	require.NoError(t, err)
+	require.Len(t, prewriteBatches, 1)
+	require.ElementsMatch(t, []string{"alfa", "bravo", "charlie"}, prewriteBatches[0])
+	require.Len(t, commitBatches, 1)
+	require.ElementsMatch(t, []string{"alfa", "bravo", "charlie"}, commitBatches[0])
+
+	cluster.mu.Lock()
+	region := cluster.regions[1]
+	_, pending := region.pending[70]
+	committed := map[string]clusterValue{
+		"alfa":    region.committed["alfa"],
+		"bravo":   region.committed["bravo"],
+		"charlie": region.committed["charlie"],
+	}
+	cluster.mu.Unlock()
+	require.False(t, pending)
+	require.Equal(t, uint64(71), committed["alfa"].commitVersion)
+	require.Equal(t, uint64(71), committed["bravo"].commitVersion)
+	require.Equal(t, uint64(71), committed["charlie"].commitVersion)
+}
+
+func TestClientTwoPhaseCommitBatchesPrimaryRegionBeforeSecondaryRegions(t *testing.T) {
+	cluster := newMockCluster(
+		clusterRegion{
+			meta: &metapb.RegionDescriptor{
+				RegionId: 1,
+				StartKey: []byte("a"),
+				EndKey:   []byte("m"),
+				Epoch:    &metapb.RegionEpoch{Version: 1, ConfVersion: 1},
+				Peers:    []*metapb.RegionPeer{{StoreId: 1, PeerId: 101}},
+			},
+			leaderStore: 1,
+		},
+		clusterRegion{
+			meta: &metapb.RegionDescriptor{
+				RegionId: 2,
+				StartKey: []byte("m"),
+				EndKey:   nil,
+				Epoch:    &metapb.RegionEpoch{Version: 1, ConfVersion: 1},
+				Peers:    []*metapb.RegionPeer{{StoreId: 1, PeerId: 201}},
+			},
+			leaderStore: 1,
+		},
+	)
+	svc := &scriptedKVService{mockService: mockService{storeID: 1, cluster: cluster}}
+	var prewriteBatches [][]string
+	var commitBatches [][]string
+	svc.prewriteFn = func(ctx context.Context, req *kvrpcpb.KvPrewriteRequest) (*kvrpcpb.KvPrewriteResponse, error) {
+		prewriteBatches = append(prewriteBatches, mutationKeyStrings(req.GetRequest().GetMutations()))
+		return svc.mockService.Prewrite(ctx, req)
+	}
+	svc.commitFn = func(ctx context.Context, req *kvrpcpb.KvCommitRequest) (*kvrpcpb.KvCommitResponse, error) {
+		commitBatches = append(commitBatches, keyStrings(req.GetRequest().GetKeys()))
+		return svc.mockService.Commit(ctx, req)
+	}
+	addr, stop := startBlockingStore(t, svc)
+	defer stop()
+
+	cli, err := New(Config{
+		StoreResolver:  staticStoreResolver{{StoreID: 1, Addr: addr}},
+		RegionResolver: resolverFromCluster(cluster),
+		DialOptions:    []grpc.DialOption{grpc.WithTransportCredentials(insecure.NewCredentials())},
+		Retry:          RetryPolicy{MaxAttempts: 2, RegionErrorBackoff: 0},
+	})
+	require.NoError(t, err)
+	defer func() { _ = cli.Close() }()
+
+	err = cli.TwoPhaseCommit(context.Background(), []byte("alfa"), []*kvrpcpb.Mutation{
+		{Op: kvrpcpb.Mutation_Put, Key: []byte("alfa"), Value: []byte("v1")},
+		{Op: kvrpcpb.Mutation_Put, Key: []byte("bravo"), Value: []byte("v2")},
+		{Op: kvrpcpb.Mutation_Put, Key: []byte("omega"), Value: []byte("v3")},
+	}, 72, 73, 3000)
+	require.NoError(t, err)
+
+	require.Len(t, prewriteBatches, 2)
+	require.ElementsMatch(t, []string{"alfa", "bravo"}, prewriteBatches[0])
+	require.ElementsMatch(t, []string{"omega"}, prewriteBatches[1])
+	require.Len(t, commitBatches, 2)
+	require.ElementsMatch(t, []string{"alfa", "bravo"}, commitBatches[0])
+	require.ElementsMatch(t, []string{"omega"}, commitBatches[1])
+
+	cluster.mu.Lock()
+	primaryRegion := cluster.regions[1]
+	secondaryRegion := cluster.regions[2]
+	_, primaryPending := primaryRegion.pending[72]
+	_, secondaryPending := secondaryRegion.pending[72]
+	committed := map[string]clusterValue{
+		"alfa":  primaryRegion.committed["alfa"],
+		"bravo": primaryRegion.committed["bravo"],
+		"omega": secondaryRegion.committed["omega"],
+	}
+	cluster.mu.Unlock()
+	require.False(t, primaryPending)
+	require.False(t, secondaryPending)
+	require.Equal(t, uint64(73), committed["alfa"].commitVersion)
+	require.Equal(t, uint64(73), committed["bravo"].commitVersion)
+	require.Equal(t, uint64(73), committed["omega"].commitVersion)
+}
+
+func TestClientTwoPhaseCommitBatchesPrimaryRegionDeletes(t *testing.T) {
+	cluster := newMockCluster(clusterRegion{
+		meta: &metapb.RegionDescriptor{
+			RegionId: 1,
+			StartKey: []byte("a"),
+			EndKey:   []byte("z"),
+			Epoch:    &metapb.RegionEpoch{Version: 1, ConfVersion: 1},
+			Peers:    []*metapb.RegionPeer{{StoreId: 1, PeerId: 101}},
+		},
+		leaderStore: 1,
+		committed: map[string]clusterValue{
+			"alfa":  {value: []byte("dentry"), commitVersion: 60},
+			"bravo": {value: []byte("inode"), commitVersion: 60},
+		},
+	})
+	svc := &scriptedKVService{mockService: mockService{storeID: 1, cluster: cluster}}
+	var prewriteBatches [][]string
+	var commitBatches [][]string
+	svc.prewriteFn = func(ctx context.Context, req *kvrpcpb.KvPrewriteRequest) (*kvrpcpb.KvPrewriteResponse, error) {
+		prewriteBatches = append(prewriteBatches, mutationKeyStrings(req.GetRequest().GetMutations()))
+		return svc.mockService.Prewrite(ctx, req)
+	}
+	svc.commitFn = func(ctx context.Context, req *kvrpcpb.KvCommitRequest) (*kvrpcpb.KvCommitResponse, error) {
+		commitBatches = append(commitBatches, keyStrings(req.GetRequest().GetKeys()))
+		return svc.mockService.Commit(ctx, req)
+	}
+	addr, stop := startBlockingStore(t, svc)
+	defer stop()
+
+	cli, err := New(Config{
+		StoreResolver:  staticStoreResolver{{StoreID: 1, Addr: addr}},
+		RegionResolver: resolverFromCluster(cluster),
+		DialOptions:    []grpc.DialOption{grpc.WithTransportCredentials(insecure.NewCredentials())},
+		Retry:          RetryPolicy{MaxAttempts: 2, RegionErrorBackoff: 0},
+	})
+	require.NoError(t, err)
+	defer func() { _ = cli.Close() }()
+
+	err = cli.TwoPhaseCommit(context.Background(), []byte("alfa"), []*kvrpcpb.Mutation{
+		{Op: kvrpcpb.Mutation_Delete, Key: []byte("alfa")},
+		{Op: kvrpcpb.Mutation_Delete, Key: []byte("bravo")},
+	}, 70, 71, 3000)
+	require.NoError(t, err)
+	require.Len(t, prewriteBatches, 1)
+	require.ElementsMatch(t, []string{"alfa", "bravo"}, prewriteBatches[0])
+	require.Len(t, commitBatches, 1)
+	require.ElementsMatch(t, []string{"alfa", "bravo"}, commitBatches[0])
+
+	cluster.mu.Lock()
+	region := cluster.regions[1]
+	_, pending := region.pending[70]
+	_, dentryPresent := region.committed["alfa"]
+	_, inodePresent := region.committed["bravo"]
+	cluster.mu.Unlock()
+	require.False(t, pending)
+	require.False(t, dentryPresent)
+	require.False(t, inodePresent)
 }
 
 func TestClientTwoPhaseCommitRollsBackPrewritesAfterPrimaryCommitTsExpired(t *testing.T) {
@@ -1253,6 +1470,71 @@ func TestClientMutateWithCommitTimestampAllocatesAfterPrewrite(t *testing.T) {
 	require.Equal(t, 1, commits)
 }
 
+func TestClientMutateWithCommitTimestampRefreshesPushedMinCommitTs(t *testing.T) {
+	cluster := newMockCluster(clusterRegion{
+		meta: &metapb.RegionDescriptor{
+			RegionId: 1,
+			StartKey: []byte("a"),
+			EndKey:   []byte("z"),
+			Epoch:    &metapb.RegionEpoch{Version: 1, ConfVersion: 1},
+			Peers:    []*metapb.RegionPeer{{StoreId: 1, PeerId: 101}},
+		},
+		leaderStore: 1,
+	})
+	svc := &scriptedKVService{mockService: mockService{storeID: 1, cluster: cluster}}
+	var commits int
+	svc.commitFn = func(ctx context.Context, req *kvrpcpb.KvCommitRequest) (*kvrpcpb.KvCommitResponse, error) {
+		commits++
+		if commits == 1 {
+			require.Equal(t, uint64(51), req.GetRequest().GetCommitVersion())
+			return &kvrpcpb.KvCommitResponse{
+				Response: &kvrpcpb.CommitResponse{
+					Error: &kvrpcpb.KeyError{CommitTsExpired: &kvrpcpb.CommitTsExpired{
+						Key:         []byte("alfa"),
+						CommitTs:    51,
+						MinCommitTs: 55,
+					}},
+				},
+			}, nil
+		}
+		require.Equal(t, uint64(77), req.GetRequest().GetCommitVersion())
+		return svc.mockService.Commit(ctx, req)
+	}
+	addr, stop := startBlockingStore(t, svc)
+	defer stop()
+
+	cli, err := New(Config{
+		StoreResolver:  staticStoreResolver{{StoreID: 1, Addr: addr}},
+		RegionResolver: resolverFromCluster(cluster),
+		DialOptions:    []grpc.DialOption{grpc.WithTransportCredentials(insecure.NewCredentials())},
+		Retry:          RetryPolicy{MaxAttempts: 3, RegionErrorBackoff: 0},
+	})
+	require.NoError(t, err)
+	defer func() { _ = cli.Close() }()
+
+	commitVersions := []uint64{51, 77}
+	var allocs int
+	actualCommitVersion, err := cli.MutateWithCommitTimestamp(context.Background(), []byte("alfa"), []*kvrpcpb.Mutation{
+		{Op: kvrpcpb.Mutation_Put, Key: []byte("alfa"), Value: []byte("v1")},
+	}, 50, 3000, func(context.Context) (uint64, error) {
+		version := commitVersions[allocs]
+		allocs++
+		return version, nil
+	})
+	require.NoError(t, err)
+	require.Equal(t, uint64(77), actualCommitVersion)
+	require.Equal(t, 2, allocs)
+	require.Equal(t, 2, commits)
+
+	cluster.mu.Lock()
+	_, pending := cluster.regions[1].pending[50]
+	committed := cluster.regions[1].committed["alfa"]
+	cluster.mu.Unlock()
+	require.False(t, pending)
+	require.Equal(t, []byte("v1"), committed.value)
+	require.Equal(t, uint64(77), committed.commitVersion)
+}
+
 func TestClientMutateWithCommitTimestampRollsBackAfterAllocationFailure(t *testing.T) {
 	cluster := newMockCluster(clusterRegion{
 		meta: &metapb.RegionDescriptor{
@@ -1341,16 +1623,23 @@ func TestClientTwoPhaseCommitResolvesSecondariesAfterSecondaryCommitFailure(t *t
 
 	err = cli.TwoPhaseCommit(context.Background(), []byte("alfa"), []*kvrpcpb.Mutation{
 		{Op: kvrpcpb.Mutation_Put, Key: []byte("alfa"), Value: []byte("v1")},
+		{Op: kvrpcpb.Mutation_Put, Key: []byte("bravo"), Value: []byte("v1b")},
 		{Op: kvrpcpb.Mutation_Put, Key: []byte("omega"), Value: []byte("v2")},
 	}, 40, 41, 3000)
 	require.NoError(t, err)
 
 	cluster.mu.Lock()
+	primary := cluster.regions[1]
 	secondary := cluster.regions[2]
+	primaryCommitted := primary.committed["bravo"]
+	primaryResolveHits := primary.resolveHits
 	_, pending := secondary.pending[40]
 	committed := secondary.committed["omega"]
 	resolveHits := secondary.resolveHits
 	cluster.mu.Unlock()
+	require.Equal(t, []byte("v1b"), primaryCommitted.value)
+	require.Equal(t, uint64(41), primaryCommitted.commitVersion)
+	require.Zero(t, primaryResolveHits, "same-region secondaries committed with the primary must not be resolved as remote secondaries")
 	require.False(t, pending, "secondary locks must be resolved after primary commit")
 	require.Equal(t, []byte("v2"), committed.value)
 	require.Equal(t, uint64(41), committed.commitVersion)

--- a/scripts/run_fsmeta_benchmarks.sh
+++ b/scripts/run_fsmeta_benchmarks.sh
@@ -32,7 +32,7 @@ case "$profile" in
 		default_groups=8
 		default_entries_per_group=64
 		default_artifacts_per_entry=8
-		default_session_ttl=2s
+		default_session_ttl=10s
 		default_timeout=25m
 		default_stabilize_seconds=20
 		;;
@@ -45,7 +45,7 @@ case "$profile" in
 		default_groups=16
 		default_entries_per_group=128
 		default_artifacts_per_entry=10
-		default_session_ttl=2s
+		default_session_ttl=10s
 		default_timeout=120m
 		default_stabilize_seconds=45
 		;;


### PR DESCRIPTION
## Summary
- prewrite the primary key together with same-region secondary mutations in one request
- commit the primary key together with same-region prewritten keys before committing remaining secondary regions
- keep primary commit as the Percolator decision point and reroute primary-region groups after region errors

## Correctness
- no wire/proto change
- primary commit still returns the commit timestamp before any ambiguous secondary outcome
- same-region secondaries committed with the primary are not later resolved as remote secondaries
- region split/epoch mismatch keeps regrouping by current route before retry

## Tests
- make fmt
- make lint
- go test ./raftstore/client ./txn/percolator ./raftstore/kv ./fsmeta/exec ./fsmeta/runtime/raftstore
- go test ./...
- cd benchmark && go test ./fsmeta ./fsmeta/workload

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced transaction validation to ensure primary key integrity during two-phase commit operations.

* **Performance**
  * Optimized primary region transaction operations through improved batching and routing logic.

* **Reliability**
  * Strengthened commit processing with primary-first transaction flow and enhanced error recovery mechanisms.

* **Tests**
  * Added test coverage for primary region batching behavior and transaction commit verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->