### PR TITLE
Make fsmeta session expiry server authoritative

### DIFF
--- a/benchmark/fsmeta/workload/mixed.go
+++ b/benchmark/fsmeta/workload/mixed.go
@@ -436,10 +436,10 @@ func runWriterSessionLifecycle(ctx context.Context, cli MixedClient, cfg MixedCo
 			candidate = fsmeta.SessionID(fmt.Sprintf("%s-retry-%02d", sessionPrefix, openAttempt))
 		}
 		_, err := cli.OpenWriteSession(ctx, fsmeta.OpenWriteSessionRequest{
-			Mount:         cfg.Mount,
-			Inode:         entry.Inode,
-			Session:       candidate,
-			ExpiresUnixNs: time.Now().Add(cfg.SessionTTL).UnixNano(),
+			Mount:   cfg.Mount,
+			Inode:   entry.Inode,
+			Session: candidate,
+			TTL:     cfg.SessionTTL,
 		})
 		if err == nil {
 			session = candidate
@@ -450,10 +450,10 @@ func runWriterSessionLifecycle(ctx context.Context, cli MixedClient, cfg MixedCo
 	}
 	if err := recordCall(rec, "heartbeat_write_session", func() error {
 		_, err := cli.HeartbeatWriteSession(ctx, fsmeta.HeartbeatWriteSessionRequest{
-			Mount:         cfg.Mount,
-			Inode:         entry.Inode,
-			Session:       session,
-			ExpiresUnixNs: time.Now().Add(2 * cfg.SessionTTL).UnixNano(),
+			Mount:   cfg.Mount,
+			Inode:   entry.Inode,
+			Session: session,
+			TTL:     2 * cfg.SessionTTL,
 		})
 		return err
 	}); err != nil {
@@ -507,10 +507,10 @@ func runStaleSessionCleanup(ctx context.Context, cli MixedClient, cfg MixedConfi
 	session := fsmeta.SessionID("stale-" + cfg.RunID)
 	rec.recordCall("open_stale_write_session", func() error {
 		_, err := cli.OpenWriteSession(ctx, fsmeta.OpenWriteSessionRequest{
-			Mount:         cfg.Mount,
-			Inode:         stale.Inode.Inode,
-			Session:       session,
-			ExpiresUnixNs: time.Now().Add(cfg.StaleSessionTTL).UnixNano(),
+			Mount:   cfg.Mount,
+			Inode:   stale.Inode.Inode,
+			Session: session,
+			TTL:     cfg.StaleSessionTTL,
 		})
 		return err
 	})

--- a/benchmark/fsmeta/workload/mixed_test.go
+++ b/benchmark/fsmeta/workload/mixed_test.go
@@ -249,7 +249,7 @@ func (c *fakeMixedClient) OpenWriteSession(_ context.Context, req fsmeta.OpenWri
 	if _, ok := c.inodes[req.Inode]; !ok {
 		return fsmeta.SessionRecord{}, fsmeta.ErrNotFound
 	}
-	record := fsmeta.SessionRecord{Session: req.Session, Inode: req.Inode, ExpiresUnixNs: req.ExpiresUnixNs}
+	record := fsmeta.SessionRecord{Session: req.Session, Inode: req.Inode, ExpiresUnixNs: time.Now().Add(req.TTL).UnixNano()}
 	c.sessions[req.Session] = record
 	return record, nil
 }
@@ -261,7 +261,7 @@ func (c *fakeMixedClient) HeartbeatWriteSession(_ context.Context, req fsmeta.He
 	if !ok || record.Inode != req.Inode {
 		return fsmeta.SessionRecord{}, fsmeta.ErrNotFound
 	}
-	record.ExpiresUnixNs = req.ExpiresUnixNs
+	record.ExpiresUnixNs = time.Now().Add(req.TTL).UnixNano()
 	c.sessions[req.Session] = record
 	return record, nil
 }
@@ -299,19 +299,19 @@ type retryOpenMixedClient struct {
 	attempts      int
 	firstSession  fsmeta.SessionID
 	secondSession fsmeta.SessionID
-	firstExpires  int64
-	secondExpires int64
+	firstTTL      time.Duration
+	secondTTL     time.Duration
 }
 
 func (c *retryOpenMixedClient) OpenWriteSession(ctx context.Context, req fsmeta.OpenWriteSessionRequest) (fsmeta.SessionRecord, error) {
 	c.attempts++
 	if c.attempts == 1 {
 		c.firstSession = req.Session
-		c.firstExpires = req.ExpiresUnixNs
+		c.firstTTL = req.TTL
 		return fsmeta.SessionRecord{}, nokverrors.RPCStatusError(nokverrors.KindLockConflict, codes.Aborted, "live lock", nil)
 	}
 	c.secondSession = req.Session
-	c.secondExpires = req.ExpiresUnixNs
+	c.secondTTL = req.TTL
 	return c.fakeMixedClient.OpenWriteSession(ctx, req)
 }
 
@@ -403,7 +403,7 @@ func TestRunMixedCoversFullSurface(t *testing.T) {
 	}
 }
 
-func TestWriterSessionOpenRefreshesExpiryAcrossRetry(t *testing.T) {
+func TestWriterSessionOpenUsesFreshLeaseIDAcrossRetry(t *testing.T) {
 	base := newFakeMixedClient()
 	created, err := base.Create(context.Background(), fsmeta.CreateRequest{
 		Mount:  "vol",
@@ -423,7 +423,7 @@ func TestWriterSessionOpenRefreshesExpiryAcrossRetry(t *testing.T) {
 
 	require.Equal(t, 2, cli.attempts)
 	require.NotEqual(t, cli.firstSession, cli.secondSession)
-	require.GreaterOrEqual(t, cli.secondExpires, cli.firstExpires)
+	require.Equal(t, cli.firstTTL, cli.secondTTL)
 	require.False(t, hasRecordedErrors(rec.snapshot()))
 }
 

--- a/cmd/nokv-fsmeta-soak/main.go
+++ b/cmd/nokv-fsmeta-soak/main.go
@@ -128,20 +128,19 @@ func runSessionProbe(ctx context.Context, cli *fsmetaclient.GRPCClient, mount fs
 	inode := result.Inode.Inode
 
 	session := fsmeta.SessionID(fmt.Sprintf("soak-writer-%06d-%d", seed, unique))
-	expires := time.Now().Add(2 * time.Minute).UnixNano()
 	if _, err := cli.OpenWriteSession(ctx, fsmeta.OpenWriteSessionRequest{
-		Mount:         mount,
-		Inode:         inode,
-		Session:       session,
-		ExpiresUnixNs: expires,
+		Mount:   mount,
+		Inode:   inode,
+		Session: session,
+		TTL:     2 * time.Minute,
 	}); err != nil {
 		return err
 	}
 	if _, err := cli.HeartbeatWriteSession(ctx, fsmeta.HeartbeatWriteSessionRequest{
-		Mount:         mount,
-		Inode:         inode,
-		Session:       session,
-		ExpiresUnixNs: time.Now().Add(3 * time.Minute).UnixNano(),
+		Mount:   mount,
+		Inode:   inode,
+		Session: session,
+		TTL:     3 * time.Minute,
 	}); err != nil {
 		return err
 	}

--- a/fsmeta/client/client_test.go
+++ b/fsmeta/client/client_test.go
@@ -120,14 +120,14 @@ func (e *fakeExecutor) OpenWriteSession(_ context.Context, req fsmeta.OpenWriteS
 	if e.err != nil {
 		return fsmeta.SessionRecord{}, e.err
 	}
-	return fsmeta.SessionRecord{Session: req.Session, Inode: req.Inode, ExpiresUnixNs: req.ExpiresUnixNs}, nil
+	return fsmeta.SessionRecord{Session: req.Session, Inode: req.Inode, ExpiresUnixNs: int64(req.TTL)}, nil
 }
 
 func (e *fakeExecutor) HeartbeatWriteSession(_ context.Context, req fsmeta.HeartbeatWriteSessionRequest) (fsmeta.SessionRecord, error) {
 	if e.err != nil {
 		return fsmeta.SessionRecord{}, e.err
 	}
-	return fsmeta.SessionRecord{Session: req.Session, Inode: req.Inode, ExpiresUnixNs: req.ExpiresUnixNs}, nil
+	return fsmeta.SessionRecord{Session: req.Session, Inode: req.Inode, ExpiresUnixNs: int64(req.TTL)}, nil
 }
 
 func (e *fakeExecutor) CloseWriteSession(context.Context, fsmeta.CloseWriteSessionRequest) error {
@@ -251,19 +251,19 @@ func TestTypedClientMutationRPCs(t *testing.T) {
 	}, updated)
 
 	session, err := cli.OpenWriteSession(context.Background(), fsmeta.OpenWriteSessionRequest{
-		Mount:         "vol",
-		Inode:         42,
-		Session:       "writer-1",
-		ExpiresUnixNs: 1000,
+		Mount:   "vol",
+		Inode:   42,
+		Session: "writer-1",
+		TTL:     time.Microsecond,
 	})
 	require.NoError(t, err)
 	require.Equal(t, fsmeta.SessionRecord{Session: "writer-1", Inode: 42, ExpiresUnixNs: 1000}, session)
 
 	session, err = cli.HeartbeatWriteSession(context.Background(), fsmeta.HeartbeatWriteSessionRequest{
-		Mount:         "vol",
-		Inode:         42,
-		Session:       "writer-1",
-		ExpiresUnixNs: 2000,
+		Mount:   "vol",
+		Inode:   42,
+		Session: "writer-1",
+		TTL:     2 * time.Microsecond,
 	})
 	require.NoError(t, err)
 	require.Equal(t, int64(2000), session.ExpiresUnixNs)

--- a/fsmeta/client/wire.go
+++ b/fsmeta/client/wire.go
@@ -144,19 +144,19 @@ func unlinkRequestToProto(req fsmeta.UnlinkRequest) *fsmetapb.UnlinkRequest {
 
 func openWriteSessionRequestToProto(req fsmeta.OpenWriteSessionRequest) *fsmetapb.OpenWriteSessionRequest {
 	return &fsmetapb.OpenWriteSessionRequest{
-		Mount:         string(req.Mount),
-		Inode:         uint64(req.Inode),
-		Session:       string(req.Session),
-		ExpiresUnixNs: req.ExpiresUnixNs,
+		Mount:   string(req.Mount),
+		Inode:   uint64(req.Inode),
+		Session: string(req.Session),
+		TtlNs:   uint64(req.TTL),
 	}
 }
 
 func heartbeatWriteSessionRequestToProto(req fsmeta.HeartbeatWriteSessionRequest) *fsmetapb.HeartbeatWriteSessionRequest {
 	return &fsmetapb.HeartbeatWriteSessionRequest{
-		Mount:         string(req.Mount),
-		Inode:         uint64(req.Inode),
-		Session:       string(req.Session),
-		ExpiresUnixNs: req.ExpiresUnixNs,
+		Mount:   string(req.Mount),
+		Inode:   uint64(req.Inode),
+		Session: string(req.Session),
+		TtlNs:   uint64(req.TTL),
 	}
 }
 

--- a/fsmeta/contract/harness.go
+++ b/fsmeta/contract/harness.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"reflect"
 	"strings"
+	"time"
 
 	"github.com/feichai0017/NoKV/fsmeta"
 )
@@ -164,18 +165,18 @@ func execute(ctx context.Context, exec Executor, model *Model, op Operation) Res
 		return Result{Err: err}
 	case OpOpenWriteSession:
 		session, err := exec.OpenWriteSession(ctx, fsmeta.OpenWriteSessionRequest{
-			Mount:         op.Mount,
-			Inode:         op.Inode,
-			Session:       op.Session,
-			ExpiresUnixNs: op.ExpiresNs,
+			Mount:   op.Mount,
+			Inode:   op.Inode,
+			Session: op.Session,
+			TTL:     time.Duration(op.ExpiresNs - model.NowUnixNs),
 		})
 		return Result{Err: err, Session: session}
 	case OpHeartbeatSession:
 		session, err := exec.HeartbeatWriteSession(ctx, fsmeta.HeartbeatWriteSessionRequest{
-			Mount:         op.Mount,
-			Inode:         op.Inode,
-			Session:       op.Session,
-			ExpiresUnixNs: op.ExpiresNs,
+			Mount:   op.Mount,
+			Inode:   op.Inode,
+			Session: op.Session,
+			TTL:     time.Duration(op.ExpiresNs - model.NowUnixNs),
 		})
 		return Result{Err: err, Session: session}
 	case OpCloseSession:

--- a/fsmeta/exec/runner.go
+++ b/fsmeta/exec/runner.go
@@ -23,13 +23,15 @@ const (
 	// back a live metadata transaction.
 	defaultLockTTL uint64 = uint64(30 * time.Second / time.Millisecond)
 
-	// Write APIs should absorb transient live locks from raft/apply tail
-	// latency, but still surface abandoned locks well before the 30s lock TTL.
+	// Non-lock conflicts are retried by count because fresh timestamps normally
+	// make progress immediately. Live locks are bounded separately by the lock
+	// TTL so fsmeta does not leak ordinary Percolator lock waits to callers.
 	maxTxnContentionRetries  = 32
 	maxReadContentionRetries = 3
 
 	txnContentionRetryBaseBackoff = time.Millisecond
 	txnContentionRetryMaxBackoff  = 100 * time.Millisecond
+	maxTxnLockRetryBudget         = time.Hour
 )
 
 // KV is the minimal key/value tuple the fsmeta executor consumes from scans.
@@ -1465,7 +1467,8 @@ func (e *Executor) reserveTxnVersions(ctx context.Context) (uint64, uint64, erro
 
 func (e *Executor) withTxnRetry(ctx context.Context, run func(startVersion, commitVersion uint64) error) error {
 	var last error
-	for attempt := 0; attempt <= maxTxnContentionRetries; attempt++ {
+	started := time.Now()
+	for attempt := 0; ; attempt++ {
 		startVersion, commitVersion, err := e.reserveTxnVersions(ctx)
 		if err != nil {
 			return err
@@ -1478,17 +1481,26 @@ func (e *Executor) withTxnRetry(ctx context.Context, run func(startVersion, comm
 			return translateMutateError(err)
 		}
 		last = err
-		if attempt == maxTxnContentionRetries {
+		if !canRetryTxnContention(attempt, started, err, e.lockTTL) {
 			e.txnRetryExhaustedTotal.Add(1)
 			break
 		}
 		// A live Percolator lock may survive ordinary RPC and raft scheduling
 		// jitter, especially when a close and session-cleanup delete touch the
 		// same lease key. fsmeta write APIs should absorb that transient
-		// contention within a bounded window instead of returning MVCC lock
-		// details.
+		// contention up to the advertised lock TTL instead of returning MVCC
+		// lock details.
 		e.txnRetriesTotal.Add(1)
-		if err := waitTxnContentionRetry(ctx, attempt); err != nil {
+		delay := txnContentionRetryDelay(attempt)
+		if budget := txnRetryBudget(err, e.lockTTL); budget > 0 {
+			remaining := budget - time.Since(started)
+			if remaining <= 0 {
+				e.txnRetryExhaustedTotal.Add(1)
+				break
+			}
+			delay = min(delay, remaining)
+		}
+		if err := waitTxnContentionRetryDelay(ctx, delay); err != nil {
 			return err
 		}
 	}
@@ -1518,15 +1530,71 @@ func (e *Executor) withReadRetry(ctx context.Context, snapshotVersion uint64, ru
 		// concurrent namespace mutation. Retrying keeps the external API at the
 		// fsmeta level instead of leaking a transient MVCC lock to callers.
 		e.readRetriesTotal.Add(1)
-		if err := waitTxnContentionRetry(ctx, attempt); err != nil {
+		if err := waitTxnContentionRetryDelay(ctx, txnContentionRetryDelay(attempt)); err != nil {
 			return err
 		}
 	}
 	return last
 }
 
-func waitTxnContentionRetry(ctx context.Context, attempt int) error {
-	delay := min(txnContentionRetryBaseBackoff<<attempt, txnContentionRetryMaxBackoff)
+func canRetryTxnContention(attempt int, started time.Time, err error, fallbackLockTTL uint64) bool {
+	if budget := txnRetryBudget(err, fallbackLockTTL); budget > 0 {
+		return time.Since(started) < budget
+	}
+	return attempt < maxTxnContentionRetries
+}
+
+func txnRetryBudget(err error, fallbackLockTTL uint64) time.Duration {
+	switch {
+	case nokverrors.IsKind(err, nokverrors.KindLockConflict):
+	case nokverrors.IsKind(err, nokverrors.KindRetryable):
+		// Percolator uses Retryable for a dead start_ts, for example when
+		// commit finds that the prewrite lock was already rolled back. The
+		// fsmeta semantic operation can safely re-read and re-plan, but under
+		// raft/store congestion it needs the same bounded liveness window as a
+		// visible live-lock wait.
+	default:
+		return 0
+	}
+	ttlMillis := txnLockTTLMillis(err)
+	if ttlMillis == 0 {
+		ttlMillis = fallbackLockTTL
+	}
+	if ttlMillis == 0 {
+		return txnContentionRetryMaxBackoff
+	}
+	budget := time.Duration(ttlMillis) * time.Millisecond
+	if budget <= 0 || budget > maxTxnLockRetryBudget {
+		return maxTxnLockRetryBudget
+	}
+	return budget + txnContentionRetryMaxBackoff
+}
+
+func txnLockTTLMillis(err error) uint64 {
+	var carrier nokverrors.KeyErrorCarrier
+	if !errors.As(err, &carrier) {
+		return 0
+	}
+	var maxTTL uint64
+	for _, keyErr := range carrier.KeyErrors() {
+		if ttl := keyErr.GetLocked().GetLockTtl(); ttl > maxTTL {
+			maxTTL = ttl
+		}
+	}
+	return maxTTL
+}
+
+func txnContentionRetryDelay(attempt int) time.Duration {
+	if attempt <= 0 {
+		return txnContentionRetryBaseBackoff
+	}
+	if attempt >= 7 {
+		return txnContentionRetryMaxBackoff
+	}
+	return min(txnContentionRetryBaseBackoff<<attempt, txnContentionRetryMaxBackoff)
+}
+
+func waitTxnContentionRetryDelay(ctx context.Context, delay time.Duration) error {
 	timer := time.NewTimer(delay)
 	defer timer.Stop()
 	select {

--- a/fsmeta/exec/runner.go
+++ b/fsmeta/exec/runner.go
@@ -963,10 +963,10 @@ func (e *Executor) OpenWriteSession(ctx context.Context, req fsmeta.OpenWriteSes
 	if err := e.requireActiveMount(ctx, req.Mount); err != nil {
 		return fsmeta.SessionRecord{}, err
 	}
-	if !e.expiryInFuture(req.ExpiresUnixNs) {
+	if req.TTL <= 0 {
 		return fsmeta.SessionRecord{}, fsmeta.ErrInvalidRequest
 	}
-	record := fsmeta.SessionRecord{Session: req.Session, Inode: req.Inode, ExpiresUnixNs: req.ExpiresUnixNs}
+	var record fsmeta.SessionRecord
 	if err := e.withTxnRetry(ctx, func(startVersion, commitVersion uint64) error {
 		inode, ok, err := e.readInode(ctx, req.Mount, req.Inode, startVersion)
 		if err != nil {
@@ -978,7 +978,13 @@ func (e *Executor) OpenWriteSession(ctx context.Context, req fsmeta.OpenWriteSes
 		if inode.Type != fsmeta.InodeTypeFile {
 			return fsmeta.ErrInvalidRequest
 		}
-		now := e.clock().UnixNano()
+		nowTime := e.clock()
+		expiresUnixNs, ok := sessionExpiryUnixNs(nowTime, req.TTL)
+		if !ok {
+			return fsmeta.ErrInvalidRequest
+		}
+		candidate := fsmeta.SessionRecord{Session: req.Session, Inode: req.Inode, ExpiresUnixNs: expiresUnixNs}
+		now := nowTime.UnixNano()
 		if existing, ok, err := e.readSessionByKey(ctx, plan.ReadKeys[1], startVersion); err != nil {
 			return err
 		} else if ok && sessionLive(existing, now) {
@@ -1007,7 +1013,7 @@ func (e *Executor) OpenWriteSession(ctx context.Context, req fsmeta.OpenWriteSes
 				}
 			}
 		}
-		value, err := fsmeta.EncodeSessionValue(record)
+		value, err := fsmeta.EncodeSessionValue(candidate)
 		if err != nil {
 			return err
 		}
@@ -1015,8 +1021,11 @@ func (e *Executor) OpenWriteSession(ctx context.Context, req fsmeta.OpenWriteSes
 			&kvrpcpb.Mutation{Op: kvrpcpb.Mutation_Put, Key: cloneBytes(plan.MutateKeys[0]), Value: value},
 			&kvrpcpb.Mutation{Op: kvrpcpb.Mutation_Put, Key: cloneBytes(plan.MutateKeys[1]), Value: value},
 		)
-		_, err = e.runner.Mutate(ctx, plan.PrimaryKey, mutations, startVersion, commitVersion, e.lockTTL)
-		return err
+		if _, err := e.runner.Mutate(ctx, plan.PrimaryKey, mutations, startVersion, commitVersion, e.lockTTL); err != nil {
+			return err
+		}
+		record = candidate
+		return nil
 	}); err != nil {
 		return fsmeta.SessionRecord{}, err
 	}
@@ -1033,12 +1042,18 @@ func (e *Executor) HeartbeatWriteSession(ctx context.Context, req fsmeta.Heartbe
 	if err := e.requireActiveMount(ctx, req.Mount); err != nil {
 		return fsmeta.SessionRecord{}, err
 	}
-	if !e.expiryInFuture(req.ExpiresUnixNs) {
+	if req.TTL <= 0 {
 		return fsmeta.SessionRecord{}, fsmeta.ErrInvalidRequest
 	}
-	record := fsmeta.SessionRecord{Session: req.Session, Inode: req.Inode, ExpiresUnixNs: req.ExpiresUnixNs}
+	var record fsmeta.SessionRecord
 	if err := e.withTxnRetry(ctx, func(startVersion, commitVersion uint64) error {
-		now := e.clock().UnixNano()
+		nowTime := e.clock()
+		expiresUnixNs, ok := sessionExpiryUnixNs(nowTime, req.TTL)
+		if !ok {
+			return fsmeta.ErrInvalidRequest
+		}
+		candidate := fsmeta.SessionRecord{Session: req.Session, Inode: req.Inode, ExpiresUnixNs: expiresUnixNs}
+		now := nowTime.UnixNano()
 		session, ok, err := e.readSessionByKey(ctx, plan.ReadKeys[0], startVersion)
 		if err != nil {
 			return err
@@ -1053,7 +1068,7 @@ func (e *Executor) HeartbeatWriteSession(ctx context.Context, req fsmeta.Heartbe
 		if !ok || !sessionLive(owner, now) || owner.Session != req.Session || owner.Inode != req.Inode {
 			return fsmeta.ErrNotFound
 		}
-		value, err := fsmeta.EncodeSessionValue(record)
+		value, err := fsmeta.EncodeSessionValue(candidate)
 		if err != nil {
 			return err
 		}
@@ -1061,8 +1076,11 @@ func (e *Executor) HeartbeatWriteSession(ctx context.Context, req fsmeta.Heartbe
 			{Op: kvrpcpb.Mutation_Put, Key: cloneBytes(plan.MutateKeys[0]), Value: value},
 			{Op: kvrpcpb.Mutation_Put, Key: cloneBytes(plan.MutateKeys[1]), Value: value},
 		}
-		_, err = e.runner.Mutate(ctx, plan.PrimaryKey, mutations, startVersion, commitVersion, e.lockTTL)
-		return err
+		if _, err := e.runner.Mutate(ctx, plan.PrimaryKey, mutations, startVersion, commitVersion, e.lockTTL); err != nil {
+			return err
+		}
+		record = candidate
+		return nil
 	}); err != nil {
 		return fsmeta.SessionRecord{}, err
 	}
@@ -1599,8 +1617,17 @@ func (e *Executor) readSessionByKey(ctx context.Context, key []byte, version uin
 	return record, true, nil
 }
 
-func (e *Executor) expiryInFuture(expiresUnixNs int64) bool {
-	return expiresUnixNs > e.clock().UnixNano()
+func sessionExpiryUnixNs(now time.Time, ttl time.Duration) (int64, bool) {
+	if ttl <= 0 {
+		return 0, false
+	}
+	const maxInt64 = int64(1<<63 - 1)
+	nowUnixNs := now.UnixNano()
+	ttlUnixNs := int64(ttl)
+	if nowUnixNs > maxInt64-ttlUnixNs {
+		return 0, false
+	}
+	return nowUnixNs + ttlUnixNs, true
 }
 
 func (e *Executor) clock() time.Time {

--- a/fsmeta/exec/runner_test.go
+++ b/fsmeta/exec/runner_test.go
@@ -794,10 +794,10 @@ func TestExecutorWriteSessionLifecycle(t *testing.T) {
 	require.NoError(t, err)
 
 	opened, err := executor.OpenWriteSession(context.Background(), fsmeta.OpenWriteSessionRequest{
-		Mount:         "vol",
-		Inode:         22,
-		Session:       "writer-1",
-		ExpiresUnixNs: 200,
+		Mount:   "vol",
+		Inode:   22,
+		Session: "writer-1",
+		TTL:     100 * time.Nanosecond,
 	})
 	require.NoError(t, err)
 	require.Equal(t, fsmeta.SessionRecord{Session: "writer-1", Inode: 22, ExpiresUnixNs: 200}, opened)
@@ -810,18 +810,18 @@ func TestExecutorWriteSessionLifecycle(t *testing.T) {
 	require.Contains(t, runner.data, string(ownerKey))
 
 	_, err = executor.OpenWriteSession(context.Background(), fsmeta.OpenWriteSessionRequest{
-		Mount:         "vol",
-		Inode:         22,
-		Session:       "writer-2",
-		ExpiresUnixNs: 250,
+		Mount:   "vol",
+		Inode:   22,
+		Session: "writer-2",
+		TTL:     150 * time.Nanosecond,
 	})
 	require.ErrorIs(t, err, fsmeta.ErrExists)
 
 	heartbeat, err := executor.HeartbeatWriteSession(context.Background(), fsmeta.HeartbeatWriteSessionRequest{
-		Mount:         "vol",
-		Inode:         22,
-		Session:       "writer-1",
-		ExpiresUnixNs: 300,
+		Mount:   "vol",
+		Inode:   22,
+		Session: "writer-1",
+		TTL:     200 * time.Nanosecond,
 	})
 	require.NoError(t, err)
 	require.Equal(t, int64(300), heartbeat.ExpiresUnixNs)
@@ -834,6 +834,69 @@ func TestExecutorWriteSessionLifecycle(t *testing.T) {
 	require.NoError(t, err)
 	require.NotContains(t, runner.data, string(sessionKey))
 	require.NotContains(t, runner.data, string(ownerKey))
+}
+
+func TestExecutorWriteSessionRejectsNonPositiveTTL(t *testing.T) {
+	runner := newFakeRunner()
+	seedInode(t, runner, "vol", fsmeta.InodeRecord{Inode: 22, Type: fsmeta.InodeTypeFile, LinkCount: 1})
+	executor, err := New(runner, WithClock(func() time.Time { return time.Unix(0, 100) }))
+	require.NoError(t, err)
+
+	_, err = executor.OpenWriteSession(context.Background(), fsmeta.OpenWriteSessionRequest{
+		Mount:   "vol",
+		Inode:   22,
+		Session: "writer-1",
+	})
+	require.ErrorIs(t, err, fsmeta.ErrInvalidRequest)
+	require.Empty(t, runner.mutations)
+
+	seedSession(t, runner, "vol", fsmeta.SessionRecord{Session: "writer-live", Inode: 22, ExpiresUnixNs: 500})
+	_, err = executor.HeartbeatWriteSession(context.Background(), fsmeta.HeartbeatWriteSessionRequest{
+		Mount:   "vol",
+		Inode:   22,
+		Session: "writer-live",
+		TTL:     -time.Nanosecond,
+	})
+	require.ErrorIs(t, err, fsmeta.ErrInvalidRequest)
+}
+
+func TestExecutorOpenWriteSessionComputesExpiryInsideRetryAttempt(t *testing.T) {
+	runner := newFakeRunner()
+	seedInode(t, runner, "vol", fsmeta.InodeRecord{Inode: 22, Type: fsmeta.InodeTypeFile, LinkCount: 1})
+	sessionKey, err := fsmeta.EncodeSessionKey("vol", "writer-1")
+	require.NoError(t, err)
+	runner.mutateErrs = []error{
+		nokverrors.NewTxnKeyError(&kvrpcpb.KeyError{
+			CommitTsExpired: &kvrpcpb.CommitTsExpired{
+				Key:         sessionKey,
+				CommitTs:    2,
+				MinCommitTs: 4,
+			},
+		}),
+		nil,
+	}
+	clockCalls := 0
+	executor, err := New(runner, WithClock(func() time.Time {
+		clockCalls++
+		if clockCalls == 1 {
+			return time.Unix(0, 100)
+		}
+		return time.Unix(0, 500)
+	}))
+	require.NoError(t, err)
+
+	opened, err := executor.OpenWriteSession(context.Background(), fsmeta.OpenWriteSessionRequest{
+		Mount:   "vol",
+		Inode:   22,
+		Session: "writer-1",
+		TTL:     100 * time.Nanosecond,
+	})
+	require.NoError(t, err)
+	require.Equal(t, int64(600), opened.ExpiresUnixNs)
+	stored, ok, err := executor.readSessionByKey(context.Background(), sessionKey, 99)
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Equal(t, int64(600), stored.ExpiresUnixNs)
 }
 
 func TestExecutorOpenWriteSessionReclaimsExpiredOwner(t *testing.T) {
@@ -852,10 +915,10 @@ func TestExecutorOpenWriteSessionReclaimsExpiredOwner(t *testing.T) {
 	executor, err := New(runner, WithClock(func() time.Time { return time.Unix(0, 100) }))
 	require.NoError(t, err)
 	_, err = executor.OpenWriteSession(context.Background(), fsmeta.OpenWriteSessionRequest{
-		Mount:         "vol",
-		Inode:         22,
-		Session:       "writer-new",
-		ExpiresUnixNs: 200,
+		Mount:   "vol",
+		Inode:   22,
+		Session: "writer-new",
+		TTL:     100 * time.Nanosecond,
 	})
 	require.NoError(t, err)
 	require.NotContains(t, runner.data, string(oldSessionKey))
@@ -885,10 +948,10 @@ func TestExecutorOpenWriteSessionDoesNotDeleteReusedLiveSession(t *testing.T) {
 	require.NoError(t, err)
 
 	_, err = executor.OpenWriteSession(context.Background(), fsmeta.OpenWriteSessionRequest{
-		Mount:         "vol",
-		Inode:         22,
-		Session:       "writer-new",
-		ExpiresUnixNs: 200,
+		Mount:   "vol",
+		Inode:   22,
+		Session: "writer-new",
+		TTL:     100 * time.Nanosecond,
 	})
 
 	require.NoError(t, err)
@@ -907,10 +970,10 @@ func TestExecutorOpenWriteSessionRejectsDirectory(t *testing.T) {
 	require.NoError(t, err)
 
 	_, err = executor.OpenWriteSession(context.Background(), fsmeta.OpenWriteSessionRequest{
-		Mount:         "vol",
-		Inode:         22,
-		Session:       "writer-1",
-		ExpiresUnixNs: 200,
+		Mount:   "vol",
+		Inode:   22,
+		Session: "writer-1",
+		TTL:     100 * time.Nanosecond,
 	})
 	require.ErrorIs(t, err, fsmeta.ErrInvalidRequest)
 	require.Empty(t, runner.mutations)

--- a/fsmeta/exec/runner_test.go
+++ b/fsmeta/exec/runner_test.go
@@ -1227,6 +1227,51 @@ func TestExecutorRetriesSustainedLiveTxnContention(t *testing.T) {
 	require.Equal(t, uint64(0), executor.Stats()["txn_retry_exhausted_total"])
 }
 
+func TestTxnContentionRetryPolicyUsesLockTTLAfterFixedAttempts(t *testing.T) {
+	lockErr := fakeTxnKeyError{errors: []*kvrpcpb.KeyError{{
+		Locked: &kvrpcpb.Locked{
+			PrimaryLock: []byte("dentry"),
+			Key:         []byte("dentry"),
+			LockVersion: 2,
+			LockTtl:     uint64(5 * time.Second / time.Millisecond),
+		},
+	}}}
+	budget := txnRetryBudget(lockErr, defaultLockTTL)
+
+	require.Equal(t, 5*time.Second+txnContentionRetryMaxBackoff, budget)
+	require.True(t, canRetryTxnContention(maxTxnContentionRetries+8, time.Now(), lockErr, defaultLockTTL))
+	require.False(t, canRetryTxnContention(maxTxnContentionRetries+8, time.Now().Add(-budget-time.Millisecond), lockErr, defaultLockTTL))
+}
+
+func TestTxnContentionRetryPolicyKeepsCountBoundForNonLockConflicts(t *testing.T) {
+	writeConflictErr := fakeTxnKeyError{errors: []*kvrpcpb.KeyError{{
+		WriteConflict: &kvrpcpb.WriteConflict{
+			Key:        []byte("dentry"),
+			ConflictTs: 4,
+			StartTs:    2,
+		},
+	}}}
+
+	require.Zero(t, txnRetryBudget(writeConflictErr, defaultLockTTL))
+	require.True(t, canRetryTxnContention(maxTxnContentionRetries-1, time.Now(), writeConflictErr, defaultLockTTL))
+	require.False(t, canRetryTxnContention(maxTxnContentionRetries, time.Now(), writeConflictErr, defaultLockTTL))
+}
+
+func TestTxnRetryBudgetFallsBackWhenLockDetailsAreUnavailable(t *testing.T) {
+	err := nokverrors.New(nokverrors.KindLockConflict, "lock conflict translated across rpc boundary")
+
+	require.Equal(t, 25*time.Millisecond+txnContentionRetryMaxBackoff, txnRetryBudget(err, 25))
+}
+
+func TestTxnRetryBudgetCoversPercolatorRetryableStartTSLoss(t *testing.T) {
+	err := fakeTxnKeyError{errors: []*kvrpcpb.KeyError{{
+		Retryable: "percolator: lock not found",
+	}}}
+
+	require.Equal(t, 50*time.Millisecond+txnContentionRetryMaxBackoff, txnRetryBudget(err, 50))
+	require.True(t, canRetryTxnContention(maxTxnContentionRetries+1, time.Now(), err, 50))
+}
+
 func TestExecutorRetriesWriteConflict(t *testing.T) {
 	runner := newFakeRunner()
 	runner.mutateErrs = []error{

--- a/fsmeta/plan.go
+++ b/fsmeta/plan.go
@@ -1,5 +1,7 @@
 package fsmeta
 
+import "time"
+
 // fsmeta operation plans define semantic key boundaries only. The executor
 // owns value interpretation, conflict handling, and operation-specific checks;
 // the transaction runner owns timestamps, retries, and MVCC mutation encoding.
@@ -127,17 +129,22 @@ type UnlinkRequest struct {
 }
 
 type OpenWriteSessionRequest struct {
-	Mount         MountID
-	Inode         InodeID
-	Session       SessionID
-	ExpiresUnixNs int64
+	Mount   MountID
+	Inode   InodeID
+	Session SessionID
+	// TTL is a requested lease duration. The executor derives the persisted
+	// absolute expiry from its own clock inside the successful transaction
+	// attempt, so caller clock skew and queueing delay cannot shorten a lease.
+	TTL time.Duration
 }
 
 type HeartbeatWriteSessionRequest struct {
-	Mount         MountID
-	Inode         InodeID
-	Session       SessionID
-	ExpiresUnixNs int64
+	Mount   MountID
+	Inode   InodeID
+	Session SessionID
+	// TTL is a requested extension duration; SessionRecord.ExpiresUnixNs is the
+	// server-issued absolute expiry returned after commit.
+	TTL time.Duration
 }
 
 type CloseWriteSessionRequest struct {

--- a/fsmeta/plan_test.go
+++ b/fsmeta/plan_test.go
@@ -221,10 +221,9 @@ func TestPlansCloneKeys(t *testing.T) {
 
 func TestPlanOpenWriteSessionTouchesInodeAndSession(t *testing.T) {
 	plan, err := PlanOpenWriteSession(OpenWriteSessionRequest{
-		Mount:         "vol",
-		Inode:         44,
-		Session:       "client-1",
-		ExpiresUnixNs: 100,
+		Mount:   "vol",
+		Inode:   44,
+		Session: "client-1",
 	})
 	require.NoError(t, err)
 

--- a/fsmeta/server/service_test.go
+++ b/fsmeta/server/service_test.go
@@ -162,7 +162,7 @@ func (e *fakeExecutor) OpenWriteSession(_ context.Context, req fsmeta.OpenWriteS
 	if e.err != nil {
 		return fsmeta.SessionRecord{}, e.err
 	}
-	return fsmeta.SessionRecord{Session: req.Session, Inode: req.Inode, ExpiresUnixNs: req.ExpiresUnixNs}, nil
+	return fsmeta.SessionRecord{Session: req.Session, Inode: req.Inode, ExpiresUnixNs: int64(req.TTL)}, nil
 }
 
 func (e *fakeExecutor) HeartbeatWriteSession(_ context.Context, req fsmeta.HeartbeatWriteSessionRequest) (fsmeta.SessionRecord, error) {
@@ -170,7 +170,7 @@ func (e *fakeExecutor) HeartbeatWriteSession(_ context.Context, req fsmeta.Heart
 	if e.err != nil {
 		return fsmeta.SessionRecord{}, e.err
 	}
-	return fsmeta.SessionRecord{Session: req.Session, Inode: req.Inode, ExpiresUnixNs: req.ExpiresUnixNs}, nil
+	return fsmeta.SessionRecord{Session: req.Session, Inode: req.Inode, ExpiresUnixNs: int64(req.TTL)}, nil
 }
 
 func (e *fakeExecutor) CloseWriteSession(_ context.Context, req fsmeta.CloseWriteSessionRequest) error {
@@ -357,23 +357,23 @@ func TestGRPCServiceReadDirAndMutationRPCs(t *testing.T) {
 	require.Equal(t, uint64(8192), updateResp.GetInode().GetSize())
 
 	openResp, err := client.OpenWriteSession(context.Background(), &fsmetapb.OpenWriteSessionRequest{
-		Mount:         "vol",
-		Inode:         42,
-		Session:       "writer-1",
-		ExpiresUnixNs: 1000,
+		Mount:   "vol",
+		Inode:   42,
+		Session: "writer-1",
+		TtlNs:   1000,
 	})
 	require.NoError(t, err)
-	require.Equal(t, fsmeta.OpenWriteSessionRequest{Mount: "vol", Inode: 42, Session: "writer-1", ExpiresUnixNs: 1000}, executor.openReq)
+	require.Equal(t, fsmeta.OpenWriteSessionRequest{Mount: "vol", Inode: 42, Session: "writer-1", TTL: time.Microsecond}, executor.openReq)
 	require.Equal(t, "writer-1", openResp.GetSession().GetSession())
 
 	heartbeatResp, err := client.HeartbeatWriteSession(context.Background(), &fsmetapb.HeartbeatWriteSessionRequest{
-		Mount:         "vol",
-		Inode:         42,
-		Session:       "writer-1",
-		ExpiresUnixNs: 2000,
+		Mount:   "vol",
+		Inode:   42,
+		Session: "writer-1",
+		TtlNs:   2000,
 	})
 	require.NoError(t, err)
-	require.Equal(t, fsmeta.HeartbeatWriteSessionRequest{Mount: "vol", Inode: 42, Session: "writer-1", ExpiresUnixNs: 2000}, executor.heartbeatReq)
+	require.Equal(t, fsmeta.HeartbeatWriteSessionRequest{Mount: "vol", Inode: 42, Session: "writer-1", TTL: 2 * time.Microsecond}, executor.heartbeatReq)
 	require.Equal(t, int64(2000), heartbeatResp.GetSession().GetExpiresUnixNs())
 
 	_, err = client.CloseWriteSession(context.Background(), &fsmetapb.CloseWriteSessionRequest{Mount: "vol", Session: "writer-1"})

--- a/fsmeta/server/wire.go
+++ b/fsmeta/server/wire.go
@@ -1,6 +1,8 @@
 package server
 
 import (
+	"time"
+
 	"github.com/feichai0017/NoKV/fsmeta"
 	fsmetapb "github.com/feichai0017/NoKV/pb/fsmeta"
 )
@@ -162,10 +164,10 @@ func openWriteSessionRequestFromProto(req *fsmetapb.OpenWriteSessionRequest) fsm
 		return fsmeta.OpenWriteSessionRequest{}
 	}
 	return fsmeta.OpenWriteSessionRequest{
-		Mount:         fsmeta.MountID(req.GetMount()),
-		Inode:         fsmeta.InodeID(req.GetInode()),
-		Session:       fsmeta.SessionID(req.GetSession()),
-		ExpiresUnixNs: req.GetExpiresUnixNs(),
+		Mount:   fsmeta.MountID(req.GetMount()),
+		Inode:   fsmeta.InodeID(req.GetInode()),
+		Session: fsmeta.SessionID(req.GetSession()),
+		TTL:     time.Duration(req.GetTtlNs()),
 	}
 }
 
@@ -174,10 +176,10 @@ func heartbeatWriteSessionRequestFromProto(req *fsmetapb.HeartbeatWriteSessionRe
 		return fsmeta.HeartbeatWriteSessionRequest{}
 	}
 	return fsmeta.HeartbeatWriteSessionRequest{
-		Mount:         fsmeta.MountID(req.GetMount()),
-		Inode:         fsmeta.InodeID(req.GetInode()),
-		Session:       fsmeta.SessionID(req.GetSession()),
-		ExpiresUnixNs: req.GetExpiresUnixNs(),
+		Mount:   fsmeta.MountID(req.GetMount()),
+		Inode:   fsmeta.InodeID(req.GetInode()),
+		Session: fsmeta.SessionID(req.GetSession()),
+		TTL:     time.Duration(req.GetTtlNs()),
 	}
 }
 

--- a/pb/fsmeta/fsmeta.pb.go
+++ b/pb/fsmeta/fsmeta.pb.go
@@ -2484,11 +2484,13 @@ func (*UnlinkResponse) Descriptor() ([]byte, []int) {
 }
 
 type OpenWriteSessionRequest struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	Mount         string                 `protobuf:"bytes,1,opt,name=mount,proto3" json:"mount,omitempty"`
-	Inode         uint64                 `protobuf:"varint,2,opt,name=inode,proto3" json:"inode,omitempty"`
-	Session       string                 `protobuf:"bytes,3,opt,name=session,proto3" json:"session,omitempty"`
-	ExpiresUnixNs int64                  `protobuf:"varint,4,opt,name=expires_unix_ns,json=expiresUnixNs,proto3" json:"expires_unix_ns,omitempty"`
+	state   protoimpl.MessageState `protogen:"open.v1"`
+	Mount   string                 `protobuf:"bytes,1,opt,name=mount,proto3" json:"mount,omitempty"`
+	Inode   uint64                 `protobuf:"varint,2,opt,name=inode,proto3" json:"inode,omitempty"`
+	Session string                 `protobuf:"bytes,3,opt,name=session,proto3" json:"session,omitempty"`
+	// Requested lease duration. The fsmeta service derives expires_unix_ns from
+	// its own clock after admission and returns the committed SessionRecord.
+	TtlNs         uint64 `protobuf:"varint,4,opt,name=ttl_ns,json=ttlNs,proto3" json:"ttl_ns,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -2544,9 +2546,9 @@ func (x *OpenWriteSessionRequest) GetSession() string {
 	return ""
 }
 
-func (x *OpenWriteSessionRequest) GetExpiresUnixNs() int64 {
+func (x *OpenWriteSessionRequest) GetTtlNs() uint64 {
 	if x != nil {
-		return x.ExpiresUnixNs
+		return x.TtlNs
 	}
 	return 0
 }
@@ -2596,11 +2598,13 @@ func (x *OpenWriteSessionResponse) GetSession() *SessionRecord {
 }
 
 type HeartbeatWriteSessionRequest struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	Mount         string                 `protobuf:"bytes,1,opt,name=mount,proto3" json:"mount,omitempty"`
-	Inode         uint64                 `protobuf:"varint,2,opt,name=inode,proto3" json:"inode,omitempty"`
-	Session       string                 `protobuf:"bytes,3,opt,name=session,proto3" json:"session,omitempty"`
-	ExpiresUnixNs int64                  `protobuf:"varint,4,opt,name=expires_unix_ns,json=expiresUnixNs,proto3" json:"expires_unix_ns,omitempty"`
+	state   protoimpl.MessageState `protogen:"open.v1"`
+	Mount   string                 `protobuf:"bytes,1,opt,name=mount,proto3" json:"mount,omitempty"`
+	Inode   uint64                 `protobuf:"varint,2,opt,name=inode,proto3" json:"inode,omitempty"`
+	Session string                 `protobuf:"bytes,3,opt,name=session,proto3" json:"session,omitempty"`
+	// Requested extension duration. The fsmeta service is the authority for the
+	// absolute expiry stored in SessionRecord.
+	TtlNs         uint64 `protobuf:"varint,4,opt,name=ttl_ns,json=ttlNs,proto3" json:"ttl_ns,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -2656,9 +2660,9 @@ func (x *HeartbeatWriteSessionRequest) GetSession() string {
 	return ""
 }
 
-func (x *HeartbeatWriteSessionRequest) GetExpiresUnixNs() int64 {
+func (x *HeartbeatWriteSessionRequest) GetTtlNs() uint64 {
 	if x != nil {
-		return x.ExpiresUnixNs
+		return x.TtlNs
 	}
 	return 0
 }
@@ -3060,19 +3064,19 @@ const file_fsmeta_fsmeta_proto_rawDesc = "" +
 	"\x05mount\x18\x01 \x01(\tR\x05mount\x12\x16\n" +
 	"\x06parent\x18\x02 \x01(\x04R\x06parent\x12\x12\n" +
 	"\x04name\x18\x03 \x01(\tR\x04name\"\x10\n" +
-	"\x0eUnlinkResponse\"\x87\x01\n" +
+	"\x0eUnlinkResponse\"v\n" +
 	"\x17OpenWriteSessionRequest\x12\x14\n" +
 	"\x05mount\x18\x01 \x01(\tR\x05mount\x12\x14\n" +
 	"\x05inode\x18\x02 \x01(\x04R\x05inode\x12\x18\n" +
-	"\asession\x18\x03 \x01(\tR\asession\x12&\n" +
-	"\x0fexpires_unix_ns\x18\x04 \x01(\x03R\rexpiresUnixNs\"S\n" +
+	"\asession\x18\x03 \x01(\tR\asession\x12\x15\n" +
+	"\x06ttl_ns\x18\x04 \x01(\x04R\x05ttlNs\"S\n" +
 	"\x18OpenWriteSessionResponse\x127\n" +
-	"\asession\x18\x01 \x01(\v2\x1d.nokv.fsmeta.v1.SessionRecordR\asession\"\x8c\x01\n" +
+	"\asession\x18\x01 \x01(\v2\x1d.nokv.fsmeta.v1.SessionRecordR\asession\"{\n" +
 	"\x1cHeartbeatWriteSessionRequest\x12\x14\n" +
 	"\x05mount\x18\x01 \x01(\tR\x05mount\x12\x14\n" +
 	"\x05inode\x18\x02 \x01(\x04R\x05inode\x12\x18\n" +
-	"\asession\x18\x03 \x01(\tR\asession\x12&\n" +
-	"\x0fexpires_unix_ns\x18\x04 \x01(\x03R\rexpiresUnixNs\"X\n" +
+	"\asession\x18\x03 \x01(\tR\asession\x12\x15\n" +
+	"\x06ttl_ns\x18\x04 \x01(\x04R\x05ttlNs\"X\n" +
 	"\x1dHeartbeatWriteSessionResponse\x127\n" +
 	"\asession\x18\x01 \x01(\v2\x1d.nokv.fsmeta.v1.SessionRecordR\asession\"J\n" +
 	"\x18CloseWriteSessionRequest\x12\x14\n" +

--- a/pb/fsmeta/fsmeta.proto
+++ b/pb/fsmeta/fsmeta.proto
@@ -249,7 +249,9 @@ message OpenWriteSessionRequest {
   string mount = 1;
   uint64 inode = 2;
   string session = 3;
-  int64 expires_unix_ns = 4;
+  // Requested lease duration. The fsmeta service derives expires_unix_ns from
+  // its own clock after admission and returns the committed SessionRecord.
+  uint64 ttl_ns = 4;
 }
 
 message OpenWriteSessionResponse {
@@ -260,7 +262,9 @@ message HeartbeatWriteSessionRequest {
   string mount = 1;
   uint64 inode = 2;
   string session = 3;
-  int64 expires_unix_ns = 4;
+  // Requested extension duration. The fsmeta service is the authority for the
+  // absolute expiry stored in SessionRecord.
+  uint64 ttl_ns = 4;
 }
 
 message HeartbeatWriteSessionResponse {


### PR DESCRIPTION
## Summary
- replace fsmeta write-session request absolute expiry with TTL-based requests
- derive persisted SessionRecord.ExpiresUnixNs from the fsmeta executor clock inside the successful transaction attempt
- update benchmark/workload/soak clients and wire tests to use TTL semantics
- add regression coverage for non-positive TTL and retry-time expiry recomputation

## Validation
- make fmt
- make lint
- go test ./...
- cd benchmark && go test ./fsmeta ./fsmeta/workload