### PR TITLE
Add dynamic coordinator duty grants

### DIFF
--- a/cmd/nokv/cmd_coordinator.go
+++ b/cmd/nokv/cmd_coordinator.go
@@ -20,6 +20,7 @@ import (
 	"github.com/feichai0017/NoKV/coordinator/rootview"
 	coordserver "github.com/feichai0017/NoKV/coordinator/server"
 	"github.com/feichai0017/NoKV/coordinator/tso"
+	rootproto "github.com/feichai0017/NoKV/meta/root/protocol"
 	rootstorage "github.com/feichai0017/NoKV/meta/root/storage"
 	coordpb "github.com/feichai0017/NoKV/pb/coordinator"
 	"google.golang.org/grpc"
@@ -41,6 +42,8 @@ func runCoordinatorCmd(w io.Writer, args []string) error {
 	coordinatorID := fs.String("coordinator-id", "", "stable coordinator owner id for grant-gated control plane (required)")
 	grantTTL := fs.Duration("grant-ttl", 10*time.Second, "coordinator grant ttl")
 	grantRenewBefore := fs.Duration("grant-renew-before", 3*time.Second, "renew/campaign before grant expiry")
+	grantCandidates := fs.String("grant-candidates", "", "comma-separated coordinator ids eligible for duty grants")
+	grantDuties := fs.String("grant-duties", "alloc_id,tso,region_lookup", "comma-separated duties eligible on this coordinator")
 	shutdownGrace := fs.Duration("shutdown-grace", 0, "maximum time to drain and seal coordinator grant before graceful shutdown (default: grant ttl, or 10s when grant ttl is disabled)")
 	configPath := fs.String("config", "", "optional raft configuration file used to resolve coordinator listen address")
 	scope := fs.String("scope", "host", "scope for config-resolved coordinator address: host|docker")
@@ -124,7 +127,11 @@ func runCoordinatorCmd(w io.Writer, args []string) error {
 	ids := idalloc.NewIDAllocator(*idStart)
 	tsAlloc := tso.NewAllocator(*tsStart)
 	svc := coordserver.NewService(cluster, ids, tsAlloc, rootStore)
-	svc.ConfigureAuthorityGrant(coordinatorIDValue, *grantTTL, *grantRenewBefore)
+	parsedDuties, err := parseCoordinatorGrantDuties(*grantDuties)
+	if err != nil {
+		return err
+	}
+	svc.ConfigureAuthorityGrantDuties(coordinatorIDValue, splitCommaList(*grantCandidates), parsedDuties, *grantTTL, *grantRenewBefore)
 	installCoordinatorExpvar(svc)
 
 	grpcServer := grpc.NewServer()
@@ -144,7 +151,7 @@ func runCoordinatorCmd(w io.Writer, args []string) error {
 
 	_, _ = fmt.Fprintf(w, "Coordinator restored %d region(s) from remote metadata root\n", loadedRegions)
 	_, _ = fmt.Fprintf(w, "Coordinator allocator starts: id=%d ts=%d\n", *idStart, *tsStart)
-	_, _ = fmt.Fprintf(w, "Coordinator grant holder: id=%s ttl=%s renew_before=%s\n", coordinatorIDValue, grantTTL.String(), grantRenewBefore.String())
+	_, _ = fmt.Fprintf(w, "Coordinator grant holder: id=%s ttl=%s renew_before=%s duties=%s candidates=%s\n", coordinatorIDValue, grantTTL.String(), grantRenewBefore.String(), strings.Join(dutyNames(parsedDuties), ","), strings.Join(splitCommaList(*grantCandidates), ","))
 	_, _ = fmt.Fprintf(w, "Coordinator service listening on %s\n", lis.Addr().String())
 	if metricsLn != nil {
 		_, _ = fmt.Fprintf(w, "Coordinator metrics endpoint listening on http://%s/debug/vars\n", metricsLn.Addr().String())
@@ -230,6 +237,41 @@ func parseReplicatedRootPeers(values []string) (map[uint64]string, error) {
 		peers[id] = addr
 	}
 	return peers, nil
+}
+
+func splitCommaList(raw string) []string {
+	parts := strings.Split(raw, ",")
+	out := make([]string, 0, len(parts))
+	for _, part := range parts {
+		part = strings.TrimSpace(part)
+		if part != "" {
+			out = append(out, part)
+		}
+	}
+	return out
+}
+
+func parseCoordinatorGrantDuties(raw string) ([]rootproto.DutyID, error) {
+	parts := splitCommaList(raw)
+	out := make([]rootproto.DutyID, 0, len(parts))
+	for _, part := range parts {
+		duty := rootproto.DutyID(part)
+		switch duty {
+		case rootproto.DutyAllocID, rootproto.DutyTSO, rootproto.DutyRegionLookup:
+			out = append(out, duty)
+		default:
+			return nil, fmt.Errorf("unknown coordinator grant duty %q", part)
+		}
+	}
+	return out, nil
+}
+
+func dutyNames(duties []rootproto.DutyID) []string {
+	out := make([]string, 0, len(duties))
+	for _, duty := range duties {
+		out = append(out, rootproto.DutyName(duty))
+	}
+	return out
 }
 
 func flagPassed(fs *flag.FlagSet, name string) bool {

--- a/coordinator/audit/report.go
+++ b/coordinator/audit/report.go
@@ -52,14 +52,15 @@ type Report struct {
 // report. It treats a crash-before-seal takeover as complete only when the
 // expired_bound retirement has been inherited by a successor grant.
 func BuildReport(snapshot rootview.Snapshot, holderID string, nowUnixNano int64) Report {
+	active := auditPrimaryGrant(snapshot)
 	report := Report{
 		HolderID:               holderID,
 		NowUnixNano:            nowUnixNano,
 		RootDescriptorRevision: rootstate.MaxDescriptorRevision(snapshot.Descriptors),
 		CatchUpState:           snapshot.CatchUpState.String(),
-		CurrentHolderID:        snapshot.ActiveGrant.HolderID,
-		CurrentEra:             snapshot.ActiveGrant.Era,
-		ActiveGrant:            snapshot.ActiveGrant,
+		CurrentHolderID:        active.HolderID,
+		CurrentEra:             active.Era,
+		ActiveGrant:            active,
 		RetiredGrants:          append([]rootproto.GrantRetirement(nil), snapshot.RetiredGrants...),
 		GrantInheritances:      append([]rootproto.GrantInheritance(nil), snapshot.GrantInheritances...),
 		RetiredEraFloor:        snapshot.RetiredEraFloor,
@@ -86,6 +87,16 @@ func BuildReport(snapshot rootview.Snapshot, holderID string, nowUnixNano int64)
 	}
 	report.AuthorityCompletion = evaluateAuthorityCompletion(report.RetiredGrants)
 	return report
+}
+
+func auditPrimaryGrant(snapshot rootview.Snapshot) rootproto.AuthorityGrant {
+	if grant, ok := snapshot.ActiveGrantFor(rootproto.DutyRegionLookup, rootproto.DutyScope{Kind: rootproto.DutyScopeGlobal}); ok {
+		return grant
+	}
+	if len(snapshot.ActiveGrants) > 0 {
+		return snapshot.ActiveGrants[0]
+	}
+	return rootproto.AuthorityGrant{}
 }
 
 func evaluateAuthorityCompletion(retirements []rootproto.GrantRetirement) AuthorityCompletionState {

--- a/coordinator/audit/report_test.go
+++ b/coordinator/audit/report_test.go
@@ -13,7 +13,7 @@ import (
 func TestBuildReportSurfacesSealedExactCompleted(t *testing.T) {
 	snapshot := rootview.Snapshot{
 		CatchUpState: rootview.CatchUpStateFresh,
-		ActiveGrant: rootproto.AuthorityGrant{
+		ActiveGrants: []rootproto.AuthorityGrant{{
 			GrantID:  "g2",
 			HolderID: "c2",
 			Era:      2,
@@ -21,7 +21,7 @@ func TestBuildReportSurfacesSealedExactCompleted(t *testing.T) {
 				rootproto.NewGlobalMonotoneDuty(rootproto.DutyAllocID, 20),
 				rootproto.NewGlobalMonotoneDuty(rootproto.DutyTSO, 30),
 			},
-		},
+		}},
 		RetiredGrants: []rootproto.GrantRetirement{
 			{
 				GrantID:            "g1",
@@ -48,7 +48,7 @@ func TestBuildReportSurfacesSealedExactCompleted(t *testing.T) {
 
 func TestBuildReportSurfacesExpiredBoundInherited(t *testing.T) {
 	report := coordaudit.BuildReport(rootview.Snapshot{
-		ActiveGrant: rootproto.AuthorityGrant{GrantID: "g2", HolderID: "c2", Era: 2},
+		ActiveGrants: []rootproto.AuthorityGrant{{GrantID: "g2", HolderID: "c2", Era: 2}},
 		RetiredGrants: []rootproto.GrantRetirement{
 			{
 				GrantID:            "g1",
@@ -80,12 +80,12 @@ func TestBuildReportSurfacesRetiredNotInherited(t *testing.T) {
 
 func TestBuildReportSurfacesInvalidSuccessorBound(t *testing.T) {
 	report := coordaudit.BuildReport(rootview.Snapshot{
-		ActiveGrant: rootproto.AuthorityGrant{
+		ActiveGrants: []rootproto.AuthorityGrant{{
 			GrantID:  "g2",
 			HolderID: "c2",
 			Era:      2,
 			Duties:   []rootproto.DutyGrant{rootproto.NewGlobalMonotoneDuty(rootproto.DutyAllocID, 5)},
-		},
+		}},
 		RetiredGrants: []rootproto.GrantRetirement{
 			{
 				GrantID:  "g1",
@@ -104,11 +104,11 @@ func TestBuildReportSurfacesInvalidSuccessorBound(t *testing.T) {
 func TestBuildReportPreservesCompactedRetiredEraFloor(t *testing.T) {
 	report := coordaudit.BuildReport(rootview.Snapshot{
 		RetiredEraFloor: 3,
-		ActiveGrant: rootproto.AuthorityGrant{
+		ActiveGrants: []rootproto.AuthorityGrant{{
 			GrantID: "g4",
 			Era:     4,
 			Duties:  []rootproto.DutyGrant{rootproto.NewGlobalMonotoneDuty(rootproto.DutyAllocID, 40)},
-		},
+		}},
 	}, "c4", 1_000)
 
 	require.Equal(t, uint64(3), report.RetiredEraFloor)

--- a/coordinator/client/client.go
+++ b/coordinator/client/client.go
@@ -43,9 +43,10 @@ type Client interface {
 
 // GRPCClient is a thin wrapper around generated coordpb.CoordinatorClient.
 type GRPCClient struct {
-	mu        sync.Mutex
-	endpoints []grpcEndpoint
-	preferred int
+	mu              sync.Mutex
+	endpoints       []grpcEndpoint
+	preferred       int
+	preferredByDuty map[rootproto.DutyID]int
 
 	verifyMu             sync.Mutex
 	verifierStore        AuthorityVerifierStore
@@ -128,6 +129,7 @@ func NewGRPCClientWithOptions(ctx context.Context, addr string, clientOpts GRPCC
 	}
 	return &GRPCClient{
 		endpoints:            endpoints,
+		preferredByDuty:      make(map[rootproto.DutyID]int),
 		verifierStore:        store,
 		verifierClusterID:    clusterID,
 		authorityClockSkew:   clockSkew,
@@ -251,7 +253,7 @@ func (c *GRPCClient) GetRegionByKey(ctx context.Context, req *coordpb.GetRegionB
 	// Region lookup is a metadata authority read: standby coordinators can
 	// reject it with grant-not-held, so it must fail over like TSO/AllocID even
 	// though the RPC does not mutate user metadata.
-	return invokeRPCValidated(c, retryableWrite, func(coord coordpb.CoordinatorClient) (*coordpb.GetRegionByKeyResponse, error) {
+	return invokeDutyRPCValidated(c, rootproto.DutyRegionLookup, retryableWrite, func(coord coordpb.CoordinatorClient) (*coordpb.GetRegionByKeyResponse, error) {
 		return coord.GetRegionByKey(ctx, req)
 	}, func(resp *coordpb.GetRegionByKeyResponse) error {
 		return c.validateGetRegionByKeyResponse(req, resp)
@@ -330,7 +332,7 @@ func (c *GRPCClient) WatchRootEvents(ctx context.Context, req *coordpb.WatchRoot
 
 // AllocID forwards ID allocation RPC.
 func (c *GRPCClient) AllocID(ctx context.Context, req *coordpb.AllocIDRequest) (*coordpb.AllocIDResponse, error) {
-	return invokeRPCValidated(c, retryableWrite, func(coord coordpb.CoordinatorClient) (*coordpb.AllocIDResponse, error) {
+	return invokeDutyRPCValidated(c, rootproto.DutyAllocID, retryableWrite, func(coord coordpb.CoordinatorClient) (*coordpb.AllocIDResponse, error) {
 		return coord.AllocID(ctx, req)
 	}, func(resp *coordpb.AllocIDResponse) error {
 		return c.validateAllocIDResponse(req, resp)
@@ -339,7 +341,7 @@ func (c *GRPCClient) AllocID(ctx context.Context, req *coordpb.AllocIDRequest) (
 
 // Tso forwards TSO allocation RPC.
 func (c *GRPCClient) Tso(ctx context.Context, req *coordpb.TsoRequest) (*coordpb.TsoResponse, error) {
-	return invokeRPCValidated(c, retryableWrite, func(coord coordpb.CoordinatorClient) (*coordpb.TsoResponse, error) {
+	return invokeDutyRPCValidated(c, rootproto.DutyTSO, retryableWrite, func(coord coordpb.CoordinatorClient) (*coordpb.TsoResponse, error) {
 		return coord.Tso(ctx, req)
 	}, func(resp *coordpb.TsoResponse) error {
 		return c.validateTSOResponse(req, resp)
@@ -405,6 +407,10 @@ func closeAllEndpoints(endpoints []grpcEndpoint) {
 }
 
 func (c *GRPCClient) orderedEndpoints() []grpcEndpoint {
+	return c.orderedEndpointsForDuty("")
+}
+
+func (c *GRPCClient) orderedEndpointsForDuty(duty rootproto.DutyID) []grpcEndpoint {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	if len(c.endpoints) == 0 {
@@ -412,6 +418,11 @@ func (c *GRPCClient) orderedEndpoints() []grpcEndpoint {
 	}
 	out := make([]grpcEndpoint, 0, len(c.endpoints))
 	start := c.preferred
+	if duty != "" {
+		if preferred, ok := c.preferredByDuty[duty]; ok {
+			start = preferred
+		}
+	}
 	if start < 0 || start >= len(c.endpoints) {
 		start = 0
 	}
@@ -422,24 +433,39 @@ func (c *GRPCClient) orderedEndpoints() []grpcEndpoint {
 }
 
 func (c *GRPCClient) markPreferred(addr string) {
+	c.markPreferredForDuty("", addr)
+}
+
+func (c *GRPCClient) markPreferredForDuty(duty rootproto.DutyID, addr string) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	for i, endpoint := range c.endpoints {
 		if endpoint.addr == addr {
-			c.preferred = i
+			if duty == "" {
+				c.preferred = i
+			} else {
+				if c.preferredByDuty == nil {
+					c.preferredByDuty = make(map[rootproto.DutyID]int)
+				}
+				c.preferredByDuty[duty] = i
+			}
 			return
 		}
 	}
 }
 
 func invokeRPCValidated[T any](c *GRPCClient, retryable func(error) bool, call func(coord coordpb.CoordinatorClient) (T, error), validate func(T) error) (T, error) {
+	return invokeDutyRPCValidated(c, "", retryable, call, validate)
+}
+
+func invokeDutyRPCValidated[T any](c *GRPCClient, duty rootproto.DutyID, retryable func(error) bool, call func(coord coordpb.CoordinatorClient) (T, error), validate func(T) error) (T, error) {
 	var zero T
 	if c == nil {
 		return zero, errNoReachableAddress
 	}
 	var lastErr error
 	for round := range maxAuthorityMissRetryRounds {
-		endpoints := c.orderedEndpoints()
+		endpoints := c.orderedEndpointsForDuty(duty)
 		if len(endpoints) == 0 {
 			return zero, errNoReachableAddress
 		}
@@ -453,7 +479,7 @@ func invokeRPCValidated[T any](c *GRPCClient, retryable func(error) bool, call f
 				err = validate(resp)
 			}
 			if err == nil {
-				c.markPreferred(endpoint.addr)
+				c.markPreferredForDuty(duty, endpoint.addr)
 				return resp, nil
 			}
 			lastErr = err

--- a/coordinator/client/client_test.go
+++ b/coordinator/client/client_test.go
@@ -300,11 +300,16 @@ func (s *clientRootStorage) ApplyGrant(_ context.Context, cmd rootproto.GrantCom
 	holderID := strings.TrimSpace(cmd.HolderID)
 	switch cmd.Kind {
 	case rootproto.GrantActIssue:
-		active := s.snapshot.ActiveGrant
+		active, _ := clientActiveGrantFor(s.snapshot, cmd.RequestedDuties)
 		if active.Present() && active.HolderID != holderID && active.ActiveAt(cmd.NowUnixNano) {
 			return s.protocolStateLocked(), rootproto.GrantCertificate{}, rootstate.ErrPrimacy
 		}
-		era := active.Era + 1
+		var era uint64 = 1
+		for _, current := range s.snapshot.ActiveGrants {
+			if current.Era >= era {
+				era = current.Era + 1
+			}
+		}
 		for _, retirement := range s.snapshot.RetiredGrants {
 			if retirement.Era >= era {
 				era = retirement.Era + 1
@@ -326,29 +331,35 @@ func (s *clientRootStorage) ApplyGrant(_ context.Context, cmd rootproto.GrantCom
 			},
 			Duties: append([]rootproto.DutyGrant(nil), cmd.RequestedDuties...),
 		}
+		if active.Present() {
+			s.snapshot.ActiveGrants = clientRemoveGrantForTest(s.snapshot.ActiveGrants, active.GrantID)
+		}
 		s.applyEventLocked(rootevent.GrantIssued(grant))
-		return s.protocolStateLocked(), clientGrantCertificateForTest(s.snapshot.ActiveGrant), nil
+		issued, _ := s.snapshot.ActiveGrantByID(grant.GrantID)
+		return s.protocolStateLocked(), clientGrantCertificateForTest(issued), nil
 	case rootproto.GrantActSeal:
-		if !s.snapshot.ActiveGrant.Present() || s.snapshot.ActiveGrant.HolderID != holderID {
+		active, ok := s.snapshot.ActiveGrantByID(strings.TrimSpace(cmd.GrantID))
+		if !ok || active.HolderID != holderID {
 			return s.protocolStateLocked(), rootproto.GrantCertificate{}, rootstate.ErrPrimacy
 		}
 		retirement := rootproto.GrantRetirement{
-			GrantID:  s.snapshot.ActiveGrant.GrantID,
-			HolderID: s.snapshot.ActiveGrant.HolderID,
-			Era:      s.snapshot.ActiveGrant.Era,
+			GrantID:  active.GrantID,
+			HolderID: active.HolderID,
+			Era:      active.Era,
 			Mode:     rootproto.GrantRetirementSealedExact,
 			Bounds:   clientDutyGrantsFromUsages(cmd.ExactUsages),
 		}
 		if len(retirement.Bounds) == 0 {
-			retirement.Bounds = append([]rootproto.DutyGrant(nil), s.snapshot.ActiveGrant.Duties...)
+			retirement.Bounds = append([]rootproto.DutyGrant(nil), active.Duties...)
 		}
 		s.applyEventLocked(rootevent.GrantSealed(retirement))
 		return s.protocolStateLocked(), rootproto.GrantCertificate{}, nil
 	case rootproto.GrantActInherit:
-		if !s.snapshot.ActiveGrant.Present() || s.snapshot.ActiveGrant.HolderID != holderID {
+		active, ok := clientActiveGrantForHolder(s.snapshot, holderID)
+		if !ok {
 			return s.protocolStateLocked(), rootproto.GrantCertificate{}, rootstate.ErrPrimacy
 		}
-		successor := s.snapshot.ActiveGrant.GrantID
+		successor := active.GrantID
 		for _, predecessor := range cmd.PredecessorGrantIDs {
 			s.applyEventLocked(rootevent.GrantInherited(rootproto.GrantInheritance{
 				PredecessorGrantID: predecessor,
@@ -377,10 +388,40 @@ func (s *clientRootStorage) applyEventLocked(event rootevent.Event) {
 
 func (s *clientRootStorage) protocolStateLocked() rootstate.EunomiaState {
 	return rootstate.EunomiaState{
-		ActiveGrant:       s.snapshot.ActiveGrant,
+		ActiveGrants:      append([]rootproto.AuthorityGrant(nil), s.snapshot.ActiveGrants...),
 		RetiredGrants:     append([]rootproto.GrantRetirement(nil), s.snapshot.RetiredGrants...),
 		GrantInheritances: append([]rootproto.GrantInheritance(nil), s.snapshot.GrantInheritances...),
 	}
+}
+
+func clientActiveGrantFor(snapshot rootview.Snapshot, duties []rootproto.DutyGrant) (rootproto.AuthorityGrant, bool) {
+	for _, grant := range snapshot.ActiveGrants {
+		for _, duty := range duties {
+			if grant.CoversDutyKey(duty.Key()) {
+				return grant, true
+			}
+		}
+	}
+	return rootproto.AuthorityGrant{}, false
+}
+
+func clientActiveGrantForHolder(snapshot rootview.Snapshot, holderID string) (rootproto.AuthorityGrant, bool) {
+	for _, grant := range snapshot.ActiveGrants {
+		if strings.TrimSpace(grant.HolderID) == holderID {
+			return grant, true
+		}
+	}
+	return rootproto.AuthorityGrant{}, false
+}
+
+func clientRemoveGrantForTest(grants []rootproto.AuthorityGrant, grantID string) []rootproto.AuthorityGrant {
+	out := grants[:0]
+	for _, grant := range grants {
+		if grant.GrantID != grantID {
+			out = append(out, grant)
+		}
+	}
+	return out
 }
 
 func clientGrantCertificateForTest(grant rootproto.AuthorityGrant) rootproto.GrantCertificate {
@@ -460,7 +501,7 @@ func TestGRPCClientRetriesTSOAcrossGrantNotHeldEndpoint(t *testing.T) {
 	require.Equal(t, uint64(2), resp.GetCount())
 	require.Equal(t, 1, servers["standby"].tsoCalls)
 	require.Equal(t, 1, servers["holder"].tsoCalls)
-	require.Equal(t, "passthrough:///holder", cli.orderedEndpoints()[0].addr)
+	require.Equal(t, "passthrough:///holder", cli.orderedEndpointsForDuty(rootproto.DutyTSO)[0].addr)
 }
 
 func TestGRPCClientRetriesAllocIDAcrossGrantNotHeldEndpoint(t *testing.T) {
@@ -486,7 +527,7 @@ func TestGRPCClientRetriesAllocIDAcrossGrantNotHeldEndpoint(t *testing.T) {
 	require.Equal(t, uint64(3), resp.GetCount())
 	require.Equal(t, 1, servers["standby"].allocCalls)
 	require.Equal(t, 1, servers["holder"].allocCalls)
-	require.Equal(t, "passthrough:///holder", cli.orderedEndpoints()[0].addr)
+	require.Equal(t, "passthrough:///holder", cli.orderedEndpointsForDuty(rootproto.DutyAllocID)[0].addr)
 }
 
 func TestGRPCClientRetriesGetRegionByKeyAcrossGrantNotHeldEndpoint(t *testing.T) {
@@ -526,7 +567,7 @@ func TestGRPCClientRetriesGetRegionByKeyAcrossGrantNotHeldEndpoint(t *testing.T)
 	require.Equal(t, uint64(11), resp.GetRegionDescriptor().GetRegionId())
 	require.Equal(t, 1, servers["standby"].getCalls)
 	require.Equal(t, 1, servers["holder"].getCalls)
-	require.Equal(t, "passthrough:///holder", cli.orderedEndpoints()[0].addr)
+	require.Equal(t, "passthrough:///holder", cli.orderedEndpointsForDuty(rootproto.DutyRegionLookup)[0].addr)
 }
 
 func TestGRPCClientRetriesTSOAfterFullGrantMissRound(t *testing.T) {
@@ -552,7 +593,7 @@ func TestGRPCClientRetriesTSOAfterFullGrantMissRound(t *testing.T) {
 	require.Equal(t, uint64(300), resp.GetTimestamp())
 	require.Equal(t, 2, servers["standby"].tsoCalls)
 	require.Equal(t, 2, servers["holder"].tsoCalls)
-	require.Equal(t, "passthrough:///holder", cli.orderedEndpoints()[0].addr)
+	require.Equal(t, "passthrough:///holder", cli.orderedEndpointsForDuty(rootproto.DutyTSO)[0].addr)
 }
 
 func TestGRPCClientRejectsInvalidAllocWitness(t *testing.T) {
@@ -648,7 +689,7 @@ func TestGRPCClientRetriesStaleWitnessEraAcrossEndpoints(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, uint64(100), resp.GetFirstId())
 
-	cli.markPreferred("passthrough:///stale")
+	cli.markPreferredForDuty(rootproto.DutyAllocID, "passthrough:///stale")
 
 	resp, err = cli.AllocID(context.Background(), &coordpb.AllocIDRequest{Count: 1})
 	require.NoError(t, err)
@@ -805,7 +846,7 @@ func TestGRPCClientRetriesStaleMetadataWitnessEraAcrossEndpoints(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, uint64(11), resp.GetRegionDescriptor().GetRegionId())
 
-	cli.markPreferred("passthrough:///stale")
+	cli.markPreferredForDuty(rootproto.DutyRegionLookup, "passthrough:///stale")
 
 	resp, err = cli.GetRegionByKey(context.Background(), &coordpb.GetRegionByKeyRequest{
 		Key:                        []byte("m"),

--- a/coordinator/integration/control_plane_protocol_test.go
+++ b/coordinator/integration/control_plane_protocol_test.go
@@ -41,7 +41,7 @@ type protocolMatrixStorage struct {
 
 func (s *protocolMatrixStorage) protocolState() rootstate.EunomiaState {
 	return rootstate.EunomiaState{
-		ActiveGrant:       s.snapshot.ActiveGrant,
+		ActiveGrants:      append([]rootproto.AuthorityGrant(nil), s.snapshot.ActiveGrants...),
 		RetiredGrants:     append([]rootproto.GrantRetirement(nil), s.snapshot.RetiredGrants...),
 		GrantInheritances: append([]rootproto.GrantInheritance(nil), s.snapshot.GrantInheritances...),
 	}
@@ -72,17 +72,25 @@ func (s *protocolMatrixStorage) ApplyGrant(_ context.Context, cmd rootproto.Gran
 		if s.campaignErr != nil {
 			return rootstate.EunomiaState{}, rootproto.GrantCertificate{}, s.campaignErr
 		}
-		if s.snapshot.ActiveGrant.Present() &&
-			s.snapshot.ActiveGrant.GrantID == strings.TrimSpace(cmd.GrantID) &&
-			s.snapshot.ActiveGrant.HolderID == holderID &&
-			protocolTestDutiesCover(s.snapshot.ActiveGrant.Duties, cmd.RequestedDuties) {
-			return s.protocolState(), protocolTestGrantCertificate(s.snapshot.ActiveGrant), nil
+		active, _ := protocolTestActiveGrantForDuties(s.snapshot, cmd.RequestedDuties)
+		if active.Present() &&
+			active.GrantID == strings.TrimSpace(cmd.GrantID) &&
+			active.HolderID == holderID &&
+			protocolTestDutiesCover(active.Duties, cmd.RequestedDuties) {
+			return s.protocolState(), protocolTestGrantCertificate(active), nil
 		}
 		s.campaigns++
-		if s.snapshot.ActiveGrant.Present() && s.snapshot.ActiveGrant.HolderID != holderID && s.snapshot.ActiveGrant.ActiveAt(cmd.NowUnixNano) {
-			return s.protocolState(), rootproto.GrantCertificate{}, rootstate.ErrPrimacy
+		for _, current := range s.snapshot.ActiveGrants {
+			if current.HolderID != holderID && current.ActiveAt(cmd.NowUnixNano) && protocolTestDutiesOverlap(current.Duties, cmd.RequestedDuties) {
+				return s.protocolState(), rootproto.GrantCertificate{}, rootstate.ErrPrimacy
+			}
 		}
-		era := s.snapshot.ActiveGrant.Era + 1
+		var era uint64 = 1
+		for _, current := range s.snapshot.ActiveGrants {
+			if current.Era >= era {
+				era = current.Era + 1
+			}
+		}
 		for _, retired := range s.snapshot.RetiredGrants {
 			if retired.Era >= era {
 				era = retired.Era + 1
@@ -92,8 +100,8 @@ func (s *protocolMatrixStorage) ApplyGrant(_ context.Context, cmd rootproto.Gran
 		if grantID == "" {
 			grantID = fmt.Sprintf("%s/%d", holderID, era)
 		}
-		predecessors := pendingGrantRetirementsForTest(s.snapshot, cmd.NowUnixNano)
-		s.snapshot.ActiveGrant = rootproto.AuthorityGrant{
+		predecessors := pendingGrantRetirementsForTest(s.snapshot, cmd.NowUnixNano, cmd.RequestedDuties)
+		grant := rootproto.AuthorityGrant{
 			GrantID:                grantID,
 			HolderID:               holderID,
 			Era:                    era,
@@ -102,6 +110,10 @@ func (s *protocolMatrixStorage) ApplyGrant(_ context.Context, cmd rootproto.Gran
 			Duties:                 append([]rootproto.DutyGrant(nil), cmd.RequestedDuties...),
 			PredecessorRetirements: append([]rootproto.GrantRetirement(nil), predecessors...),
 		}
+		for _, predecessor := range predecessors {
+			s.snapshot.ActiveGrants = protocolTestRemoveGrant(s.snapshot.ActiveGrants, predecessor.GrantID)
+		}
+		s.snapshot.ActiveGrants = protocolTestUpsertGrant(s.snapshot.ActiveGrants, grant)
 		s.snapshot.RetiredGrants = append([]rootproto.GrantRetirement(nil), predecessors...)
 		for _, duty := range cmd.RequestedDuties {
 			if duty.Bound.Kind != rootproto.DutyBoundMonotone {
@@ -119,34 +131,35 @@ func (s *protocolMatrixStorage) ApplyGrant(_ context.Context, cmd rootproto.Gran
 			}
 		}
 		s.advanceRootToken()
-		return s.protocolState(), protocolTestGrantCertificate(s.snapshot.ActiveGrant), nil
+		return s.protocolState(), protocolTestGrantCertificate(grant), nil
 	case rootproto.GrantActSeal:
-		if !s.snapshot.ActiveGrant.Present() || s.snapshot.ActiveGrant.HolderID != strings.TrimSpace(cmd.HolderID) {
+		active, ok := s.snapshot.ActiveGrantByID(strings.TrimSpace(cmd.GrantID))
+		if !ok || active.HolderID != strings.TrimSpace(cmd.HolderID) {
 			return s.protocolState(), rootproto.GrantCertificate{}, rootstate.ErrPrimacy
 		}
 		s.snapshot.RetiredGrants = append(s.snapshot.RetiredGrants, rootproto.GrantRetirement{
-			GrantID:  s.snapshot.ActiveGrant.GrantID,
-			HolderID: s.snapshot.ActiveGrant.HolderID,
-			Era:      s.snapshot.ActiveGrant.Era,
+			GrantID:  active.GrantID,
+			HolderID: active.HolderID,
+			Era:      active.Era,
 			Mode:     rootproto.GrantRetirementSealedExact,
 			Bounds:   dutyGrantsFromUsagesForProtocolTest(cmd.ExactUsages),
 		})
-		s.snapshot.ActiveGrant = rootproto.AuthorityGrant{}
+		s.snapshot.ActiveGrants = protocolTestRemoveGrant(s.snapshot.ActiveGrants, active.GrantID)
 		s.advanceRootToken()
 		return s.protocolState(), rootproto.GrantCertificate{}, nil
 	case rootproto.GrantActInherit:
 		s.reattaches++
-		if !s.snapshot.ActiveGrant.Present() || s.snapshot.ActiveGrant.HolderID != holderID {
+		successor, ok := protocolTestActiveGrantForHolder(s.snapshot, holderID)
+		if !ok {
 			return s.protocolState(), rootproto.GrantCertificate{}, rootstate.ErrPrimacy
 		}
-		successor := s.snapshot.ActiveGrant.GrantID
 		for _, predecessor := range cmd.PredecessorGrantIDs {
 			for i := range s.snapshot.RetiredGrants {
 				if s.snapshot.RetiredGrants[i].GrantID == predecessor {
-					s.snapshot.RetiredGrants[i].InheritedByGrantID = successor
+					s.snapshot.RetiredGrants[i].InheritedByGrantID = successor.GrantID
 					s.snapshot.GrantInheritances = append(s.snapshot.GrantInheritances, rootproto.GrantInheritance{
 						PredecessorGrantID: predecessor,
-						SuccessorGrantID:   successor,
+						SuccessorGrantID:   successor.GrantID,
 					})
 				}
 			}
@@ -166,19 +179,22 @@ func (s *protocolMatrixStorage) advanceRootToken() {
 	s.snapshot.RootToken.Revision++
 }
 
-func pendingGrantRetirementsForTest(snapshot rootview.Snapshot, nowUnixNano int64) []rootproto.GrantRetirement {
+func pendingGrantRetirementsForTest(snapshot rootview.Snapshot, nowUnixNano int64, duties []rootproto.DutyGrant) []rootproto.GrantRetirement {
 	var out []rootproto.GrantRetirement
-	if snapshot.ActiveGrant.Present() {
+	for _, grant := range snapshot.ActiveGrants {
+		if !grant.Present() || !protocolTestDutiesOverlap(grant.Duties, duties) {
+			continue
+		}
 		mode := rootproto.GrantRetirementSealedExact
-		if !snapshot.ActiveGrant.ActiveAt(nowUnixNano) {
+		if !grant.ActiveAt(nowUnixNano) {
 			mode = rootproto.GrantRetirementExpiredBound
 		}
 		out = append(out, rootproto.GrantRetirement{
-			GrantID:  snapshot.ActiveGrant.GrantID,
-			HolderID: snapshot.ActiveGrant.HolderID,
-			Era:      snapshot.ActiveGrant.Era,
+			GrantID:  grant.GrantID,
+			HolderID: grant.HolderID,
+			Era:      grant.Era,
 			Mode:     mode,
-			Bounds:   append([]rootproto.DutyGrant(nil), snapshot.ActiveGrant.Duties...),
+			Bounds:   append([]rootproto.DutyGrant(nil), grant.Duties...),
 		})
 	}
 	for _, retired := range snapshot.RetiredGrants {
@@ -220,6 +236,56 @@ func protocolTestDutiesCover(grants, usages []rootproto.DutyGrant) bool {
 		}
 	}
 	return true
+}
+
+func protocolTestDutiesOverlap(left, right []rootproto.DutyGrant) bool {
+	for _, a := range left {
+		for _, b := range right {
+			if rootproto.DutyKeyEqual(a.Key(), b.Key()) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func protocolTestActiveGrantForDuties(snapshot rootview.Snapshot, duties []rootproto.DutyGrant) (rootproto.AuthorityGrant, bool) {
+	for _, grant := range snapshot.ActiveGrants {
+		if protocolTestDutiesOverlap(grant.Duties, duties) {
+			return grant, true
+		}
+	}
+	return rootproto.AuthorityGrant{}, false
+}
+
+func protocolTestActiveGrantForHolder(snapshot rootview.Snapshot, holderID string) (rootproto.AuthorityGrant, bool) {
+	for _, grant := range snapshot.ActiveGrants {
+		if strings.TrimSpace(grant.HolderID) == strings.TrimSpace(holderID) {
+			return grant, true
+		}
+	}
+	return rootproto.AuthorityGrant{}, false
+}
+
+func protocolTestUpsertGrant(grants []rootproto.AuthorityGrant, grant rootproto.AuthorityGrant) []rootproto.AuthorityGrant {
+	out := append([]rootproto.AuthorityGrant(nil), grants...)
+	for i := range out {
+		if out[i].GrantID == grant.GrantID {
+			out[i] = grant
+			return out
+		}
+	}
+	return append(out, grant)
+}
+
+func protocolTestRemoveGrant(grants []rootproto.AuthorityGrant, grantID string) []rootproto.AuthorityGrant {
+	out := grants[:0]
+	for _, grant := range grants {
+		if grant.GrantID != grantID {
+			out = append(out, grant)
+		}
+	}
+	return out
 }
 
 func (s *protocolMatrixStorage) Refresh() error { return nil }
@@ -331,7 +397,7 @@ func TestDetachedGrantFaultMatrix(t *testing.T) {
 		store := &protocolMatrixStorage{
 			leader: true,
 			snapshot: rootview.Snapshot{
-				ActiveGrant: grant("c2", 1, rootproto.NewGlobalMonotoneDuty(rootproto.DutyAllocID, 20)),
+				ActiveGrants: []rootproto.AuthorityGrant{grant("c2", 1, rootproto.NewGlobalMonotoneDuty(rootproto.DutyAllocID, 20))},
 			},
 		}
 		svc := coordserver.NewService(catalog.NewCluster(), idalloc.NewIDAllocator(10), tso.NewAllocator(100), store)
@@ -347,11 +413,11 @@ func TestDetachedGrantFaultMatrix(t *testing.T) {
 		store := &protocolMatrixStorage{
 			leader: true,
 			snapshot: rootview.Snapshot{
-				ActiveGrant: grant("c1", 1,
+				ActiveGrants: []rootproto.AuthorityGrant{grant("c1", 1,
 					rootproto.NewGlobalMonotoneDuty(rootproto.DutyAllocID, 20),
 					rootproto.NewGlobalMonotoneDuty(rootproto.DutyTSO, 120),
 					rootproto.NewGlobalVersionDuty(rootproto.DutyRegionLookup, rootproto.AuthorityRootToken{}, 6, 0),
-				),
+				)},
 				Descriptors: map[uint64]topology.Descriptor{1: descriptor},
 			},
 		}
@@ -380,7 +446,7 @@ func TestDetachedGrantFaultMatrix(t *testing.T) {
 		store := &protocolMatrixStorage{
 			leader: true,
 			snapshot: rootview.Snapshot{
-				ActiveGrant:   grant("c2", 2, rootproto.NewGlobalMonotoneDuty(rootproto.DutyAllocID, 40)),
+				ActiveGrants:  []rootproto.AuthorityGrant{grant("c2", 2, rootproto.NewGlobalMonotoneDuty(rootproto.DutyAllocID, 40))},
 				RetiredGrants: []rootproto.GrantRetirement{retired},
 			},
 		}
@@ -411,7 +477,7 @@ func TestDetachedLateReplyAfterRetiredGrantRejectedByClientVerifier(t *testing.T
 	staleStore := &protocolMatrixStorage{
 		leader: true,
 		snapshot: rootview.Snapshot{
-			ActiveGrant: c1Grant,
+			ActiveGrants: []rootproto.AuthorityGrant{c1Grant},
 		},
 	}
 	staleSvc := coordserver.NewService(catalog.NewCluster(), idalloc.NewIDAllocator(10), tso.NewAllocator(100), staleStore)
@@ -434,7 +500,7 @@ func TestDetachedLateReplyAfterRetiredGrantRejectedByClientVerifier(t *testing.T
 	successorStore := &protocolMatrixStorage{
 		leader: true,
 		snapshot: rootview.Snapshot{
-			ActiveGrant: rootproto.AuthorityGrant{
+			ActiveGrants: []rootproto.AuthorityGrant{{
 				GrantID:         "c2/2",
 				HolderID:        "c2",
 				ExpiresUnixNano: activeExpiry,
@@ -445,7 +511,7 @@ func TestDetachedLateReplyAfterRetiredGrantRejectedByClientVerifier(t *testing.T
 					rootproto.NewGlobalVersionDuty(rootproto.DutyRegionLookup, rootproto.AuthorityRootToken{}, 0, 0),
 				},
 				PredecessorRetirements: []rootproto.GrantRetirement{retired},
-			},
+			}},
 			RetiredGrants: []rootproto.GrantRetirement{retired},
 		},
 	}

--- a/coordinator/integration/separated_mode_test.go
+++ b/coordinator/integration/separated_mode_test.go
@@ -54,7 +54,8 @@ func TestSeparatedModeCoordinatorCrashAndRecoveryPreservesAllocatorFence(t *test
 			return false
 		}
 		return state.IDFence >= next.GetFirstId() &&
-			state.ActiveGrant.HolderID == "c1" &&
+			len(state.ActiveGrants) > 0 &&
+			state.ActiveGrants[0].HolderID == "c1" &&
 			state.IDFence >= lastID
 	}, 8*time.Second, 50*time.Millisecond)
 }
@@ -199,7 +200,8 @@ func TestSeparatedModeCoordinatorContestedFailoverPreservesAllocatorFence(t *tes
 		if currentErr != nil {
 			return false
 		}
-		return state.ActiveGrant.HolderID == "c2" &&
+		return len(state.ActiveGrants) > 0 &&
+			state.ActiveGrants[0].HolderID == "c2" &&
 			state.IDFence >= lastID &&
 			state.IDFence >= next.GetFirstId()
 	}, 8*time.Second, 50*time.Millisecond)
@@ -271,7 +273,8 @@ func TestSeparatedModeCoordinatorChaosMonotonicAllocID(t *testing.T) {
 			require.Eventually(t, func() bool {
 				state, err := rootCluster.Roots[leaderID].Current()
 				return err == nil &&
-					state.ActiveGrant.HolderID == "c1" &&
+					len(state.ActiveGrants) > 0 &&
+					state.ActiveGrants[0].HolderID == "c1" &&
 					state.IDFence >= prevLastID
 			}, 8*time.Second, 50*time.Millisecond, "iteration %d grant campaign did not inherit previous allocator fence", i)
 		}

--- a/coordinator/rootview/root.go
+++ b/coordinator/rootview/root.go
@@ -391,7 +391,7 @@ func (s *RootStore) applyAndReload(run func() (rootstate.EunomiaState, error)) (
 }
 
 func eunomiaStatePresent(state rootstate.EunomiaState) bool {
-	return state.ActiveGrant.Present() ||
+	return len(state.ActiveGrants) > 0 ||
 		len(state.RetiredGrants) > 0 ||
 		len(state.GrantInheritances) > 0 ||
 		state.RetiredEraFloor != 0
@@ -406,14 +406,14 @@ func (s *RootStore) mergeEunomiaState(state rootstate.EunomiaState) {
 		return
 	}
 	incoming := Snapshot{
-		ActiveGrant:       state.ActiveGrant,
+		ActiveGrants:      cloneAuthorityGrants(state.ActiveGrants),
 		RetiredGrants:     append([]rootproto.GrantRetirement(nil), state.RetiredGrants...),
 		GrantInheritances: append([]rootproto.GrantInheritance(nil), state.GrantInheritances...),
 		RetiredEraFloor:   state.RetiredEraFloor,
 	}
 	s.mu.Lock()
 	merged := PreserveNewerAuthorityState(incoming, s.snapshot)
-	s.snapshot.ActiveGrant = merged.ActiveGrant
+	s.snapshot.ActiveGrants = cloneAuthorityGrants(merged.ActiveGrants)
 	s.snapshot.RetiredGrants = append([]rootproto.GrantRetirement(nil), merged.RetiredGrants...)
 	s.snapshot.GrantInheritances = append([]rootproto.GrantInheritance(nil), merged.GrantInheritances...)
 	s.snapshot.RetiredEraFloor = merged.RetiredEraFloor

--- a/coordinator/rootview/root_test.go
+++ b/coordinator/rootview/root_test.go
@@ -151,7 +151,7 @@ func (f *fakeRootBackend) ApplyGrant(_ context.Context, _ rootproto.GrantCommand
 	if f.applyGrantErr != nil {
 		return f.applyGrantResult, rootproto.GrantCertificate{}, f.applyGrantErr
 	}
-	f.snapshot.State.ActiveGrant = f.applyGrantResult.ActiveGrant
+	f.snapshot.State.ActiveGrants = append([]rootproto.AuthorityGrant(nil), f.applyGrantResult.ActiveGrants...)
 	f.snapshot.State.RetiredGrants = append([]rootproto.GrantRetirement(nil), f.applyGrantResult.RetiredGrants...)
 	f.snapshot.State.GrantInheritances = append([]rootproto.GrantInheritance(nil), f.applyGrantResult.GrantInheritances...)
 	if f.useObserved {
@@ -213,12 +213,12 @@ func TestSnapshotHelpersAndBootstrap(t *testing.T) {
 			desc1.RegionID: {Kind: rootstate.PendingRangeChangeSplit, ParentRegionID: desc1.RegionID, Left: desc1, Right: desc2},
 		},
 		Allocator: AllocatorState{IDCurrent: 20, TSCurrent: 30},
-		ActiveGrant: rootproto.AuthorityGrant{
+		ActiveGrants: []rootproto.AuthorityGrant{{
 			GrantID:         "grant-7",
 			HolderID:        "coord",
 			Era:             7,
 			ExpiresUnixNano: 999,
-		},
+		}},
 	}
 
 	cloned := CloneSnapshot(snapshot)
@@ -233,7 +233,7 @@ func TestSnapshotHelpersAndBootstrap(t *testing.T) {
 			LastCommitted: rootstate.Cursor{Term: 3, Index: 10},
 			IDFence:       40,
 			TSOFence:      50,
-			ActiveGrant:   snapshot.ActiveGrant,
+			ActiveGrants:  snapshot.ActiveGrants,
 		},
 		Stores: map[uint64]rootstate.StoreMembership{
 			7: {StoreID: 7, State: rootstate.StoreMembershipActive, JoinedAt: rootstate.Cursor{Term: 2, Index: 3}},
@@ -389,13 +389,13 @@ func TestRootStoreWithOptionalBackend(t *testing.T) {
 			rootstorage.TailToken{Cursor: rootstate.Cursor{Term: 1, Index: 2}, Revision: 2},
 		),
 		applyGrantResult: rootstate.EunomiaState{
-			ActiveGrant: rootproto.AuthorityGrant{
+			ActiveGrants: []rootproto.AuthorityGrant{{
 				GrantID:         "grant-2",
 				HolderID:        "coord-2",
 				Era:             2,
 				ExpiresUnixNano: 999,
 				Duties:          []rootproto.DutyGrant{rootproto.NewGlobalMonotoneDuty(rootproto.DutyAllocID, 50)},
-			},
+			}},
 		},
 	}
 
@@ -433,11 +433,11 @@ func TestRootStoreWithOptionalBackend(t *testing.T) {
 
 	leaseState, _, err := store.ApplyGrant(context.Background(), rootproto.GrantCommand{Kind: rootproto.GrantActIssue})
 	require.NoError(t, err)
-	require.Equal(t, "coord-2", leaseState.ActiveGrant.HolderID)
+	require.Equal(t, "coord-2", leaseState.ActiveGrants[0].HolderID)
 
 	sealState, _, err := store.ApplyGrant(context.Background(), rootproto.GrantCommand{Kind: rootproto.GrantActSeal, GrantID: "grant-2"})
 	require.NoError(t, err)
-	require.Equal(t, "coord-2", sealState.ActiveGrant.HolderID)
+	require.Equal(t, "coord-2", sealState.ActiveGrants[0].HolderID)
 
 	require.NoError(t, store.Close())
 	require.True(t, fake.closeCalled)
@@ -447,22 +447,22 @@ func TestRootStoreMergesGrantStateFromHeldRejection(t *testing.T) {
 	initial := rootstate.Snapshot{
 		State: rootstate.State{
 			LastCommitted: rootstate.Cursor{Term: 1, Index: 10},
-			ActiveGrant: rootproto.AuthorityGrant{
+			ActiveGrants: []rootproto.AuthorityGrant{{
 				GrantID:         "stale-grant",
 				HolderID:        "stale",
 				Era:             1,
 				ExpiresUnixNano: 100,
-			},
+			}},
 		},
 	}
 	authoritative := rootstate.EunomiaState{
-		ActiveGrant: rootproto.AuthorityGrant{
+		ActiveGrants: []rootproto.AuthorityGrant{{
 			GrantID:         "grant-2",
 			HolderID:        "coord-1",
 			Era:             2,
 			ExpiresUnixNano: 1_000,
 			Duties:          []rootproto.DutyGrant{rootproto.NewGlobalMonotoneDuty(rootproto.DutyAllocID, 10)},
-		},
+		}},
 	}
 	fake := &fakeRootBackend{
 		snapshot:         initial,
@@ -480,31 +480,31 @@ func TestRootStoreMergesGrantStateFromHeldRejection(t *testing.T) {
 	require.Equal(t, authoritative, state)
 	loaded, err := store.Load()
 	require.NoError(t, err)
-	require.Equal(t, "coord-1", loaded.ActiveGrant.HolderID)
-	require.Equal(t, uint64(2), loaded.ActiveGrant.Era)
+	require.Equal(t, "coord-1", loaded.ActiveGrants[0].HolderID)
+	require.Equal(t, uint64(2), loaded.ActiveGrants[0].Era)
 }
 
 func TestRootStorePreservesAppliedGrantAcrossStaleObservedReload(t *testing.T) {
 	stale := rootstate.Snapshot{
 		State: rootstate.State{
 			LastCommitted: rootstate.Cursor{Term: 1, Index: 10},
-			ActiveGrant: rootproto.AuthorityGrant{
+			ActiveGrants: []rootproto.AuthorityGrant{{
 				GrantID:         "stale-grant",
 				HolderID:        "coord-2",
 				Era:             1,
 				ExpiresUnixNano: 1_000,
-			},
+			}},
 		},
 	}
 	authoritative := rootstate.EunomiaState{
-		ActiveGrant: rootproto.AuthorityGrant{
+		ActiveGrants: []rootproto.AuthorityGrant{{
 			GrantID:         "grant-2",
 			HolderID:        "coord-1",
 			Era:             2,
 			ExpiresUnixNano: 2_000,
 			IssuedAt:        rootstate.Cursor{Term: 1, Index: 11},
 			Duties:          []rootproto.DutyGrant{rootproto.NewGlobalMonotoneDuty(rootproto.DutyTSO, 20)},
-		},
+		}},
 	}
 	fake := &fakeRootBackend{
 		snapshot:         stale,
@@ -521,42 +521,45 @@ func TestRootStorePreservesAppliedGrantAcrossStaleObservedReload(t *testing.T) {
 	require.Equal(t, authoritative, state)
 	loaded, err := store.Load()
 	require.NoError(t, err)
-	require.Equal(t, "coord-1", loaded.ActiveGrant.HolderID)
-	require.Equal(t, uint64(2), loaded.ActiveGrant.Era)
+	require.Equal(t, "coord-1", loaded.ActiveGrants[0].HolderID)
+	require.Equal(t, uint64(2), loaded.ActiveGrants[0].Era)
 }
 
 func TestRootStoreDoesNotOverwriteFresherReloadWithOlderApplyGrantResult(t *testing.T) {
 	initial := rootstate.Snapshot{
 		State: rootstate.State{
 			LastCommitted: rootstate.Cursor{Term: 1, Index: 10},
-			ActiveGrant: rootproto.AuthorityGrant{
+			ActiveGrants: []rootproto.AuthorityGrant{{
 				GrantID:         "grant-1",
 				HolderID:        "coord-1",
 				Era:             1,
 				ExpiresUnixNano: 1_000,
-			},
+				Duties:          []rootproto.DutyGrant{rootproto.NewGlobalMonotoneDuty(rootproto.DutyAllocID, 10)},
+			}},
 		},
 	}
 	fresher := rootstate.Snapshot{
 		State: rootstate.State{
 			LastCommitted: rootstate.Cursor{Term: 1, Index: 12},
-			ActiveGrant: rootproto.AuthorityGrant{
+			ActiveGrants: []rootproto.AuthorityGrant{{
 				GrantID:         "grant-3",
 				HolderID:        "coord-3",
 				Era:             3,
 				ExpiresUnixNano: 3_000,
 				IssuedAt:        rootstate.Cursor{Term: 1, Index: 12},
-			},
+				Duties:          []rootproto.DutyGrant{rootproto.NewGlobalMonotoneDuty(rootproto.DutyAllocID, 30)},
+			}},
 		},
 	}
 	olderApply := rootstate.EunomiaState{
-		ActiveGrant: rootproto.AuthorityGrant{
+		ActiveGrants: []rootproto.AuthorityGrant{{
 			GrantID:         "grant-2",
 			HolderID:        "coord-2",
 			Era:             2,
 			ExpiresUnixNano: 2_000,
 			IssuedAt:        rootstate.Cursor{Term: 1, Index: 11},
-		},
+			Duties:          []rootproto.DutyGrant{rootproto.NewGlobalMonotoneDuty(rootproto.DutyAllocID, 20)},
+		}},
 	}
 	fake := &fakeRootBackend{
 		snapshot:         initial,
@@ -572,8 +575,39 @@ func TestRootStoreDoesNotOverwriteFresherReloadWithOlderApplyGrantResult(t *test
 	require.NoError(t, err)
 	loaded, err := store.Load()
 	require.NoError(t, err)
-	require.Equal(t, "coord-3", loaded.ActiveGrant.HolderID)
-	require.Equal(t, uint64(3), loaded.ActiveGrant.Era)
+	require.Equal(t, "coord-3", loaded.ActiveGrants[0].HolderID)
+	require.Equal(t, uint64(3), loaded.ActiveGrants[0].Era)
+}
+
+func TestPreserveNewerAuthorityStateMergesPerDuty(t *testing.T) {
+	observed := Snapshot{
+		ActiveGrants: []rootproto.AuthorityGrant{{
+			GrantID:         "alloc/3",
+			HolderID:        "coord-1",
+			Era:             3,
+			IssuedAt:        rootstate.Cursor{Term: 1, Index: 30},
+			ExpiresUnixNano: 3_000,
+			Duties:          []rootproto.DutyGrant{rootproto.NewGlobalMonotoneDuty(rootproto.DutyAllocID, 30)},
+		}},
+	}
+	current := Snapshot{
+		ActiveGrants: []rootproto.AuthorityGrant{{
+			GrantID:         "tso/4",
+			HolderID:        "coord-2",
+			Era:             4,
+			IssuedAt:        rootstate.Cursor{Term: 1, Index: 40},
+			ExpiresUnixNano: 4_000,
+			Duties:          []rootproto.DutyGrant{rootproto.NewGlobalMonotoneDuty(rootproto.DutyTSO, 40)},
+		}},
+	}
+
+	merged := PreserveNewerAuthorityState(observed, current)
+	alloc, ok := merged.ActiveGrantFor(rootproto.DutyAllocID, rootproto.DutyScope{Kind: rootproto.DutyScopeGlobal})
+	require.True(t, ok)
+	require.Equal(t, "coord-1", alloc.HolderID)
+	tso, ok := merged.ActiveGrantFor(rootproto.DutyTSO, rootproto.DutyScope{Kind: rootproto.DutyScopeGlobal})
+	require.True(t, ok)
+	require.Equal(t, "coord-2", tso.HolderID)
 }
 
 func TestRootStoreUnsupportedApplyCommands(t *testing.T) {

--- a/coordinator/rootview/snapshot.go
+++ b/coordinator/rootview/snapshot.go
@@ -56,10 +56,28 @@ type Snapshot struct {
 	PendingPeerChanges  map[uint64]rootstate.PendingPeerChange
 	PendingRangeChanges map[uint64]rootstate.PendingRangeChange
 	Allocator           AllocatorState
-	ActiveGrant         rootproto.AuthorityGrant
+	ActiveGrants        []rootproto.AuthorityGrant
 	RetiredGrants       []rootproto.GrantRetirement
 	GrantInheritances   []rootproto.GrantInheritance
 	RetiredEraFloor     uint64
+}
+
+func (s Snapshot) ActiveGrantFor(duty rootproto.DutyID, scope rootproto.DutyScope) (rootproto.AuthorityGrant, bool) {
+	for _, grant := range s.ActiveGrants {
+		if grant.CoversDutyKey(rootproto.DutyKey{DutyID: duty, Scope: scope}) {
+			return cloneAuthorityGrant(grant), true
+		}
+	}
+	return rootproto.AuthorityGrant{}, false
+}
+
+func (s Snapshot) ActiveGrantByID(grantID string) (rootproto.AuthorityGrant, bool) {
+	for _, grant := range s.ActiveGrants {
+		if grant.GrantID == grantID {
+			return cloneAuthorityGrant(grant), true
+		}
+	}
+	return rootproto.AuthorityGrant{}, false
 }
 
 func CloneSnapshot(snapshot Snapshot) Snapshot {
@@ -76,7 +94,7 @@ func CloneSnapshot(snapshot Snapshot) Snapshot {
 		PendingPeerChanges:  rootstate.ClonePendingPeerChanges(snapshot.PendingPeerChanges),
 		PendingRangeChanges: rootstate.ClonePendingRangeChanges(snapshot.PendingRangeChanges),
 		Allocator:           snapshot.Allocator,
-		ActiveGrant:         snapshot.ActiveGrant,
+		ActiveGrants:        cloneAuthorityGrants(snapshot.ActiveGrants),
 		RetiredGrants:       append([]rootproto.GrantRetirement(nil), snapshot.RetiredGrants...),
 		GrantInheritances:   append([]rootproto.GrantInheritance(nil), snapshot.GrantInheritances...),
 		RetiredEraFloor:     snapshot.RetiredEraFloor,
@@ -89,37 +107,26 @@ func CloneSnapshot(snapshot Snapshot) Snapshot {
 // Eunomia authority mirror is protected against stale replacement.
 func PreserveNewerAuthorityState(observed, current Snapshot) Snapshot {
 	out := CloneSnapshot(observed)
-	if !authorityStateNewer(current, observed) {
-		return out
+	for _, currentGrant := range current.ActiveGrants {
+		if !currentGrant.Present() || observedRetiresGrant(observed, currentGrant) {
+			continue
+		}
+		observedGrant, ok := activeGrantOverlapping(out.ActiveGrants, currentGrant)
+		if ok && !authorityGrantNewer(currentGrant, observedGrant) {
+			continue
+		}
+		out.ActiveGrants = removeOverlappingActiveGrant(out.ActiveGrants, currentGrant)
+		out.ActiveGrants = append(out.ActiveGrants, cloneAuthorityGrant(currentGrant))
 	}
-	out.ActiveGrant = current.ActiveGrant
-	out.RetiredGrants = append([]rootproto.GrantRetirement(nil), current.RetiredGrants...)
-	out.GrantInheritances = append([]rootproto.GrantInheritance(nil), current.GrantInheritances...)
-	out.RetiredEraFloor = current.RetiredEraFloor
+	out.RetiredGrants = mergeGrantRetirements(out.RetiredGrants, current.RetiredGrants)
+	out.GrantInheritances = mergeGrantInheritances(out.GrantInheritances, current.GrantInheritances)
+	if current.RetiredEraFloor > out.RetiredEraFloor {
+		out.RetiredEraFloor = current.RetiredEraFloor
+	}
 	return out
 }
 
-func authorityStateNewer(current, observed Snapshot) bool {
-	currentGeneration := authorityGeneration(current)
-	observedGeneration := authorityGeneration(observed)
-	if currentGeneration > observedGeneration {
-		return true
-	}
-	if currentGeneration < observedGeneration {
-		return false
-	}
-	if observedRetiresGrant(observed, current.ActiveGrant) {
-		return false
-	}
-	currentCursor := authorityCursor(current)
-	observedCursor := authorityCursor(observed)
-	return rootstate.CursorAfter(currentCursor, observedCursor)
-}
-
 func observedRetiresGrant(observed Snapshot, grant rootproto.AuthorityGrant) bool {
-	if !grant.Present() {
-		return false
-	}
 	for _, retirement := range observed.RetiredGrants {
 		if retirement.GrantID == grant.GrantID && retirement.Era == grant.Era {
 			return true
@@ -128,29 +135,73 @@ func observedRetiresGrant(observed Snapshot, grant rootproto.AuthorityGrant) boo
 	return false
 }
 
-func authorityGeneration(snapshot Snapshot) uint64 {
-	generation := max(snapshot.RetiredEraFloor, snapshot.ActiveGrant.Era)
-	for _, retirement := range snapshot.RetiredGrants {
-		if retirement.Era > generation {
-			generation = retirement.Era
+func activeGrantOverlapping(grants []rootproto.AuthorityGrant, needle rootproto.AuthorityGrant) (rootproto.AuthorityGrant, bool) {
+	for _, grant := range grants {
+		if authorityGrantsOverlap(grant, needle) {
+			return grant, true
 		}
 	}
-	return generation
+	return rootproto.AuthorityGrant{}, false
 }
 
-func authorityCursor(snapshot Snapshot) rootstate.Cursor {
-	cursor := snapshot.ActiveGrant.IssuedAt
-	for _, retirement := range snapshot.RetiredGrants {
-		if rootstate.CursorAfter(retirement.RetiredAt, cursor) {
-			cursor = retirement.RetiredAt
+func authorityGrantNewer(current, observed rootproto.AuthorityGrant) bool {
+	if current.Era != observed.Era {
+		return current.Era > observed.Era
+	}
+	return rootstate.CursorAfter(current.IssuedAt, observed.IssuedAt)
+}
+
+func removeOverlappingActiveGrant(grants []rootproto.AuthorityGrant, needle rootproto.AuthorityGrant) []rootproto.AuthorityGrant {
+	out := grants[:0]
+	for _, grant := range grants {
+		if !authorityGrantsOverlap(grant, needle) {
+			out = append(out, grant)
 		}
 	}
-	for _, inheritance := range snapshot.GrantInheritances {
-		if rootstate.CursorAfter(inheritance.InheritedAt, cursor) {
-			cursor = inheritance.InheritedAt
+	return out
+}
+
+func authorityGrantsOverlap(left, right rootproto.AuthorityGrant) bool {
+	for _, a := range left.Duties {
+		for _, b := range right.Duties {
+			if rootproto.DutyKeyEqual(a.Key(), b.Key()) {
+				return true
+			}
 		}
 	}
-	return cursor
+	return false
+}
+
+func mergeGrantRetirements(observed, current []rootproto.GrantRetirement) []rootproto.GrantRetirement {
+	out := append([]rootproto.GrantRetirement(nil), observed...)
+	seen := make(map[string]struct{}, len(out))
+	for _, retirement := range out {
+		seen[retirement.GrantID] = struct{}{}
+	}
+	for _, retirement := range current {
+		if _, ok := seen[retirement.GrantID]; ok {
+			continue
+		}
+		seen[retirement.GrantID] = struct{}{}
+		out = append(out, retirement)
+	}
+	return out
+}
+
+func mergeGrantInheritances(observed, current []rootproto.GrantInheritance) []rootproto.GrantInheritance {
+	out := append([]rootproto.GrantInheritance(nil), observed...)
+	seen := make(map[string]struct{}, len(out))
+	for _, inheritance := range out {
+		seen[inheritance.PredecessorGrantID] = struct{}{}
+	}
+	for _, inheritance := range current {
+		if _, ok := seen[inheritance.PredecessorGrantID]; ok {
+			continue
+		}
+		seen[inheritance.PredecessorGrantID] = struct{}{}
+		out = append(out, inheritance)
+	}
+	return out
 }
 
 func SnapshotFromRoot(snapshot rootstate.Snapshot) Snapshot {
@@ -173,7 +224,7 @@ func SnapshotFromRoot(snapshot rootstate.Snapshot) Snapshot {
 			IDCurrent: snapshot.State.IDFence,
 			TSCurrent: snapshot.State.TSOFence,
 		},
-		ActiveGrant:       snapshot.State.ActiveGrant,
+		ActiveGrants:      cloneAuthorityGrants(snapshot.State.ActiveGrants),
 		RetiredGrants:     append([]rootproto.GrantRetirement(nil), snapshot.State.RetiredGrants...),
 		GrantInheritances: append([]rootproto.GrantInheritance(nil), snapshot.State.GrantInheritances...),
 		RetiredEraFloor:   snapshot.State.RetiredEraFloor,
@@ -187,7 +238,7 @@ func (s Snapshot) RootSnapshot() rootstate.Snapshot {
 			LastCommitted:     s.RootToken.Cursor,
 			IDFence:           s.Allocator.IDCurrent,
 			TSOFence:          s.Allocator.TSCurrent,
-			ActiveGrant:       s.ActiveGrant,
+			ActiveGrants:      cloneAuthorityGrants(s.ActiveGrants),
 			RetiredGrants:     append([]rootproto.GrantRetirement(nil), s.RetiredGrants...),
 			GrantInheritances: append([]rootproto.GrantInheritance(nil), s.GrantInheritances...),
 			RetiredEraFloor:   s.RetiredEraFloor,
@@ -201,6 +252,25 @@ func (s Snapshot) RootSnapshot() rootstate.Snapshot {
 		PendingPeerChanges:  rootstate.ClonePendingPeerChanges(s.PendingPeerChanges),
 		PendingRangeChanges: rootstate.ClonePendingRangeChanges(s.PendingRangeChanges),
 	}
+}
+
+func cloneAuthorityGrants(grants []rootproto.AuthorityGrant) []rootproto.AuthorityGrant {
+	if len(grants) == 0 {
+		return nil
+	}
+	out := make([]rootproto.AuthorityGrant, len(grants))
+	for i, grant := range grants {
+		grant.Duties = append([]rootproto.DutyGrant(nil), grant.Duties...)
+		grant.PredecessorRetirements = append([]rootproto.GrantRetirement(nil), grant.PredecessorRetirements...)
+		out[i] = grant
+	}
+	return out
+}
+
+func cloneAuthorityGrant(grant rootproto.AuthorityGrant) rootproto.AuthorityGrant {
+	grant.Duties = append([]rootproto.DutyGrant(nil), grant.Duties...)
+	grant.PredecessorRetirements = append([]rootproto.GrantRetirement(nil), grant.PredecessorRetirements...)
+	return grant
 }
 
 // SnapshotRetentionFloor returns the oldest active fsmeta snapshot read version

--- a/coordinator/server/diagnostics.go
+++ b/coordinator/server/diagnostics.go
@@ -45,7 +45,7 @@ func (s *Service) DiagnosticsSnapshot() map[string]any {
 	snapshotRetention := rootSnapshot.SnapshotRetentionIndex()
 
 	nowUnixNano, _, holderID, renewIn, clockSkew := s.grantCampaignBounds()
-	grant := rootSnapshot.ActiveGrant
+	grant := diagnosticsPrimaryGrant(rootSnapshot)
 	latestRetirement := diagnosticsLatestRetirement(rootSnapshot.RetiredGrants)
 
 	s.allocMu.Lock()
@@ -181,6 +181,16 @@ func (s *Service) DiagnosticsSnapshot() map[string]any {
 		},
 		"eunomia_metrics": s.eunomiaMetrics.snapshot(),
 	}
+}
+
+func diagnosticsPrimaryGrant(snapshot rootview.Snapshot) rootproto.AuthorityGrant {
+	if grant, ok := snapshot.ActiveGrantFor(rootproto.DutyRegionLookup, rootproto.DutyScope{Kind: rootproto.DutyScopeGlobal}); ok {
+		return grant
+	}
+	if len(snapshot.ActiveGrants) > 0 {
+		return snapshot.ActiveGrants[0]
+	}
+	return rootproto.AuthorityGrant{}
 }
 
 func diagnosticsTailToken(token rootstorage.TailToken) map[string]any {

--- a/coordinator/server/service.go
+++ b/coordinator/server/service.go
@@ -17,6 +17,8 @@
 package server
 
 import (
+	"sort"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -40,29 +42,30 @@ import (
 type Service struct {
 	coordpb.UnimplementedCoordinatorServer
 
-	cluster           *catalog.Cluster
-	ids               *idalloc.IDAllocator
-	tso               *tso.Allocator
-	storage           rootview.RootStorage
-	idWindowHigh      uint64
-	idWindowSize      uint64
-	tsoWindowHigh     uint64
-	tsoWindowSize     uint64
-	allocMu           sync.Mutex
-	writeMu           sync.Mutex
-	grantMu           sync.RWMutex
-	coordinatorID     string
-	grantTTL          time.Duration
-	grantRenewIn      time.Duration
-	grantClockSkew    time.Duration
-	now               func() time.Time
-	grantView         coordinatorGrantView
-	authorityMu       sync.Mutex
-	authorityState    authorityServingState
-	authorityInflight uint64
-	rootViewMu        sync.RWMutex
-	rootView          coordinatorRootSnapshotView
-	rootViewTTL       time.Duration
+	cluster         *catalog.Cluster
+	ids             *idalloc.IDAllocator
+	tso             *tso.Allocator
+	storage         rootview.RootStorage
+	idWindowHigh    uint64
+	idWindowSize    uint64
+	tsoWindowHigh   uint64
+	tsoWindowSize   uint64
+	allocMu         sync.Mutex
+	writeMu         sync.Mutex
+	grantMu         sync.RWMutex
+	coordinatorID   string
+	grantTTL        time.Duration
+	grantRenewIn    time.Duration
+	grantClockSkew  time.Duration
+	grantCandidates []string
+	grantDuties     []rootproto.DutyID
+	now             func() time.Time
+	grantView       coordinatorGrantView
+	authorityMu     sync.Mutex
+	authorityDuties map[rootproto.DutyID]authorityDutyServing
+	rootViewMu      sync.RWMutex
+	rootView        coordinatorRootSnapshotView
+	rootViewTTL     time.Duration
 	// storeHeartbeatTTL holds the time.Duration value as an int64 so callers
 	// (storeState reads, ConfigureStoreHeartbeatTTL writes) avoid a data race
 	// without taking a lock on the read path.
@@ -94,9 +97,14 @@ func (s authorityServingState) String() string {
 	}
 }
 
+type authorityDutyServing struct {
+	state    authorityServingState
+	inflight uint64
+}
+
 type coordinatorGrantView struct {
-	grant           rootproto.AuthorityGrant
-	certificate     rootproto.GrantCertificate
+	grants          []rootproto.AuthorityGrant
+	certificates    map[string]rootproto.GrantCertificate
 	retirements     []rootproto.GrantRetirement
 	inheritances    []rootproto.GrantInheritance
 	retiredEraFloor uint64
@@ -113,8 +121,8 @@ func (v *coordinatorGrantView) Reset() {
 	if v == nil {
 		return
 	}
-	v.grant = rootproto.AuthorityGrant{}
-	v.certificate = rootproto.GrantCertificate{}
+	v.grants = nil
+	v.certificates = nil
 	v.retirements = nil
 	v.inheritances = nil
 	v.retiredEraFloor = 0
@@ -124,29 +132,64 @@ func (v *coordinatorGrantView) Refresh(snapshot rootview.Snapshot) {
 	if v == nil {
 		return
 	}
-	cert := v.certificate
-	if grantCertificateCoversGrant(cert, snapshot.ActiveGrant) {
-		v.grant = cert.Grant
-		v.certificate = cert
-	} else {
-		v.grant = snapshot.ActiveGrant
-		v.certificate = rootproto.GrantCertificate{}
+	certs := v.certificates
+	nextCerts := make(map[string]rootproto.GrantCertificate)
+	v.grants = make([]rootproto.AuthorityGrant, 0, len(snapshot.ActiveGrants))
+	for _, grant := range snapshot.ActiveGrants {
+		if cert, ok := certs[grant.GrantID]; ok && grantCertificateCoversGrant(cert, grant) {
+			v.grants = append(v.grants, cert.Grant)
+			nextCerts[grant.GrantID] = cert
+			continue
+		}
+		v.grants = append(v.grants, cloneGrantForView(grant))
 	}
+	v.certificates = nextCerts
 	v.retirements = append([]rootproto.GrantRetirement(nil), snapshot.RetiredGrants...)
 	v.inheritances = append([]rootproto.GrantInheritance(nil), snapshot.GrantInheritances...)
 	v.retiredEraFloor = snapshot.RetiredEraFloor
 }
 
-func (v coordinatorGrantView) Grant() rootproto.AuthorityGrant {
-	return v.grant
+func (v coordinatorGrantView) Grants() []rootproto.AuthorityGrant {
+	out := make([]rootproto.AuthorityGrant, len(v.grants))
+	for i, grant := range v.grants {
+		out[i] = cloneGrantForView(grant)
+	}
+	return out
 }
 
-func (v coordinatorGrantView) Certificate() rootproto.GrantCertificate {
-	return v.certificate
+func (v coordinatorGrantView) GrantFor(duty rootproto.DutyID, scope rootproto.DutyScope) (rootproto.AuthorityGrant, bool) {
+	for _, grant := range v.grants {
+		if grant.CoversDutyKey(rootproto.DutyKey{DutyID: duty, Scope: scope}) {
+			return cloneGrantForView(grant), true
+		}
+	}
+	return rootproto.AuthorityGrant{}, false
+}
+
+func (v coordinatorGrantView) GrantByID(grantID string) (rootproto.AuthorityGrant, bool) {
+	for _, grant := range v.grants {
+		if grant.GrantID == grantID {
+			return cloneGrantForView(grant), true
+		}
+	}
+	return rootproto.AuthorityGrant{}, false
+}
+
+func (v coordinatorGrantView) CertificateFor(grant rootproto.AuthorityGrant) rootproto.GrantCertificate {
+	if v.certificates == nil {
+		return rootproto.GrantCertificate{}
+	}
+	return v.certificates[grant.GrantID]
 }
 
 func (v coordinatorGrantView) Retirements() []rootproto.GrantRetirement {
 	return append([]rootproto.GrantRetirement(nil), v.retirements...)
+}
+
+func cloneGrantForView(grant rootproto.AuthorityGrant) rootproto.AuthorityGrant {
+	grant.Duties = append([]rootproto.DutyGrant(nil), grant.Duties...)
+	grant.PredecessorRetirements = append([]rootproto.GrantRetirement(nil), grant.PredecessorRetirements...)
+	return grant
 }
 
 const defaultAllocatorWindowSize uint64 = 10_000
@@ -192,6 +235,10 @@ func NewService(cluster *catalog.Cluster, ids *idalloc.IDAllocator, tsAlloc *tso
 // ConfigureAuthorityGrant enables the explicit coordinator owner grant gate.
 // Empty holderID disables the gate and keeps the current in-memory-only behavior.
 func (s *Service) ConfigureAuthorityGrant(holderID string, ttl, renewIn time.Duration) {
+	s.ConfigureAuthorityGrantDuties(holderID, nil, nil, ttl, renewIn)
+}
+
+func (s *Service) ConfigureAuthorityGrantDuties(holderID string, candidates []string, duties []rootproto.DutyID, ttl, renewIn time.Duration) {
 	if s == nil {
 		return
 	}
@@ -203,6 +250,8 @@ func (s *Service) ConfigureAuthorityGrant(holderID string, ttl, renewIn time.Dur
 		s.grantTTL = 0
 		s.grantRenewIn = 0
 		s.grantClockSkew = 0
+		s.grantCandidates = nil
+		s.grantDuties = nil
 		s.grantView.Reset()
 		return
 	}
@@ -225,6 +274,49 @@ func (s *Service) ConfigureAuthorityGrant(holderID string, ttl, renewIn time.Dur
 	s.grantTTL = ttl
 	s.grantRenewIn = renewIn
 	s.grantClockSkew = clockSkew
+	s.grantCandidates = normalizeGrantCandidates(holderID, candidates)
+	s.grantDuties = normalizeGrantDuties(duties)
+}
+
+func normalizeGrantCandidates(holderID string, candidates []string) []string {
+	seen := map[string]struct{}{}
+	out := make([]string, 0, len(candidates)+1)
+	add := func(candidate string) {
+		candidate = strings.TrimSpace(candidate)
+		if candidate == "" {
+			return
+		}
+		if _, ok := seen[candidate]; ok {
+			return
+		}
+		seen[candidate] = struct{}{}
+		out = append(out, candidate)
+	}
+	for _, candidate := range candidates {
+		add(candidate)
+	}
+	add(holderID)
+	sort.Strings(out)
+	return out
+}
+
+func normalizeGrantDuties(duties []rootproto.DutyID) []rootproto.DutyID {
+	if len(duties) == 0 {
+		return nil
+	}
+	seen := map[rootproto.DutyID]struct{}{}
+	out := make([]rootproto.DutyID, 0, len(duties))
+	for _, duty := range duties {
+		if duty == "" {
+			continue
+		}
+		if _, ok := seen[duty]; ok {
+			continue
+		}
+		seen[duty] = struct{}{}
+		out = append(out, duty)
+	}
+	return out
 }
 
 // ConfigureAllocatorWindows overrides the rooted allocator refill window sizes.

--- a/coordinator/server/service_admission.go
+++ b/coordinator/server/service_admission.go
@@ -31,8 +31,7 @@ func (s *Service) resetAuthorityServing() {
 		return
 	}
 	s.authorityMu.Lock()
-	s.authorityState = authorityServing
-	s.authorityInflight = 0
+	s.authorityDuties = nil
 	s.authorityMu.Unlock()
 }
 
@@ -40,10 +39,10 @@ func (s *Service) beginDutyAdmission(ctx context.Context, duty rootproto.DutyID)
 	if s == nil || !s.coordinatorGrantEnabled() {
 		return dutyAdmission{done: func() {}}, nil
 	}
-	if err := s.rejectIfAuthorityClosed(); err != nil {
+	if err := s.rejectIfAuthorityClosed(duty); err != nil {
 		return dutyAdmission{}, err
 	}
-	if err := s.ensureGrant(ctx); err != nil {
+	if err := s.ensureGrant(ctx, duty); err != nil {
 		return dutyAdmission{}, translateGrantError(err)
 	}
 	if s.grantInheritanceCandidate() {
@@ -74,27 +73,31 @@ func (s *Service) beginAuthorityServing(ctx context.Context, duty rootproto.Duty
 	}
 	s.authorityMu.Lock()
 	defer s.authorityMu.Unlock()
-	switch s.authorityState {
+	slot := s.authorityDuties[duty]
+	switch slot.state {
 	case authorityServing:
-		s.authorityInflight++
-		return func() { s.finishAuthorityServing() }, nil
+		slot.inflight++
+		s.setAuthorityDutyLocked(duty, slot)
+		return func() { s.finishAuthorityServing(duty) }, nil
 	case authorityDraining:
 		return nil, statusGrant(fmt.Errorf("%w: authority is draining", rootstate.ErrSilence))
 	case authoritySealed:
 		return nil, statusGrant(fmt.Errorf("%w: authority is sealed", rootstate.ErrSilence))
 	default:
-		return nil, statusGrant(fmt.Errorf("%w: unknown authority state=%d", rootstate.ErrPrimacy, s.authorityState))
+		return nil, statusGrant(fmt.Errorf("%w: unknown authority state=%d", rootstate.ErrPrimacy, slot.state))
 	}
 }
 
-func (s *Service) finishAuthorityServing() {
+func (s *Service) finishAuthorityServing(duty rootproto.DutyID) {
 	if s == nil || !s.coordinatorGrantEnabled() {
 		return
 	}
 	s.authorityMu.Lock()
-	if s.authorityInflight > 0 {
-		s.authorityInflight--
+	slot := s.authorityDuties[duty]
+	if slot.inflight > 0 {
+		slot.inflight--
 	}
+	s.setAuthorityDutyLocked(duty, slot)
 	s.authorityMu.Unlock()
 }
 
@@ -104,7 +107,22 @@ func (s *Service) authorityServingSnapshot() (authorityServingState, uint64) {
 	}
 	s.authorityMu.Lock()
 	defer s.authorityMu.Unlock()
-	return s.authorityState, s.authorityInflight
+	if len(s.authorityDuties) == 0 {
+		return authorityServing, 0
+	}
+	state := authorityServing
+	var inflight uint64
+	for _, slot := range s.authorityDuties {
+		inflight += slot.inflight
+		if slot.state == authorityDraining {
+			state = authorityDraining
+			continue
+		}
+		if slot.state == authoritySealed && state == authorityServing {
+			state = authoritySealed
+		}
+	}
+	return state, inflight
 }
 
 func (s *Service) requireExpectedClusterEpoch(expected uint64) error {
@@ -149,12 +167,12 @@ const (
 	gateDutyAdmission gateKind = iota
 )
 
-func (s *Service) rejectIfAuthorityClosed() error {
+func (s *Service) rejectIfAuthorityClosed(duty rootproto.DutyID) error {
 	if s == nil || !s.coordinatorGrantEnabled() {
 		return nil
 	}
 	s.authorityMu.Lock()
-	state := s.authorityState
+	state := s.authorityDuties[duty].state
 	s.authorityMu.Unlock()
 	switch state {
 	case authorityServing:
@@ -168,6 +186,17 @@ func (s *Service) rejectIfAuthorityClosed() error {
 	}
 }
 
+func (s *Service) setAuthorityDutyLocked(duty rootproto.DutyID, slot authorityDutyServing) {
+	if s.authorityDuties == nil {
+		s.authorityDuties = make(map[rootproto.DutyID]authorityDutyServing)
+	}
+	if slot.state == authorityServing && slot.inflight == 0 {
+		delete(s.authorityDuties, duty)
+		return
+	}
+	s.authorityDuties[duty] = slot
+}
+
 func (s *Service) admitDutyFromCachedGrant(duty rootproto.DutyID) (dutyAdmission, error) {
 	if s == nil {
 		return dutyAdmission{}, nil
@@ -178,23 +207,29 @@ func (s *Service) admitDutyFromCachedGrant(duty rootproto.DutyID) (dutyAdmission
 	holderID := strings.TrimSpace(s.coordinatorID)
 	clockSkew := s.grantClockSkew
 	s.grantMu.RUnlock()
-	if err := s.validateGateGrant(gateDutyAdmission, duty, view.grant); err != nil {
+	grant, ok := view.GrantFor(duty, rootproto.DutyScope{Kind: rootproto.DutyScopeGlobal})
+	if !ok {
+		s.eunomiaMetrics.recordGateRejection(gateDutyAdmission)
+		return dutyAdmission{}, statusGrant(fmt.Errorf("%w: required_duty=%s", rootstate.ErrDuty, rootproto.DutyName(duty)))
+	}
+	if err := s.validateGateGrant(gateDutyAdmission, duty, grant); err != nil {
 		return dutyAdmission{}, err
 	}
-	if view.grant.ExpiresUnixNano <= nowUnixNano+clockSkew.Nanoseconds() {
+	if grant.ExpiresUnixNano <= nowUnixNano+clockSkew.Nanoseconds() {
 		s.eunomiaMetrics.recordGateRejection(gateDutyAdmission)
-		return dutyAdmission{}, statusGrant(fmt.Errorf("%w: grant inside clock-skew window era=%d", rootstate.ErrInvalidGrant, view.grant.Era))
+		return dutyAdmission{}, statusGrant(fmt.Errorf("%w: grant inside clock-skew window era=%d", rootstate.ErrInvalidGrant, grant.Era))
 	}
-	if holderID == "" || view.grant.HolderID != holderID {
-		return dutyAdmission{}, statusGrant(fmt.Errorf("%w: rooted holder=%s local_holder=%s", rootstate.ErrPrimacy, view.grant.HolderID, holderID))
+	if holderID == "" || grant.HolderID != holderID {
+		return dutyAdmission{}, statusGrant(fmt.Errorf("%w: rooted holder=%s local_holder=%s", rootstate.ErrPrimacy, grant.HolderID, holderID))
 	}
-	if !grantCertificateMatches(view.certificate, view.grant) {
+	cert := view.CertificateFor(grant)
+	if !grantCertificateMatches(cert, grant) {
 		s.eunomiaMetrics.recordGateRejection(gateDutyAdmission)
-		return dutyAdmission{}, statusGrant(fmt.Errorf("%w: missing root-issued grant certificate grant_id=%s era=%d", rootstate.ErrInvalidGrant, view.grant.GrantID, view.grant.Era))
+		return dutyAdmission{}, statusGrant(fmt.Errorf("%w: missing root-issued grant certificate grant_id=%s era=%d", rootstate.ErrInvalidGrant, grant.GrantID, grant.Era))
 	}
 	return dutyAdmission{
-		grant:           view.grant,
-		certificate:     view.certificate,
+		grant:           grant,
+		certificate:     cert,
 		retirements:     append([]rootproto.GrantRetirement(nil), view.retirements...),
 		retiredEraFloor: view.retiredEraFloor,
 		duty:            duty,

--- a/coordinator/server/service_grant.go
+++ b/coordinator/server/service_grant.go
@@ -4,10 +4,14 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"hash/fnv"
+	"slices"
+	"sort"
 	"strings"
 	"time"
 
 	coordfailpoints "github.com/feichai0017/NoKV/coordinator/failpoints"
+	"github.com/feichai0017/NoKV/coordinator/rootview"
 	"github.com/feichai0017/NoKV/coordinator/scheduling"
 	rootfailpoints "github.com/feichai0017/NoKV/meta/root/failpoints"
 	rootproto "github.com/feichai0017/NoKV/meta/root/protocol"
@@ -38,7 +42,7 @@ func (s *Service) grantScopedStoreOperations(ctx context.Context, storeID uint64
 	if s.storage != nil && !s.storage.CanSubmitRootWrites() {
 		return nil
 	}
-	if err := s.ensureGrant(ctx); err != nil {
+	if err := s.ensureGrant(ctx, rootproto.DutyRegionLookup); err != nil {
 		return nil
 	}
 	return s.storeControlOperations(storeID)
@@ -73,7 +77,7 @@ func (s *Service) RunGrantLoop(ctx context.Context) {
 		case <-timer.C:
 			next := s.coordinatorGrantLoopInterval()
 			if s.storage.CanSubmitRootWrites() {
-				if err := s.ensureGrant(ctx); err != nil {
+				if err := s.ensureConfiguredGrants(ctx); err != nil {
 					failures++
 					next = s.coordinatorGrantRetryDelay(failures)
 				} else {
@@ -108,24 +112,25 @@ func (s *Service) DrainAndSealGrant(ctx context.Context) error {
 	if !s.storage.CanSubmitRootWrites() {
 		return nil
 	}
+	duties := s.localActiveAuthorityDuties()
+	if len(duties) == 0 {
+		duties = s.localGrantDuties()
+	}
 	if s.localGrantAlreadySealed() {
-		s.markAuthoritySealed()
+		s.markAuthoritySealed(duties)
 		return nil
 	}
-	s.authorityMu.Lock()
-	if s.authorityState == authoritySealed {
-		s.authorityMu.Unlock()
+	if s.allAuthorityDutiesSealed(duties) {
 		return nil
 	}
-	s.authorityState = authorityDraining
-	s.authorityMu.Unlock()
+	s.markAuthorityDraining(duties)
 
-	if err := s.waitAuthorityInflightDrained(ctx); err != nil {
-		s.markAuthorityServing()
+	if err := s.waitAuthorityInflightDrained(ctx, duties); err != nil {
+		s.markAuthorityServing(duties)
 		return err
 	}
 	if s.localGrantAlreadySealed() {
-		s.markAuthoritySealed()
+		s.markAuthoritySealed(duties)
 		return nil
 	}
 	if err := s.sealGrant(ctx); err != nil {
@@ -133,21 +138,21 @@ func (s *Service) DrainAndSealGrant(ctx context.Context) error {
 			_ = s.reloadAndFenceAllocators(true)
 		}
 		if s.localGrantAlreadySealed() {
-			s.markAuthoritySealed()
+			s.markAuthoritySealed(duties)
 			return nil
 		}
-		s.markAuthorityServing()
+		s.markAuthorityServing(duties)
 		return err
 	}
-	s.markAuthoritySealed()
+	s.markAuthoritySealed(duties)
 	return nil
 }
 
-func (s *Service) waitAuthorityInflightDrained(ctx context.Context) error {
+func (s *Service) waitAuthorityInflightDrained(ctx context.Context, duties []rootproto.DutyID) error {
 	ticker := time.NewTicker(5 * time.Millisecond)
 	defer ticker.Stop()
 	for {
-		_, inflight := s.authorityServingSnapshot()
+		inflight := s.authorityInflightForDuties(duties)
 		if inflight == 0 {
 			return nil
 		}
@@ -162,49 +167,105 @@ func (s *Service) waitAuthorityInflightDrained(ctx context.Context) error {
 func (s *Service) localGrantAlreadySealed() bool {
 	s.grantMu.RLock()
 	holderID := strings.TrimSpace(s.coordinatorID)
-	grant := s.grantView.Grant()
+	grants := s.grantView.Grants()
 	retirements := s.grantView.Retirements()
 	s.grantMu.RUnlock()
 	if holderID == "" {
 		return false
 	}
-	if !grant.Present() {
-		for _, retirement := range retirements {
-			if strings.TrimSpace(retirement.HolderID) == holderID && retirement.Present() {
-				return true
-			}
-		}
-		return false
-	}
-	if strings.TrimSpace(grant.HolderID) != holderID {
-		return false
-	}
+	retiredByGrant := make(map[string]struct{}, len(retirements))
+	hasLocalRetirement := false
 	for _, retirement := range retirements {
-		if retirement.GrantID == grant.GrantID && retirement.Present() {
-			return true
+		if strings.TrimSpace(retirement.HolderID) != holderID || !retirement.Present() {
+			continue
+		}
+		hasLocalRetirement = true
+		retiredByGrant[retirement.GrantID] = struct{}{}
+	}
+	hasLocalActive := false
+	for _, grant := range grants {
+		if strings.TrimSpace(grant.HolderID) != holderID {
+			continue
+		}
+		hasLocalActive = true
+		if _, ok := retiredByGrant[grant.GrantID]; !ok {
+			return false
 		}
 	}
-	return false
+	if hasLocalActive {
+		return true
+	}
+	return hasLocalRetirement
 }
 
-func (s *Service) markAuthorityServing() {
+func (s *Service) markAuthorityServing(duties []rootproto.DutyID) {
 	if s == nil {
 		return
 	}
 	s.authorityMu.Lock()
-	if s.authorityState != authoritySealed {
-		s.authorityState = authorityServing
+	for _, duty := range duties {
+		slot := s.authorityDuties[duty]
+		if slot.state != authoritySealed {
+			slot.state = authorityServing
+		}
+		s.setAuthorityDutyLocked(duty, slot)
 	}
 	s.authorityMu.Unlock()
 }
 
-func (s *Service) markAuthoritySealed() {
+func (s *Service) markAuthorityDraining(duties []rootproto.DutyID) {
 	if s == nil {
 		return
 	}
 	s.authorityMu.Lock()
-	s.authorityState = authoritySealed
+	for _, duty := range duties {
+		slot := s.authorityDuties[duty]
+		if slot.state != authoritySealed {
+			slot.state = authorityDraining
+		}
+		s.setAuthorityDutyLocked(duty, slot)
+	}
 	s.authorityMu.Unlock()
+}
+
+func (s *Service) markAuthoritySealed(duties []rootproto.DutyID) {
+	if s == nil {
+		return
+	}
+	s.authorityMu.Lock()
+	for _, duty := range duties {
+		slot := s.authorityDuties[duty]
+		slot.state = authoritySealed
+		s.setAuthorityDutyLocked(duty, slot)
+	}
+	s.authorityMu.Unlock()
+}
+
+func (s *Service) allAuthorityDutiesSealed(duties []rootproto.DutyID) bool {
+	if s == nil || len(duties) == 0 {
+		return false
+	}
+	s.authorityMu.Lock()
+	defer s.authorityMu.Unlock()
+	for _, duty := range duties {
+		if s.authorityDuties[duty].state != authoritySealed {
+			return false
+		}
+	}
+	return true
+}
+
+func (s *Service) authorityInflightForDuties(duties []rootproto.DutyID) uint64 {
+	if s == nil {
+		return 0
+	}
+	s.authorityMu.Lock()
+	defer s.authorityMu.Unlock()
+	var inflight uint64
+	for _, duty := range duties {
+		inflight += s.authorityDuties[duty].inflight
+	}
+	return inflight
 }
 
 func (s *Service) releaseGrant(ctx context.Context) error {
@@ -224,10 +285,6 @@ func (s *Service) sealGrant(ctx context.Context) error {
 	if !s.storage.CanSubmitRootWrites() {
 		return nil
 	}
-	s.allocMu.Lock()
-	consumedIDFrontier := s.ids.Current()
-	consumedTSOFrontier := s.tso.Current()
-	s.allocMu.Unlock()
 	if err := rootfailpoints.InjectBeforeGrantStorageRead(); err != nil {
 		return statusInternal(err.Error())
 	}
@@ -236,26 +293,28 @@ func (s *Service) sealGrant(ctx context.Context) error {
 		return statusInternalf("load rooted snapshot: %v", err)
 	}
 	s.refreshCurrentRootSnapshot(snapshot)
-	grant := snapshot.ActiveGrant
-	if !grant.Present() {
-		return nil
-	}
 	s.grantMu.RLock()
 	holderID := strings.TrimSpace(s.coordinatorID)
 	s.grantMu.RUnlock()
-	if holderID == "" || grant.HolderID != holderID {
-		return statusGrant(fmt.Errorf("%w: rooted holder=%s local_holder=%s", rootstate.ErrPrimacy, grant.HolderID, holderID))
+	for _, grant := range snapshot.ActiveGrants {
+		if !grant.Present() || strings.TrimSpace(grant.HolderID) != holderID {
+			continue
+		}
+		if err := s.sealGrantInstance(ctx, holderID, grant); err != nil {
+			return err
+		}
 	}
+	return s.reloadAndFenceAllocators(true)
+}
+
+func (s *Service) sealGrantInstance(ctx context.Context, holderID string, grant rootproto.AuthorityGrant) error {
+	exactUsages := s.exactUsagesForGrant(grant)
 	protocolState, _, err := s.storage.ApplyGrant(ctx, rootproto.GrantCommand{
 		Kind:        rootproto.GrantActSeal,
 		HolderID:    holderID,
 		GrantID:     grant.GrantID,
 		NowUnixNano: s.nowUnixNano(),
-		ExactUsages: []rootproto.AuthorityUsage{
-			{DutyID: rootproto.DutyAllocID, Scope: rootproto.DutyScope{Kind: rootproto.DutyScopeGlobal}, Usage: rootproto.DutyBound{Kind: rootproto.DutyBoundMonotone, MonotoneUpper: consumedIDFrontier}},
-			{DutyID: rootproto.DutyTSO, Scope: rootproto.DutyScope{Kind: rootproto.DutyScopeGlobal}, Usage: rootproto.DutyBound{Kind: rootproto.DutyBoundMonotone, MonotoneUpper: consumedTSOFrontier}},
-			{DutyID: rootproto.DutyRegionLookup, Scope: rootproto.DutyScope{Kind: rootproto.DutyScopeGlobal}, Usage: rootproto.DutyBound{Kind: rootproto.DutyBoundVersion, DescriptorRevisionCeiling: s.currentDescriptorRevision()}},
-		},
+		ExactUsages: exactUsages,
 	})
 	if err != nil {
 		s.eunomiaMetrics.recordGuaranteeViolationForError(err)
@@ -265,7 +324,26 @@ func (s *Service) sealGrant(ctx context.Context) error {
 	if err := coordfailpoints.InjectAfterSealGrantBeforeReload(); err != nil {
 		return err
 	}
-	return s.reloadAndFenceAllocators(true)
+	return nil
+}
+
+func (s *Service) exactUsagesForGrant(grant rootproto.AuthorityGrant) []rootproto.AuthorityUsage {
+	s.allocMu.Lock()
+	consumedIDFrontier := s.ids.Current()
+	consumedTSOFrontier := s.tso.Current()
+	s.allocMu.Unlock()
+	out := make([]rootproto.AuthorityUsage, 0, len(grant.Duties))
+	for _, duty := range grant.Duties {
+		switch duty.DutyID {
+		case rootproto.DutyAllocID:
+			out = append(out, rootproto.AuthorityUsage{DutyID: duty.DutyID, Scope: duty.Scope, Usage: rootproto.DutyBound{Kind: rootproto.DutyBoundMonotone, MonotoneUpper: consumedIDFrontier}})
+		case rootproto.DutyTSO:
+			out = append(out, rootproto.AuthorityUsage{DutyID: duty.DutyID, Scope: duty.Scope, Usage: rootproto.DutyBound{Kind: rootproto.DutyBoundMonotone, MonotoneUpper: consumedTSOFrontier}})
+		case rootproto.DutyRegionLookup:
+			out = append(out, rootproto.AuthorityUsage{DutyID: duty.DutyID, Scope: duty.Scope, Usage: rootproto.DutyBound{Kind: rootproto.DutyBoundVersion, DescriptorRevisionCeiling: s.currentDescriptorRevision()}})
+		}
+	}
+	return out
 }
 
 func (s *Service) InheritRetiredGrants(ctx context.Context) error {
@@ -286,7 +364,7 @@ func (s *Service) InheritRetiredGrants(ctx context.Context) error {
 	s.grantMu.RLock()
 	holderID := strings.TrimSpace(s.coordinatorID)
 	s.grantMu.RUnlock()
-	if holderID == "" || strings.TrimSpace(snapshot.ActiveGrant.HolderID) != holderID || !snapshot.ActiveGrant.Present() {
+	if holderID == "" || !snapshotHasLocalGrant(snapshot, holderID) {
 		return nil
 	}
 	pending := make([]string, 0, len(snapshot.RetiredGrants))
@@ -317,8 +395,7 @@ func (s *Service) grantInheritanceCandidate() bool {
 	if s == nil || !s.coordinatorGrantEnabled() || s.storage == nil {
 		return false
 	}
-	grant := s.currentGrant()
-	return grant.Present()
+	return len(s.localActiveAuthorityDuties()) > 0
 }
 
 func grantInheritanceIgnorable(err error) bool {
@@ -334,17 +411,29 @@ func grantInheritanceIgnorable(err error) bool {
 	return code == codes.FailedPrecondition || code == codes.InvalidArgument
 }
 
-func (s *Service) ensureGrant(ctx context.Context) error {
+func (s *Service) ensureConfiguredGrants(ctx context.Context) error {
+	for _, duty := range s.localGrantDuties() {
+		if err := s.ensureGrant(ctx, duty); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (s *Service) ensureGrant(ctx context.Context, duty rootproto.DutyID) error {
 	if s == nil || !s.coordinatorGrantEnabled() || s.storage == nil {
+		return nil
+	}
+	if duty == "" || !s.localCoordinatorOwnsDuty(duty) {
 		return nil
 	}
 	// Fast path: avoid serializing read traffic behind the campaign lock while
 	// the current grant is still outside the renew and clock-skew windows.
 	nowUnixNano, _, holderID, renewIn, clockSkew := s.grantCampaignBounds()
-	if s.coordinatorGrantStillValid(holderID, nowUnixNano, renewIn, clockSkew) {
+	if s.coordinatorGrantStillValid(duty, holderID, nowUnixNano, renewIn, clockSkew) {
 		return nil
 	}
-	if err := s.activeOtherGrantError(holderID, nowUnixNano); err != nil {
+	if err := s.activeOtherGrantError(duty, holderID, nowUnixNano); err != nil {
 		return err
 	}
 
@@ -353,49 +442,35 @@ func (s *Service) ensureGrant(ctx context.Context) error {
 	// Another request or the background renew loop may have refreshed grant
 	// while this caller waited for writeMu.
 	nowUnixNano, _, holderID, renewIn, clockSkew = s.grantCampaignBounds()
-	if s.coordinatorGrantStillValid(holderID, nowUnixNano, renewIn, clockSkew) {
+	if s.coordinatorGrantStillValid(duty, holderID, nowUnixNano, renewIn, clockSkew) {
 		return nil
 	}
-	if err := s.refreshCurrentGrantCertificateIfNeeded(ctx, holderID, nowUnixNano); err != nil {
+	if err := s.refreshCurrentGrantCertificateIfNeeded(ctx, duty, holderID, nowUnixNano); err != nil {
 		return err
 	}
-	if s.coordinatorGrantStillValid(holderID, nowUnixNano, renewIn, clockSkew) {
+	if s.coordinatorGrantStillValid(duty, holderID, nowUnixNano, renewIn, clockSkew) {
 		return nil
 	}
-	if err := s.activeOtherGrantError(holderID, nowUnixNano); err != nil {
+	if err := s.activeOtherGrantError(duty, holderID, nowUnixNano); err != nil {
 		return err
 	}
 
-	s.allocMu.Lock()
-	consumedIDFrontier := s.ids.Current()
-	consumedTSOFrontier := s.tso.Current()
-	idUpper, _ := addUint64(s.currentIDFenceLocked(), s.effectiveIDWindowSize())
-	tsoUpper, _ := addUint64(s.currentTSOFenceLocked(), s.effectiveTSOWindowSize())
-	s.allocMu.Unlock()
-	descriptorRevision := s.currentDescriptorRevision()
+	requestedDuty, exactUsage := s.grantDutyRequest(duty)
 	// Recompute time and expiry after sampling allocator fences so the grant
 	// command carries fresh bounds and does not campaign unnecessarily.
 	nowUnixNano, expiresUnixNano, holderID, renewIn, clockSkew := s.grantCampaignBounds()
-	if s.coordinatorGrantStillValid(holderID, nowUnixNano, renewIn, clockSkew) {
+	if s.coordinatorGrantStillValid(duty, holderID, nowUnixNano, renewIn, clockSkew) {
 		return nil
 	}
-	currentEra := s.currentGrant().Era
+	currentEra := s.currentGrant(duty).Era
 	protocolState, cert, err := s.storage.ApplyGrant(ctx, rootproto.GrantCommand{
 		Kind:            rootproto.GrantActIssue,
 		HolderID:        holderID,
-		GrantID:         nextCoordinatorGrantID(holderID, currentEra),
+		GrantID:         nextCoordinatorGrantID(holderID, duty, currentEra),
 		ExpiresUnixNano: expiresUnixNano,
 		NowUnixNano:     nowUnixNano,
-		RequestedDuties: []rootproto.DutyGrant{
-			rootproto.NewGlobalMonotoneDuty(rootproto.DutyAllocID, idUpper),
-			rootproto.NewGlobalMonotoneDuty(rootproto.DutyTSO, tsoUpper),
-			rootproto.NewGlobalVersionDuty(rootproto.DutyRegionLookup, rootproto.AuthorityRootToken{}, descriptorRevision, 0),
-		},
-		ExactUsages: []rootproto.AuthorityUsage{
-			{DutyID: rootproto.DutyAllocID, Scope: rootproto.DutyScope{Kind: rootproto.DutyScopeGlobal}, Usage: rootproto.DutyBound{Kind: rootproto.DutyBoundMonotone, MonotoneUpper: consumedIDFrontier}},
-			{DutyID: rootproto.DutyTSO, Scope: rootproto.DutyScope{Kind: rootproto.DutyScopeGlobal}, Usage: rootproto.DutyBound{Kind: rootproto.DutyBoundMonotone, MonotoneUpper: consumedTSOFrontier}},
-			{DutyID: rootproto.DutyRegionLookup, Scope: rootproto.DutyScope{Kind: rootproto.DutyScopeGlobal}, Usage: rootproto.DutyBound{Kind: rootproto.DutyBoundVersion, DescriptorRevisionCeiling: descriptorRevision}},
-		},
+		RequestedDuties: []rootproto.DutyGrant{requestedDuty},
+		ExactUsages:     []rootproto.AuthorityUsage{exactUsage},
 	})
 	if err != nil {
 		s.eunomiaMetrics.recordGuaranteeViolationForError(err)
@@ -403,20 +478,170 @@ func (s *Service) ensureGrant(ctx context.Context) error {
 	}
 	s.publishEunomiaState(protocolState)
 	s.cacheGrantCertificate(cert)
-	s.eunomiaMetrics.recordGrantEraTransition(currentEra, protocolState.ActiveGrant.Era)
+	if cert.Grant.Present() {
+		s.eunomiaMetrics.recordGrantEraTransition(currentEra, cert.Grant.Era)
+	}
 	return s.reloadAndFenceAllocators(true)
 }
 
-func nextCoordinatorGrantID(holderID string, currentEra uint64) string {
+func nextCoordinatorGrantID(holderID string, duty rootproto.DutyID, currentEra uint64) string {
 	holderID = strings.TrimSpace(holderID)
 	if holderID == "" {
 		return ""
 	}
-	return fmt.Sprintf("%s/%d", holderID, currentEra+1)
+	return fmt.Sprintf("%s/%s/%d", holderID, rootproto.DutyName(duty), currentEra+1)
 }
 
-func (s *Service) activeOtherGrantError(holderID string, nowUnixNano int64) error {
-	current := s.currentGrant()
+func (s *Service) grantDutyRequest(duty rootproto.DutyID) (rootproto.DutyGrant, rootproto.AuthorityUsage) {
+	scope := rootproto.DutyScope{Kind: rootproto.DutyScopeGlobal}
+	switch duty {
+	case rootproto.DutyAllocID:
+		s.allocMu.Lock()
+		consumed := s.ids.Current()
+		upper, _ := addUint64(s.currentIDFenceLocked(), s.effectiveIDWindowSize())
+		s.allocMu.Unlock()
+		return rootproto.NewGlobalMonotoneDuty(rootproto.DutyAllocID, upper),
+			rootproto.AuthorityUsage{DutyID: duty, Scope: scope, Usage: rootproto.DutyBound{Kind: rootproto.DutyBoundMonotone, MonotoneUpper: consumed}}
+	case rootproto.DutyTSO:
+		s.allocMu.Lock()
+		consumed := s.tso.Current()
+		upper, _ := addUint64(s.currentTSOFenceLocked(), s.effectiveTSOWindowSize())
+		s.allocMu.Unlock()
+		return rootproto.NewGlobalMonotoneDuty(rootproto.DutyTSO, upper),
+			rootproto.AuthorityUsage{DutyID: duty, Scope: scope, Usage: rootproto.DutyBound{Kind: rootproto.DutyBoundMonotone, MonotoneUpper: consumed}}
+	case rootproto.DutyRegionLookup:
+		revision := s.currentRegionLookupRevision()
+		return rootproto.NewGlobalVersionDuty(rootproto.DutyRegionLookup, rootproto.AuthorityRootToken{}, revision, 0),
+			rootproto.AuthorityUsage{DutyID: duty, Scope: scope, Usage: rootproto.DutyBound{Kind: rootproto.DutyBoundVersion, DescriptorRevisionCeiling: revision}}
+	default:
+		return rootproto.DutyGrant{}, rootproto.AuthorityUsage{}
+	}
+}
+
+func (s *Service) currentRegionLookupRevision() uint64 {
+	revision := s.currentDescriptorRevision()
+	snapshot, err := s.currentRootSnapshot()
+	if err == nil && snapshot.RootToken.Revision > revision {
+		revision = snapshot.RootToken.Revision
+	}
+	return revision
+}
+
+func (s *Service) localGrantDuties() []rootproto.DutyID {
+	if s == nil {
+		return nil
+	}
+	s.grantMu.RLock()
+	holderID := strings.TrimSpace(s.coordinatorID)
+	candidates := append([]string(nil), s.grantCandidates...)
+	duties := append([]rootproto.DutyID(nil), s.grantDuties...)
+	s.grantMu.RUnlock()
+	if len(duties) == 0 {
+		duties = []rootproto.DutyID{rootproto.DutyAllocID, rootproto.DutyTSO, rootproto.DutyRegionLookup}
+	}
+	if holderID == "" {
+		return nil
+	}
+	if len(candidates) <= 1 {
+		return duties
+	}
+	out := make([]rootproto.DutyID, 0, len(duties))
+	for _, duty := range duties {
+		if preferredDutyHolder(duty, candidates) == holderID {
+			out = append(out, duty)
+		}
+	}
+	return out
+}
+
+func (s *Service) localCoordinatorOwnsDuty(duty rootproto.DutyID) bool {
+	return slices.Contains(s.localGrantDuties(), duty)
+}
+
+func (s *Service) localActiveAuthorityDuties() []rootproto.DutyID {
+	if s == nil {
+		return nil
+	}
+	s.grantMu.RLock()
+	holderID := strings.TrimSpace(s.coordinatorID)
+	grants := s.grantView.Grants()
+	s.grantMu.RUnlock()
+	seen := make(map[rootproto.DutyID]struct{})
+	out := make([]rootproto.DutyID, 0, len(grants))
+	for _, grant := range grants {
+		if strings.TrimSpace(grant.HolderID) != holderID {
+			continue
+		}
+		for _, duty := range grant.Duties {
+			if duty.Scope.Kind != rootproto.DutyScopeGlobal {
+				continue
+			}
+			if _, ok := seen[duty.DutyID]; ok {
+				continue
+			}
+			seen[duty.DutyID] = struct{}{}
+			out = append(out, duty.DutyID)
+		}
+	}
+	sort.Slice(out, func(i, j int) bool {
+		return rootproto.DutyName(out[i]) < rootproto.DutyName(out[j])
+	})
+	return out
+}
+
+func preferredDutyHolder(duty rootproto.DutyID, candidates []string) string {
+	normalized := make([]string, 0, len(candidates))
+	seen := make(map[string]struct{}, len(candidates))
+	for _, candidate := range candidates {
+		candidate = strings.TrimSpace(candidate)
+		if candidate == "" {
+			continue
+		}
+		if _, ok := seen[candidate]; ok {
+			continue
+		}
+		seen[candidate] = struct{}{}
+		normalized = append(normalized, candidate)
+	}
+	if len(normalized) == 0 {
+		return ""
+	}
+	sort.Strings(normalized)
+	var (
+		bestHolder string
+		bestScore  uint64
+	)
+	for _, candidate := range normalized {
+		h := fnv.New64a()
+		// The first scoped-duty release only enables the global scope. Keep a
+		// cluster salt in the rendezvous key so the default three-duty compose
+		// deployment spreads alloc_id, tso, and region_lookup instead of letting
+		// FNV's short duty strings cluster on one coordinator.
+		_, _ = h.Write([]byte("cluster"))
+		_, _ = h.Write([]byte{0})
+		_, _ = h.Write([]byte(rootproto.DutyName(duty)))
+		_, _ = h.Write([]byte{0})
+		_, _ = h.Write([]byte(candidate))
+		score := h.Sum64()
+		if bestHolder == "" || score > bestScore {
+			bestHolder = candidate
+			bestScore = score
+		}
+	}
+	return bestHolder
+}
+
+func snapshotHasLocalGrant(snapshot rootview.Snapshot, holderID string) bool {
+	for _, grant := range snapshot.ActiveGrants {
+		if strings.TrimSpace(grant.HolderID) == holderID && grant.Present() {
+			return true
+		}
+	}
+	return false
+}
+
+func (s *Service) activeOtherGrantError(duty rootproto.DutyID, holderID string, nowUnixNano int64) error {
+	current := s.currentGrant(duty)
 	currentHolder := strings.TrimSpace(current.HolderID)
 	localHolder := strings.TrimSpace(holderID)
 	if currentHolder == "" || currentHolder == localHolder || !current.ActiveAt(nowUnixNano) {
@@ -428,11 +653,11 @@ func (s *Service) activeOtherGrantError(holderID string, nowUnixNano int64) erro
 	return fmt.Errorf("%w: rooted holder=%s local_holder=%s expires_unix_nano=%d", rootstate.ErrPrimacy, currentHolder, localHolder, current.ExpiresUnixNano)
 }
 
-func (s *Service) coordinatorGrantStillValid(holderID string, nowUnixNano int64, renewIn, clockSkew time.Duration) bool {
+func (s *Service) coordinatorGrantStillValid(duty rootproto.DutyID, holderID string, nowUnixNano int64, renewIn, clockSkew time.Duration) bool {
 	if s == nil {
 		return false
 	}
-	current := s.currentGrant()
+	current := s.currentGrant(duty)
 	if strings.TrimSpace(holderID) == "" ||
 		strings.TrimSpace(current.HolderID) != strings.TrimSpace(holderID) ||
 		!current.ActiveAt(nowUnixNano) {
@@ -453,13 +678,13 @@ func (s *Service) currentGrantCertificateValid(grant rootproto.AuthorityGrant) b
 		return false
 	}
 	s.grantMu.RLock()
-	cert := s.grantView.Certificate()
+	cert := s.grantView.CertificateFor(grant)
 	s.grantMu.RUnlock()
 	return grantCertificateMatches(cert, grant)
 }
 
-func (s *Service) refreshCurrentGrantCertificateIfNeeded(ctx context.Context, holderID string, nowUnixNano int64) error {
-	current := s.currentGrant()
+func (s *Service) refreshCurrentGrantCertificateIfNeeded(ctx context.Context, duty rootproto.DutyID, holderID string, nowUnixNano int64) error {
+	current := s.currentGrant(duty)
 	if !current.Present() ||
 		strings.TrimSpace(current.HolderID) != strings.TrimSpace(holderID) ||
 		!current.ActiveAt(nowUnixNano) ||
@@ -565,13 +790,14 @@ func (s *Service) coordinatorGrantEnabled() bool {
 	return s.coordinatorID != "" && s.grantTTL > 0
 }
 
-func (s *Service) currentGrant() rootproto.AuthorityGrant {
+func (s *Service) currentGrant(duty rootproto.DutyID) rootproto.AuthorityGrant {
 	if s == nil {
 		return rootproto.AuthorityGrant{}
 	}
 	s.grantMu.RLock()
 	defer s.grantMu.RUnlock()
-	return s.grantView.Grant()
+	grant, _ := s.grantView.GrantFor(duty, rootproto.DutyScope{Kind: rootproto.DutyScopeGlobal})
+	return grant
 }
 
 func (s *Service) grantCampaignBounds() (nowUnixNano, expiresUnixNano int64, holderID string, renewIn, clockSkew time.Duration) {

--- a/coordinator/server/service_metadata.go
+++ b/coordinator/server/service_metadata.go
@@ -24,7 +24,7 @@ func (s *Service) GetRegionByKey(ctx context.Context, req *coordpb.GetRegionByKe
 	if req == nil {
 		return nil, statusInvalidArgument("get region by key request is nil")
 	}
-	if err := s.rejectIfAuthorityClosed(); err != nil {
+	if err := s.rejectIfAuthorityClosed(rootproto.DutyRegionLookup); err != nil {
 		return nil, err
 	}
 	state, err := s.currentReadState()
@@ -239,12 +239,13 @@ func (s *Service) currentReadState() (readState, error) {
 		state.catchUpState = rootview.CatchUpStateUnavailable
 		return state, err
 	}
-	if snapshot.ActiveGrant.Era != 0 && strings.TrimSpace(snapshot.ActiveGrant.HolderID) != "" {
+	if grant, ok := snapshot.ActiveGrantFor(rootproto.DutyRegionLookup, rootproto.DutyScope{Kind: rootproto.DutyScopeGlobal}); ok {
 		state.grantPresent = true
-		state.grantActive = snapshot.ActiveGrant.ActiveAt(nowUnixNano)
-		_, state.grantHasLookup = snapshot.ActiveGrant.Duty(rootproto.DutyRegionLookup)
-		state.grantHolderID = snapshot.ActiveGrant.HolderID
-		state.grantExpiresAt = snapshot.ActiveGrant.ExpiresUnixNano
+		state.grantActive = grant.ActiveAt(nowUnixNano)
+		state.grantHasLookup = true
+		state.grantHolderID = grant.HolderID
+		state.grantExpiresAt = grant.ExpiresUnixNano
+		state.era = s.metadataReplyEra(grant.Era)
 	}
 	state.retiredEraFloor = snapshot.RetiredEraFloor
 	for _, retirement := range snapshot.RetiredGrants {
@@ -255,7 +256,6 @@ func (s *Service) currentReadState() (readState, error) {
 	state.currentToken = snapshot.RootToken
 	state.rootLag = rootLag(state.currentToken, state.servedToken)
 	state.catchUpState = snapshot.CatchUpState
-	state.era = s.metadataReplyEra(snapshot.ActiveGrant.Era)
 	if s.cachedRootSnapshotStale() {
 		if errText := s.lastRootReloadError(); strings.TrimSpace(errText) != "" {
 			state.degraded = coordpb.DegradedMode_DEGRADED_MODE_ROOT_UNAVAILABLE
@@ -295,7 +295,7 @@ func (s *Service) ensureMetadataGrantIfNeeded(ctx context.Context, state readSta
 		nowFn = time.Now
 	}
 	nowUnixNano := nowFn().UnixNano()
-	current := s.currentGrant()
+	current := s.currentGrant(rootproto.DutyRegionLookup)
 	currentHasLookup := false
 	if current.Present() && strings.TrimSpace(current.HolderID) == holderID {
 		_, currentHasLookup = current.Duty(rootproto.DutyRegionLookup)
@@ -304,7 +304,7 @@ func (s *Service) ensureMetadataGrantIfNeeded(ctx context.Context, state readSta
 		if !currentHasLookup || !current.ActiveAt(nowUnixNano) {
 			return false, nil
 		}
-		if err := s.ensureGrant(ctx); err != nil {
+		if err := s.ensureGrant(ctx, rootproto.DutyRegionLookup); err != nil {
 			return false, translateGrantError(err)
 		}
 		return true, nil
@@ -318,7 +318,7 @@ func (s *Service) ensureMetadataGrantIfNeeded(ctx context.Context, state readSta
 		!s.coordinatorGrantNeedsRenewal(current) {
 		return false, nil
 	}
-	if err := s.ensureGrant(ctx); err != nil {
+	if err := s.ensureGrant(ctx, rootproto.DutyRegionLookup); err != nil {
 		return false, translateGrantError(err)
 	}
 	return true, nil

--- a/coordinator/server/service_metrics_test.go
+++ b/coordinator/server/service_metrics_test.go
@@ -70,7 +70,7 @@ func TestServiceDiagnosticsMarksInheritedGrantFinality(t *testing.T) {
 				IDCurrent: 12,
 				TSCurrent: 34,
 			},
-			ActiveGrant: rootproto.AuthorityGrant{
+			ActiveGrants: []rootproto.AuthorityGrant{{
 				GrantID:         "c1/3",
 				HolderID:        "c1",
 				ExpiresUnixNano: time.Unix(0, 20_000).UnixNano(),
@@ -80,7 +80,7 @@ func TestServiceDiagnosticsMarksInheritedGrantFinality(t *testing.T) {
 					rootproto.NewGlobalMonotoneDuty(rootproto.DutyTSO, 40),
 					rootproto.NewGlobalVersionDuty(rootproto.DutyRegionLookup, rootproto.AuthorityRootToken{}, 7, 0),
 				},
-			},
+			}},
 			RetiredGrants: []rootproto.GrantRetirement{
 				{
 					GrantID:            "c0/2",

--- a/coordinator/server/service_rootcache.go
+++ b/coordinator/server/service_rootcache.go
@@ -39,7 +39,12 @@ func (s *Service) reloadAndFenceAllocators(refresh bool) error {
 	}
 	s.allocMu.Lock()
 	defer s.allocMu.Unlock()
-	idGranted, tsoGranted := s.installGrantAllocatorWindowsLocked(snapshot.ActiveGrant)
+	var idGranted, tsoGranted bool
+	for _, grant := range snapshot.ActiveGrants {
+		grantID, grantTSO := s.installGrantAllocatorWindowsLocked(grant)
+		idGranted = idGranted || grantID
+		tsoGranted = tsoGranted || grantTSO
+	}
 	if !idGranted {
 		s.fenceIDFromStorage(snapshot.Allocator.IDCurrent)
 	}
@@ -64,9 +69,11 @@ func (s *Service) cacheGrantCertificate(cert rootproto.GrantCertificate) {
 		return
 	}
 	s.grantMu.Lock()
-	if grantCertificateCoversGrant(cert, s.grantView.grant) {
-		s.grantView.grant = cert.Grant
-		s.grantView.certificate = cert
+	if grant, ok := s.grantView.GrantByID(cert.Grant.GrantID); ok && grantCertificateCoversGrant(cert, grant) {
+		if s.grantView.certificates == nil {
+			s.grantView.certificates = make(map[string]rootproto.GrantCertificate)
+		}
+		s.grantView.certificates[cert.Grant.GrantID] = cert
 	}
 	s.grantMu.Unlock()
 }
@@ -135,7 +142,7 @@ func (s *Service) currentAuthoritySnapshot() rootview.Snapshot {
 	s.grantMu.RLock()
 	defer s.grantMu.RUnlock()
 	return rootview.Snapshot{
-		ActiveGrant:       s.grantView.grant,
+		ActiveGrants:      s.grantView.Grants(),
 		RetiredGrants:     append([]rootproto.GrantRetirement(nil), s.grantView.retirements...),
 		GrantInheritances: append([]rootproto.GrantInheritance(nil), s.grantView.inheritances...),
 		RetiredEraFloor:   s.grantView.retiredEraFloor,
@@ -147,7 +154,7 @@ func (s *Service) publishEunomiaState(state rootstate.EunomiaState) {
 		return
 	}
 	snapshot := rootview.Snapshot{
-		ActiveGrant:       state.ActiveGrant,
+		ActiveGrants:      state.ActiveGrants,
 		RetiredGrants:     append([]rootproto.GrantRetirement(nil), state.RetiredGrants...),
 		GrantInheritances: append([]rootproto.GrantInheritance(nil), state.GrantInheritances...),
 		RetiredEraFloor:   state.RetiredEraFloor,
@@ -155,7 +162,7 @@ func (s *Service) publishEunomiaState(state rootstate.EunomiaState) {
 	s.refreshGrantMirror(snapshot)
 	s.rootViewMu.Lock()
 	if s.rootView.loaded {
-		s.rootView.snapshot.ActiveGrant = snapshot.ActiveGrant
+		s.rootView.snapshot.ActiveGrants = snapshot.ActiveGrants
 		s.rootView.snapshot.RetiredGrants = append([]rootproto.GrantRetirement(nil), snapshot.RetiredGrants...)
 		s.rootView.snapshot.GrantInheritances = append([]rootproto.GrantInheritance(nil), snapshot.GrantInheritances...)
 		s.rootView.snapshot.RetiredEraFloor = snapshot.RetiredEraFloor
@@ -164,7 +171,7 @@ func (s *Service) publishEunomiaState(state rootstate.EunomiaState) {
 }
 
 func serviceEunomiaStatePresent(state rootstate.EunomiaState) bool {
-	return state.ActiveGrant.Present() ||
+	return len(state.ActiveGrants) > 0 ||
 		len(state.RetiredGrants) > 0 ||
 		len(state.GrantInheritances) > 0 ||
 		state.RetiredEraFloor != 0
@@ -180,7 +187,7 @@ func (s *Service) publishRootSnapshot(snapshot rootview.Snapshot) {
 	if s.cluster != nil {
 		s.cluster.ReplaceRootSnapshot(rootstate.Snapshot{
 			State: rootstate.State{
-				ActiveGrant:       snapshot.ActiveGrant,
+				ActiveGrants:      snapshot.ActiveGrants,
 				RetiredGrants:     append([]rootproto.GrantRetirement(nil), snapshot.RetiredGrants...),
 				GrantInheritances: append([]rootproto.GrantInheritance(nil), snapshot.GrantInheritances...),
 				RetiredEraFloor:   snapshot.RetiredEraFloor,

--- a/coordinator/server/service_test.go
+++ b/coordinator/server/service_test.go
@@ -98,7 +98,7 @@ func TestTranslateGrantContextErrors(t *testing.T) {
 
 func (f *fakeStorage) protocolState() rootstate.EunomiaState {
 	return rootstate.EunomiaState{
-		ActiveGrant:       f.snapshot.ActiveGrant,
+		ActiveGrants:      append([]rootproto.AuthorityGrant(nil), f.snapshot.ActiveGrants...),
 		RetiredGrants:     append([]rootproto.GrantRetirement(nil), f.snapshot.RetiredGrants...),
 		GrantInheritances: append([]rootproto.GrantInheritance(nil), f.snapshot.GrantInheritances...),
 		RetiredEraFloor:   f.snapshot.RetiredEraFloor,
@@ -132,6 +132,46 @@ func testDutyGrantsCover(grants, usages []rootproto.DutyGrant) bool {
 	return true
 }
 
+func testActiveGrantForDuties(snapshot rootview.Snapshot, duties []rootproto.DutyGrant) (rootproto.AuthorityGrant, bool) {
+	for _, grant := range snapshot.ActiveGrants {
+		for _, duty := range duties {
+			if grant.CoversDutyKey(duty.Key()) {
+				return grant, true
+			}
+		}
+	}
+	return rootproto.AuthorityGrant{}, false
+}
+
+func testActiveGrantForHolder(snapshot rootview.Snapshot, holderID string) (rootproto.AuthorityGrant, bool) {
+	for _, grant := range snapshot.ActiveGrants {
+		if strings.TrimSpace(grant.HolderID) == holderID {
+			return grant, true
+		}
+	}
+	return rootproto.AuthorityGrant{}, false
+}
+
+func upsertTestGrant(grants []rootproto.AuthorityGrant, grant rootproto.AuthorityGrant) []rootproto.AuthorityGrant {
+	for i := range grants {
+		if grants[i].GrantID == grant.GrantID {
+			grants[i] = grant
+			return grants
+		}
+	}
+	return append(grants, grant)
+}
+
+func removeTestGrant(grants []rootproto.AuthorityGrant, grantID string) []rootproto.AuthorityGrant {
+	for i := 0; i < len(grants); i++ {
+		if grants[i].GrantID == grantID {
+			grants = append(grants[:i], grants[i+1:]...)
+			i--
+		}
+	}
+	return grants
+}
+
 func (f *fakeStorage) Load() (rootview.Snapshot, error) {
 	f.loadCalls++
 	if f.loadErr != nil {
@@ -154,7 +194,7 @@ func (f *fakeStorage) AppendRootEvent(_ context.Context, event rootevent.Event) 
 			ClusterEpoch:  f.snapshot.ClusterEpoch,
 			IDFence:       f.snapshot.Allocator.IDCurrent,
 			TSOFence:      f.snapshot.Allocator.TSCurrent,
-			ActiveGrant:   f.snapshot.ActiveGrant,
+			ActiveGrants:  append([]rootproto.AuthorityGrant(nil), f.snapshot.ActiveGrants...),
 			RetiredGrants: append([]rootproto.GrantRetirement(nil), f.snapshot.RetiredGrants...),
 			LastCommitted: rootstate.Cursor{Term: 1, Index: uint64(f.eventCalls)},
 		},
@@ -179,30 +219,31 @@ func (f *fakeStorage) ApplyGrant(_ context.Context, cmd rootproto.GrantCommand) 
 		if f.campaignErr != nil {
 			return rootstate.EunomiaState{}, rootproto.GrantCertificate{}, f.campaignErr
 		}
-		if f.snapshot.ActiveGrant.Present() &&
-			f.snapshot.ActiveGrant.GrantID == strings.TrimSpace(cmd.GrantID) &&
-			f.snapshot.ActiveGrant.HolderID == holderID &&
-			testDutyGrantsCover(f.snapshot.ActiveGrant.Duties, cmd.RequestedDuties) {
-			return f.protocolState(), testGrantCertificate(f.snapshot.ActiveGrant), nil
+		active, _ := testActiveGrantForDuties(f.snapshot, cmd.RequestedDuties)
+		if active.Present() &&
+			active.GrantID == strings.TrimSpace(cmd.GrantID) &&
+			active.HolderID == holderID &&
+			testDutyGrantsCover(active.Duties, cmd.RequestedDuties) {
+			return f.protocolState(), testGrantCertificate(active), nil
 		}
 		f.campaignCalls++
-		if f.snapshot.ActiveGrant.Present() &&
-			f.snapshot.ActiveGrant.HolderID != holderID &&
-			f.snapshot.ActiveGrant.ActiveAt(cmd.NowUnixNano) {
+		if active.Present() &&
+			active.HolderID != holderID &&
+			active.ActiveAt(cmd.NowUnixNano) {
 			return f.protocolState(), rootproto.GrantCertificate{}, rootstate.ErrPrimacy
 		}
 		predecessors := []rootproto.GrantRetirement(nil)
-		if f.snapshot.ActiveGrant.Present() {
+		if active.Present() {
 			mode := rootproto.GrantRetirementSealedExact
-			if !f.snapshot.ActiveGrant.ActiveAt(cmd.NowUnixNano) {
+			if !active.ActiveAt(cmd.NowUnixNano) {
 				mode = rootproto.GrantRetirementExpiredBound
 			}
 			predecessors = append(predecessors, rootproto.GrantRetirement{
-				GrantID:  f.snapshot.ActiveGrant.GrantID,
-				HolderID: f.snapshot.ActiveGrant.HolderID,
-				Era:      f.snapshot.ActiveGrant.Era,
+				GrantID:  active.GrantID,
+				HolderID: active.HolderID,
+				Era:      active.Era,
 				Mode:     mode,
-				Bounds:   append([]rootproto.DutyGrant(nil), f.snapshot.ActiveGrant.Duties...),
+				Bounds:   append([]rootproto.DutyGrant(nil), active.Duties...),
 			})
 		}
 		for _, retired := range f.snapshot.RetiredGrants {
@@ -210,7 +251,7 @@ func (f *fakeStorage) ApplyGrant(_ context.Context, cmd rootproto.GrantCommand) 
 				predecessors = append(predecessors, retired)
 			}
 		}
-		era := f.snapshot.ActiveGrant.Era + 1
+		era := active.Era + 1
 		for _, retired := range f.snapshot.RetiredGrants {
 			if retired.Era >= era {
 				era = retired.Era + 1
@@ -220,7 +261,7 @@ func (f *fakeStorage) ApplyGrant(_ context.Context, cmd rootproto.GrantCommand) 
 		if strings.TrimSpace(grantID) == "" {
 			grantID = fmt.Sprintf("%s/%d", holderID, era)
 		}
-		f.snapshot.ActiveGrant = rootproto.AuthorityGrant{
+		grant := rootproto.AuthorityGrant{
 			GrantID:                grantID,
 			HolderID:               holderID,
 			Era:                    era,
@@ -229,6 +270,10 @@ func (f *fakeStorage) ApplyGrant(_ context.Context, cmd rootproto.GrantCommand) 
 			Duties:                 append([]rootproto.DutyGrant(nil), cmd.RequestedDuties...),
 			PredecessorRetirements: append([]rootproto.GrantRetirement(nil), predecessors...),
 		}
+		for _, predecessor := range predecessors {
+			f.snapshot.ActiveGrants = removeTestGrant(f.snapshot.ActiveGrants, predecessor.GrantID)
+		}
+		f.snapshot.ActiveGrants = upsertTestGrant(f.snapshot.ActiveGrants, grant)
 		f.snapshot.RetiredGrants = append([]rootproto.GrantRetirement(nil), predecessors...)
 		for _, duty := range cmd.RequestedDuties {
 			if duty.Bound.Kind != rootproto.DutyBoundMonotone {
@@ -246,56 +291,59 @@ func (f *fakeStorage) ApplyGrant(_ context.Context, cmd rootproto.GrantCommand) 
 			}
 		}
 		f.advanceRootToken()
-		return f.protocolState(), testGrantCertificate(f.snapshot.ActiveGrant), nil
+		return f.protocolState(), testGrantCertificate(grant), nil
 	case rootproto.GrantActSeal:
 		f.sealCalls++
 		if f.sealErr != nil {
 			return rootstate.EunomiaState{}, rootproto.GrantCertificate{}, f.sealErr
 		}
-		if !f.snapshot.ActiveGrant.Present() {
+		active, ok := f.snapshot.ActiveGrantByID(strings.TrimSpace(cmd.GrantID))
+		if !ok {
 			return f.protocolState(), rootproto.GrantCertificate{}, rootstate.ErrInvalidGrant
 		}
-		if holder := strings.TrimSpace(cmd.HolderID); holder != "" && holder != f.snapshot.ActiveGrant.HolderID {
+		if holder := strings.TrimSpace(cmd.HolderID); holder != "" && holder != active.HolderID {
 			return f.protocolState(), rootproto.GrantCertificate{}, rootstate.ErrPrimacy
 		}
 		retirement := rootproto.GrantRetirement{
-			GrantID:  f.snapshot.ActiveGrant.GrantID,
-			HolderID: f.snapshot.ActiveGrant.HolderID,
-			Era:      f.snapshot.ActiveGrant.Era,
+			GrantID:  active.GrantID,
+			HolderID: active.HolderID,
+			Era:      active.Era,
 			Mode:     rootproto.GrantRetirementSealedExact,
 			Bounds:   dutyGrantsFromAuthorityUsagesForTest(cmd.ExactUsages),
 		}
 		if len(retirement.Bounds) == 0 {
-			retirement.Bounds = append([]rootproto.DutyGrant(nil), f.snapshot.ActiveGrant.Duties...)
+			retirement.Bounds = append([]rootproto.DutyGrant(nil), active.Duties...)
 		}
 		f.snapshot.RetiredGrants = append(f.snapshot.RetiredGrants, retirement)
-		f.snapshot.ActiveGrant = rootproto.AuthorityGrant{}
+		f.snapshot.ActiveGrants = removeTestGrant(f.snapshot.ActiveGrants, active.GrantID)
 		f.advanceRootToken()
 		return f.protocolState(), rootproto.GrantCertificate{}, nil
 	case rootproto.GrantActRetireExpired:
-		if !f.snapshot.ActiveGrant.Present() {
+		active, ok := f.snapshot.ActiveGrantByID(strings.TrimSpace(cmd.GrantID))
+		if !ok {
 			return f.protocolState(), rootproto.GrantCertificate{}, rootstate.ErrInvalidGrant
 		}
-		if cmd.NowUnixNano < f.snapshot.ActiveGrant.ExpiresUnixNano {
+		if cmd.NowUnixNano < active.ExpiresUnixNano {
 			return f.protocolState(), rootproto.GrantCertificate{}, rootstate.ErrInvalidGrant
 		}
 		retirement := rootproto.GrantRetirement{
-			GrantID:  f.snapshot.ActiveGrant.GrantID,
-			HolderID: f.snapshot.ActiveGrant.HolderID,
-			Era:      f.snapshot.ActiveGrant.Era,
+			GrantID:  active.GrantID,
+			HolderID: active.HolderID,
+			Era:      active.Era,
 			Mode:     rootproto.GrantRetirementExpiredBound,
-			Bounds:   append([]rootproto.DutyGrant(nil), f.snapshot.ActiveGrant.Duties...),
+			Bounds:   append([]rootproto.DutyGrant(nil), active.Duties...),
 		}
 		f.snapshot.RetiredGrants = append(f.snapshot.RetiredGrants, retirement)
-		f.snapshot.ActiveGrant = rootproto.AuthorityGrant{}
+		f.snapshot.ActiveGrants = removeTestGrant(f.snapshot.ActiveGrants, active.GrantID)
 		f.advanceRootToken()
 		return f.protocolState(), rootproto.GrantCertificate{}, nil
 	case rootproto.GrantActInherit:
 		f.reattachCalls++
-		if !f.snapshot.ActiveGrant.Present() || f.snapshot.ActiveGrant.HolderID != holderID {
+		active, ok := testActiveGrantForHolder(f.snapshot, holderID)
+		if !ok {
 			return f.protocolState(), rootproto.GrantCertificate{}, rootstate.ErrPrimacy
 		}
-		successor := f.snapshot.ActiveGrant.GrantID
+		successor := active.GrantID
 		for _, predecessor := range cmd.PredecessorGrantIDs {
 			for i := range f.snapshot.RetiredGrants {
 				if f.snapshot.RetiredGrants[i].GrantID == predecessor {
@@ -631,7 +679,7 @@ func TestServiceDiagnosticsSnapshot(t *testing.T) {
 				IDCurrent: 55,
 				TSCurrent: 88,
 			},
-			ActiveGrant: rootproto.AuthorityGrant{
+			ActiveGrants: []rootproto.AuthorityGrant{{
 				GrantID:         "c1/3",
 				HolderID:        "c1",
 				ExpiresUnixNano: now.Add(5 * time.Second).UnixNano(),
@@ -643,7 +691,7 @@ func TestServiceDiagnosticsSnapshot(t *testing.T) {
 					rootproto.NewGlobalMonotoneDuty(rootproto.DutyTSO, 88),
 					rootproto.NewGlobalVersionDuty(rootproto.DutyRegionLookup, rootproto.AuthorityRootToken{Term: 2, Index: 9, Revision: 4}, 5, 0),
 				},
-			},
+			}},
 			RetiredGrants: []rootproto.GrantRetirement{
 				{
 					GrantID:   "c0/2",
@@ -796,7 +844,7 @@ func TestServiceGetRegionByKeyRenewsSelfHeldExpiringGrant(t *testing.T) {
 		snapshot: rootview.Snapshot{
 			RootToken:   token,
 			Descriptors: map[uint64]topology.Descriptor{desc.RegionID: desc},
-			ActiveGrant: rootproto.AuthorityGrant{
+			ActiveGrants: []rootproto.AuthorityGrant{{
 				GrantID:         "c1/1",
 				HolderID:        "c1",
 				ExpiresUnixNano: 100,
@@ -806,7 +854,7 @@ func TestServiceGetRegionByKeyRenewsSelfHeldExpiringGrant(t *testing.T) {
 					rootproto.NewGlobalMonotoneDuty(rootproto.DutyTSO, 10),
 					rootproto.NewGlobalVersionDuty(rootproto.DutyRegionLookup, rootproto.AuthorityRootToken{}, 5, 0),
 				},
-			},
+			}},
 		},
 	}
 	svc := NewService(cluster, idalloc.NewIDAllocator(1), tso.NewAllocator(1), storage)
@@ -819,10 +867,12 @@ func TestServiceGetRegionByKeyRenewsSelfHeldExpiringGrant(t *testing.T) {
 	require.False(t, resp.GetNotFound())
 	require.Equal(t, uint64(11), resp.GetRegionDescriptor().GetRegionId())
 	require.Equal(t, 1, storage.campaignCalls)
-	require.Equal(t, "c1", storage.snapshot.ActiveGrant.HolderID)
-	require.Equal(t, uint64(2), storage.snapshot.ActiveGrant.Era)
+	renewedGrant, ok := storage.snapshot.ActiveGrantFor(rootproto.DutyRegionLookup, rootproto.DutyScope{Kind: rootproto.DutyScopeGlobal})
+	require.True(t, ok)
+	require.Equal(t, "c1", renewedGrant.HolderID)
+	require.Equal(t, uint64(2), renewedGrant.Era)
 	require.Equal(t, uint64(2), resp.GetEra())
-	require.True(t, storage.snapshot.ActiveGrant.ActiveAt(200))
+	require.True(t, renewedGrant.ActiveAt(200))
 	require.NotNil(t, resp.GetAuthorityEvidence())
 }
 
@@ -839,13 +889,13 @@ func TestServiceGetRegionByKeyRejectsOtherActiveGrant(t *testing.T) {
 		snapshot: rootview.Snapshot{
 			RootToken:   token,
 			Descriptors: map[uint64]topology.Descriptor{desc.RegionID: desc},
-			ActiveGrant: rootproto.AuthorityGrant{
+			ActiveGrants: []rootproto.AuthorityGrant{{
 				GrantID:         "c2/4",
 				HolderID:        "c2",
 				ExpiresUnixNano: time.Second.Nanoseconds(),
 				Era:             4,
 				Duties:          []rootproto.DutyGrant{rootproto.NewGlobalVersionDuty(rootproto.DutyRegionLookup, rootproto.AuthorityRootToken{}, 5, 0)},
-			},
+			}},
 		},
 	}
 	svc := NewService(cluster, idalloc.NewIDAllocator(1), tso.NewAllocator(1), storage)
@@ -857,7 +907,9 @@ func TestServiceGetRegionByKeyRejectsOtherActiveGrant(t *testing.T) {
 	require.Error(t, err)
 	require.Equal(t, codes.FailedPrecondition, status.Code(err))
 	require.Equal(t, 0, storage.campaignCalls)
-	require.Equal(t, "c2", storage.snapshot.ActiveGrant.HolderID)
+	otherGrant, ok := storage.snapshot.ActiveGrantFor(rootproto.DutyRegionLookup, rootproto.DutyScope{Kind: rootproto.DutyScopeGlobal})
+	require.True(t, ok)
+	require.Equal(t, "c2", otherGrant.HolderID)
 }
 
 func TestServiceGetRegionByKeyRequiredRootToken(t *testing.T) {
@@ -872,7 +924,7 @@ func TestServiceGetRegionByKeyRequiredRootToken(t *testing.T) {
 		snapshot: rootview.Snapshot{
 			RootToken:   rootstorage.TailToken{Cursor: rootstate.Cursor{Term: 1, Index: 3}, Revision: 5},
 			Descriptors: map[uint64]topology.Descriptor{desc.RegionID: desc},
-			ActiveGrant: rootproto.AuthorityGrant{
+			ActiveGrants: []rootproto.AuthorityGrant{{
 				GrantID:         "c1/4",
 				HolderID:        "c1",
 				ExpiresUnixNano: time.Second.Nanoseconds(),
@@ -882,7 +934,7 @@ func TestServiceGetRegionByKeyRequiredRootToken(t *testing.T) {
 					rootproto.NewGlobalMonotoneDuty(rootproto.DutyTSO, 10),
 					rootproto.NewGlobalVersionDuty(rootproto.DutyRegionLookup, rootproto.AuthorityRootToken{Term: 1, Index: 3, Revision: 5}, 5, 0),
 				},
-			},
+			}},
 		},
 	}
 	svc := NewService(cluster, idalloc.NewIDAllocator(1), tso.NewAllocator(1), storage)
@@ -2112,13 +2164,13 @@ func TestServiceAuthorityEvidenceUsesRootedAllocatorFence(t *testing.T) {
 func TestServiceAuthorityEvidenceRejectsUnrootedAllocatorFrontier(t *testing.T) {
 	store := &fakeStorage{
 		snapshot: rootview.Snapshot{
-			ActiveGrant: rootproto.AuthorityGrant{
+			ActiveGrants: []rootproto.AuthorityGrant{{
 				GrantID:         "grant-1",
 				HolderID:        "c1",
 				ExpiresUnixNano: time.Now().Add(time.Hour).UnixNano(),
 				Era:             1,
 				Duties:          []rootproto.DutyGrant{rootproto.NewGlobalMonotoneDuty(rootproto.DutyAllocID, 5)},
-			},
+			}},
 			Allocator: rootview.AllocatorState{IDCurrent: 5},
 		},
 	}
@@ -2126,9 +2178,11 @@ func TestServiceAuthorityEvidenceRejectsUnrootedAllocatorFrontier(t *testing.T) 
 	svc.ConfigureAuthorityGrant("c1", 10*time.Second, 3*time.Second)
 	require.NoError(t, svc.RefreshFromStorage())
 
+	grant, ok := store.snapshot.ActiveGrantFor(rootproto.DutyAllocID, rootproto.DutyScope{Kind: rootproto.DutyScopeGlobal})
+	require.True(t, ok)
 	admission := dutyAdmission{
-		grant:          store.snapshot.ActiveGrant,
-		certificate:    rootproto.GrantCertificate{Grant: store.snapshot.ActiveGrant, SignerKeyID: rootproto.GrantSignerKeyID, Signature: []byte("test-signature")},
+		grant:          grant,
+		certificate:    rootproto.GrantCertificate{Grant: grant, SignerKeyID: rootproto.GrantSignerKeyID, Signature: []byte("test-signature")},
 		duty:           rootproto.DutyAllocID,
 		servedUnixNano: time.Now().UnixNano(),
 	}
@@ -2281,8 +2335,10 @@ func TestServiceGrantReusedAcrossAllocatorRequests(t *testing.T) {
 	require.Equal(t, uint64(1), idResp.GetEra())
 	require.Equal(t, uint64(10), idResp.GetConsumedFrontier())
 	require.Equal(t, 1, store.campaignCalls)
-	require.Equal(t, "c1", store.snapshot.ActiveGrant.HolderID)
-	require.Equal(t, uint64(1), store.snapshot.ActiveGrant.Era)
+	allocGrant, ok := store.snapshot.ActiveGrantFor(rootproto.DutyAllocID, rootproto.DutyScope{Kind: rootproto.DutyScopeGlobal})
+	require.True(t, ok)
+	require.Equal(t, "c1", allocGrant.HolderID)
+	require.Equal(t, uint64(1), allocGrant.Era)
 	require.NotNil(t, idResp.GetAuthorityEvidence())
 
 	tsResp, err := svc.Tso(context.Background(), &coordpb.TsoRequest{Count: 1})
@@ -2290,8 +2346,57 @@ func TestServiceGrantReusedAcrossAllocatorRequests(t *testing.T) {
 	require.Equal(t, uint64(100), tsResp.GetTimestamp())
 	require.Equal(t, uint64(1), tsResp.GetEra())
 	require.Equal(t, uint64(100), tsResp.GetConsumedFrontier())
-	require.Equal(t, 1, store.campaignCalls)
+	require.Equal(t, 2, store.campaignCalls)
 	require.NotNil(t, tsResp.GetAuthorityEvidence())
+}
+
+func TestServicePreferredDutyHolderSpreadsDefaultDuties(t *testing.T) {
+	candidates := []string{"coord-1", "coord-2", "coord-3"}
+	assignments := map[rootproto.DutyID]string{
+		rootproto.DutyAllocID:      preferredDutyHolder(rootproto.DutyAllocID, candidates),
+		rootproto.DutyTSO:          preferredDutyHolder(rootproto.DutyTSO, candidates),
+		rootproto.DutyRegionLookup: preferredDutyHolder(rootproto.DutyRegionLookup, candidates),
+	}
+	holders := make(map[string]struct{}, len(assignments))
+	for _, holder := range assignments {
+		holders[holder] = struct{}{}
+	}
+	require.Len(t, holders, 3)
+}
+
+func TestServicePerDutyAdmissionIsIsolated(t *testing.T) {
+	store := &fakeStorage{
+		leader: true,
+		snapshot: rootview.Snapshot{
+			ActiveGrants: []rootproto.AuthorityGrant{
+				{
+					GrantID:         "c1/alloc_id/1",
+					HolderID:        "c1",
+					Era:             1,
+					ExpiresUnixNano: time.Now().Add(time.Hour).UnixNano(),
+					Duties:          []rootproto.DutyGrant{rootproto.NewGlobalMonotoneDuty(rootproto.DutyAllocID, 20)},
+				},
+				{
+					GrantID:         "c2/tso/2",
+					HolderID:        "c2",
+					Era:             2,
+					ExpiresUnixNano: time.Now().Add(time.Hour).UnixNano(),
+					Duties:          []rootproto.DutyGrant{rootproto.NewGlobalMonotoneDuty(rootproto.DutyTSO, 200)},
+				},
+			},
+			Allocator: rootview.AllocatorState{IDCurrent: 20, TSCurrent: 200},
+		},
+	}
+	svc := NewService(catalog.NewCluster(), idalloc.NewIDAllocator(10), tso.NewAllocator(100), store)
+	svc.ConfigureAuthorityGrantDuties("c1", nil, []rootproto.DutyID{rootproto.DutyAllocID, rootproto.DutyTSO}, 10*time.Second, 3*time.Second)
+	require.NoError(t, svc.ReloadFromStorage())
+
+	_, err := svc.AllocID(context.Background(), &coordpb.AllocIDRequest{Count: 1})
+	require.NoError(t, err)
+	_, err = svc.Tso(context.Background(), &coordpb.TsoRequest{Count: 1})
+	require.Error(t, err)
+	require.Equal(t, nokverrors.KindNotLeader, nokverrors.KindOf(err))
+	require.Equal(t, 0, store.campaignCalls)
 }
 
 func TestServiceGrantRenewsInsideRenewWindow(t *testing.T) {
@@ -2305,15 +2410,18 @@ func TestServiceGrantRenewsInsideRenewWindow(t *testing.T) {
 	_, err := svc.AllocID(context.Background(), &coordpb.AllocIDRequest{Count: 1})
 	require.NoError(t, err)
 	require.Equal(t, 1, store.campaignCalls)
-	firstGrant := store.snapshot.ActiveGrant.GrantID
+	firstGrant, ok := store.snapshot.ActiveGrantFor(rootproto.DutyAllocID, rootproto.DutyScope{Kind: rootproto.DutyScopeGlobal})
+	require.True(t, ok)
 
 	now = now.Add(85 * time.Millisecond)
-	_, err = svc.Tso(context.Background(), &coordpb.TsoRequest{Count: 1})
+	_, err = svc.AllocID(context.Background(), &coordpb.AllocIDRequest{Count: 1})
 	require.NoError(t, err)
 	require.Equal(t, 2, store.campaignCalls)
-	require.Equal(t, uint64(2), store.snapshot.ActiveGrant.Era)
-	require.NotEqual(t, firstGrant, store.snapshot.ActiveGrant.GrantID)
-	require.NotEmpty(t, store.snapshot.ActiveGrant.PredecessorRetirements)
+	renewedGrant, ok := store.snapshot.ActiveGrantFor(rootproto.DutyAllocID, rootproto.DutyScope{Kind: rootproto.DutyScopeGlobal})
+	require.True(t, ok)
+	require.Equal(t, uint64(2), renewedGrant.Era)
+	require.NotEqual(t, firstGrant.GrantID, renewedGrant.GrantID)
+	require.NotEmpty(t, renewedGrant.PredecessorRetirements)
 }
 
 func TestServiceGrantLoopSkipsFollower(t *testing.T) {
@@ -2332,13 +2440,13 @@ func TestServiceGrantLoopDoesNotCampaignOverActiveOtherHolder(t *testing.T) {
 	store := &fakeStorage{
 		leader: true,
 		snapshot: rootview.Snapshot{
-			ActiveGrant: rootproto.AuthorityGrant{
+			ActiveGrants: []rootproto.AuthorityGrant{{
 				GrantID:         "c2/1",
 				HolderID:        "c2",
 				ExpiresUnixNano: time.Now().Add(time.Hour).UnixNano(),
 				Era:             1,
 				Duties:          []rootproto.DutyGrant{rootproto.NewGlobalMonotoneDuty(rootproto.DutyAllocID, 10)},
-			},
+			}},
 		},
 	}
 	svc := NewService(catalog.NewCluster(), idalloc.NewIDAllocator(10), tso.NewAllocator(100), store)
@@ -2393,13 +2501,13 @@ func TestServiceRejectsDrainingAdmissionBeforeGrantRenewal(t *testing.T) {
 	store := &fakeStorage{
 		leader: true,
 		snapshot: rootview.Snapshot{
-			ActiveGrant: rootproto.AuthorityGrant{
+			ActiveGrants: []rootproto.AuthorityGrant{{
 				GrantID:         "c1/1",
 				HolderID:        "c1",
 				Era:             1,
 				ExpiresUnixNano: now.Add(10 * time.Millisecond).UnixNano(),
 				Duties:          []rootproto.DutyGrant{rootproto.NewGlobalMonotoneDuty(rootproto.DutyAllocID, 10)},
-			},
+			}},
 		},
 	}
 	svc := NewService(catalog.NewCluster(), idalloc.NewIDAllocator(10), tso.NewAllocator(100), store)
@@ -2407,7 +2515,7 @@ func TestServiceRejectsDrainingAdmissionBeforeGrantRenewal(t *testing.T) {
 	svc.now = func() time.Time { return now }
 	require.NoError(t, svc.ReloadFromStorage())
 	svc.authorityMu.Lock()
-	svc.authorityState = authorityDraining
+	svc.setAuthorityDutyLocked(rootproto.DutyAllocID, authorityDutyServing{state: authorityDraining})
 	svc.authorityMu.Unlock()
 
 	_, err := svc.beginDutyAdmission(context.Background(), rootproto.DutyAllocID)
@@ -2425,13 +2533,13 @@ func TestServiceRejectsDrainingMetadataBeforeGrantRenewal(t *testing.T) {
 	store := &fakeStorage{
 		leader: true,
 		snapshot: rootview.Snapshot{
-			ActiveGrant: rootproto.AuthorityGrant{
+			ActiveGrants: []rootproto.AuthorityGrant{{
 				GrantID:         "c1/1",
 				HolderID:        "c1",
 				Era:             1,
 				ExpiresUnixNano: now.Add(10 * time.Millisecond).UnixNano(),
 				Duties:          []rootproto.DutyGrant{rootproto.NewGlobalVersionDuty(rootproto.DutyRegionLookup, rootproto.AuthorityRootToken{}, 1, 0)},
-			},
+			}},
 		},
 	}
 	svc := NewService(catalog.NewCluster(), idalloc.NewIDAllocator(10), tso.NewAllocator(100), store)
@@ -2439,7 +2547,7 @@ func TestServiceRejectsDrainingMetadataBeforeGrantRenewal(t *testing.T) {
 	svc.now = func() time.Time { return now }
 	require.NoError(t, svc.ReloadFromStorage())
 	svc.authorityMu.Lock()
-	svc.authorityState = authorityDraining
+	svc.setAuthorityDutyLocked(rootproto.DutyRegionLookup, authorityDutyServing{state: authorityDraining})
 	svc.authorityMu.Unlock()
 
 	_, err := svc.GetRegionByKey(context.Background(), &coordpb.GetRegionByKeyRequest{
@@ -2466,13 +2574,13 @@ func TestServiceInheritRetiredGrants(t *testing.T) {
 	store := &fakeStorage{
 		leader: true,
 		snapshot: rootview.Snapshot{
-			ActiveGrant: rootproto.AuthorityGrant{
+			ActiveGrants: []rootproto.AuthorityGrant{{
 				GrantID:         "c2/2",
 				HolderID:        "c2",
 				Era:             2,
 				ExpiresUnixNano: time.Unix(0, 10_000).UnixNano(),
 				Duties:          []rootproto.DutyGrant{rootproto.NewGlobalMonotoneDuty(rootproto.DutyAllocID, 20)},
-			},
+			}},
 			RetiredGrants: []rootproto.GrantRetirement{retired},
 		},
 	}
@@ -2490,7 +2598,7 @@ func TestServiceInheritRetiredGrants(t *testing.T) {
 func TestServiceGrantAdmissionSurvivesStaleReloadAfterIssue(t *testing.T) {
 	stale := rootview.Snapshot{
 		RootToken: rootstorage.TailToken{Cursor: rootstate.Cursor{Term: 1, Index: 10}, Revision: 10},
-		ActiveGrant: rootproto.AuthorityGrant{
+		ActiveGrants: []rootproto.AuthorityGrant{{
 			GrantID:         "c2/1",
 			HolderID:        "c2",
 			Era:             1,
@@ -2499,14 +2607,14 @@ func TestServiceGrantAdmissionSurvivesStaleReloadAfterIssue(t *testing.T) {
 				rootproto.NewGlobalMonotoneDuty(rootproto.DutyAllocID, 10),
 				rootproto.NewGlobalMonotoneDuty(rootproto.DutyTSO, 100),
 			},
-		},
+		}},
 	}
 	store := &staleGrantReloadStorage{
 		fakeStorage: &fakeStorage{
 			leader: true,
 			snapshot: rootview.Snapshot{
 				RootToken: rootstorage.TailToken{Cursor: rootstate.Cursor{Term: 1, Index: 11}, Revision: 11},
-				ActiveGrant: rootproto.AuthorityGrant{
+				ActiveGrants: []rootproto.AuthorityGrant{{
 					GrantID:         "expired/1",
 					HolderID:        "expired",
 					Era:             1,
@@ -2515,7 +2623,7 @@ func TestServiceGrantAdmissionSurvivesStaleReloadAfterIssue(t *testing.T) {
 						rootproto.NewGlobalMonotoneDuty(rootproto.DutyAllocID, 10),
 						rootproto.NewGlobalMonotoneDuty(rootproto.DutyTSO, 100),
 					},
-				},
+				}},
 				Allocator: rootview.AllocatorState{IDCurrent: 10, TSCurrent: 100},
 			},
 		},
@@ -2528,8 +2636,9 @@ func TestServiceGrantAdmissionSurvivesStaleReloadAfterIssue(t *testing.T) {
 	resp, err := svc.Tso(context.Background(), &coordpb.TsoRequest{Count: 1})
 	require.NoError(t, err)
 	require.Equal(t, uint64(100), resp.GetTimestamp())
-	require.Equal(t, "c1", svc.currentGrant().HolderID)
-	require.Equal(t, uint64(2), svc.currentGrant().Era)
+	current := svc.currentGrant(rootproto.DutyTSO)
+	require.Equal(t, "c1", current.HolderID)
+	require.Equal(t, uint64(2), current.Era)
 	require.Equal(t, 1, store.campaignCalls)
 }
 
@@ -2560,7 +2669,8 @@ func TestServiceReleaseGrantSealsGrant(t *testing.T) {
 
 	require.NoError(t, svc.ReleaseGrant())
 	require.Equal(t, 1, store.sealCalls)
-	require.Empty(t, store.snapshot.ActiveGrant.GrantID)
+	_, ok := store.snapshot.ActiveGrantFor(rootproto.DutyAllocID, rootproto.DutyScope{Kind: rootproto.DutyScopeGlobal})
+	require.False(t, ok)
 	require.Len(t, store.snapshot.RetiredGrants, 1)
 	require.Equal(t, rootproto.GrantRetirementSealedExact, store.snapshot.RetiredGrants[0].Mode)
 }
@@ -2582,36 +2692,39 @@ func TestServiceSealGrant(t *testing.T) {
 	campaignCallsBeforeSeal := store.campaignCalls
 
 	require.NoError(t, svc.SealGrant())
-	require.Equal(t, 1, store.sealCalls)
-	require.Empty(t, store.snapshot.ActiveGrant.GrantID)
-	require.Len(t, store.snapshot.RetiredGrants, 1)
-	retired := store.snapshot.RetiredGrants[0]
-	require.Equal(t, "c1/1", retired.GrantID)
+	require.Equal(t, 2, store.sealCalls)
+	require.Empty(t, store.snapshot.ActiveGrants)
+	require.Len(t, store.snapshot.RetiredGrants, 2)
+	retired := grantRetirementForDuty(t, store.snapshot.RetiredGrants, rootproto.DutyAllocID)
+	require.Equal(t, "c1/alloc_id/1", retired.GrantID)
 	require.Equal(t, "c1", retired.HolderID)
 	require.Equal(t, uint64(1), retired.Era)
 	require.Equal(t, rootproto.GrantRetirementSealedExact, retired.Mode)
 	require.Equal(t, uint64(11), grantMonotoneBoundForTest(retired.Bounds, rootproto.DutyAllocID))
-	require.Equal(t, uint64(102), grantMonotoneBoundForTest(retired.Bounds, rootproto.DutyTSO))
+	tsoRetired := grantRetirementForDuty(t, store.snapshot.RetiredGrants, rootproto.DutyTSO)
+	require.Equal(t, uint64(102), grantMonotoneBoundForTest(tsoRetired.Bounds, rootproto.DutyTSO))
 
 	nextID, err := svc.AllocID(context.Background(), &coordpb.AllocIDRequest{Count: 1})
 	require.NoError(t, err)
 	require.Equal(t, uint64(2), nextID.GetEra())
 	require.Equal(t, campaignCallsBeforeSeal+1, store.campaignCalls)
-	require.NotEmpty(t, store.snapshot.ActiveGrant.PredecessorRetirements)
-	require.Equal(t, "c1/1", store.snapshot.ActiveGrant.PredecessorRetirements[0].GrantID)
+	nextGrant, ok := store.snapshot.ActiveGrantFor(rootproto.DutyAllocID, rootproto.DutyScope{Kind: rootproto.DutyScopeGlobal})
+	require.True(t, ok)
+	require.NotEmpty(t, nextGrant.PredecessorRetirements)
+	require.Equal(t, "c1/alloc_id/1", nextGrant.PredecessorRetirements[0].GrantID)
 }
 
-func TestServiceSealGrantRejectsOtherHolder(t *testing.T) {
+func TestServiceSealGrantIgnoresOtherHolder(t *testing.T) {
 	store := &fakeStorage{
 		leader: true,
 		snapshot: rootview.Snapshot{
-			ActiveGrant: rootproto.AuthorityGrant{
+			ActiveGrants: []rootproto.AuthorityGrant{{
 				GrantID:         "c2/2",
 				HolderID:        "c2",
 				ExpiresUnixNano: time.Unix(0, 10_000).UnixNano(),
 				Era:             2,
 				Duties:          []rootproto.DutyGrant{rootproto.NewGlobalMonotoneDuty(rootproto.DutyAllocID, 20)},
-			},
+			}},
 		},
 	}
 	svc := NewService(catalog.NewCluster(), idalloc.NewIDAllocator(10), tso.NewAllocator(100), store)
@@ -2620,27 +2733,24 @@ func TestServiceSealGrantRejectsOtherHolder(t *testing.T) {
 	require.NoError(t, svc.ReloadFromStorage())
 
 	err := svc.SealGrant()
-	require.Error(t, err)
-	require.Equal(t, codes.FailedPrecondition, status.Code(err))
-	require.Equal(t, nokverrors.KindNotLeader, nokverrors.KindOf(err))
-	_, metadata, ok := nokverrors.RPCErrorInfo(err)
-	require.True(t, ok)
-	require.Equal(t, reasonGrantNotHeld, metadata[coordinatorReasonMetadata])
+	require.NoError(t, err)
 	require.Equal(t, 0, store.sealCalls)
-	require.Equal(t, "c2/2", store.snapshot.ActiveGrant.GrantID)
+	otherGrant, ok := store.snapshot.ActiveGrantFor(rootproto.DutyAllocID, rootproto.DutyScope{Kind: rootproto.DutyScopeGlobal})
+	require.True(t, ok)
+	require.Equal(t, "c2/2", otherGrant.GrantID)
 }
 
 func TestServiceDutyAdmissionRejectsOtherActiveGrant(t *testing.T) {
 	store := &fakeStorage{
 		leader: true,
 		snapshot: rootview.Snapshot{
-			ActiveGrant: rootproto.AuthorityGrant{
+			ActiveGrants: []rootproto.AuthorityGrant{{
 				GrantID:         "c2/1",
 				HolderID:        "c2",
 				ExpiresUnixNano: time.Now().Add(time.Hour).UnixNano(),
 				Era:             1,
 				Duties:          []rootproto.DutyGrant{rootproto.NewGlobalMonotoneDuty(rootproto.DutyAllocID, 20)},
-			},
+			}},
 		},
 	}
 	svc := NewService(catalog.NewCluster(), idalloc.NewIDAllocator(10), tso.NewAllocator(100), store)
@@ -2657,11 +2767,11 @@ func TestServiceDutyAdmissionRejectsOtherActiveGrant(t *testing.T) {
 	require.Equal(t, 0, store.campaignCalls)
 }
 
-func TestServiceAllocIDFailsWhenGrantDoesNotCoverDuty(t *testing.T) {
+func TestServiceAllocIDIssuesMissingDutyGrant(t *testing.T) {
 	store := &fakeStorage{
 		leader: true,
 		snapshot: rootview.Snapshot{
-			ActiveGrant: rootproto.AuthorityGrant{
+			ActiveGrants: []rootproto.AuthorityGrant{{
 				GrantID:         "c1/2",
 				HolderID:        "c1",
 				ExpiresUnixNano: time.Unix(10, 0).UnixNano(),
@@ -2670,27 +2780,27 @@ func TestServiceAllocIDFailsWhenGrantDoesNotCoverDuty(t *testing.T) {
 					rootproto.NewGlobalMonotoneDuty(rootproto.DutyTSO, 200),
 					rootproto.NewGlobalVersionDuty(rootproto.DutyRegionLookup, rootproto.AuthorityRootToken{}, 0, 0),
 				},
-			},
+			}},
 		},
 	}
 	svc := NewService(catalog.NewCluster(), idalloc.NewIDAllocator(10), tso.NewAllocator(100), store)
 	svc.ConfigureAuthorityGrant("c1", 10*time.Second, 3*time.Second)
 	svc.now = func() time.Time { return time.Unix(0, 200) }
 	require.NoError(t, svc.ReloadFromStorage())
-	_, hasAllocID := svc.currentGrant().Duty(rootproto.DutyAllocID)
+	_, hasAllocID := svc.currentGrant(rootproto.DutyAllocID).Duty(rootproto.DutyAllocID)
 	require.False(t, hasAllocID)
 
-	_, err := svc.AllocID(context.Background(), &coordpb.AllocIDRequest{Count: 1})
-	require.Error(t, err)
-	require.Equal(t, codes.FailedPrecondition, status.Code(err))
-	require.Contains(t, err.Error(), "required_duty=alloc_id")
+	resp, err := svc.AllocID(context.Background(), &coordpb.AllocIDRequest{Count: 1})
+	require.NoError(t, err)
+	require.Equal(t, uint64(10), resp.GetFirstId())
+	require.Equal(t, 1, store.campaignCalls)
 }
 
-func TestServiceGetRegionByKeyFailsWhenGrantDoesNotCoverDuty(t *testing.T) {
+func TestServiceGetRegionByKeyIssuesMissingDutyGrant(t *testing.T) {
 	store := &fakeStorage{
 		leader: true,
 		snapshot: rootview.Snapshot{
-			ActiveGrant: rootproto.AuthorityGrant{
+			ActiveGrants: []rootproto.AuthorityGrant{{
 				GrantID:         "c1/2",
 				HolderID:        "c1",
 				ExpiresUnixNano: time.Unix(10, 0).UnixNano(),
@@ -2699,7 +2809,7 @@ func TestServiceGetRegionByKeyFailsWhenGrantDoesNotCoverDuty(t *testing.T) {
 					rootproto.NewGlobalMonotoneDuty(rootproto.DutyAllocID, 20),
 					rootproto.NewGlobalMonotoneDuty(rootproto.DutyTSO, 200),
 				},
-			},
+			}},
 			Descriptors: map[uint64]topology.Descriptor{
 				11: {RegionID: 11, StartKey: []byte("a"), EndKey: []byte("z"), RootEpoch: 7},
 			},
@@ -2709,23 +2819,23 @@ func TestServiceGetRegionByKeyFailsWhenGrantDoesNotCoverDuty(t *testing.T) {
 	svc.ConfigureAuthorityGrant("c1", 10*time.Second, 3*time.Second)
 	svc.now = func() time.Time { return time.Unix(0, 200) }
 	require.NoError(t, svc.ReloadFromStorage())
-	_, hasRegionLookup := svc.currentGrant().Duty(rootproto.DutyRegionLookup)
+	_, hasRegionLookup := svc.currentGrant(rootproto.DutyRegionLookup).Duty(rootproto.DutyRegionLookup)
 	require.False(t, hasRegionLookup)
 
-	_, err := svc.GetRegionByKey(context.Background(), &coordpb.GetRegionByKeyRequest{
+	resp, err := svc.GetRegionByKey(context.Background(), &coordpb.GetRegionByKeyRequest{
 		Key:       []byte("m"),
 		Freshness: coordpb.Freshness_FRESHNESS_BEST_EFFORT,
 	})
-	require.Error(t, err)
-	require.Equal(t, codes.FailedPrecondition, status.Code(err))
-	require.Contains(t, err.Error(), "required_duty=region_lookup")
+	require.NoError(t, err)
+	require.Equal(t, uint64(11), resp.GetRegionDescriptor().GetRegionId())
+	require.Equal(t, 1, store.campaignCalls)
 }
 
 func TestServiceGetRegionByKeyRenewsWhenDescriptorOutsideGrant(t *testing.T) {
 	store := &fakeStorage{
 		leader: true,
 		snapshot: rootview.Snapshot{
-			ActiveGrant: rootproto.AuthorityGrant{
+			ActiveGrants: []rootproto.AuthorityGrant{{
 				GrantID:         "c1/2",
 				HolderID:        "c1",
 				ExpiresUnixNano: time.Unix(10, 0).UnixNano(),
@@ -2735,7 +2845,7 @@ func TestServiceGetRegionByKeyRenewsWhenDescriptorOutsideGrant(t *testing.T) {
 					rootproto.NewGlobalMonotoneDuty(rootproto.DutyTSO, 200),
 					rootproto.NewGlobalVersionDuty(rootproto.DutyRegionLookup, rootproto.AuthorityRootToken{}, 6, 0),
 				},
-			},
+			}},
 			Descriptors: map[uint64]topology.Descriptor{
 				11: {RegionID: 11, StartKey: []byte("a"), EndKey: []byte("z"), RootEpoch: 7},
 			},
@@ -2765,13 +2875,13 @@ func TestServiceStoreHeartbeatSuppressesOperationsWithoutGrant(t *testing.T) {
 				1: {StoreID: 1, State: rootstate.StoreMembershipActive},
 				2: {StoreID: 2, State: rootstate.StoreMembershipActive},
 			},
-			ActiveGrant: rootproto.AuthorityGrant{
+			ActiveGrants: []rootproto.AuthorityGrant{{
 				GrantID:         "other/1",
 				HolderID:        "other",
 				ExpiresUnixNano: 10_000,
 				Era:             1,
 				Duties:          []rootproto.DutyGrant{rootproto.NewGlobalVersionDuty(rootproto.DutyRegionLookup, rootproto.AuthorityRootToken{}, 0, 0)},
-			},
+			}},
 		},
 	}
 	svc := NewService(catalog.NewCluster(), nil, nil, store)
@@ -2806,6 +2916,19 @@ func grantMonotoneBoundForTest(duties []rootproto.DutyGrant, duty rootproto.Duty
 		}
 	}
 	return 0
+}
+
+func grantRetirementForDuty(t *testing.T, retirements []rootproto.GrantRetirement, duty rootproto.DutyID) rootproto.GrantRetirement {
+	t.Helper()
+	for _, retirement := range retirements {
+		for _, bound := range retirement.Bounds {
+			if bound.DutyID == duty {
+				return retirement
+			}
+		}
+	}
+	t.Fatalf("missing retirement for duty %s", rootproto.DutyName(duty))
+	return rootproto.GrantRetirement{}
 }
 
 func TestServiceRejectsWritesOnFollower(t *testing.T) {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -136,6 +136,8 @@ services:
       - "--addr=0.0.0.0:2379"
       - "--metrics-addr=0.0.0.0:9100"
       - "--coordinator-id=coord-1"
+      - "--grant-candidates=coord-1,coord-2,coord-3"
+      - "--grant-duties=alloc_id,tso,region_lookup"
       - "--grant-ttl=30s"
       - "--grant-renew-before=10s"
     volumes:
@@ -160,6 +162,8 @@ services:
       - "--addr=0.0.0.0:2379"
       - "--metrics-addr=0.0.0.0:9100"
       - "--coordinator-id=coord-2"
+      - "--grant-candidates=coord-1,coord-2,coord-3"
+      - "--grant-duties=alloc_id,tso,region_lookup"
       - "--grant-ttl=30s"
       - "--grant-renew-before=10s"
     volumes:
@@ -184,6 +188,8 @@ services:
       - "--addr=0.0.0.0:2379"
       - "--metrics-addr=0.0.0.0:9100"
       - "--coordinator-id=coord-3"
+      - "--grant-candidates=coord-1,coord-2,coord-3"
+      - "--grant-duties=alloc_id,tso,region_lookup"
       - "--grant-ttl=30s"
       - "--grant-renew-before=10s"
     volumes:

--- a/docs/rooted_truth.md
+++ b/docs/rooted_truth.md
@@ -55,7 +55,7 @@ type State struct {
     LastCommitted      Cursor         // highest committed (term, index)
     IDFence            uint64         // globally fenced ID allocator floor
     TSOFence           uint64         // globally fenced TSO allocator floor
-    ActiveGrant        AuthorityGrant
+    ActiveGrants       []AuthorityGrant // mutually exclusive by {DutyID, Scope}
     RetiredGrants      []GrantRetirement
     GrantInheritances  []GrantInheritance
 }
@@ -137,7 +137,7 @@ These are **validated, typed writes** that internally:
 2. Emit the appropriate `KindGrantIssued` / `KindGrantSealed` /
    `KindGrantRetired` / `KindGrantInherited` event
 3. Append through the normal log path
-4. Return the new `EunomiaState = { ActiveGrant, RetiredGrants,
+4. Return the new `EunomiaState = { ActiveGrants, RetiredGrants,
    GrantInheritances, RetiredEraFloor }` and, for issue, a root-signed
    deterministic `GrantCertificate`
 

--- a/meta/root/integration/cluster_test.go
+++ b/meta/root/integration/cluster_test.go
@@ -99,8 +99,9 @@ func TestMetaRootLeaderChangePreservesClosureLineage(t *testing.T) {
 			if err != nil {
 				return false
 			}
-			if current.ActiveGrant.HolderID != "c2" ||
-				current.ActiveGrant.Era != successor.Era ||
+			if len(current.ActiveGrants) != 1 ||
+				current.ActiveGrants[0].HolderID != "c2" ||
+				current.ActiveGrants[0].Era != successor.Era ||
 				len(current.RetiredGrants) != 1 ||
 				current.RetiredGrants[0].Era != retirement.Era ||
 				current.RetiredGrants[0].HolderID != "c1" ||
@@ -160,7 +161,10 @@ func issueGrant(store interface {
 			rootproto.NewGlobalVersionDuty(rootproto.DutyRegionLookup, rootproto.AuthorityRootToken{}, descriptorRevision, 0),
 		},
 	})
-	return state.ActiveGrant, err
+	if err != nil || len(state.ActiveGrants) == 0 {
+		return rootproto.AuthorityGrant{}, err
+	}
+	return state.ActiveGrants[0], nil
 }
 
 func sealGrant(store interface {

--- a/meta/root/protocol/types.go
+++ b/meta/root/protocol/types.go
@@ -66,6 +66,11 @@ type DutyGrant struct {
 	Bound  DutyBound
 }
 
+type DutyKey struct {
+	DutyID DutyID
+	Scope  DutyScope
+}
+
 type AuthorityGrant struct {
 	GrantID                string
 	HolderID               string
@@ -258,6 +263,22 @@ func NewGlobalMonotoneDuty(duty DutyID, upper uint64) DutyGrant {
 	}
 }
 
+func NewGlobalDutyKey(duty DutyID) DutyKey {
+	return DutyKey{DutyID: duty, Scope: DutyScope{Kind: DutyScopeGlobal}}
+}
+
+func (g DutyGrant) Key() DutyKey {
+	return DutyKey{DutyID: g.DutyID, Scope: g.Scope}
+}
+
+func (u AuthorityUsage) Key() DutyKey {
+	return DutyKey{DutyID: u.DutyID, Scope: u.Scope}
+}
+
+func DutyKeyEqual(left, right DutyKey) bool {
+	return left.DutyID == right.DutyID && ScopeEqual(left.Scope, right.Scope)
+}
+
 func NewGlobalVersionDuty(duty DutyID, token AuthorityRootToken, descriptorRevisionCeiling, maxRootLag uint64) DutyGrant {
 	return DutyGrant{
 		DutyID: duty,
@@ -295,6 +316,11 @@ func (g AuthorityGrant) DutyFor(duty DutyID, scope DutyScope) (DutyGrant, bool) 
 		}
 	}
 	return DutyGrant{}, false
+}
+
+func (g AuthorityGrant) CoversDutyKey(key DutyKey) bool {
+	_, ok := g.DutyFor(key.DutyID, key.Scope)
+	return ok
 }
 
 func (r GrantRetirement) Present() bool {

--- a/meta/root/replicated/store.go
+++ b/meta/root/replicated/store.go
@@ -341,13 +341,17 @@ func (s *Store) issueGrantLocked(ctx context.Context, cmd rootproto.GrantCommand
 	if !validDutyGrants(cmd.RequestedDuties) || !validAuthorityUsages(cmd.ExactUsages) {
 		return s.state.Eunomia(), rootproto.GrantCertificate{}, rootstate.ErrDuty
 	}
+	requestedKeys := dutyKeysFromGrants(cmd.RequestedDuties)
 	requestedGrantID := strings.TrimSpace(cmd.GrantID)
 	if requestedGrantID != "" &&
-		s.state.ActiveGrant.Present() &&
-		s.state.ActiveGrant.GrantID == requestedGrantID &&
-		s.state.ActiveGrant.HolderID == holderID &&
-		dutyBoundsCovered(s.state.ActiveGrant.Duties, cmd.RequestedDuties) {
-		cert, err := signGrantCertificate(s.state.ActiveGrant)
+		func() bool {
+			active, ok := activeGrantByID(s.state.ActiveGrants, requestedGrantID)
+			return ok &&
+				active.HolderID == holderID &&
+				dutyBoundsCovered(active.Duties, cmd.RequestedDuties)
+		}() {
+		active, _ := activeGrantByID(s.state.ActiveGrants, requestedGrantID)
+		cert, err := signGrantCertificate(active)
 		if err != nil {
 			return rootstate.EunomiaState{}, rootproto.GrantCertificate{}, err
 		}
@@ -359,13 +363,20 @@ func (s *Store) issueGrantLocked(ctx context.Context, cmd rootproto.GrantCommand
 		if strings.TrimSpace(retirement.InheritedByGrantID) != "" {
 			continue
 		}
+		if !dutyBoundsOverlap(retirement.Bounds, requestedKeys) {
+			continue
+		}
 		if !dutyBoundsCovered(cmd.RequestedDuties, retirement.Bounds) {
 			return s.state.Eunomia(), rootproto.GrantCertificate{}, rootstate.ErrInheritance
 		}
 		predecessors = append(predecessors, retirement)
 	}
-	active := s.state.ActiveGrant
-	if active.Present() {
+	var active rootproto.AuthorityGrant
+	for _, candidate := range s.state.ActiveGrants {
+		if !grantOverlapsDutyKeys(candidate, requestedKeys) {
+			continue
+		}
+		active = candidate
 		if active.ActiveAt(cmd.NowUnixNano) && active.HolderID != holderID {
 			return s.state.Eunomia(), rootproto.GrantCertificate{}, rootstate.ErrPrimacy
 		}
@@ -394,7 +405,7 @@ func (s *Store) issueGrantLocked(ctx context.Context, cmd rootproto.GrantCommand
 	}
 	era := nextGrantEra(s.state)
 	grantID := requestedGrantID
-	if grantID == "" || grantID == active.GrantID || retiredGrantIDExists(s.state.RetiredGrants, grantID) {
+	if grantID == "" || activeGrantIDExists(s.state.ActiveGrants, grantID) || retiredGrantIDExists(s.state.RetiredGrants, grantID) {
 		grantID = fmt.Sprintf("%s/%d", holderID, era)
 	}
 	grant := rootproto.AuthorityGrant{
@@ -410,11 +421,20 @@ func (s *Store) issueGrantLocked(ctx context.Context, cmd rootproto.GrantCommand
 	if err != nil {
 		return rootstate.EunomiaState{}, rootproto.GrantCertificate{}, err
 	}
-	cert, err := signGrantCertificate(commit.State.ActiveGrant)
+	committed, ok := commit.State.ActiveGrantByID(grantID)
+	if !ok {
+		return rootstate.EunomiaState{}, rootproto.GrantCertificate{}, rootstate.ErrFinality
+	}
+	cert, err := signGrantCertificate(committed)
 	if err != nil {
 		return rootstate.EunomiaState{}, rootproto.GrantCertificate{}, err
 	}
 	return commit.State.Eunomia(), cert, nil
+}
+
+func activeGrantIDExists(grants []rootproto.AuthorityGrant, grantID string) bool {
+	_, ok := activeGrantByID(grants, grantID)
+	return ok
 }
 
 func retiredGrantIDExists(retirements []rootproto.GrantRetirement, grantID string) bool {
@@ -427,14 +447,11 @@ func retiredGrantIDExists(retirements []rootproto.GrantRetirement, grantID strin
 }
 
 func (s *Store) sealGrantLocked(ctx context.Context, cmd rootproto.GrantCommand) (rootstate.EunomiaState, error) {
-	active := s.state.ActiveGrant
-	if !active.Present() {
+	active, ok := activeGrantByID(s.state.ActiveGrants, strings.TrimSpace(cmd.GrantID))
+	if !ok {
 		return s.state.Eunomia(), rootstate.ErrPrimacy
 	}
 	if strings.TrimSpace(cmd.HolderID) != active.HolderID {
-		return s.state.Eunomia(), rootstate.ErrPrimacy
-	}
-	if cmd.GrantID != "" && cmd.GrantID != active.GrantID {
 		return s.state.Eunomia(), rootstate.ErrPrimacy
 	}
 	if !validAuthorityUsages(cmd.ExactUsages) {
@@ -458,12 +475,9 @@ func (s *Store) sealGrantLocked(ctx context.Context, cmd rootproto.GrantCommand)
 }
 
 func (s *Store) retireExpiredGrantLocked(ctx context.Context, cmd rootproto.GrantCommand) (rootstate.EunomiaState, error) {
-	active := s.state.ActiveGrant
-	if !active.Present() {
+	active, ok := activeGrantByID(s.state.ActiveGrants, strings.TrimSpace(cmd.GrantID))
+	if !ok {
 		return s.state.Eunomia(), nil
-	}
-	if cmd.GrantID != "" && cmd.GrantID != active.GrantID {
-		return s.state.Eunomia(), rootstate.ErrPrimacy
 	}
 	if active.ExpiresUnixNano > cmd.NowUnixNano {
 		return s.state.Eunomia(), rootstate.ErrPrimacy
@@ -482,13 +496,9 @@ func (s *Store) retireExpiredGrantLocked(ctx context.Context, cmd rootproto.Gran
 }
 
 func (s *Store) inheritGrantLocked(ctx context.Context, cmd rootproto.GrantCommand) (rootstate.EunomiaState, error) {
-	if !s.state.ActiveGrant.Present() {
+	if len(s.state.ActiveGrants) == 0 {
 		return s.state.Eunomia(), rootstate.ErrPrimacy
 	}
-	if strings.TrimSpace(cmd.HolderID) != s.state.ActiveGrant.HolderID {
-		return s.state.Eunomia(), rootstate.ErrPrimacy
-	}
-	successor := s.state.ActiveGrant.GrantID
 	events := make([]rootevent.Event, 0, len(cmd.PredecessorGrantIDs))
 	seen := make(map[string]struct{}, len(cmd.PredecessorGrantIDs))
 	for _, predecessor := range cmd.PredecessorGrantIDs {
@@ -504,18 +514,22 @@ func (s *Store) inheritGrantLocked(ctx context.Context, cmd rootproto.GrantComma
 		if !ok {
 			return s.state.Eunomia(), rootstate.ErrInheritance
 		}
+		successor, ok := successorGrantForRetirement(s.state.ActiveGrants, strings.TrimSpace(cmd.HolderID), retirement)
+		if !ok {
+			return s.state.Eunomia(), rootstate.ErrPrimacy
+		}
 		if retirement.InheritedByGrantID != "" {
-			if retirement.InheritedByGrantID == successor {
+			if retirement.InheritedByGrantID == successor.GrantID {
 				continue
 			}
 			return s.state.Eunomia(), rootstate.ErrFinality
 		}
-		if !predecessorRetirementCovered(s.state.ActiveGrant, retirement) {
+		if !predecessorRetirementCovered(successor, retirement) {
 			return s.state.Eunomia(), rootstate.ErrInheritance
 		}
 		events = append(events, rootevent.GrantInherited(rootproto.GrantInheritance{
 			PredecessorGrantID: predecessor,
-			SuccessorGrantID:   successor,
+			SuccessorGrantID:   successor.GrantID,
 		}))
 	}
 	if len(events) == 0 {
@@ -529,7 +543,12 @@ func (s *Store) inheritGrantLocked(ctx context.Context, cmd rootproto.GrantComma
 }
 
 func nextGrantEra(state rootstate.State) uint64 {
-	era := state.ActiveGrant.Era
+	var era uint64
+	for _, grant := range state.ActiveGrants {
+		if grant.Era > era {
+			era = grant.Era
+		}
+	}
 	for _, retirement := range state.RetiredGrants {
 		if retirement.Era > era {
 			era = retirement.Era
@@ -566,6 +585,50 @@ func findDutyGrant(grants []rootproto.DutyGrant, duty rootproto.DutyID, scope ro
 		}
 	}
 	return rootproto.DutyGrant{}, false
+}
+
+func dutyKeysFromGrants(grants []rootproto.DutyGrant) []rootproto.DutyKey {
+	out := make([]rootproto.DutyKey, 0, len(grants))
+	for _, grant := range grants {
+		out = append(out, grant.Key())
+	}
+	return out
+}
+
+func dutyBoundsOverlap(grants []rootproto.DutyGrant, keys []rootproto.DutyKey) bool {
+	for _, grant := range grants {
+		for _, key := range keys {
+			if rootproto.DutyKeyEqual(grant.Key(), key) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func grantOverlapsDutyKeys(grant rootproto.AuthorityGrant, keys []rootproto.DutyKey) bool {
+	return dutyBoundsOverlap(grant.Duties, keys)
+}
+
+func activeGrantByID(grants []rootproto.AuthorityGrant, grantID string) (rootproto.AuthorityGrant, bool) {
+	for _, grant := range grants {
+		if grant.GrantID == grantID {
+			return grant, true
+		}
+	}
+	return rootproto.AuthorityGrant{}, false
+}
+
+func successorGrantForRetirement(grants []rootproto.AuthorityGrant, holderID string, retirement rootproto.GrantRetirement) (rootproto.AuthorityGrant, bool) {
+	for _, grant := range grants {
+		if strings.TrimSpace(grant.HolderID) != holderID {
+			continue
+		}
+		if dutyBoundsCovered(grant.Duties, retirement.Bounds) {
+			return grant, true
+		}
+	}
+	return rootproto.AuthorityGrant{}, false
 }
 
 func validDutyGrants(grants []rootproto.DutyGrant) bool {

--- a/meta/root/replicated/store_test.go
+++ b/meta/root/replicated/store_test.go
@@ -27,7 +27,7 @@ func issueGrant(store *Store, holderID string, expiresUnixNano, nowUnixNano int6
 			rootproto.NewGlobalVersionDuty(rootproto.DutyRegionLookup, rootproto.AuthorityRootToken{}, descriptorRevision, 0),
 		},
 	})
-	return state.ActiveGrant, cert, err
+	return firstActiveGrant(state), cert, err
 }
 
 func issueGrantWithDuties(store *Store, holderID string, expiresUnixNano, nowUnixNano int64, duties []rootproto.DutyGrant) (rootproto.AuthorityGrant, error) {
@@ -38,7 +38,14 @@ func issueGrantWithDuties(store *Store, holderID string, expiresUnixNano, nowUni
 		NowUnixNano:     nowUnixNano,
 		RequestedDuties: duties,
 	})
-	return state.ActiveGrant, err
+	return firstActiveGrant(state), err
+}
+
+func firstActiveGrant(state rootstate.EunomiaState) rootproto.AuthorityGrant {
+	if len(state.ActiveGrants) == 0 {
+		return rootproto.AuthorityGrant{}
+	}
+	return state.ActiveGrants[0]
 }
 
 func sealGrant(store *Store, holderID, grantID string, usages []rootproto.AuthorityUsage) (rootproto.GrantRetirement, error) {
@@ -319,11 +326,40 @@ func TestReplicatedStoreIssueGrant(t *testing.T) {
 		if err != nil {
 			return false
 		}
-		return current.ActiveGrant.HolderID == "c1" &&
-			current.ActiveGrant.Era == 1 &&
+		grant, ok := current.ActiveGrantFor(rootproto.DutyAllocID, rootproto.DutyScope{Kind: rootproto.DutyScopeGlobal})
+		return ok &&
+			grant.HolderID == "c1" &&
+			grant.Era == 1 &&
 			current.IDFence == 123 &&
 			current.TSOFence == 456
 	}, 5*time.Second, 50*time.Millisecond)
+}
+
+func TestReplicatedStoreAllowsDisjointDutyGrants(t *testing.T) {
+	stores, _, leaderID := openNetworkTestCluster(t, 4)
+	store := stores[leaderID]
+
+	allocGrant, err := issueGrantWithDuties(store, "c1", 1_000, 100, []rootproto.DutyGrant{
+		rootproto.NewGlobalMonotoneDuty(rootproto.DutyAllocID, 123),
+	})
+	require.NoError(t, err)
+	_, err = issueGrantWithDuties(store, "c2", 1_000, 100, []rootproto.DutyGrant{
+		rootproto.NewGlobalMonotoneDuty(rootproto.DutyTSO, 456),
+	})
+	require.NoError(t, err)
+
+	current, err := store.Current()
+	require.NoError(t, err)
+	require.Len(t, current.ActiveGrants, 2)
+	activeAlloc, ok := current.ActiveGrantFor(rootproto.DutyAllocID, rootproto.DutyScope{Kind: rootproto.DutyScopeGlobal})
+	require.True(t, ok)
+	require.Equal(t, allocGrant.GrantID, activeAlloc.GrantID)
+	activeTSO, ok := current.ActiveGrantFor(rootproto.DutyTSO, rootproto.DutyScope{Kind: rootproto.DutyScopeGlobal})
+	require.True(t, ok)
+	require.Equal(t, "c2", activeTSO.HolderID)
+	require.Empty(t, current.RetiredGrants)
+	require.Equal(t, uint64(123), current.IDFence)
+	require.Equal(t, uint64(456), current.TSOFence)
 }
 
 func TestReplicatedStoreIssueGrantIdempotentByGrantID(t *testing.T) {
@@ -345,10 +381,10 @@ func TestReplicatedStoreIssueGrantIdempotentByGrantID(t *testing.T) {
 	secondState, secondCert, err := stores[leaderID].ApplyGrant(context.Background(), cmd)
 	require.NoError(t, err)
 
-	require.Equal(t, firstState.ActiveGrant, secondState.ActiveGrant)
+	require.Equal(t, firstActiveGrant(firstState), firstActiveGrant(secondState))
 	require.Equal(t, firstCert.Grant, secondCert.Grant)
-	require.Equal(t, uint64(1), secondState.ActiveGrant.Era)
-	require.Equal(t, "c1/request-1", secondState.ActiveGrant.GrantID)
+	require.Equal(t, uint64(1), firstActiveGrant(secondState).Era)
+	require.Equal(t, "c1/request-1", firstActiveGrant(secondState).GrantID)
 	require.Empty(t, secondState.RetiredGrants)
 
 	wider := cmd
@@ -358,8 +394,8 @@ func TestReplicatedStoreIssueGrantIdempotentByGrantID(t *testing.T) {
 	}
 	widerState, _, err := stores[leaderID].ApplyGrant(context.Background(), wider)
 	require.NoError(t, err)
-	require.Equal(t, uint64(2), widerState.ActiveGrant.Era)
-	require.NotEqual(t, "c1/request-1", widerState.ActiveGrant.GrantID)
+	require.Equal(t, uint64(2), firstActiveGrant(widerState).Era)
+	require.NotEqual(t, "c1/request-1", firstActiveGrant(widerState).GrantID)
 	require.Len(t, widerState.RetiredGrants, 1)
 	require.Equal(t, "c1/request-1", widerState.RetiredGrants[0].GrantID)
 }
@@ -505,9 +541,11 @@ func TestReplicatedStoreGrantFenceSurvivesLeaderChange(t *testing.T) {
 			return false
 		}
 		current, err := stores[followerID].Current()
+		grant, ok := current.ActiveGrantFor(rootproto.DutyAllocID, rootproto.DutyScope{Kind: rootproto.DutyScopeGlobal})
 		return err == nil &&
-			current.ActiveGrant.HolderID == "c1" &&
-			current.ActiveGrant.Era == 1 &&
+			ok &&
+			grant.HolderID == "c1" &&
+			grant.Era == 1 &&
 			current.IDFence == 123 &&
 			current.TSOFence == 456
 	}, 5*time.Second, 50*time.Millisecond)
@@ -531,9 +569,11 @@ func TestReplicatedStoreGrantFenceSurvivesLeaderChange(t *testing.T) {
 				return false
 			}
 			current, err := stores[id].Current()
+			grant, ok := current.ActiveGrantFor(rootproto.DutyAllocID, rootproto.DutyScope{Kind: rootproto.DutyScopeGlobal})
 			return err == nil &&
-				current.ActiveGrant.HolderID == "c1" &&
-				current.ActiveGrant.Era == 2 &&
+				ok &&
+				grant.HolderID == "c1" &&
+				grant.Era == 2 &&
 				current.IDFence == 200 &&
 				current.TSOFence == 600
 		}, 5*time.Second, 50*time.Millisecond)
@@ -557,7 +597,7 @@ func TestReplicatedStoreRetireExpiredGrant(t *testing.T) {
 
 	current, err := stores[leaderID].Current()
 	require.NoError(t, err)
-	require.False(t, current.ActiveGrant.Present())
+	require.Empty(t, current.ActiveGrants)
 }
 
 func testDescriptor(id uint64, start, end []byte) topology.Descriptor {

--- a/meta/root/server/service_test.go
+++ b/meta/root/server/service_test.go
@@ -421,7 +421,7 @@ func TestServiceApplyGrant(t *testing.T) {
 		Duties:          []rootproto.DutyGrant{rootproto.NewGlobalMonotoneDuty(rootproto.DutyAllocID, 10)},
 	}
 	grantState := rootstate.EunomiaState{
-		ActiveGrant: grant,
+		ActiveGrants: []rootproto.AuthorityGrant{grant},
 	}
 	cert := rootproto.GrantCertificate{Grant: grant, SignerKeyID: rootproto.GrantSignerKeyID, Signature: []byte("sig")}
 	cmd := rootproto.GrantCommand{

--- a/meta/root/state/eunomia.go
+++ b/meta/root/state/eunomia.go
@@ -3,7 +3,7 @@ package state
 import rootproto "github.com/feichai0017/NoKV/meta/root/protocol"
 
 type EunomiaState struct {
-	ActiveGrant       rootproto.AuthorityGrant
+	ActiveGrants      []rootproto.AuthorityGrant
 	RetiredGrants     []rootproto.GrantRetirement
 	GrantInheritances []rootproto.GrantInheritance
 	RetiredEraFloor   uint64
@@ -11,7 +11,7 @@ type EunomiaState struct {
 
 func (s State) Eunomia() EunomiaState {
 	return EunomiaState{
-		ActiveGrant:       s.ActiveGrant,
+		ActiveGrants:      cloneAuthorityGrants(s.ActiveGrants),
 		RetiredGrants:     append([]rootproto.GrantRetirement(nil), s.RetiredGrants...),
 		GrantInheritances: append([]rootproto.GrantInheritance(nil), s.GrantInheritances...),
 		RetiredEraFloor:   s.RetiredEraFloor,

--- a/meta/root/state/eunomia_test.go
+++ b/meta/root/state/eunomia_test.go
@@ -10,14 +10,14 @@ import (
 
 func TestEunomiaProjectionCarriesGrantLifecycle(t *testing.T) {
 	st := rootstate.State{
-		ActiveGrant: rootproto.AuthorityGrant{
+		ActiveGrants: []rootproto.AuthorityGrant{{
 			GrantID:  "c2/2",
 			HolderID: "c2",
 			Era:      2,
 			Duties: []rootproto.DutyGrant{
 				rootproto.NewGlobalMonotoneDuty(rootproto.DutyAllocID, 20),
 			},
-		},
+		}},
 		RetiredGrants: []rootproto.GrantRetirement{
 			{
 				GrantID: "c1/1",
@@ -35,8 +35,9 @@ func TestEunomiaProjectionCarriesGrantLifecycle(t *testing.T) {
 
 	projected := st.Eunomia()
 
-	require.True(t, projected.ActiveGrant.Present())
-	require.Equal(t, "c2/2", projected.ActiveGrant.GrantID)
+	require.Len(t, projected.ActiveGrants, 1)
+	require.True(t, projected.ActiveGrants[0].Present())
+	require.Equal(t, "c2/2", projected.ActiveGrants[0].GrantID)
 	require.Len(t, projected.RetiredGrants, 1)
 	require.Equal(t, rootproto.GrantRetirementExpiredBound, projected.RetiredGrants[0].Mode)
 	require.Len(t, projected.GrantInheritances, 1)

--- a/meta/root/state/state.go
+++ b/meta/root/state/state.go
@@ -39,10 +39,28 @@ type State struct {
 	LastCommitted     Cursor
 	IDFence           uint64
 	TSOFence          uint64
-	ActiveGrant       rootproto.AuthorityGrant
+	ActiveGrants      []rootproto.AuthorityGrant
 	RetiredGrants     []rootproto.GrantRetirement
 	GrantInheritances []rootproto.GrantInheritance
 	RetiredEraFloor   uint64
+}
+
+func (s State) ActiveGrantFor(duty rootproto.DutyID, scope rootproto.DutyScope) (rootproto.AuthorityGrant, bool) {
+	for _, grant := range s.ActiveGrants {
+		if grant.CoversDutyKey(rootproto.DutyKey{DutyID: duty, Scope: scope}) {
+			return cloneAuthorityGrant(grant), true
+		}
+	}
+	return rootproto.AuthorityGrant{}, false
+}
+
+func (s State) ActiveGrantByID(grantID string) (rootproto.AuthorityGrant, bool) {
+	for _, grant := range s.ActiveGrants {
+		if grant.GrantID == grantID {
+			return cloneAuthorityGrant(grant), true
+		}
+	}
+	return rootproto.AuthorityGrant{}, false
 }
 
 type StoreMembershipState uint8
@@ -199,8 +217,7 @@ type CommitInfo struct {
 
 func CloneSnapshot(snapshot Snapshot) Snapshot {
 	state := snapshot.State
-	state.ActiveGrant.Duties = append([]rootproto.DutyGrant(nil), state.ActiveGrant.Duties...)
-	state.ActiveGrant.PredecessorRetirements = append([]rootproto.GrantRetirement(nil), state.ActiveGrant.PredecessorRetirements...)
+	state.ActiveGrants = cloneAuthorityGrants(state.ActiveGrants)
 	state.RetiredGrants = append([]rootproto.GrantRetirement(nil), state.RetiredGrants...)
 	state.GrantInheritances = append([]rootproto.GrantInheritance(nil), state.GrantInheritances...)
 	out := Snapshot{
@@ -457,16 +474,24 @@ func applyGrantIssuedToState(state *State, cursor Cursor, event rootevent.Event)
 	if state == nil || event.Grant == nil {
 		return
 	}
-	grant := *event.Grant
-	grant.Duties = append([]rootproto.DutyGrant(nil), event.Grant.Duties...)
-	grant.PredecessorRetirements = append([]rootproto.GrantRetirement(nil), event.Grant.PredecessorRetirements...)
+	grant := cloneAuthorityGrant(*event.Grant)
 	if grant.IssuedAt.Term == 0 && grant.IssuedAt.Index == 0 {
 		grant.IssuedAt = cursor
 	}
 	if grant.IssuedRootToken.Term == 0 && grant.IssuedRootToken.Index == 0 && grant.IssuedRootToken.Revision == 0 {
 		grant.IssuedRootToken = rootproto.AuthorityRootToken{Term: cursor.Term, Index: cursor.Index}
 	}
-	state.ActiveGrant = grant
+	replaced := false
+	for i := range state.ActiveGrants {
+		if state.ActiveGrants[i].GrantID == grant.GrantID {
+			state.ActiveGrants[i] = grant
+			replaced = true
+			break
+		}
+	}
+	if !replaced {
+		state.ActiveGrants = append(state.ActiveGrants, grant)
+	}
 	for _, duty := range grant.Duties {
 		if duty.Bound.Kind != rootproto.DutyBoundMonotone {
 			continue
@@ -510,8 +535,11 @@ func applyGrantRetirementToState(state *State, cursor Cursor, event rootevent.Ev
 	if !replaced {
 		state.RetiredGrants = append(state.RetiredGrants, retirement)
 	}
-	if state.ActiveGrant.GrantID == retirement.GrantID {
-		state.ActiveGrant = rootproto.AuthorityGrant{}
+	for i := 0; i < len(state.ActiveGrants); i++ {
+		if state.ActiveGrants[i].GrantID == retirement.GrantID {
+			state.ActiveGrants = append(state.ActiveGrants[:i], state.ActiveGrants[i+1:]...)
+			i--
+		}
 	}
 }
 
@@ -539,10 +567,12 @@ func CompactEunomiaState(state State) State {
 		return state
 	}
 	originalRetirements := append([]rootproto.GrantRetirement(nil), state.RetiredGrants...)
-	activePredecessors := make(map[string]struct{}, len(state.ActiveGrant.PredecessorRetirements))
-	for _, retirement := range state.ActiveGrant.PredecessorRetirements {
-		if retirement.GrantID != "" {
-			activePredecessors[retirement.GrantID] = struct{}{}
+	activePredecessors := make(map[string]struct{})
+	for _, grant := range state.ActiveGrants {
+		for _, retirement := range grant.PredecessorRetirements {
+			if retirement.GrantID != "" {
+				activePredecessors[retirement.GrantID] = struct{}{}
+			}
 		}
 	}
 	retirements := make([]rootproto.GrantRetirement, 0, len(originalRetirements))
@@ -574,6 +604,23 @@ func CompactEunomiaState(state State) State {
 	state.RetiredGrants = retirements
 	state.GrantInheritances = inheritances
 	return state
+}
+
+func cloneAuthorityGrant(grant rootproto.AuthorityGrant) rootproto.AuthorityGrant {
+	grant.Duties = append([]rootproto.DutyGrant(nil), grant.Duties...)
+	grant.PredecessorRetirements = append([]rootproto.GrantRetirement(nil), grant.PredecessorRetirements...)
+	return grant
+}
+
+func cloneAuthorityGrants(grants []rootproto.AuthorityGrant) []rootproto.AuthorityGrant {
+	if len(grants) == 0 {
+		return nil
+	}
+	out := make([]rootproto.AuthorityGrant, len(grants))
+	for i, grant := range grants {
+		out[i] = cloneAuthorityGrant(grant)
+	}
+	return out
 }
 
 // NextCursor returns the next ordered root cursor.

--- a/meta/wire/root.go
+++ b/meta/wire/root.go
@@ -26,7 +26,7 @@ func RootStateToProto(state rootstate.State) *metapb.RootState {
 		LastCommitted:     RootCursorToProto(state.LastCommitted),
 		IdFence:           state.IDFence,
 		TsoFence:          state.TSOFence,
-		ActiveGrant:       RootAuthorityGrantToProto(state.ActiveGrant),
+		ActiveGrants:      RootAuthorityGrantsToProto(state.ActiveGrants),
 		RetiredGrants:     RootGrantRetirementsToProto(state.RetiredGrants),
 		GrantInheritances: RootGrantInheritancesToProto(state.GrantInheritances),
 		RetiredEraFloor:   state.RetiredEraFloor,
@@ -43,7 +43,7 @@ func RootStateFromProto(pbState *metapb.RootState) rootstate.State {
 		LastCommitted:     RootCursorFromProto(pbState.LastCommitted),
 		IDFence:           pbState.IdFence,
 		TSOFence:          pbState.TsoFence,
-		ActiveGrant:       RootAuthorityGrantFromProto(pbState.GetActiveGrant()),
+		ActiveGrants:      RootAuthorityGrantsFromProto(pbState.GetActiveGrants()),
 		RetiredGrants:     RootGrantRetirementsFromProto(pbState.GetRetiredGrants()),
 		GrantInheritances: RootGrantInheritancesFromProto(pbState.GetGrantInheritances()),
 		RetiredEraFloor:   pbState.GetRetiredEraFloor(),
@@ -80,6 +80,32 @@ func RootAuthorityGrantFromProto(grant *metapb.RootAuthorityGrant) rootproto.Aut
 		Duties:                 RootDutyGrantsFromProto(grant.GetDuties()),
 		PredecessorRetirements: RootGrantRetirementsFromProto(grant.GetPredecessorRetirements()),
 	}
+}
+
+func RootAuthorityGrantsToProto(grants []rootproto.AuthorityGrant) []*metapb.RootAuthorityGrant {
+	if len(grants) == 0 {
+		return nil
+	}
+	out := make([]*metapb.RootAuthorityGrant, 0, len(grants))
+	for _, grant := range grants {
+		if pbGrant := RootAuthorityGrantToProto(grant); pbGrant != nil {
+			out = append(out, pbGrant)
+		}
+	}
+	return out
+}
+
+func RootAuthorityGrantsFromProto(grants []*metapb.RootAuthorityGrant) []rootproto.AuthorityGrant {
+	if len(grants) == 0 {
+		return nil
+	}
+	out := make([]rootproto.AuthorityGrant, 0, len(grants))
+	for _, grant := range grants {
+		if parsed := RootAuthorityGrantFromProto(grant); parsed.Present() {
+			out = append(out, parsed)
+		}
+	}
+	return out
 }
 
 func RootGrantRetirementToProto(retirement rootproto.GrantRetirement) *metapb.RootGrantRetirement {
@@ -189,7 +215,7 @@ func RootGrantInheritancesFromProto(inheritances []*metapb.RootGrantInheritance)
 
 func RootEunomiaStateToProto(state rootstate.EunomiaState) *metapb.RootEunomiaState {
 	return &metapb.RootEunomiaState{
-		ActiveGrant:       RootAuthorityGrantToProto(state.ActiveGrant),
+		ActiveGrants:      RootAuthorityGrantsToProto(state.ActiveGrants),
 		RetiredGrants:     RootGrantRetirementsToProto(state.RetiredGrants),
 		GrantInheritances: RootGrantInheritancesToProto(state.GrantInheritances),
 		RetiredEraFloor:   state.RetiredEraFloor,
@@ -201,7 +227,7 @@ func RootEunomiaStateFromProto(state *metapb.RootEunomiaState) rootstate.Eunomia
 		return rootstate.EunomiaState{}
 	}
 	return rootstate.EunomiaState{
-		ActiveGrant:       RootAuthorityGrantFromProto(state.GetActiveGrant()),
+		ActiveGrants:      RootAuthorityGrantsFromProto(state.GetActiveGrants()),
 		RetiredGrants:     RootGrantRetirementsFromProto(state.GetRetiredGrants()),
 		GrantInheritances: RootGrantInheritancesFromProto(state.GetGrantInheritances()),
 		RetiredEraFloor:   state.GetRetiredEraFloor(),

--- a/meta/wire/root_test.go
+++ b/meta/wire/root_test.go
@@ -75,7 +75,7 @@ func TestRootStateProtocolAndCommandRoundTrip(t *testing.T) {
 		LastCommitted:     rootproto.Cursor{Term: 2, Index: 9},
 		IDFence:           100,
 		TSOFence:          200,
-		ActiveGrant:       grant,
+		ActiveGrants:      []rootproto.AuthorityGrant{grant},
 		RetiredGrants:     []rootproto.GrantRetirement{retirement},
 		GrantInheritances: []rootproto.GrantInheritance{inheritance},
 	}
@@ -93,7 +93,7 @@ func TestRootStateProtocolAndCommandRoundTrip(t *testing.T) {
 	require.Equal(t, inheritance, RootGrantInheritanceFromProto(RootGrantInheritanceToProto(inheritance)))
 
 	protocolState := rootstate.EunomiaState{
-		ActiveGrant:       state.ActiveGrant,
+		ActiveGrants:      state.ActiveGrants,
 		RetiredGrants:     state.RetiredGrants,
 		GrantInheritances: state.GrantInheritances,
 	}

--- a/pb/meta/root.pb.go
+++ b/pb/meta/root.pb.go
@@ -723,7 +723,7 @@ type RootState struct {
 	LastCommitted     *RootCursor             `protobuf:"bytes,4,opt,name=last_committed,json=lastCommitted,proto3" json:"last_committed,omitempty"`
 	IdFence           uint64                  `protobuf:"varint,5,opt,name=id_fence,json=idFence,proto3" json:"id_fence,omitempty"`
 	TsoFence          uint64                  `protobuf:"varint,6,opt,name=tso_fence,json=tsoFence,proto3" json:"tso_fence,omitempty"`
-	ActiveGrant       *RootAuthorityGrant     `protobuf:"bytes,7,opt,name=active_grant,json=activeGrant,proto3" json:"active_grant,omitempty"`
+	ActiveGrants      []*RootAuthorityGrant   `protobuf:"bytes,7,rep,name=active_grants,json=activeGrants,proto3" json:"active_grants,omitempty"`
 	RetiredGrants     []*RootGrantRetirement  `protobuf:"bytes,8,rep,name=retired_grants,json=retiredGrants,proto3" json:"retired_grants,omitempty"`
 	GrantInheritances []*RootGrantInheritance `protobuf:"bytes,9,rep,name=grant_inheritances,json=grantInheritances,proto3" json:"grant_inheritances,omitempty"`
 	RetiredEraFloor   uint64                  `protobuf:"varint,10,opt,name=retired_era_floor,json=retiredEraFloor,proto3" json:"retired_era_floor,omitempty"`
@@ -796,9 +796,9 @@ func (x *RootState) GetTsoFence() uint64 {
 	return 0
 }
 
-func (x *RootState) GetActiveGrant() *RootAuthorityGrant {
+func (x *RootState) GetActiveGrants() []*RootAuthorityGrant {
 	if x != nil {
-		return x.ActiveGrant
+		return x.ActiveGrants
 	}
 	return nil
 }
@@ -3766,7 +3766,7 @@ func (x *MetadataRootStatusResponse) GetLeaderId() uint64 {
 
 type RootEunomiaState struct {
 	state             protoimpl.MessageState  `protogen:"open.v1"`
-	ActiveGrant       *RootAuthorityGrant     `protobuf:"bytes,1,opt,name=active_grant,json=activeGrant,proto3" json:"active_grant,omitempty"`
+	ActiveGrants      []*RootAuthorityGrant   `protobuf:"bytes,1,rep,name=active_grants,json=activeGrants,proto3" json:"active_grants,omitempty"`
 	RetiredGrants     []*RootGrantRetirement  `protobuf:"bytes,2,rep,name=retired_grants,json=retiredGrants,proto3" json:"retired_grants,omitempty"`
 	GrantInheritances []*RootGrantInheritance `protobuf:"bytes,3,rep,name=grant_inheritances,json=grantInheritances,proto3" json:"grant_inheritances,omitempty"`
 	RetiredEraFloor   uint64                  `protobuf:"varint,4,opt,name=retired_era_floor,json=retiredEraFloor,proto3" json:"retired_era_floor,omitempty"`
@@ -3804,9 +3804,9 @@ func (*RootEunomiaState) Descriptor() ([]byte, []int) {
 	return file_meta_root_proto_rawDescGZIP(), []int{42}
 }
 
-func (x *RootEunomiaState) GetActiveGrant() *RootAuthorityGrant {
+func (x *RootEunomiaState) GetActiveGrants() []*RootAuthorityGrant {
 	if x != nil {
-		return x.ActiveGrant
+		return x.ActiveGrants
 	}
 	return nil
 }
@@ -4544,14 +4544,14 @@ const file_meta_root_proto_rawDesc = "" +
 	"\n" +
 	"RootCursor\x12\x12\n" +
 	"\x04term\x18\x01 \x01(\x04R\x04term\x12\x14\n" +
-	"\x05index\x18\x02 \x01(\x04R\x05index\"\xe2\x03\n" +
+	"\x05index\x18\x02 \x01(\x04R\x05index\"\xe4\x03\n" +
 	"\tRootState\x12#\n" +
 	"\rcluster_epoch\x18\x01 \x01(\x04R\fclusterEpoch\x12)\n" +
 	"\x10membership_epoch\x18\x02 \x01(\x04R\x0fmembershipEpoch\x12?\n" +
 	"\x0elast_committed\x18\x04 \x01(\v2\x18.nokv.meta.v1.RootCursorR\rlastCommitted\x12\x19\n" +
 	"\bid_fence\x18\x05 \x01(\x04R\aidFence\x12\x1b\n" +
-	"\ttso_fence\x18\x06 \x01(\x04R\btsoFence\x12C\n" +
-	"\factive_grant\x18\a \x01(\v2 .nokv.meta.v1.RootAuthorityGrantR\vactiveGrant\x12H\n" +
+	"\ttso_fence\x18\x06 \x01(\x04R\btsoFence\x12E\n" +
+	"\ractive_grants\x18\a \x03(\v2 .nokv.meta.v1.RootAuthorityGrantR\factiveGrants\x12H\n" +
 	"\x0eretired_grants\x18\b \x03(\v2!.nokv.meta.v1.RootGrantRetirementR\rretiredGrants\x12Q\n" +
 	"\x12grant_inheritances\x18\t \x03(\v2\".nokv.meta.v1.RootGrantInheritanceR\x11grantInheritances\x12*\n" +
 	"\x11retired_era_floor\x18\n" +
@@ -4796,9 +4796,9 @@ const file_meta_root_proto_rawDesc = "" +
 	"\x19MetadataRootStatusRequest\"V\n" +
 	"\x1aMetadataRootStatusResponse\x12\x1b\n" +
 	"\tis_leader\x18\x01 \x01(\bR\bisLeader\x12\x1b\n" +
-	"\tleader_id\x18\x02 \x01(\x04R\bleaderId\"\xa0\x02\n" +
-	"\x10RootEunomiaState\x12C\n" +
-	"\factive_grant\x18\x01 \x01(\v2 .nokv.meta.v1.RootAuthorityGrantR\vactiveGrant\x12H\n" +
+	"\tleader_id\x18\x02 \x01(\x04R\bleaderId\"\xa2\x02\n" +
+	"\x10RootEunomiaState\x12E\n" +
+	"\ractive_grants\x18\x01 \x03(\v2 .nokv.meta.v1.RootAuthorityGrantR\factiveGrants\x12H\n" +
 	"\x0eretired_grants\x18\x02 \x03(\v2!.nokv.meta.v1.RootGrantRetirementR\rretiredGrants\x12Q\n" +
 	"\x12grant_inheritances\x18\x03 \x03(\v2\".nokv.meta.v1.RootGrantInheritanceR\x11grantInheritances\x12*\n" +
 	"\x11retired_era_floor\x18\x04 \x01(\x04R\x0fretiredEraFloor\"\x8b\x03\n" +
@@ -5031,7 +5031,7 @@ var file_meta_root_proto_goTypes = []any{
 }
 var file_meta_root_proto_depIdxs = []int32{
 	11,  // 0: nokv.meta.v1.RootState.last_committed:type_name -> nokv.meta.v1.RootCursor
-	28,  // 1: nokv.meta.v1.RootState.active_grant:type_name -> nokv.meta.v1.RootAuthorityGrant
+	28,  // 1: nokv.meta.v1.RootState.active_grants:type_name -> nokv.meta.v1.RootAuthorityGrant
 	29,  // 2: nokv.meta.v1.RootState.retired_grants:type_name -> nokv.meta.v1.RootGrantRetirement
 	30,  // 3: nokv.meta.v1.RootState.grant_inheritances:type_name -> nokv.meta.v1.RootGrantInheritance
 	12,  // 4: nokv.meta.v1.RootCheckpoint.state:type_name -> nokv.meta.v1.RootState
@@ -5121,7 +5121,7 @@ var file_meta_root_proto_depIdxs = []int32{
 	11,  // 88: nokv.meta.v1.MetadataRootAppendResponse.cursor:type_name -> nokv.meta.v1.RootCursor
 	12,  // 89: nokv.meta.v1.MetadataRootAppendResponse.state:type_name -> nokv.meta.v1.RootState
 	8,   // 90: nokv.meta.v1.MetadataRootFenceAllocatorRequest.kind:type_name -> nokv.meta.v1.RootAllocatorKind
-	28,  // 91: nokv.meta.v1.RootEunomiaState.active_grant:type_name -> nokv.meta.v1.RootAuthorityGrant
+	28,  // 91: nokv.meta.v1.RootEunomiaState.active_grants:type_name -> nokv.meta.v1.RootAuthorityGrant
 	29,  // 92: nokv.meta.v1.RootEunomiaState.retired_grants:type_name -> nokv.meta.v1.RootGrantRetirement
 	30,  // 93: nokv.meta.v1.RootEunomiaState.grant_inheritances:type_name -> nokv.meta.v1.RootGrantInheritance
 	9,   // 94: nokv.meta.v1.RootGrantCommand.kind:type_name -> nokv.meta.v1.RootGrantAct

--- a/pb/meta/root.proto
+++ b/pb/meta/root.proto
@@ -53,7 +53,7 @@ message RootState {
   RootCursor last_committed = 4;
   uint64 id_fence = 5;
   uint64 tso_fence = 6;
-  RootAuthorityGrant active_grant = 7;
+  repeated RootAuthorityGrant active_grants = 7;
   repeated RootGrantRetirement retired_grants = 8;
   repeated RootGrantInheritance grant_inheritances = 9;
   uint64 retired_era_floor = 10;
@@ -398,7 +398,7 @@ message MetadataRootStatusResponse {
 }
 
 message RootEunomiaState {
-  RootAuthorityGrant active_grant = 1;
+  repeated RootAuthorityGrant active_grants = 1;
   repeated RootGrantRetirement retired_grants = 2;
   repeated RootGrantInheritance grant_inheritances = 3;
   uint64 retired_era_floor = 4;

--- a/raftstore/testcluster/cluster.go
+++ b/raftstore/testcluster/cluster.go
@@ -200,7 +200,7 @@ func (s *coordinatorRootStorage) ApplyGrant(_ context.Context, cmd rootproto.Gra
 	holderID := strings.TrimSpace(cmd.HolderID)
 	switch cmd.Kind {
 	case rootproto.GrantActIssue:
-		active := s.snapshot.ActiveGrant
+		active, _ := coordinatorRootActiveGrantFor(s.snapshot, cmd.RequestedDuties)
 		requestedGrantID := strings.TrimSpace(cmd.GrantID)
 		if requestedGrantID != "" &&
 			active.Present() &&
@@ -236,29 +236,32 @@ func (s *coordinatorRootStorage) ApplyGrant(_ context.Context, cmd rootproto.Gra
 			Duties: append([]rootproto.DutyGrant(nil), cmd.RequestedDuties...),
 		}
 		s.applyEventLocked(rootevent.GrantIssued(grant))
-		cert, err := coordinatorRootGrantCertificate(s.snapshot.ActiveGrant)
+		issued, _ := s.snapshot.ActiveGrantByID(grant.GrantID)
+		cert, err := coordinatorRootGrantCertificate(issued)
 		return s.protocolStateLocked(), cert, err
 	case rootproto.GrantActSeal:
-		if !s.snapshot.ActiveGrant.Present() || s.snapshot.ActiveGrant.HolderID != holderID {
+		active, ok := s.snapshot.ActiveGrantByID(strings.TrimSpace(cmd.GrantID))
+		if !ok || active.HolderID != holderID {
 			return s.protocolStateLocked(), rootproto.GrantCertificate{}, rootstate.ErrPrimacy
 		}
 		retirement := rootproto.GrantRetirement{
-			GrantID:  s.snapshot.ActiveGrant.GrantID,
-			HolderID: s.snapshot.ActiveGrant.HolderID,
-			Era:      s.snapshot.ActiveGrant.Era,
+			GrantID:  active.GrantID,
+			HolderID: active.HolderID,
+			Era:      active.Era,
 			Mode:     rootproto.GrantRetirementSealedExact,
 			Bounds:   coordinatorDutyGrantsFromUsages(cmd.ExactUsages),
 		}
 		if len(retirement.Bounds) == 0 {
-			retirement.Bounds = append([]rootproto.DutyGrant(nil), s.snapshot.ActiveGrant.Duties...)
+			retirement.Bounds = append([]rootproto.DutyGrant(nil), active.Duties...)
 		}
 		s.applyEventLocked(rootevent.GrantSealed(retirement))
 		return s.protocolStateLocked(), rootproto.GrantCertificate{}, nil
 	case rootproto.GrantActInherit:
-		if !s.snapshot.ActiveGrant.Present() || s.snapshot.ActiveGrant.HolderID != holderID {
+		active, ok := coordinatorRootActiveGrantForHolder(s.snapshot, holderID)
+		if !ok {
 			return s.protocolStateLocked(), rootproto.GrantCertificate{}, rootstate.ErrPrimacy
 		}
-		successor := s.snapshot.ActiveGrant.GrantID
+		successor := active.GrantID
 		for _, predecessor := range cmd.PredecessorGrantIDs {
 			s.applyEventLocked(rootevent.GrantInherited(rootproto.GrantInheritance{
 				PredecessorGrantID: predecessor,
@@ -287,11 +290,31 @@ func (s *coordinatorRootStorage) applyEventLocked(event rootevent.Event) {
 
 func (s *coordinatorRootStorage) protocolStateLocked() rootstate.EunomiaState {
 	return rootstate.EunomiaState{
-		ActiveGrant:       s.snapshot.ActiveGrant,
+		ActiveGrants:      append([]rootproto.AuthorityGrant(nil), s.snapshot.ActiveGrants...),
 		RetiredGrants:     append([]rootproto.GrantRetirement(nil), s.snapshot.RetiredGrants...),
 		GrantInheritances: append([]rootproto.GrantInheritance(nil), s.snapshot.GrantInheritances...),
 		RetiredEraFloor:   s.snapshot.RetiredEraFloor,
 	}
+}
+
+func coordinatorRootActiveGrantFor(snapshot rootview.Snapshot, duties []rootproto.DutyGrant) (rootproto.AuthorityGrant, bool) {
+	for _, grant := range snapshot.ActiveGrants {
+		for _, duty := range duties {
+			if grant.CoversDutyKey(duty.Key()) {
+				return grant, true
+			}
+		}
+	}
+	return rootproto.AuthorityGrant{}, false
+}
+
+func coordinatorRootActiveGrantForHolder(snapshot rootview.Snapshot, holderID string) (rootproto.AuthorityGrant, bool) {
+	for _, grant := range snapshot.ActiveGrants {
+		if strings.TrimSpace(grant.HolderID) == holderID {
+			return grant, true
+		}
+	}
+	return rootproto.AuthorityGrant{}, false
 }
 
 func coordinatorRootGrantCertificate(grant rootproto.AuthorityGrant) (rootproto.GrantCertificate, error) {


### PR DESCRIPTION
## Summary
- represent root authority as multiple active grants keyed by duty and scope
- make coordinator admission, draining, sealing, and campaigning per duty
- route coordinator client preferences per duty so TSO, AllocID, and RegionLookup failover independently
- configure Docker Compose coordinators to split global duties across candidates

## Tests
- make fmt
- make lint
- go test ./...
