### PR TITLE
Extend fsmeta atomic mutate fast paths

### DIFF
--- a/benchmark/fsmeta/workload/mixed.go
+++ b/benchmark/fsmeta/workload/mixed.go
@@ -278,7 +278,7 @@ func runMixedTask(ctx context.Context, cli MixedClient, cfg MixedConfig, dirs mi
 		rec.record("rename_run_publish", 0, err)
 		return
 	}
-	rec.recordCall("rename_run_publish", func() error {
+	if err := recordCall(rec, "rename_run_publish", func() error {
 		starts.put(key, time.Now())
 		return cli.Rename(ctx, fsmeta.RenameRequest{
 			Mount:      cfg.Mount,
@@ -287,7 +287,9 @@ func runMixedTask(ctx context.Context, cli MixedClient, cfg MixedConfig, dirs mi
 			ToParent:   dirs.runs,
 			ToName:     finalName,
 		})
-	})
+	}); err != nil {
+		return
+	}
 
 	rec.recordCall("lookup_run", func() error {
 		_, err := cli.Lookup(ctx, fsmeta.LookupRequest{Mount: cfg.Mount, Parent: dirs.runs, Name: finalName})
@@ -407,7 +409,7 @@ func runCheckpointPublish(ctx context.Context, cli MixedClient, cfg MixedConfig,
 			return err
 		})
 	}
-	rec.recordCall("publish_checkpoint", func() error {
+	if err := recordCall(rec, "publish_checkpoint", func() error {
 		return cli.Rename(ctx, fsmeta.RenameRequest{
 			Mount:      cfg.Mount,
 			FromParent: dirs.scratch,
@@ -415,7 +417,9 @@ func runCheckpointPublish(ctx context.Context, cli MixedClient, cfg MixedConfig,
 			ToParent:   dirs.checkpoints,
 			ToName:     finalName,
 		})
-	})
+	}); err != nil {
+		return
+	}
 	rec.recordCall("lookup_checkpoint", func() error {
 		_, err := cli.Lookup(ctx, fsmeta.LookupRequest{Mount: cfg.Mount, Parent: dirs.checkpoints, Name: finalName})
 		return err

--- a/fsmeta/exec/runner.go
+++ b/fsmeta/exec/runner.go
@@ -121,26 +121,32 @@ type DirPageCache interface {
 
 // Executor interprets fsmeta operation plans against a TxnRunner.
 type Executor struct {
-	runner                               TxnRunner
-	inodes                               InodeAllocator
-	mounts                               MountResolver
-	quotas                               QuotaResolver
-	subtrees                             SubtreeHandoffPublisher
-	authorities                          SubtreeAuthorityResolver
-	negCache                             NegativeCache
-	dirPages                             DirPageCache
-	lockTTL                              uint64
-	now                                  func() time.Time
-	readRetriesTotal                     atomic.Uint64
-	readRetryExhaustedTotal              atomic.Uint64
-	txnRetriesTotal                      atomic.Uint64
-	txnRetryExhaustedTotal               atomic.Uint64
-	createTotal                          atomic.Uint64
-	createFastPathAttemptTotal           atomic.Uint64
-	createFastPathSkipQuotaTotal         atomic.Uint64
-	createFastPathRunnerUnsupportedTotal atomic.Uint64
-	createFastPathFallbackTotal          atomic.Uint64
-	createFastPathSuccessTotal           atomic.Uint64
+	runner                  TxnRunner
+	inodes                  InodeAllocator
+	mounts                  MountResolver
+	quotas                  QuotaResolver
+	subtrees                SubtreeHandoffPublisher
+	authorities             SubtreeAuthorityResolver
+	negCache                NegativeCache
+	dirPages                DirPageCache
+	lockTTL                 uint64
+	now                     func() time.Time
+	readRetriesTotal        atomic.Uint64
+	readRetryExhaustedTotal atomic.Uint64
+	txnRetriesTotal         atomic.Uint64
+	txnRetryExhaustedTotal  atomic.Uint64
+	createTotal             atomic.Uint64
+	atomicFastPath          map[fsmeta.OperationKind]*atomicFastPathCounters
+}
+
+type atomicFastPathCounters struct {
+	attemptTotal           atomic.Uint64
+	skipTotal              atomic.Uint64
+	backoffSkipTotal       atomic.Uint64
+	runnerUnsupportedTotal atomic.Uint64
+	fallbackTotal          atomic.Uint64
+	successTotal           atomic.Uint64
+	consecutiveFallbacks   atomic.Uint64
 }
 
 // Option configures an Executor.
@@ -239,8 +245,9 @@ func New(runner TxnRunner, opts ...Option) (*Executor, error) {
 		return nil, errRunnerRequired
 	}
 	executor := &Executor{
-		runner:  runner,
-		lockTTL: defaultLockTTL,
+		runner:         runner,
+		lockTTL:        defaultLockTTL,
+		atomicFastPath: newAtomicFastPathCounters(),
 	}
 	for _, opt := range opts {
 		if opt != nil {
@@ -254,33 +261,25 @@ func New(runner TxnRunner, opts ...Option) (*Executor, error) {
 func (e *Executor) Stats() map[string]any {
 	if e == nil {
 		return map[string]any{
-			"read_retries_total":                       uint64(0),
-			"read_retry_exhausted_total":               uint64(0),
-			"txn_retries_total":                        uint64(0),
-			"txn_retry_exhausted_total":                uint64(0),
-			"create_total":                             uint64(0),
-			"create_fastpath_attempt_total":            uint64(0),
-			"create_fastpath_skip_quota_total":         uint64(0),
-			"create_fastpath_runner_unsupported_total": uint64(0),
-			"create_fastpath_fallback_total":           uint64(0),
-			"create_fastpath_success_total":            uint64(0),
-			"negative_cache_enabled":                   false,
-			"dirpage_cache_enabled":                    false,
+			"read_retries_total":         uint64(0),
+			"read_retry_exhausted_total": uint64(0),
+			"txn_retries_total":          uint64(0),
+			"txn_retry_exhausted_total":  uint64(0),
+			"create_total":               uint64(0),
+			"atomic_fastpath":            atomicFastPathStats(nil),
+			"negative_cache_enabled":     false,
+			"dirpage_cache_enabled":      false,
 		}
 	}
 	out := map[string]any{
-		"read_retries_total":                       e.readRetriesTotal.Load(),
-		"read_retry_exhausted_total":               e.readRetryExhaustedTotal.Load(),
-		"txn_retries_total":                        e.txnRetriesTotal.Load(),
-		"txn_retry_exhausted_total":                e.txnRetryExhaustedTotal.Load(),
-		"create_total":                             e.createTotal.Load(),
-		"create_fastpath_attempt_total":            e.createFastPathAttemptTotal.Load(),
-		"create_fastpath_skip_quota_total":         e.createFastPathSkipQuotaTotal.Load(),
-		"create_fastpath_runner_unsupported_total": e.createFastPathRunnerUnsupportedTotal.Load(),
-		"create_fastpath_fallback_total":           e.createFastPathFallbackTotal.Load(),
-		"create_fastpath_success_total":            e.createFastPathSuccessTotal.Load(),
-		"negative_cache_enabled":                   e.negCache != nil,
-		"dirpage_cache_enabled":                    e.dirPages != nil,
+		"read_retries_total":         e.readRetriesTotal.Load(),
+		"read_retry_exhausted_total": e.readRetryExhaustedTotal.Load(),
+		"txn_retries_total":          e.txnRetriesTotal.Load(),
+		"txn_retry_exhausted_total":  e.txnRetryExhaustedTotal.Load(),
+		"create_total":               e.createTotal.Load(),
+		"atomic_fastpath":            atomicFastPathStats(e.atomicFastPath),
+		"negative_cache_enabled":     e.negCache != nil,
+		"dirpage_cache_enabled":      e.dirPages != nil,
 	}
 	if stats, ok := e.runner.(statsProvider); ok {
 		out["runner"] = stats.Stats()
@@ -297,6 +296,60 @@ func (e *Executor) Stats() map[string]any {
 		out["inode_allocator"] = stats.Stats()
 	}
 	return out
+}
+
+var atomicFastPathKinds = [...]fsmeta.OperationKind{
+	fsmeta.OperationCreate,
+	fsmeta.OperationUpdateInode,
+	fsmeta.OperationRename,
+	fsmeta.OperationLink,
+	fsmeta.OperationUnlink,
+	fsmeta.OperationOpenWriteSession,
+	fsmeta.OperationHeartbeatSession,
+	fsmeta.OperationCloseSession,
+}
+
+func newAtomicFastPathCounters() map[fsmeta.OperationKind]*atomicFastPathCounters {
+	out := make(map[fsmeta.OperationKind]*atomicFastPathCounters, len(atomicFastPathKinds))
+	for _, kind := range atomicFastPathKinds {
+		out[kind] = &atomicFastPathCounters{}
+	}
+	return out
+}
+
+func atomicFastPathStats(counters map[fsmeta.OperationKind]*atomicFastPathCounters) map[string]any {
+	out := make(map[string]any, len(atomicFastPathKinds))
+	for _, kind := range atomicFastPathKinds {
+		var stats *atomicFastPathCounters
+		if counters != nil {
+			stats = counters[kind]
+		}
+		out[string(kind)] = atomicFastPathStatsFor(stats)
+	}
+	return out
+}
+
+func atomicFastPathStatsFor(stats *atomicFastPathCounters) map[string]uint64 {
+	if stats == nil {
+		return map[string]uint64{
+			"attempt_total":            0,
+			"skip_total":               0,
+			"backoff_skip_total":       0,
+			"runner_unsupported_total": 0,
+			"fallback_total":           0,
+			"success_total":            0,
+			"consecutive_fallbacks":    0,
+		}
+	}
+	return map[string]uint64{
+		"attempt_total":            stats.attemptTotal.Load(),
+		"skip_total":               stats.skipTotal.Load(),
+		"backoff_skip_total":       stats.backoffSkipTotal.Load(),
+		"runner_unsupported_total": stats.runnerUnsupportedTotal.Load(),
+		"fallback_total":           stats.fallbackTotal.Load(),
+		"success_total":            stats.successTotal.Load(),
+		"consecutive_fallbacks":    stats.consecutiveFallbacks.Load(),
+	}
 }
 
 // Create creates one dentry and its inode record in a single transaction.
@@ -353,10 +406,7 @@ func (e *Executor) Create(ctx context.Context, req fsmeta.CreateRequest) (fsmeta
 			AssertionNotExist: true,
 		},
 	}
-	predicates := []*kvrpcpb.AtomicPredicate{
-		{Key: cloneBytes(plan.MutateKeys[0]), Kind: kvrpcpb.AtomicPredicateKind_ATOMIC_PREDICATE_KIND_NOT_EXISTS},
-		{Key: cloneBytes(plan.MutateKeys[1]), Kind: kvrpcpb.AtomicPredicateKind_ATOMIC_PREDICATE_KIND_NOT_EXISTS},
-	}
+	predicates := []*kvrpcpb.AtomicPredicate{atomicNotExists(plan.MutateKeys[0]), atomicNotExists(plan.MutateKeys[1])}
 	e.createTotal.Add(1)
 	if err := e.withTxnRetry(ctx, func(startVersion, commitVersion uint64) error {
 		quotaMutations, err := e.reserveQuota(ctx, []QuotaChange{{
@@ -370,26 +420,11 @@ func (e *Executor) Create(ctx context.Context, req fsmeta.CreateRequest) (fsmeta
 		}
 		all := append(cloneMutations(mutations), quotaMutations...)
 		if len(quotaMutations) == 0 {
-			if fast, ok := e.runner.(AtomicMutateFastPath); ok {
-				// Fast-path counters are per transaction attempt, not per logical
-				// Create, so contention retries and admission misses stay visible.
-				e.createFastPathAttemptTotal.Add(1)
-				handled, err := fast.TryAtomicMutate(ctx, plan.PrimaryKey, cloneAtomicPredicates(predicates), all, startVersion, commitVersion)
-				if err != nil || handled {
-					if err == nil {
-						e.createFastPathSuccessTotal.Add(1)
-					}
-					return err
-				}
-				e.createFastPathFallbackTotal.Add(1)
-			} else {
-				e.createFastPathRunnerUnsupportedTotal.Add(1)
-			}
-		} else {
-			e.createFastPathSkipQuotaTotal.Add(1)
+			// Fast-path counters are per transaction attempt, not per logical
+			// Create, so contention retries and admission misses stay visible.
+			return e.mutateWithAtomicFastPath(ctx, plan.Kind, plan.PrimaryKey, predicates, all, startVersion, commitVersion)
 		}
-		_, err = e.runner.Mutate(ctx, plan.PrimaryKey, all, startVersion, commitVersion, e.lockTTL)
-		return err
+		return e.mutateWithoutAtomicFastPath(ctx, plan.Kind, plan.PrimaryKey, all, startVersion, commitVersion)
 	}); err != nil {
 		return fsmeta.CreateResult{}, err
 	}
@@ -399,6 +434,79 @@ func (e *Executor) Create(ctx context.Context, req fsmeta.CreateRequest) (fsmeta
 	e.invalidateNegative(plan.MutateKeys[0])
 	e.invalidateDirPages(req.Mount, req.Parent)
 	return fsmeta.CreateResult{Dentry: dentry, Inode: inode}, nil
+}
+
+func (e *Executor) mutateWithAtomicFastPath(ctx context.Context, kind fsmeta.OperationKind, primary []byte, predicates []*kvrpcpb.AtomicPredicate, mutations []*kvrpcpb.Mutation, startVersion, commitVersion uint64) error {
+	stats := e.atomicFastPathCounters(kind)
+	fast, ok := e.runner.(AtomicMutateFastPath)
+	if !ok {
+		if stats != nil {
+			stats.runnerUnsupportedTotal.Add(1)
+		}
+		_, err := e.runner.Mutate(ctx, primary, mutations, startVersion, commitVersion, e.lockTTL)
+		return err
+	}
+	if stats != nil && !stats.allowAttempt() {
+		stats.skipTotal.Add(1)
+		_, err := e.runner.Mutate(ctx, primary, mutations, startVersion, commitVersion, e.lockTTL)
+		return err
+	}
+	if stats != nil {
+		stats.attemptTotal.Add(1)
+	}
+	handled, err := fast.TryAtomicMutate(ctx, primary, cloneAtomicPredicates(predicates), cloneMutations(mutations), startVersion, commitVersion)
+	if err != nil || handled {
+		if err == nil && stats != nil {
+			stats.successTotal.Add(1)
+			stats.consecutiveFallbacks.Store(0)
+			stats.backoffSkipTotal.Store(0)
+		}
+		return err
+	}
+	if stats != nil {
+		stats.fallbackTotal.Add(1)
+		stats.consecutiveFallbacks.Add(1)
+	}
+	_, err = e.runner.Mutate(ctx, primary, mutations, startVersion, commitVersion, e.lockTTL)
+	return err
+}
+
+const (
+	atomicFastPathBackoffAfter = 16
+	atomicFastPathProbeEvery   = 128
+)
+
+func (s *atomicFastPathCounters) allowAttempt() bool {
+	if s.consecutiveFallbacks.Load() < atomicFastPathBackoffAfter {
+		return true
+	}
+	// Some plans are only conditionally co-located. Back off after repeated
+	// admission misses, but keep rare probes so a changed placement policy or
+	// key pattern can re-enable the fast path without restarting the gateway.
+	return s.backoffSkipTotal.Add(1)%atomicFastPathProbeEvery == 0
+}
+
+func (e *Executor) mutateWithoutAtomicFastPath(ctx context.Context, kind fsmeta.OperationKind, primary []byte, mutations []*kvrpcpb.Mutation, startVersion, commitVersion uint64) error {
+	if stats := e.atomicFastPathCounters(kind); stats != nil {
+		stats.skipTotal.Add(1)
+	}
+	_, err := e.runner.Mutate(ctx, primary, mutations, startVersion, commitVersion, e.lockTTL)
+	return err
+}
+
+func (e *Executor) atomicFastPathCounters(kind fsmeta.OperationKind) *atomicFastPathCounters {
+	if e == nil {
+		return nil
+	}
+	return e.atomicFastPath[kind]
+}
+
+func atomicExists(key []byte) *kvrpcpb.AtomicPredicate {
+	return &kvrpcpb.AtomicPredicate{Key: cloneBytes(key), Kind: kvrpcpb.AtomicPredicateKind_ATOMIC_PREDICATE_KIND_EXISTS}
+}
+
+func atomicNotExists(key []byte) *kvrpcpb.AtomicPredicate {
+	return &kvrpcpb.AtomicPredicate{Key: cloneBytes(key), Kind: kvrpcpb.AtomicPredicateKind_ATOMIC_PREDICATE_KIND_NOT_EXISTS}
 }
 
 // UpdateInode updates mutable inode attributes and applies the size quota delta
@@ -474,8 +582,14 @@ func (e *Executor) UpdateInode(ctx context.Context, req fsmeta.UpdateInodeReques
 			}
 			mutations = append(mutations, quotaMutations...)
 		}
-		if _, err := e.runner.Mutate(ctx, plan.PrimaryKey, mutations, startVersion, commitVersion, e.lockTTL); err != nil {
-			return err
+		if sizeDelta == 0 || len(mutations) == 1 {
+			if err := e.mutateWithAtomicFastPath(ctx, plan.Kind, plan.PrimaryKey, []*kvrpcpb.AtomicPredicate{atomicExists(plan.MutateKeys[0])}, mutations, startVersion, commitVersion); err != nil {
+				return err
+			}
+		} else {
+			if err := e.mutateWithoutAtomicFastPath(ctx, plan.Kind, plan.PrimaryKey, mutations, startVersion, commitVersion); err != nil {
+				return err
+			}
 		}
 		updated = inode
 		return nil
@@ -879,8 +993,11 @@ func (e *Executor) Link(ctx context.Context, req fsmeta.LinkRequest) error {
 			return err
 		}
 		mutations = append(mutations, quotaMutations...)
-		_, err = e.runner.Mutate(ctx, plan.PrimaryKey, mutations, startVersion, commitVersion, e.lockTTL)
-		return err
+		if len(quotaMutations) == 0 {
+			predicates := []*kvrpcpb.AtomicPredicate{atomicNotExists(plan.ReadKeys[1]), atomicExists(inodeKey)}
+			return e.mutateWithAtomicFastPath(ctx, plan.Kind, plan.PrimaryKey, predicates, mutations, startVersion, commitVersion)
+		}
+		return e.mutateWithoutAtomicFastPath(ctx, plan.Kind, plan.PrimaryKey, mutations, startVersion, commitVersion)
 	}); err != nil {
 		return err
 	}
@@ -911,6 +1028,7 @@ func (e *Executor) Unlink(ctx context.Context, req fsmeta.UnlinkRequest) error {
 			Op:  kvrpcpb.Mutation_Delete,
 			Key: cloneBytes(plan.MutateKeys[0]),
 		}}
+		predicates := []*kvrpcpb.AtomicPredicate{atomicExists(plan.PrimaryKey)}
 		if inode, ok, err := e.readInode(ctx, req.Mount, record.Inode, startVersion); err != nil {
 			return err
 		} else if ok {
@@ -918,6 +1036,7 @@ func (e *Executor) Unlink(ctx context.Context, req fsmeta.UnlinkRequest) error {
 			if err != nil {
 				return err
 			}
+			predicates = append(predicates, atomicExists(inodeKey))
 			if inode.LinkCount <= 1 {
 				mutations = append(mutations, &kvrpcpb.Mutation{Op: kvrpcpb.Mutation_Delete, Key: inodeKey})
 			} else {
@@ -939,8 +1058,10 @@ func (e *Executor) Unlink(ctx context.Context, req fsmeta.UnlinkRequest) error {
 			}
 			mutations = append(mutations, quotaMutations...)
 		}
-		_, err = e.runner.Mutate(ctx, plan.PrimaryKey, mutations, startVersion, commitVersion, e.lockTTL)
-		return err
+		if len(mutations) == len(predicates) {
+			return e.mutateWithAtomicFastPath(ctx, plan.Kind, plan.PrimaryKey, predicates, mutations, startVersion, commitVersion)
+		}
+		return e.mutateWithoutAtomicFastPath(ctx, plan.Kind, plan.PrimaryKey, mutations, startVersion, commitVersion)
 	}); err != nil {
 		return err
 	}
@@ -987,10 +1108,15 @@ func (e *Executor) OpenWriteSession(ctx context.Context, req fsmeta.OpenWriteSes
 		}
 		candidate := fsmeta.SessionRecord{Session: req.Session, Inode: req.Inode, ExpiresUnixNs: expiresUnixNs}
 		now := nowTime.UnixNano()
+		predicates := make([]*kvrpcpb.AtomicPredicate, 0, 2)
 		if existing, ok, err := e.readSessionByKey(ctx, plan.ReadKeys[1], startVersion); err != nil {
 			return err
 		} else if ok && sessionLive(existing, now) {
 			return fsmeta.ErrExists
+		} else if ok {
+			predicates = append(predicates, atomicExists(plan.ReadKeys[1]))
+		} else {
+			predicates = append(predicates, atomicNotExists(plan.ReadKeys[1]))
 		}
 		mutations := make([]*kvrpcpb.Mutation, 0, 3)
 		if owner, ok, err := e.readSessionByKey(ctx, plan.ReadKeys[2], startVersion); err != nil {
@@ -999,6 +1125,7 @@ func (e *Executor) OpenWriteSession(ctx context.Context, req fsmeta.OpenWriteSes
 			if sessionLive(owner, now) {
 				return fsmeta.ErrExists
 			}
+			predicates = append(predicates, atomicExists(plan.ReadKeys[2]))
 			staleSessionKey, err := fsmeta.EncodeSessionKey(req.Mount, owner.Session)
 			if err != nil {
 				return err
@@ -1014,6 +1141,8 @@ func (e *Executor) OpenWriteSession(ctx context.Context, req fsmeta.OpenWriteSes
 					mutations = append(mutations, &kvrpcpb.Mutation{Op: kvrpcpb.Mutation_Delete, Key: staleSessionKey})
 				}
 			}
+		} else {
+			predicates = append(predicates, atomicNotExists(plan.ReadKeys[2]))
 		}
 		value, err := fsmeta.EncodeSessionValue(candidate)
 		if err != nil {
@@ -1023,7 +1152,13 @@ func (e *Executor) OpenWriteSession(ctx context.Context, req fsmeta.OpenWriteSes
 			&kvrpcpb.Mutation{Op: kvrpcpb.Mutation_Put, Key: cloneBytes(plan.MutateKeys[0]), Value: value},
 			&kvrpcpb.Mutation{Op: kvrpcpb.Mutation_Put, Key: cloneBytes(plan.MutateKeys[1]), Value: value},
 		)
-		if _, err := e.runner.Mutate(ctx, plan.PrimaryKey, mutations, startVersion, commitVersion, e.lockTTL); err != nil {
+		// Deleting an arbitrary stale session needs value-compare semantics that
+		// AtomicMutate does not expose; keep that rare cleanup case on 2PC.
+		if len(mutations) == 2 {
+			if err := e.mutateWithAtomicFastPath(ctx, plan.Kind, plan.PrimaryKey, predicates, mutations, startVersion, commitVersion); err != nil {
+				return err
+			}
+		} else if err := e.mutateWithoutAtomicFastPath(ctx, plan.Kind, plan.PrimaryKey, mutations, startVersion, commitVersion); err != nil {
 			return err
 		}
 		record = candidate
@@ -1078,7 +1213,8 @@ func (e *Executor) HeartbeatWriteSession(ctx context.Context, req fsmeta.Heartbe
 			{Op: kvrpcpb.Mutation_Put, Key: cloneBytes(plan.MutateKeys[0]), Value: value},
 			{Op: kvrpcpb.Mutation_Put, Key: cloneBytes(plan.MutateKeys[1]), Value: value},
 		}
-		if _, err := e.runner.Mutate(ctx, plan.PrimaryKey, mutations, startVersion, commitVersion, e.lockTTL); err != nil {
+		predicates := []*kvrpcpb.AtomicPredicate{atomicExists(plan.ReadKeys[0]), atomicExists(plan.ReadKeys[1])}
+		if err := e.mutateWithAtomicFastPath(ctx, plan.Kind, plan.PrimaryKey, predicates, mutations, startVersion, commitVersion); err != nil {
 			return err
 		}
 		record = candidate
@@ -1114,8 +1250,11 @@ func (e *Executor) CloseWriteSession(ctx context.Context, req fsmeta.CloseWriteS
 		} else if ok && owner.Session == req.Session && owner.Inode == session.Inode {
 			mutations = append(mutations, &kvrpcpb.Mutation{Op: kvrpcpb.Mutation_Delete, Key: ownerKey})
 		}
-		_, err = e.runner.Mutate(ctx, plan.PrimaryKey, mutations, startVersion, commitVersion, e.lockTTL)
-		return err
+		predicates := []*kvrpcpb.AtomicPredicate{atomicExists(plan.ReadKeys[0])}
+		if len(mutations) > 1 {
+			predicates = append(predicates, atomicExists(ownerKey))
+		}
+		return e.mutateWithAtomicFastPath(ctx, plan.Kind, plan.PrimaryKey, predicates, mutations, startVersion, commitVersion)
 	}); err != nil {
 		return err
 	}
@@ -1246,8 +1385,11 @@ func (e *Executor) Rename(ctx context.Context, req fsmeta.RenameRequest) error {
 		if err != nil {
 			return err
 		}
-		_, err = e.runner.Mutate(ctx, plan.PrimaryKey, mutations, startVersion, commitVersion, e.lockTTL)
-		return err
+		if len(mutations) == 2 {
+			predicates := []*kvrpcpb.AtomicPredicate{atomicExists(plan.ReadKeys[0]), atomicNotExists(plan.ReadKeys[1])}
+			return e.mutateWithAtomicFastPath(ctx, plan.Kind, plan.PrimaryKey, predicates, mutations, startVersion, commitVersion)
+		}
+		return e.mutateWithoutAtomicFastPath(ctx, plan.Kind, plan.PrimaryKey, mutations, startVersion, commitVersion)
 	}); err != nil {
 		return err
 	}

--- a/fsmeta/exec/runner_test.go
+++ b/fsmeta/exec/runner_test.go
@@ -55,6 +55,19 @@ func requireStatUint(t *testing.T, stats map[string]any, key string, want uint64
 	require.Equal(t, want, got)
 }
 
+func requireAtomicStatUint(t *testing.T, stats map[string]any, kind fsmeta.OperationKind, key string, want uint64) {
+	t.Helper()
+	raw, ok := stats["atomic_fastpath"]
+	require.True(t, ok, "missing atomic_fastpath stats")
+	byOp, ok := raw.(map[string]any)
+	require.Truef(t, ok, "atomic_fastpath has type %T", raw)
+	rawOp, ok := byOp[string(kind)]
+	require.Truef(t, ok, "missing atomic_fastpath stats for %s", kind)
+	opStats, ok := rawOp.(map[string]uint64)
+	require.Truef(t, ok, "atomic_fastpath[%s] has type %T", kind, rawOp)
+	require.Equal(t, want, opStats[key])
+}
+
 func txnLockedError(mount fsmeta.MountID, parent fsmeta.InodeID, name string) error {
 	key, err := fsmeta.EncodeDentryKey(mount, parent, name)
 	if err != nil {
@@ -480,11 +493,11 @@ func TestExecutorCreateUsesAtomicMutateFastPathWhenHandled(t *testing.T) {
 	require.NoError(t, err)
 	stats := executor.Stats()
 	requireStatUint(t, stats, "create_total", 1)
-	requireStatUint(t, stats, "create_fastpath_attempt_total", 1)
-	requireStatUint(t, stats, "create_fastpath_success_total", 1)
-	requireStatUint(t, stats, "create_fastpath_fallback_total", 0)
-	requireStatUint(t, stats, "create_fastpath_skip_quota_total", 0)
-	requireStatUint(t, stats, "create_fastpath_runner_unsupported_total", 0)
+	requireAtomicStatUint(t, stats, fsmeta.OperationCreate, "attempt_total", 1)
+	requireAtomicStatUint(t, stats, fsmeta.OperationCreate, "success_total", 1)
+	requireAtomicStatUint(t, stats, fsmeta.OperationCreate, "fallback_total", 0)
+	requireAtomicStatUint(t, stats, fsmeta.OperationCreate, "skip_total", 0)
+	requireAtomicStatUint(t, stats, fsmeta.OperationCreate, "runner_unsupported_total", 0)
 	require.Len(t, runner.atomicCalls, 1)
 	call := runner.atomicCalls[0]
 	require.Equal(t, plan.PrimaryKey, call.primary)
@@ -526,11 +539,11 @@ func TestExecutorCreateFallsBackWhenAtomicMutateNotHandled(t *testing.T) {
 	require.Len(t, runner.atomicCalls, 1)
 	stats := executor.Stats()
 	requireStatUint(t, stats, "create_total", 1)
-	requireStatUint(t, stats, "create_fastpath_attempt_total", 1)
-	requireStatUint(t, stats, "create_fastpath_success_total", 0)
-	requireStatUint(t, stats, "create_fastpath_fallback_total", 1)
-	requireStatUint(t, stats, "create_fastpath_skip_quota_total", 0)
-	requireStatUint(t, stats, "create_fastpath_runner_unsupported_total", 0)
+	requireAtomicStatUint(t, stats, fsmeta.OperationCreate, "attempt_total", 1)
+	requireAtomicStatUint(t, stats, fsmeta.OperationCreate, "success_total", 0)
+	requireAtomicStatUint(t, stats, fsmeta.OperationCreate, "fallback_total", 1)
+	requireAtomicStatUint(t, stats, fsmeta.OperationCreate, "skip_total", 0)
+	requireAtomicStatUint(t, stats, fsmeta.OperationCreate, "runner_unsupported_total", 0)
 	require.Len(t, base.mutations, 1)
 	require.Len(t, base.mutations[0], 2)
 }
@@ -550,11 +563,11 @@ func TestExecutorCreateRecordsUnsupportedAtomicRunner(t *testing.T) {
 
 	stats := executor.Stats()
 	requireStatUint(t, stats, "create_total", 1)
-	requireStatUint(t, stats, "create_fastpath_attempt_total", 0)
-	requireStatUint(t, stats, "create_fastpath_success_total", 0)
-	requireStatUint(t, stats, "create_fastpath_fallback_total", 0)
-	requireStatUint(t, stats, "create_fastpath_skip_quota_total", 0)
-	requireStatUint(t, stats, "create_fastpath_runner_unsupported_total", 1)
+	requireAtomicStatUint(t, stats, fsmeta.OperationCreate, "attempt_total", 0)
+	requireAtomicStatUint(t, stats, fsmeta.OperationCreate, "success_total", 0)
+	requireAtomicStatUint(t, stats, fsmeta.OperationCreate, "fallback_total", 0)
+	requireAtomicStatUint(t, stats, fsmeta.OperationCreate, "skip_total", 0)
+	requireAtomicStatUint(t, stats, fsmeta.OperationCreate, "runner_unsupported_total", 1)
 	require.Len(t, runner.mutations, 1)
 }
 
@@ -580,15 +593,68 @@ func TestExecutorCreateSkipsAtomicMutateWhenQuotaMutates(t *testing.T) {
 	// atomic local apply group.
 	stats := executor.Stats()
 	requireStatUint(t, stats, "create_total", 1)
-	requireStatUint(t, stats, "create_fastpath_attempt_total", 0)
-	requireStatUint(t, stats, "create_fastpath_success_total", 0)
-	requireStatUint(t, stats, "create_fastpath_fallback_total", 0)
-	requireStatUint(t, stats, "create_fastpath_skip_quota_total", 1)
-	requireStatUint(t, stats, "create_fastpath_runner_unsupported_total", 0)
+	requireAtomicStatUint(t, stats, fsmeta.OperationCreate, "attempt_total", 0)
+	requireAtomicStatUint(t, stats, fsmeta.OperationCreate, "success_total", 0)
+	requireAtomicStatUint(t, stats, fsmeta.OperationCreate, "fallback_total", 0)
+	requireAtomicStatUint(t, stats, fsmeta.OperationCreate, "skip_total", 1)
+	requireAtomicStatUint(t, stats, fsmeta.OperationCreate, "runner_unsupported_total", 0)
 	require.Empty(t, runner.atomicCalls)
 	require.Len(t, base.mutations, 1)
 	require.Len(t, base.mutations[0], 3)
 	require.Equal(t, quotaKey, base.mutations[0][2].GetKey())
+}
+
+func TestExecutorUpdateInodeUsesAtomicMutateWhenQuotaDoesNotMutate(t *testing.T) {
+	base := newFakeRunner()
+	runner := &fakeAtomicRunner{fakeRunner: base, handled: true}
+	seedDentry(t, runner.fakeRunner, "vol", 7, "file", 22)
+	seedInode(t, runner.fakeRunner, "vol", fsmeta.InodeRecord{Inode: 22, Type: fsmeta.InodeTypeFile, Mode: 0o644, LinkCount: 1})
+	executor, err := New(runner)
+	require.NoError(t, err)
+
+	updated, err := executor.UpdateInode(context.Background(), fsmeta.UpdateInodeRequest{
+		Mount:   "vol",
+		Parent:  7,
+		Inode:   22,
+		Name:    "file",
+		SetMode: true,
+		Mode:    0o600,
+	})
+	require.NoError(t, err)
+	require.Equal(t, uint32(0o600), updated.Mode)
+	require.Len(t, runner.atomicCalls, 1)
+	require.Empty(t, base.mutations)
+	requireAtomicStatUint(t, executor.Stats(), fsmeta.OperationUpdateInode, "success_total", 1)
+
+	stored, ok, err := executor.readInode(context.Background(), "vol", 22, 99)
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Equal(t, uint32(0o600), stored.Mode)
+}
+
+func TestExecutorUpdateInodeSkipsAtomicMutateWhenQuotaMutates(t *testing.T) {
+	base := newFakeRunner()
+	runner := &fakeAtomicRunner{fakeRunner: base, handled: true}
+	seedDentry(t, runner.fakeRunner, "vol", 7, "file", 22)
+	seedInode(t, runner.fakeRunner, "vol", fsmeta.InodeRecord{Inode: 22, Type: fsmeta.InodeTypeFile, Size: 1024, LinkCount: 1})
+	quotaKey, err := fsmeta.EncodeUsageKey("vol", 7)
+	require.NoError(t, err)
+	quota := &fakeQuotaResolver{mutation: &kvrpcpb.Mutation{Op: kvrpcpb.Mutation_Put, Key: quotaKey, Value: []byte("usage")}}
+	executor, err := New(runner, WithQuotaResolver(quota))
+	require.NoError(t, err)
+
+	_, err = executor.UpdateInode(context.Background(), fsmeta.UpdateInodeRequest{
+		Mount:   "vol",
+		Parent:  7,
+		Inode:   22,
+		Name:    "file",
+		SetSize: true,
+		Size:    2048,
+	})
+	require.NoError(t, err)
+	require.Empty(t, runner.atomicCalls)
+	require.Len(t, base.mutations, 1)
+	requireAtomicStatUint(t, executor.Stats(), fsmeta.OperationUpdateInode, "skip_total", 1)
 }
 
 func TestExecutorCreateRejectsExistingDentry(t *testing.T) {
@@ -836,6 +902,69 @@ func TestExecutorWriteSessionLifecycle(t *testing.T) {
 	require.NotContains(t, runner.data, string(ownerKey))
 }
 
+func TestExecutorWriteSessionLifecycleUsesAtomicMutate(t *testing.T) {
+	base := newFakeRunner()
+	runner := &fakeAtomicRunner{fakeRunner: base, handled: true}
+	seedInode(t, runner.fakeRunner, "vol", fsmeta.InodeRecord{Inode: 22, Type: fsmeta.InodeTypeFile, LinkCount: 1})
+	now := time.Unix(0, 100)
+	executor, err := New(runner, WithClock(func() time.Time { return now }))
+	require.NoError(t, err)
+
+	_, err = executor.OpenWriteSession(context.Background(), fsmeta.OpenWriteSessionRequest{
+		Mount:   "vol",
+		Inode:   22,
+		Session: "writer-1",
+		TTL:     100 * time.Nanosecond,
+	})
+	require.NoError(t, err)
+	_, err = executor.HeartbeatWriteSession(context.Background(), fsmeta.HeartbeatWriteSessionRequest{
+		Mount:   "vol",
+		Inode:   22,
+		Session: "writer-1",
+		TTL:     200 * time.Nanosecond,
+	})
+	require.NoError(t, err)
+	err = executor.CloseWriteSession(context.Background(), fsmeta.CloseWriteSessionRequest{Mount: "vol", Session: "writer-1"})
+	require.NoError(t, err)
+
+	require.Len(t, runner.atomicCalls, 3)
+	require.Empty(t, base.mutations)
+	stats := executor.Stats()
+	requireAtomicStatUint(t, stats, fsmeta.OperationOpenWriteSession, "success_total", 1)
+	requireAtomicStatUint(t, stats, fsmeta.OperationHeartbeatSession, "success_total", 1)
+	requireAtomicStatUint(t, stats, fsmeta.OperationCloseSession, "success_total", 1)
+}
+
+func TestExecutorOpenWriteSessionSkipsAtomicMutateForStaleSessionCleanup(t *testing.T) {
+	base := newFakeRunner()
+	runner := &fakeAtomicRunner{fakeRunner: base, handled: true}
+	seedInode(t, runner.fakeRunner, "vol", fsmeta.InodeRecord{Inode: 22, Type: fsmeta.InodeTypeFile, LinkCount: 1})
+	oldRecord := fsmeta.SessionRecord{Session: "writer-old", Inode: 22, ExpiresUnixNs: 50}
+	oldValue, err := fsmeta.EncodeSessionValue(oldRecord)
+	require.NoError(t, err)
+	oldSessionKey, err := fsmeta.EncodeSessionKey("vol", "writer-old")
+	require.NoError(t, err)
+	ownerKey, err := fsmeta.EncodeInodeSessionKey("vol", 22)
+	require.NoError(t, err)
+	runner.data[string(oldSessionKey)] = oldValue
+	runner.data[string(ownerKey)] = oldValue
+	executor, err := New(runner, WithClock(func() time.Time { return time.Unix(0, 100) }))
+	require.NoError(t, err)
+
+	_, err = executor.OpenWriteSession(context.Background(), fsmeta.OpenWriteSessionRequest{
+		Mount:   "vol",
+		Inode:   22,
+		Session: "writer-new",
+		TTL:     100 * time.Nanosecond,
+	})
+	require.NoError(t, err)
+
+	require.Empty(t, runner.atomicCalls)
+	require.Len(t, base.mutations, 1)
+	require.NotContains(t, runner.data, string(oldSessionKey))
+	requireAtomicStatUint(t, executor.Stats(), fsmeta.OperationOpenWriteSession, "skip_total", 1)
+}
+
 func TestExecutorWriteSessionRejectsNonPositiveTTL(t *testing.T) {
 	runner := newFakeRunner()
 	seedInode(t, runner, "vol", fsmeta.InodeRecord{Inode: 22, Type: fsmeta.InodeTypeFile, LinkCount: 1})
@@ -1072,6 +1201,32 @@ func TestExecutorLinkCreatesDentryAndIncrementsLinkCount(t *testing.T) {
 	require.True(t, ok)
 	require.Equal(t, uint32(2), inode.LinkCount)
 	require.Equal(t, [][]QuotaChange{{{Mount: "vol", Scope: 8, Bytes: 4096, Inodes: 1}}}, quota.changes)
+}
+
+func TestExecutorLinkUsesAtomicMutateWhenQuotaDoesNotMutate(t *testing.T) {
+	base := newFakeRunner()
+	runner := &fakeAtomicRunner{fakeRunner: base, handled: true}
+	seedDentry(t, runner.fakeRunner, "vol", 7, "file", 22)
+	seedInode(t, runner.fakeRunner, "vol", fsmeta.InodeRecord{Inode: 22, Type: fsmeta.InodeTypeFile, Size: 4096, LinkCount: 1})
+	executor, err := New(runner)
+	require.NoError(t, err)
+
+	err = executor.Link(context.Background(), fsmeta.LinkRequest{
+		Mount:      "vol",
+		FromParent: 7,
+		FromName:   "file",
+		ToParent:   8,
+		ToName:     "alias",
+	})
+	require.NoError(t, err)
+
+	require.Len(t, runner.atomicCalls, 1)
+	require.Empty(t, base.mutations)
+	requireAtomicStatUint(t, executor.Stats(), fsmeta.OperationLink, "success_total", 1)
+	inode, ok, err := executor.readInode(context.Background(), "vol", 22, 99)
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Equal(t, uint32(2), inode.LinkCount)
 }
 
 func TestExecutorLinkRejectsDirectory(t *testing.T) {
@@ -1495,6 +1650,25 @@ func TestExecutorUnlinkRemovesDentry(t *testing.T) {
 	require.False(t, ok)
 }
 
+func TestExecutorUnlinkUsesAtomicMutateWhenQuotaDoesNotMutate(t *testing.T) {
+	base := newFakeRunner()
+	runner := &fakeAtomicRunner{fakeRunner: base, handled: true}
+	seedDentry(t, runner.fakeRunner, "vol", 7, "file", 22)
+	seedInode(t, runner.fakeRunner, "vol", fsmeta.InodeRecord{Inode: 22, Type: fsmeta.InodeTypeFile, LinkCount: 1})
+	executor, err := New(runner)
+	require.NoError(t, err)
+
+	err = executor.Unlink(context.Background(), fsmeta.UnlinkRequest{Mount: "vol", Parent: 7, Name: "file"})
+	require.NoError(t, err)
+
+	require.Len(t, runner.atomicCalls, 1)
+	require.Empty(t, base.mutations)
+	requireAtomicStatUint(t, executor.Stats(), fsmeta.OperationUnlink, "success_total", 1)
+	_, ok, err := executor.readInode(context.Background(), "vol", 22, 99)
+	require.NoError(t, err)
+	require.False(t, ok)
+}
+
 func TestExecutorUnlinkDecrementsMultiLinkInode(t *testing.T) {
 	runner := newFakeRunner()
 	seedDentry(t, runner, "vol", 7, "file", 22)
@@ -1597,6 +1771,75 @@ func TestExecutorRenameMovesDentryWithoutSubtreeHandoff(t *testing.T) {
 	require.Empty(t, publisher.starts)
 	require.Empty(t, publisher.completes)
 	require.Equal(t, 1, authority.calls)
+}
+
+func TestExecutorRenameUsesAtomicMutateWithoutSubtreeHandoff(t *testing.T) {
+	base := newFakeRunner()
+	runner := &fakeAtomicRunner{fakeRunner: base, handled: true}
+	seedDentry(t, runner.fakeRunner, "vol", 7, "old", 22)
+	seedInode(t, runner.fakeRunner, "vol", fsmeta.InodeRecord{Inode: 22, Type: fsmeta.InodeTypeFile, LinkCount: 1})
+	publisher := &fakeSubtreePublisher{}
+	authority := &fakeAuthorityResolver{same: true}
+	resolver := &fakeMountResolver{records: map[fsmeta.MountID]MountAdmission{
+		"vol": {MountID: "vol", RootInode: fsmeta.RootInode, SchemaVersion: 1},
+	}}
+	executor, err := New(
+		runner,
+		WithMountResolver(resolver),
+		WithSubtreeAuthorityResolver(authority),
+		WithSubtreeHandoffPublisher(publisher),
+	)
+	require.NoError(t, err)
+
+	err = executor.Rename(context.Background(), fsmeta.RenameRequest{
+		Mount:      "vol",
+		FromParent: 7,
+		FromName:   "old",
+		ToParent:   8,
+		ToName:     "new",
+	})
+	require.NoError(t, err)
+
+	require.Len(t, runner.atomicCalls, 1)
+	require.Empty(t, base.mutations)
+	require.Empty(t, publisher.starts)
+	require.Empty(t, publisher.completes)
+	requireAtomicStatUint(t, executor.Stats(), fsmeta.OperationRename, "success_total", 1)
+	record, err := executor.Lookup(context.Background(), fsmeta.LookupRequest{Mount: "vol", Parent: 8, Name: "new"})
+	require.NoError(t, err)
+	require.Equal(t, fsmeta.InodeID(22), record.Inode)
+}
+
+func TestExecutorAtomicFastPathBacksOffAfterRepeatedFallback(t *testing.T) {
+	base := newFakeRunner()
+	runner := &fakeAtomicRunner{fakeRunner: base, handled: false}
+	authority := &fakeAuthorityResolver{same: true}
+	resolver := &fakeMountResolver{records: map[fsmeta.MountID]MountAdmission{
+		"vol": {MountID: "vol", RootInode: fsmeta.RootInode, SchemaVersion: 1},
+	}}
+	executor, err := New(runner, WithMountResolver(resolver), WithSubtreeAuthorityResolver(authority))
+	require.NoError(t, err)
+
+	total := atomicFastPathBackoffAfter + 3
+	for i := range total {
+		oldName := fmt.Sprintf("old-%d", i)
+		newName := fmt.Sprintf("new-%d", i)
+		seedDentry(t, runner.fakeRunner, "vol", 7, oldName, fsmeta.InodeID(100+i))
+		err := executor.Rename(context.Background(), fsmeta.RenameRequest{
+			Mount:      "vol",
+			FromParent: 7,
+			FromName:   oldName,
+			ToParent:   8,
+			ToName:     newName,
+		})
+		require.NoError(t, err)
+	}
+
+	require.Len(t, runner.atomicCalls, atomicFastPathBackoffAfter)
+	stats := executor.Stats()
+	requireAtomicStatUint(t, stats, fsmeta.OperationRename, "fallback_total", atomicFastPathBackoffAfter)
+	requireAtomicStatUint(t, stats, fsmeta.OperationRename, "skip_total", 3)
+	requireAtomicStatUint(t, stats, fsmeta.OperationRename, "backoff_skip_total", 3)
 }
 
 func TestExecutorRenameRejectsCrossAuthority(t *testing.T) {

--- a/raftstore/client/client_kv.go
+++ b/raftstore/client/client_kv.go
@@ -639,9 +639,13 @@ func (c *Client) twoPhaseCommit(ctx context.Context, primary []byte, mutations [
 				continue
 			}
 		}
-		if shouldRollbackAfterPrimaryCommitFailure(err) {
-			if rollbackErr := c.rollbackPrewrites(ctx, prewritten, startVersion); rollbackErr != nil {
-				return commitVersion, errors.Join(err, fmt.Errorf("client: rollback after primary commit failure: %w", rollbackErr))
+		if shouldRecoverAfterPrimaryCommitFailure(err) {
+			recoveredCommitVersion, recovered, recoverErr := c.recoverPrimaryCommitFailure(ctx, primary, prewritten, startVersion, commitVersion)
+			if recoverErr != nil {
+				return commitVersion, errors.Join(err, fmt.Errorf("client: recover after primary commit failure: %w", recoverErr))
+			}
+			if recovered {
+				return recoveredCommitVersion, nil
 			}
 		}
 		return commitVersion, err
@@ -780,9 +784,36 @@ func (c *Client) resolveCommittedSecondaries(ctx context.Context, keys [][]byte,
 	return err
 }
 
-func shouldRollbackAfterPrimaryCommitFailure(err error) bool {
-	_, ok := commitTsExpiredMin(err)
+func shouldRecoverAfterPrimaryCommitFailure(err error) bool {
+	_, ok := nokverrors.AsTxnKeyError(err)
 	return ok
+}
+
+func (c *Client) recoverPrimaryCommitFailure(ctx context.Context, primary []byte, prewritten map[uint64][][]byte, startVersion, commitVersion uint64) (uint64, bool, error) {
+	statusResp, err := c.CheckTxnStatus(ctx, primary, startVersion, commitVersion, 0)
+	if err != nil {
+		return 0, false, err
+	}
+	if statusResp == nil {
+		return 0, false, &ProtocolError{Operation: "recover primary commit", Detail: fmt.Sprintf("nil check txn status response for primary %q", primary)}
+	}
+	if keyErr := statusResp.GetError(); keyErr != nil {
+		return 0, false, txnKeyError(keyErr)
+	}
+	if resolvedCommitVersion := statusResp.GetCommitVersion(); resolvedCommitVersion != 0 {
+		if err := c.resolveCommittedSecondaries(ctx, flattenPrewritten(prewritten), startVersion, resolvedCommitVersion); err != nil {
+			return resolvedCommitVersion, false, err
+		}
+		return resolvedCommitVersion, true, nil
+	}
+	// A KeyError response from Commit is a deterministic protocol rejection,
+	// not an unknown transport outcome. If the primary has no committed
+	// decision, clear this start_ts before returning so fsmeta can retry the
+	// semantic operation immediately instead of waiting for lock TTL expiry.
+	if err := c.rollbackPrewrites(ctx, prewritten, startVersion); err != nil {
+		return 0, false, err
+	}
+	return 0, false, nil
 }
 
 func commitTsExpiredMin(err error) (uint64, bool) {

--- a/raftstore/client/client_kv_test.go
+++ b/raftstore/client/client_kv_test.go
@@ -1417,6 +1417,127 @@ func TestClientTwoPhaseCommitRollsBackPrewritesAfterPrimaryCommitTsExpired(t *te
 	require.Equal(t, 1, rollbackHits)
 }
 
+func TestClientTwoPhaseCommitRollsBackPrewritesAfterPrimaryCommitRetryableLoss(t *testing.T) {
+	cluster := newMockCluster(clusterRegion{
+		meta: &metapb.RegionDescriptor{
+			RegionId: 1,
+			StartKey: []byte("a"),
+			EndKey:   []byte("z"),
+			Epoch:    &metapb.RegionEpoch{Version: 1, ConfVersion: 1},
+			Peers:    []*metapb.RegionPeer{{StoreId: 1, PeerId: 101}},
+		},
+		leaderStore: 1,
+	})
+	svc := &scriptedKVService{mockService: mockService{storeID: 1, cluster: cluster}}
+	var statusChecks int
+	svc.commitFn = func(context.Context, *kvrpcpb.KvCommitRequest) (*kvrpcpb.KvCommitResponse, error) {
+		return &kvrpcpb.KvCommitResponse{
+			Response: &kvrpcpb.CommitResponse{
+				Error: &kvrpcpb.KeyError{Retryable: "percolator: lock not found"},
+			},
+		}, nil
+	}
+	svc.checkTxnStatusFn = func(context.Context, *kvrpcpb.KvCheckTxnStatusRequest) (*kvrpcpb.KvCheckTxnStatusResponse, error) {
+		statusChecks++
+		return &kvrpcpb.KvCheckTxnStatusResponse{Response: &kvrpcpb.CheckTxnStatusResponse{}}, nil
+	}
+	addr, stop := startBlockingStore(t, svc)
+	defer stop()
+
+	cli, err := New(Config{
+		StoreResolver:  staticStoreResolver{{StoreID: 1, Addr: addr}},
+		RegionResolver: resolverFromCluster(cluster),
+		DialOptions:    []grpc.DialOption{grpc.WithTransportCredentials(insecure.NewCredentials())},
+		Retry:          RetryPolicy{MaxAttempts: 2, RegionErrorBackoff: 0},
+	})
+	require.NoError(t, err)
+	defer func() { _ = cli.Close() }()
+
+	err = cli.TwoPhaseCommit(context.Background(), []byte("alfa"), []*kvrpcpb.Mutation{
+		{Op: kvrpcpb.Mutation_Put, Key: []byte("alfa"), Value: []byte("v1")},
+		{Op: kvrpcpb.Mutation_Put, Key: []byte("bravo"), Value: []byte("v2")},
+	}, 50, 51, 3000)
+	txnErr, ok := nokverrors.AsTxnKeyError(err)
+	require.True(t, ok)
+	require.Len(t, txnErr.Errors, 1)
+	require.Equal(t, "percolator: lock not found", txnErr.Errors[0].GetRetryable())
+	require.Equal(t, 1, statusChecks)
+
+	cluster.mu.Lock()
+	_, pending := cluster.regions[1].pending[50]
+	rollbackHits := cluster.regions[1].rollbackHits
+	cluster.mu.Unlock()
+	require.False(t, pending, "retryable primary commit rejection must not leave a dead start_ts behind")
+	require.Equal(t, 1, rollbackHits)
+}
+
+func TestClientTwoPhaseCommitResolvesWhenPrimaryCommittedAfterCommitError(t *testing.T) {
+	cluster := newMockCluster(clusterRegion{
+		meta: &metapb.RegionDescriptor{
+			RegionId: 1,
+			StartKey: []byte("a"),
+			EndKey:   []byte("z"),
+			Epoch:    &metapb.RegionEpoch{Version: 1, ConfVersion: 1},
+			Peers:    []*metapb.RegionPeer{{StoreId: 1, PeerId: 101}},
+		},
+		leaderStore: 1,
+	})
+	svc := &scriptedKVService{mockService: mockService{storeID: 1, cluster: cluster}}
+	var commitCalls int
+	var resolveCalls int
+	svc.commitFn = func(ctx context.Context, req *kvrpcpb.KvCommitRequest) (*kvrpcpb.KvCommitResponse, error) {
+		commitCalls++
+		if commitCalls == 1 {
+			resp, regionErr := svc.cluster.commit(svc.storeID, req.GetContext().GetRegionId(), req.GetRequest())
+			require.Nil(t, regionErr)
+			require.NotNil(t, resp)
+			return &kvrpcpb.KvCommitResponse{
+				Response: &kvrpcpb.CommitResponse{
+					Error: &kvrpcpb.KeyError{Retryable: "injected post-commit error"},
+				},
+			}, nil
+		}
+		return svc.mockService.Commit(ctx, req)
+	}
+	svc.checkTxnStatusFn = func(context.Context, *kvrpcpb.KvCheckTxnStatusRequest) (*kvrpcpb.KvCheckTxnStatusResponse, error) {
+		return &kvrpcpb.KvCheckTxnStatusResponse{Response: &kvrpcpb.CheckTxnStatusResponse{CommitVersion: 51}}, nil
+	}
+	svc.resolveLockFn = func(ctx context.Context, req *kvrpcpb.KvResolveLockRequest) (*kvrpcpb.KvResolveLockResponse, error) {
+		resolveCalls++
+		return svc.mockService.ResolveLock(ctx, req)
+	}
+	addr, stop := startBlockingStore(t, svc)
+	defer stop()
+
+	cli, err := New(Config{
+		StoreResolver:  staticStoreResolver{{StoreID: 1, Addr: addr}},
+		RegionResolver: resolverFromCluster(cluster),
+		DialOptions:    []grpc.DialOption{grpc.WithTransportCredentials(insecure.NewCredentials())},
+		Retry:          RetryPolicy{MaxAttempts: 2, RegionErrorBackoff: 0},
+	})
+	require.NoError(t, err)
+	defer func() { _ = cli.Close() }()
+
+	err = cli.TwoPhaseCommit(context.Background(), []byte("alfa"), []*kvrpcpb.Mutation{
+		{Op: kvrpcpb.Mutation_Put, Key: []byte("alfa"), Value: []byte("v1")},
+		{Op: kvrpcpb.Mutation_Put, Key: []byte("bravo"), Value: []byte("v2")},
+	}, 50, 51, 3000)
+	require.NoError(t, err)
+	require.Equal(t, 1, resolveCalls)
+
+	cluster.mu.Lock()
+	region := cluster.regions[1]
+	_, pending := region.pending[50]
+	alfa := region.committed["alfa"]
+	bravo := region.committed["bravo"]
+	cluster.mu.Unlock()
+	require.False(t, pending)
+	require.Equal(t, []byte("v1"), alfa.value)
+	require.Equal(t, []byte("v2"), bravo.value)
+	require.Equal(t, uint64(51), alfa.commitVersion)
+	require.Equal(t, uint64(51), bravo.commitVersion)
+}
+
 func TestClientMutateWithCommitTimestampAllocatesAfterPrewrite(t *testing.T) {
 	cluster := newMockCluster(clusterRegion{
 		meta: &metapb.RegionDescriptor{


### PR DESCRIPTION
## Summary

- generalize fsmeta AtomicMutate fast path counters from create-only to per-operation stats
- route Create, UpdateInode, ordinary writer-session lifecycle operations, Link, Unlink, and same-authority Rename through the existing AtomicMutate fast path when eligible
- add executor-level fallback backoff: operations that repeatedly miss AtomicMutate admission stop paying the extra raft round trip, with periodic probes so changed placement/key patterns can re-enable the fast path
- keep the existing safety gate unchanged: raftstore/percolator must still accept the request as one region-local and one local atomic apply group, otherwise executor falls back to 2PC

This is the first performance-line PR from the 1000 ops/s plan. It intentionally does not include scoped duty allocation, proposal batching, or key-placement rewrites.

## Correctness notes

- quota mutations stay on 2PC because they add extra accounting keys that may not share the local atomic apply group
- stale writer-session cleanup stays on 2PC because AtomicMutate currently has exists/not-exists predicates, not value-compare predicates for arbitrary stale owner records
- AtomicMutate conflict detection remains in txn/percolator; this PR only chooses when fsmeta asks for the existing fast path
- fallback backoff is only an admission optimization; it never accepts a mutation that raftstore/percolator would reject

## Benchmark evidence

The first pushed version regressed CI median because Rename had a 100% AtomicMutate fallback rate and paid an extra raft proposal before 2PC:

```text
#245 median mixed: 133.5 ops/s
#247 first push median mixed: 117.7 ops/s
```

A too-conservative fix removed fallback overhead but also disabled useful session/link hits:

```text
#247 conservative CI rerun mixed: 109.2 ops/s
runner atomic_local_fallback_total=0, but session/link fast-path hits were also removed
```

Final CI median with fallback backoff:

```text
artifact: fsmeta-median-25545475994
mixed aggregate: 143.2 ops/s, 0 errors
checkpoint-storm aggregate: 138.6 ops/s, 0 errors
hotspot-fanin aggregate: 95.3 ops/s, 0 errors
watch-subtree aggregate: 273.1 ops/s, 0 errors
negative-lookup aggregate: 1796.5 ops/s, 0 errors
```

Compared with #245 on the same benchmark profile, mixed improves from 133.5 to 143.2 ops/s, and checkpoint-storm improves from 131.7 to 138.6 ops/s.

## Tests

- make fmt
- make lint
- go test ./fsmeta/exec
- go test ./fsmeta/... ./raftstore/client ./raftstore/kv ./txn/percolator ./coordinator/...
- cd benchmark && go test ./fsmeta ./fsmeta/workload
- go test ./...
- Benchmark / fsmeta median CI: success, artifact fsmeta-median-25545475994


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced transaction commit recovery: when primary commit fails with retryable errors, the system now checks transaction status and resolves committed transactions instead of immediately rolling back, improving resilience.

* **Refactor**
  * Optimized atomic fast-path execution with generalized counter tracking across operations.

* **Tests**
  * Added test coverage for transaction recovery and atomic operation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->