### PR TITLE
ci: skip DCO on private mirror sync

### DIFF
--- a/.github/workflows/dco.yml
+++ b/.github/workflows/dco.yml
@@ -11,6 +11,9 @@ permissions:
 
 jobs:
   signoff:
+    # Public PR/main checks are the DCO source of truth. The private mirror syncs
+    # public main in bulk and would otherwise re-scan historical public commits.
+    if: github.repository != 'feichai0017/NoKV-private'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6


### PR DESCRIPTION
## Summary
- keep public DCO checks as the source of truth
- skip DCO in the private mirror so bulk public-main syncs do not re-scan historical commits

## Validation
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflow configurations to optimize task execution in specific deployment contexts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->