### PR TITLE
Coalesce fsmeta runtime TSO requests

### DIFF
--- a/benchmark/fsmeta/fsmeta_bench_test.go
+++ b/benchmark/fsmeta/fsmeta_bench_test.go
@@ -41,7 +41,8 @@ var (
 	fsmetaGroups          = flag.Int("fsmeta_groups", 4, "mixed workload group directory count")
 	fsmetaEntriesPerGroup = flag.Int("fsmeta_entries_per_group", 8, "mixed workload published entry count per group")
 	fsmetaArtifactsPerRun = flag.Int("fsmeta_artifacts_per_entry", 4, "mixed workload artifact file count per entry; minimum 4")
-	fsmetaSessionTTL      = flag.Duration("fsmeta_session_ttl", 10*time.Second, "mixed writer session TTL")
+	fsmetaSessionTTL      = flag.Duration("fsmeta_session_ttl", 5*time.Minute, "mixed writer session TTL")
+	fsmetaStaleSessionTTL = flag.Duration("fsmeta_stale_session_ttl", 2*time.Second, "mixed stale-session cleanup TTL")
 	fsmetaTimeout         = flag.Duration("fsmeta_timeout", 5*time.Minute, "overall benchmark timeout")
 	fsmetaOutput          = flag.String("fsmeta_output", "", "summary CSV output path")
 )
@@ -227,6 +228,7 @@ func runBenchmarkWorkload(ctx context.Context, cli workload.Client, workloadName
 			ArtifactsPerRun: *fsmetaArtifactsPerRun,
 			PageLimit:       uint32(*fsmetaPageLimit),
 			SessionTTL:      *fsmetaSessionTTL,
+			StaleSessionTTL: *fsmetaStaleSessionTTL,
 		})
 	default:
 		return workload.Result{}, fmt.Errorf("unknown workload %q", workloadName)

--- a/benchmark/fsmeta/workload/mixed.go
+++ b/benchmark/fsmeta/workload/mixed.go
@@ -43,6 +43,7 @@ type MixedConfig struct {
 	ArtifactsPerRun int
 	PageLimit       uint32
 	SessionTTL      time.Duration
+	StaleSessionTTL time.Duration
 }
 
 type mixedDirs struct {
@@ -422,15 +423,27 @@ func runCheckpointPublish(ctx context.Context, cli MixedClient, cfg MixedConfig,
 }
 
 func runWriterSessionLifecycle(ctx context.Context, cli MixedClient, cfg MixedConfig, entry fsmeta.DentryRecord, task mixedTask, rec *recorder) {
-	session := fsmeta.SessionID(fmt.Sprintf("group-%s-%02d-%04d", cfg.RunID, task.group, task.run))
-	expires := time.Now().Add(cfg.SessionTTL).UnixNano()
+	sessionPrefix := fsmeta.SessionID(fmt.Sprintf("group-%s-%02d-%04d", cfg.RunID, task.group, task.run))
+	var session fsmeta.SessionID
+	openAttempt := 0
 	if err := recordCall(rec, "open_write_session", func() error {
+		openAttempt++
+		candidate := sessionPrefix
+		if openAttempt > 1 {
+			// OpenWriteSession is a lease acquisition, not an idempotent create.
+			// If an earlier attempt left an ambiguous primary lock, a real client
+			// can abandon that lease id and request a fresh one.
+			candidate = fsmeta.SessionID(fmt.Sprintf("%s-retry-%02d", sessionPrefix, openAttempt))
+		}
 		_, err := cli.OpenWriteSession(ctx, fsmeta.OpenWriteSessionRequest{
 			Mount:         cfg.Mount,
 			Inode:         entry.Inode,
-			Session:       session,
-			ExpiresUnixNs: expires,
+			Session:       candidate,
+			ExpiresUnixNs: time.Now().Add(cfg.SessionTTL).UnixNano(),
 		})
+		if err == nil {
+			session = candidate
+		}
 		return err
 	}); err != nil {
 		return
@@ -497,11 +510,11 @@ func runStaleSessionCleanup(ctx context.Context, cli MixedClient, cfg MixedConfi
 			Mount:         cfg.Mount,
 			Inode:         stale.Inode.Inode,
 			Session:       session,
-			ExpiresUnixNs: time.Now().Add(cfg.SessionTTL).UnixNano(),
+			ExpiresUnixNs: time.Now().Add(cfg.StaleSessionTTL).UnixNano(),
 		})
 		return err
 	})
-	wait := cfg.SessionTTL + 10*time.Millisecond
+	wait := cfg.StaleSessionTTL + 10*time.Millisecond
 	select {
 	case <-time.After(wait):
 	case <-ctx.Done():
@@ -544,6 +557,9 @@ func normalizeMixedConfig(cfg MixedConfig) MixedConfig {
 	}
 	if cfg.SessionTTL <= 0 {
 		cfg.SessionTTL = 2 * time.Second
+	}
+	if cfg.StaleSessionTTL <= 0 {
+		cfg.StaleSessionTTL = cfg.SessionTTL
 	}
 	return cfg
 }

--- a/benchmark/fsmeta/workload/mixed_test.go
+++ b/benchmark/fsmeta/workload/mixed_test.go
@@ -8,9 +8,11 @@ import (
 	"testing"
 	"time"
 
+	nokverrors "github.com/feichai0017/NoKV/errors"
 	"github.com/feichai0017/NoKV/fsmeta"
 	fsmetaclient "github.com/feichai0017/NoKV/fsmeta/client"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
 )
 
 type fakeMixedClient struct {
@@ -292,6 +294,27 @@ func (c *fakeMixedClient) ExpireWriteSessions(_ context.Context, req fsmeta.Expi
 	return fsmeta.ExpireWriteSessionsResult{Expired: expired}, nil
 }
 
+type retryOpenMixedClient struct {
+	*fakeMixedClient
+	attempts      int
+	firstSession  fsmeta.SessionID
+	secondSession fsmeta.SessionID
+	firstExpires  int64
+	secondExpires int64
+}
+
+func (c *retryOpenMixedClient) OpenWriteSession(ctx context.Context, req fsmeta.OpenWriteSessionRequest) (fsmeta.SessionRecord, error) {
+	c.attempts++
+	if c.attempts == 1 {
+		c.firstSession = req.Session
+		c.firstExpires = req.ExpiresUnixNs
+		return fsmeta.SessionRecord{}, nokverrors.RPCStatusError(nokverrors.KindLockConflict, codes.Aborted, "live lock", nil)
+	}
+	c.secondSession = req.Session
+	c.secondExpires = req.ExpiresUnixNs
+	return c.fakeMixedClient.OpenWriteSession(ctx, req)
+}
+
 func (c *fakeMixedClient) emitDentryEventLocked(mount fsmeta.MountID, entry fsmeta.DentryRecord) {
 	if c.stream == nil {
 		return
@@ -319,7 +342,8 @@ func TestRunMixedCoversFullSurface(t *testing.T) {
 		EntriesPerGroup: 2,
 		ArtifactsPerRun: 5,
 		PageLimit:       8,
-		SessionTTL:      2 * time.Millisecond,
+		SessionTTL:      time.Hour,
+		StaleSessionTTL: 2 * time.Millisecond,
 	})
 	require.NoError(t, err)
 	require.Equal(t, Mixed, result.Name)
@@ -377,6 +401,30 @@ func TestRunMixedCoversFullSurface(t *testing.T) {
 	for version := range versions {
 		require.Contains(t, seen, version)
 	}
+}
+
+func TestWriterSessionOpenRefreshesExpiryAcrossRetry(t *testing.T) {
+	base := newFakeMixedClient()
+	created, err := base.Create(context.Background(), fsmeta.CreateRequest{
+		Mount:  "vol",
+		Parent: 1,
+		Name:   "state.bin",
+		Attrs:  fsmeta.CreateAttrs{Type: fsmeta.InodeTypeFile, Mode: 0o644},
+	})
+	require.NoError(t, err)
+	cli := &retryOpenMixedClient{fakeMixedClient: base}
+	rec := newRecorder()
+
+	runWriterSessionLifecycle(context.Background(), cli, MixedConfig{
+		Mount:      "vol",
+		RunID:      "retry-expiry",
+		SessionTTL: time.Second,
+	}, created.Dentry, mixedTask{group: 1, run: 2}, rec)
+
+	require.Equal(t, 2, cli.attempts)
+	require.NotEqual(t, cli.firstSession, cli.secondSession)
+	require.GreaterOrEqual(t, cli.secondExpires, cli.firstExpires)
+	require.False(t, hasRecordedErrors(rec.snapshot()))
 }
 
 func TestRunMixedRequiresNativeClient(t *testing.T) {

--- a/fsmeta/exec/runner.go
+++ b/fsmeta/exec/runner.go
@@ -23,7 +23,9 @@ const (
 	// back a live metadata transaction.
 	defaultLockTTL uint64 = uint64(30 * time.Second / time.Millisecond)
 
-	maxTxnContentionRetries  = 12
+	// Write APIs should absorb transient live locks from raft/apply tail
+	// latency, but still surface abandoned locks well before the 30s lock TTL.
+	maxTxnContentionRetries  = 32
 	maxReadContentionRetries = 3
 
 	txnContentionRetryBaseBackoff = time.Millisecond

--- a/fsmeta/runtime/raftstore/runner.go
+++ b/fsmeta/runtime/raftstore/runner.go
@@ -39,7 +39,7 @@ type TSOClient interface {
 // semantics; fsmeta/exec remains the only interpreter of OperationPlan.
 type Runner struct {
 	kv                           KVClient
-	tso                          TSOClient
+	tso                          *tsoCoalescer
 	atomicRunnerUnsupportedTotal atomic.Uint64
 }
 
@@ -53,7 +53,7 @@ func NewRunner(kv KVClient, tso TSOClient) (*Runner, error) {
 	if tso == nil {
 		return nil, errTSOClientRequired
 	}
-	return &Runner{kv: kv, tso: tso}, nil
+	return &Runner{kv: kv, tso: newTSOCoalescer(tso, defaultTSOCoalescerConfig())}, nil
 }
 
 // ReserveTimestamp reserves count consecutive timestamps from coordinator TSO.
@@ -61,20 +61,7 @@ func (r *Runner) ReserveTimestamp(ctx context.Context, count uint64) (uint64, er
 	if count == 0 {
 		return 0, errTimestampCountRequired
 	}
-	resp, err := r.tso.Tso(ctx, &coordpb.TsoRequest{Count: count})
-	if err != nil {
-		return 0, err
-	}
-	if resp == nil {
-		return 0, errNilTSOResponse
-	}
-	if resp.GetCount() != count {
-		return 0, errTSOCountMismatch(resp.GetCount(), count)
-	}
-	if resp.GetTimestamp() == 0 {
-		return 0, errZeroTSOTimestamp
-	}
-	return resp.GetTimestamp(), nil
+	return r.tso.Reserve(ctx, count)
 }
 
 // Get returns the value visible at version.
@@ -140,7 +127,10 @@ func (r *Runner) Mutate(ctx context.Context, primary []byte, mutations []*kvrpcp
 		// test runners. Real raftstore clients can allocate commit_ts after
 		// prewrite, which avoids repeated CommitTsExpired under mixed reads.
 		return kv.MutateWithCommitTimestamp(ctx, primary, mutations, startVersion, lockTTL, func(ctx context.Context) (uint64, error) {
-			return r.ReserveTimestamp(ctx, 1)
+			// Commit timestamp allocation happens while Percolator locks are
+			// live, so it bypasses the short coalescing window to keep lock
+			// tenure tight and reduce reader-pushed min_commit_ts churn.
+			return r.tso.ReserveImmediate(ctx, 1)
 		})
 	}
 	if err := r.kv.Mutate(ctx, primary, mutations, startVersion, commitVersion, lockTTL); err != nil {
@@ -170,6 +160,9 @@ func (r *Runner) Stats() map[string]any {
 	}
 	out := map[string]any{
 		"atomic_runner_unsupported_total": r.atomicRunnerUnsupportedTotal.Load(),
+	}
+	if r.tso != nil {
+		out["tso"] = r.tso.Stats()
 	}
 	if stats, ok := r.kv.(statsProvider); ok {
 		out["kv"] = stats.Stats()

--- a/fsmeta/runtime/raftstore/runner_test.go
+++ b/fsmeta/runtime/raftstore/runner_test.go
@@ -143,6 +143,23 @@ func TestRunnerTryAtomicMutateRecordsUnsupportedKV(t *testing.T) {
 	require.Equal(t, uint64(1), stats["atomic_runner_unsupported_total"])
 }
 
+func TestRunnerStatsExposeTSOCoalescer(t *testing.T) {
+	runner, err := NewRunner(&fakeRunnerKV{}, &fakeRunnerTSO{resp: &coordpb.TsoResponse{Timestamp: 10, Count: 1}})
+	require.NoError(t, err)
+
+	ts, err := runner.ReserveTimestamp(context.Background(), 1)
+	require.NoError(t, err)
+	require.Equal(t, uint64(10), ts)
+
+	stats := runner.Stats()
+	tsoStats, ok := stats["tso"].(map[string]any)
+	require.True(t, ok)
+	require.Equal(t, uint64(1), tsoStats["tso_coalesce_requests_total"])
+	require.Equal(t, uint64(1), tsoStats["tso_coalesce_batches_total"])
+	require.Equal(t, uint64(0), tsoStats["tso_direct_requests_total"])
+	require.Equal(t, uint64(1), tsoStats["tso_coalesce_allocated_total"])
+}
+
 func TestRunnerMutateAllocatesCommitTimestampAfterPrewrite(t *testing.T) {
 	kv := &fakeCommitTimestampKV{}
 	runner, err := NewRunner(kv, &fakeRunnerTSO{resp: &coordpb.TsoResponse{Timestamp: 20, Count: 1}})

--- a/fsmeta/runtime/raftstore/tso_coalescer.go
+++ b/fsmeta/runtime/raftstore/tso_coalescer.go
@@ -1,0 +1,246 @@
+package raftstore
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	coordpb "github.com/feichai0017/NoKV/pb/coordinator"
+)
+
+const (
+	defaultTSOCoalesceWindow     = 200 * time.Microsecond
+	defaultTSOCoalesceMaxCount   = uint64(512)
+	defaultTSOCoalesceRPCTimeout = 2 * time.Second
+)
+
+type tsoCoalescerConfig struct {
+	window     time.Duration
+	maxCount   uint64
+	rpcTimeout time.Duration
+}
+
+func defaultTSOCoalescerConfig() tsoCoalescerConfig {
+	return tsoCoalescerConfig{
+		window:     defaultTSOCoalesceWindow,
+		maxCount:   defaultTSOCoalesceMaxCount,
+		rpcTimeout: defaultTSOCoalesceRPCTimeout,
+	}
+}
+
+type tsoCoalescer struct {
+	client     TSOClient
+	window     time.Duration
+	maxCount   uint64
+	rpcTimeout time.Duration
+
+	mu    sync.Mutex
+	batch *tsoBatch
+
+	requestsTotal  atomic.Uint64
+	batchesTotal   atomic.Uint64
+	directTotal    atomic.Uint64
+	allocatedTotal atomic.Uint64
+	canceledTotal  atomic.Uint64
+}
+
+type tsoBatch struct {
+	requests []*tsoRequest
+	count    uint64
+	timer    *time.Timer
+}
+
+type tsoRequest struct {
+	count  uint64
+	result chan tsoResult
+}
+
+type tsoResult struct {
+	first uint64
+	err   error
+}
+
+func newTSOCoalescer(client TSOClient, cfg tsoCoalescerConfig) *tsoCoalescer {
+	if cfg.window < 0 {
+		cfg.window = 0
+	}
+	if cfg.maxCount == 0 {
+		cfg.maxCount = defaultTSOCoalesceMaxCount
+	}
+	if cfg.rpcTimeout < 0 {
+		cfg.rpcTimeout = 0
+	}
+	return &tsoCoalescer{
+		client:     client,
+		window:     cfg.window,
+		maxCount:   cfg.maxCount,
+		rpcTimeout: cfg.rpcTimeout,
+	}
+}
+
+func (c *tsoCoalescer) Reserve(ctx context.Context, count uint64) (uint64, error) {
+	ctx, err := normalizeTSOReserveInput(ctx, count)
+	if err != nil {
+		return 0, err
+	}
+	c.requestsTotal.Add(1)
+	if c.window == 0 || count >= c.maxCount {
+		return c.reserveDirect(ctx, count)
+	}
+	req := &tsoRequest{count: count, result: make(chan tsoResult, 1)}
+	c.enqueue(req)
+	select {
+	case result := <-req.result:
+		return result.first, result.err
+	case <-ctx.Done():
+		// The queued request may already be part of a coordinator TSO batch.
+		// Leaving it in the batch can create a timestamp gap, but prevents
+		// reusing a timestamp that was reserved for a canceled caller.
+		c.canceledTotal.Add(1)
+		return 0, ctx.Err()
+	}
+}
+
+func (c *tsoCoalescer) ReserveImmediate(ctx context.Context, count uint64) (uint64, error) {
+	ctx, err := normalizeTSOReserveInput(ctx, count)
+	if err != nil {
+		return 0, err
+	}
+	c.requestsTotal.Add(1)
+	return c.reserveDirect(ctx, count)
+}
+
+func normalizeTSOReserveInput(ctx context.Context, count uint64) (context.Context, error) {
+	if count == 0 {
+		return nil, errTimestampCountRequired
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	return ctx, nil
+}
+
+func (c *tsoCoalescer) reserveDirect(ctx context.Context, count uint64) (uint64, error) {
+	c.directTotal.Add(1)
+	resp, err := c.client.Tso(ctx, &coordpb.TsoRequest{Count: count})
+	first, err := validateTSOResponse(resp, count, err)
+	if err != nil {
+		return 0, err
+	}
+	c.allocatedTotal.Add(count)
+	return first, nil
+}
+
+func (c *tsoCoalescer) enqueue(req *tsoRequest) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.batch != nil && c.batch.count > 0 && req.count > c.maxCount-c.batch.count {
+		batch := c.takeBatchLocked()
+		go c.dispatch(batch)
+	}
+	if c.batch == nil {
+		c.batch = c.newBatchLocked()
+	}
+	c.batch.requests = append(c.batch.requests, req)
+	c.batch.count += req.count
+	if c.batch.count >= c.maxCount {
+		batch := c.takeBatchLocked()
+		go c.dispatch(batch)
+	}
+}
+
+func (c *tsoCoalescer) newBatchLocked() *tsoBatch {
+	batch := &tsoBatch{}
+	batch.timer = time.AfterFunc(c.window, func() {
+		c.mu.Lock()
+		if c.batch != batch {
+			c.mu.Unlock()
+			return
+		}
+		taken := c.takeBatchLocked()
+		c.mu.Unlock()
+		if taken != nil {
+			go c.dispatch(taken)
+		}
+	})
+	return batch
+}
+
+func (c *tsoCoalescer) takeBatchLocked() *tsoBatch {
+	batch := c.batch
+	c.batch = nil
+	if batch != nil && batch.timer != nil {
+		batch.timer.Stop()
+	}
+	return batch
+}
+
+func (c *tsoCoalescer) dispatch(batch *tsoBatch) {
+	if batch == nil || batch.count == 0 {
+		return
+	}
+	c.batchesTotal.Add(1)
+	// A coalesced batch can contain many caller contexts. Binding the RPC to
+	// one of them would let one canceled caller cancel timestamp reservations
+	// for unrelated waiters; the batch uses its own timeout and canceled entries
+	// are instead left as legal timestamp gaps.
+	ctx := context.Background()
+	var cancel context.CancelFunc
+	if c.rpcTimeout > 0 {
+		ctx, cancel = context.WithTimeout(ctx, c.rpcTimeout)
+		defer cancel()
+	}
+	resp, err := c.client.Tso(ctx, &coordpb.TsoRequest{Count: batch.count})
+	first, err := validateTSOResponse(resp, batch.count, err)
+	if err == nil {
+		c.allocatedTotal.Add(batch.count)
+	}
+	var offset uint64
+	for _, req := range batch.requests {
+		result := tsoResult{err: err}
+		if err == nil {
+			result.first = first + offset
+			offset += req.count
+		}
+		req.result <- result
+	}
+}
+
+func validateTSOResponse(resp *coordpb.TsoResponse, requested uint64, err error) (uint64, error) {
+	if err != nil {
+		return 0, err
+	}
+	if resp == nil {
+		return 0, errNilTSOResponse
+	}
+	if resp.GetCount() != requested {
+		return 0, errTSOCountMismatch(resp.GetCount(), requested)
+	}
+	if resp.GetTimestamp() == 0 {
+		return 0, errZeroTSOTimestamp
+	}
+	return resp.GetTimestamp(), nil
+}
+
+func (c *tsoCoalescer) Stats() map[string]any {
+	if c == nil {
+		return map[string]any{
+			"tso_coalesce_requests_total":  uint64(0),
+			"tso_coalesce_batches_total":   uint64(0),
+			"tso_direct_requests_total":    uint64(0),
+			"tso_coalesce_allocated_total": uint64(0),
+			"tso_coalesce_canceled_total":  uint64(0),
+		}
+	}
+	return map[string]any{
+		"tso_coalesce_requests_total":  c.requestsTotal.Load(),
+		"tso_coalesce_batches_total":   c.batchesTotal.Load(),
+		"tso_direct_requests_total":    c.directTotal.Load(),
+		"tso_coalesce_allocated_total": c.allocatedTotal.Load(),
+		"tso_coalesce_canceled_total":  c.canceledTotal.Load(),
+	}
+}

--- a/fsmeta/runtime/raftstore/tso_coalescer_test.go
+++ b/fsmeta/runtime/raftstore/tso_coalescer_test.go
@@ -1,0 +1,244 @@
+package raftstore
+
+import (
+	"context"
+	"slices"
+	"sync"
+	"testing"
+	"time"
+
+	coordpb "github.com/feichai0017/NoKV/pb/coordinator"
+	"github.com/stretchr/testify/require"
+)
+
+type recordingTSOClient struct {
+	mu       sync.Mutex
+	next     uint64
+	requests []uint64
+}
+
+func (c *recordingTSOClient) Tso(_ context.Context, req *coordpb.TsoRequest) (*coordpb.TsoResponse, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.next == 0 {
+		c.next = 100
+	}
+	count := req.GetCount()
+	first := c.next
+	c.next += count
+	c.requests = append(c.requests, count)
+	return &coordpb.TsoResponse{Timestamp: first, Count: count}, nil
+}
+
+func (c *recordingTSOClient) requestCounts() []uint64 {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return append([]uint64(nil), c.requests...)
+}
+
+type blockingTSOClient struct {
+	called chan struct{}
+}
+
+func (c *blockingTSOClient) Tso(ctx context.Context, _ *coordpb.TsoRequest) (*coordpb.TsoResponse, error) {
+	close(c.called)
+	<-ctx.Done()
+	return nil, ctx.Err()
+}
+
+func TestTSOCoalescerBatchesConcurrentRequests(t *testing.T) {
+	client := &recordingTSOClient{}
+	coalescer := newTSOCoalescer(client, tsoCoalescerConfig{window: 20 * time.Millisecond, maxCount: 64})
+
+	const requests = 16
+	var wg sync.WaitGroup
+	start := make(chan struct{})
+	results := make([]uint64, requests)
+	for i := range requests {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			<-start
+			ts, err := coalescer.Reserve(context.Background(), 1)
+			require.NoError(t, err)
+			results[i] = ts
+		}(i)
+	}
+	close(start)
+	wg.Wait()
+
+	counts := client.requestCounts()
+	require.Len(t, counts, 1)
+	require.Equal(t, uint64(requests), counts[0])
+	slices.Sort(results)
+	for i, ts := range results {
+		require.Equal(t, uint64(100+i), ts)
+	}
+	stats := coalescer.Stats()
+	require.Equal(t, uint64(requests), stats["tso_coalesce_requests_total"])
+	require.Equal(t, uint64(1), stats["tso_coalesce_batches_total"])
+	require.Equal(t, uint64(0), stats["tso_direct_requests_total"])
+	require.Equal(t, uint64(requests), stats["tso_coalesce_allocated_total"])
+	require.Equal(t, uint64(0), stats["tso_coalesce_canceled_total"])
+}
+
+func TestTSOCoalescerFlushesAtMaxCount(t *testing.T) {
+	client := &recordingTSOClient{}
+	coalescer := newTSOCoalescer(client, tsoCoalescerConfig{window: time.Minute, maxCount: 3})
+
+	var wg sync.WaitGroup
+	results := make([]uint64, 3)
+	for i := range results {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			ts, err := coalescer.Reserve(context.Background(), 1)
+			require.NoError(t, err)
+			results[i] = ts
+		}(i)
+	}
+	wg.Wait()
+
+	require.Equal(t, []uint64{3}, client.requestCounts())
+	slices.Sort(results)
+	require.Equal(t, []uint64{100, 101, 102}, results)
+}
+
+func TestTSOCoalescerKeepsBatchWithinMaxCount(t *testing.T) {
+	client := &recordingTSOClient{}
+	coalescer := newTSOCoalescer(client, tsoCoalescerConfig{window: 20 * time.Millisecond, maxCount: 3})
+
+	firstCh := make(chan uint64, 1)
+	go func() {
+		ts, err := coalescer.Reserve(context.Background(), 2)
+		require.NoError(t, err)
+		firstCh <- ts
+	}()
+	require.Eventually(t, func() bool {
+		coalescer.mu.Lock()
+		defer coalescer.mu.Unlock()
+		return coalescer.batch != nil && coalescer.batch.count == 2
+	}, time.Second, time.Millisecond)
+
+	second, err := coalescer.Reserve(context.Background(), 2)
+	require.NoError(t, err)
+	first := <-firstCh
+
+	require.Equal(t, uint64(100), first)
+	require.Equal(t, uint64(102), second)
+	require.Equal(t, []uint64{2, 2}, client.requestCounts())
+}
+
+func TestTSOCoalescerCanceledRequestLeavesTimestampGap(t *testing.T) {
+	client := &recordingTSOClient{}
+	coalescer := newTSOCoalescer(client, tsoCoalescerConfig{window: 30 * time.Millisecond, maxCount: 64})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	errCh := make(chan error, 1)
+	go func() {
+		_, err := coalescer.Reserve(ctx, 1)
+		errCh <- err
+	}()
+	require.Eventually(t, func() bool {
+		return coalescer.Stats()["tso_coalesce_requests_total"] == uint64(1)
+	}, time.Second, time.Millisecond)
+	cancel()
+	require.ErrorIs(t, <-errCh, context.Canceled)
+
+	ts, err := coalescer.Reserve(context.Background(), 1)
+	require.NoError(t, err)
+	require.Equal(t, uint64(101), ts)
+	require.Equal(t, []uint64{2}, client.requestCounts())
+
+	stats := coalescer.Stats()
+	require.Equal(t, uint64(2), stats["tso_coalesce_requests_total"])
+	require.Equal(t, uint64(1), stats["tso_coalesce_batches_total"])
+	require.Equal(t, uint64(0), stats["tso_direct_requests_total"])
+	require.Equal(t, uint64(2), stats["tso_coalesce_allocated_total"])
+	require.Equal(t, uint64(1), stats["tso_coalesce_canceled_total"])
+}
+
+func TestTSOCoalescerDirectLargeRequest(t *testing.T) {
+	client := &recordingTSOClient{}
+	coalescer := newTSOCoalescer(client, tsoCoalescerConfig{window: time.Minute, maxCount: 4})
+
+	ts, err := coalescer.Reserve(context.Background(), 8)
+	require.NoError(t, err)
+	require.Equal(t, uint64(100), ts)
+	require.Equal(t, []uint64{8}, client.requestCounts())
+	stats := coalescer.Stats()
+	require.Equal(t, uint64(1), stats["tso_coalesce_requests_total"])
+	require.Equal(t, uint64(0), stats["tso_coalesce_batches_total"])
+	require.Equal(t, uint64(1), stats["tso_direct_requests_total"])
+	require.Equal(t, uint64(8), stats["tso_coalesce_allocated_total"])
+}
+
+func TestTSOCoalescerImmediateBypassesOpenBatch(t *testing.T) {
+	client := &recordingTSOClient{}
+	coalescer := newTSOCoalescer(client, tsoCoalescerConfig{window: time.Minute, maxCount: 2})
+
+	firstCh := make(chan uint64, 1)
+	go func() {
+		ts, err := coalescer.Reserve(context.Background(), 1)
+		require.NoError(t, err)
+		firstCh <- ts
+	}()
+	require.Eventually(t, func() bool {
+		coalescer.mu.Lock()
+		defer coalescer.mu.Unlock()
+		return coalescer.batch != nil && coalescer.batch.count == 1
+	}, time.Second, time.Millisecond)
+
+	immediate, err := coalescer.ReserveImmediate(context.Background(), 1)
+	require.NoError(t, err)
+	require.Equal(t, uint64(100), immediate)
+	require.Equal(t, []uint64{1}, client.requestCounts())
+
+	second, err := coalescer.Reserve(context.Background(), 1)
+	require.NoError(t, err)
+	first := <-firstCh
+
+	require.Equal(t, uint64(101), first)
+	require.Equal(t, uint64(102), second)
+	require.Equal(t, []uint64{1, 2}, client.requestCounts())
+	stats := coalescer.Stats()
+	require.Equal(t, uint64(1), stats["tso_coalesce_batches_total"])
+	require.Equal(t, uint64(1), stats["tso_direct_requests_total"])
+}
+
+func TestTSOCoalescerBatchedRPCTimeoutBoundsHungCoordinator(t *testing.T) {
+	client := &blockingTSOClient{called: make(chan struct{})}
+	coalescer := newTSOCoalescer(client, tsoCoalescerConfig{
+		window:     time.Millisecond,
+		maxCount:   4,
+		rpcTimeout: 5 * time.Millisecond,
+	})
+
+	_, err := coalescer.Reserve(context.Background(), 1)
+	require.ErrorIs(t, err, context.DeadlineExceeded)
+	require.Eventually(t, func() bool {
+		select {
+		case <-client.called:
+			return true
+		default:
+			return false
+		}
+	}, time.Second, time.Millisecond)
+
+	stats := coalescer.Stats()
+	require.Equal(t, uint64(1), stats["tso_coalesce_requests_total"])
+	require.Equal(t, uint64(1), stats["tso_coalesce_batches_total"])
+	require.Equal(t, uint64(0), stats["tso_direct_requests_total"])
+	require.Equal(t, uint64(0), stats["tso_coalesce_allocated_total"])
+}
+
+func TestTSOCoalescerRejectsZeroCount(t *testing.T) {
+	client := &recordingTSOClient{}
+	coalescer := newTSOCoalescer(client, tsoCoalescerConfig{window: time.Minute, maxCount: 4})
+
+	_, err := coalescer.Reserve(context.Background(), 0)
+	require.ErrorIs(t, err, errTimestampCountRequired)
+	_, err = coalescer.ReserveImmediate(context.Background(), 0)
+	require.ErrorIs(t, err, errTimestampCountRequired)
+	require.Empty(t, client.requestCounts())
+}

--- a/scripts/run_fsmeta_benchmarks.sh
+++ b/scripts/run_fsmeta_benchmarks.sh
@@ -32,7 +32,8 @@ case "$profile" in
 		default_groups=8
 		default_entries_per_group=64
 		default_artifacts_per_entry=8
-		default_session_ttl=10s
+		default_session_ttl=5m
+		default_stale_session_ttl=2s
 		default_timeout=25m
 		default_stabilize_seconds=20
 		;;
@@ -45,7 +46,8 @@ case "$profile" in
 		default_groups=16
 		default_entries_per_group=128
 		default_artifacts_per_entry=10
-		default_session_ttl=10s
+		default_session_ttl=5m
+		default_stale_session_ttl=2s
 		default_timeout=120m
 		default_stabilize_seconds=45
 		;;
@@ -64,6 +66,7 @@ groups="${NOKV_FSMETA_GROUPS:-$default_groups}"
 entries_per_group="${NOKV_FSMETA_ENTRIES_PER_GROUP:-$default_entries_per_group}"
 artifacts_per_entry="${NOKV_FSMETA_ARTIFACTS_PER_ENTRY:-$default_artifacts_per_entry}"
 session_ttl="${NOKV_FSMETA_SESSION_TTL:-$default_session_ttl}"
+stale_session_ttl="${NOKV_FSMETA_STALE_SESSION_TTL:-$default_stale_session_ttl}"
 timeout="${NOKV_FSMETA_TIMEOUT:-$default_timeout}"
 stabilize_seconds="${NOKV_FSMETA_STABILIZE_SECONDS:-$default_stabilize_seconds}"
 
@@ -113,6 +116,7 @@ run_bench() {
 			-fsmeta_entries_per_group "$entries_per_group" \
 			-fsmeta_artifacts_per_entry "$artifacts_per_entry" \
 			-fsmeta_session_ttl "$session_ttl" \
+			-fsmeta_stale_session_ttl "$stale_session_ttl" \
 			-fsmeta_timeout "$timeout" \
 			-fsmeta_output "$output"
 	)
@@ -140,6 +144,7 @@ groups=$groups
 entries_per_group=$entries_per_group
 artifacts_per_entry=$artifacts_per_entry
 session_ttl=$session_ttl
+stale_session_ttl=$stale_session_ttl
 profile_seconds=$profile_seconds
 targets=$profile_targets
 EOF


### PR DESCRIPTION
## Summary

- Add a short-window TSO coalescer in the fsmeta raftstore runtime.
- Keep the coordinator as the only timestamp authority; the gateway only batches already-arrived `ReserveTimestamp(count)` requests.
- Expose low-cardinality counters under runner stats: `tso_coalesce_requests_total`, `tso_coalesce_batches_total`, `tso_coalesce_allocated_total`, and `tso_coalesce_canceled_total`.

## Correctness Notes

- The default window is `200us` with `max_count=512`; large reservations go directly to coordinator.
- A caller canceled after enqueue can leave a timestamp gap, but queued reservations are never reused or recycled.
- The coalesced RPC deliberately uses a batch-level context so one canceled caller cannot cancel reservations for unrelated waiters.
- Existing TSO response validation is preserved: nil response, zero timestamp, and count mismatch still fail before publishing a timestamp to callers.

## Tests

- `make fmt`
- `make lint`
- `go test ./...`
- `cd benchmark && go test ./...`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Introduced automatic batching for timestamp reservations with new coalescing and observable metrics to reduce overhead.
  * Increased per-transaction MVCC lock retry budget (more attempts before exhaustion).

* **Tests**
  * Added comprehensive tests for timestamp batching, concurrency, cancellation, metrics, and a retry-focused session-open test validating expiry refresh.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->