### PR TITLE
Optimize fsmeta placement for atomic mutations

### DIFF
--- a/benchmark/fsmeta/workload/mixed.go
+++ b/benchmark/fsmeta/workload/mixed.go
@@ -464,7 +464,7 @@ func runWriterSessionLifecycle(ctx context.Context, cli MixedClient, cfg MixedCo
 		return
 	}
 	rec.recordCall("close_write_session", func() error {
-		return cli.CloseWriteSession(ctx, fsmeta.CloseWriteSessionRequest{Mount: cfg.Mount, Session: session})
+		return cli.CloseWriteSession(ctx, fsmeta.CloseWriteSessionRequest{Mount: cfg.Mount, Inode: entry.Inode, Session: session})
 	})
 }
 

--- a/benchmark/fsmeta/workload/mixed_test.go
+++ b/benchmark/fsmeta/workload/mixed_test.go
@@ -19,7 +19,7 @@ type fakeMixedClient struct {
 	mu        sync.Mutex
 	dentries  map[string]fsmeta.DentryRecord
 	inodes    map[fsmeta.InodeID]fsmeta.InodeRecord
-	sessions  map[fsmeta.SessionID]fsmeta.SessionRecord
+	sessions  map[fakeSessionKey]fsmeta.SessionRecord
 	snapshots map[uint64]fsmeta.SnapshotSubtreeToken
 	versions  map[uint64]struct{}
 	reads     []fsmeta.ReadDirRequest
@@ -28,11 +28,16 @@ type fakeMixedClient struct {
 	stream    *fakeWatchStream
 }
 
+type fakeSessionKey struct {
+	inode   fsmeta.InodeID
+	session fsmeta.SessionID
+}
+
 func newFakeMixedClient() *fakeMixedClient {
 	return &fakeMixedClient{
 		dentries:  make(map[string]fsmeta.DentryRecord),
 		inodes:    make(map[fsmeta.InodeID]fsmeta.InodeRecord),
-		sessions:  make(map[fsmeta.SessionID]fsmeta.SessionRecord),
+		sessions:  make(map[fakeSessionKey]fsmeta.SessionRecord),
 		snapshots: make(map[uint64]fsmeta.SnapshotSubtreeToken),
 		versions:  make(map[uint64]struct{}),
 		next:      100,
@@ -250,26 +255,31 @@ func (c *fakeMixedClient) OpenWriteSession(_ context.Context, req fsmeta.OpenWri
 		return fsmeta.SessionRecord{}, fsmeta.ErrNotFound
 	}
 	record := fsmeta.SessionRecord{Session: req.Session, Inode: req.Inode, ExpiresUnixNs: time.Now().Add(req.TTL).UnixNano()}
-	c.sessions[req.Session] = record
+	c.sessions[fakeSessionKey{inode: req.Inode, session: req.Session}] = record
 	return record, nil
 }
 
 func (c *fakeMixedClient) HeartbeatWriteSession(_ context.Context, req fsmeta.HeartbeatWriteSessionRequest) (fsmeta.SessionRecord, error) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	record, ok := c.sessions[req.Session]
+	key := fakeSessionKey{inode: req.Inode, session: req.Session}
+	record, ok := c.sessions[key]
 	if !ok || record.Inode != req.Inode {
 		return fsmeta.SessionRecord{}, fsmeta.ErrNotFound
 	}
 	record.ExpiresUnixNs = time.Now().Add(req.TTL).UnixNano()
-	c.sessions[req.Session] = record
+	c.sessions[key] = record
 	return record, nil
 }
 
 func (c *fakeMixedClient) CloseWriteSession(_ context.Context, req fsmeta.CloseWriteSessionRequest) error {
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	delete(c.sessions, req.Session)
+	key := fakeSessionKey{inode: req.Inode, session: req.Session}
+	if _, ok := c.sessions[key]; !ok {
+		return fsmeta.ErrNotFound
+	}
+	delete(c.sessions, key)
 	return nil
 }
 

--- a/cmd/nokv-fsmeta-soak/main.go
+++ b/cmd/nokv-fsmeta-soak/main.go
@@ -146,6 +146,7 @@ func runSessionProbe(ctx context.Context, cli *fsmetaclient.GRPCClient, mount fs
 	}
 	if err := cli.CloseWriteSession(ctx, fsmeta.CloseWriteSessionRequest{
 		Mount:   mount,
+		Inode:   inode,
 		Session: session,
 	}); err != nil {
 		return err

--- a/cmd/nokv/cmd_serve.go
+++ b/cmd/nokv/cmd_serve.go
@@ -200,6 +200,7 @@ func runServeCmd(w io.Writer, args []string) error {
 	opt.WorkDir = *workDir
 	opt.MemTableEngine = local.MemTableEngineART
 	opt.ControlLogPointerSnapshot = raftstorestats.ControlLogPointers(localMeta.RaftPointerSnapshot)
+	opt.UserKeyShardRouter = fsmeta.ShardForUserKey
 	opt.AllowedModes = []workdirmode.Mode{
 		workdirmode.ModeStandalone,
 		workdirmode.ModeSeeded,

--- a/fsmeta/client/client_test.go
+++ b/fsmeta/client/client_test.go
@@ -267,7 +267,7 @@ func TestTypedClientMutationRPCs(t *testing.T) {
 	})
 	require.NoError(t, err)
 	require.Equal(t, int64(2000), session.ExpiresUnixNs)
-	require.NoError(t, cli.CloseWriteSession(context.Background(), fsmeta.CloseWriteSessionRequest{Mount: "vol", Session: "writer-1"}))
+	require.NoError(t, cli.CloseWriteSession(context.Background(), fsmeta.CloseWriteSessionRequest{Mount: "vol", Inode: 42, Session: "writer-1"}))
 	expired, err := cli.ExpireWriteSessions(context.Background(), fsmeta.ExpireWriteSessionsRequest{Mount: "vol", Limit: 64})
 	require.NoError(t, err)
 	require.Equal(t, fsmeta.ExpireWriteSessionsResult{Expired: 2}, expired)

--- a/fsmeta/client/wire.go
+++ b/fsmeta/client/wire.go
@@ -164,6 +164,7 @@ func closeWriteSessionRequestToProto(req fsmeta.CloseWriteSessionRequest) *fsmet
 	return &fsmetapb.CloseWriteSessionRequest{
 		Mount:   string(req.Mount),
 		Session: string(req.Session),
+		Inode:   uint64(req.Inode),
 	}
 }
 

--- a/fsmeta/contract/harness.go
+++ b/fsmeta/contract/harness.go
@@ -182,6 +182,7 @@ func execute(ctx context.Context, exec Executor, model *Model, op Operation) Res
 	case OpCloseSession:
 		err := exec.CloseWriteSession(ctx, fsmeta.CloseWriteSessionRequest{
 			Mount:   op.Mount,
+			Inode:   op.Inode,
 			Session: op.Session,
 		})
 		return Result{Err: err}

--- a/fsmeta/contract/history.go
+++ b/fsmeta/contract/history.go
@@ -384,7 +384,7 @@ func cloneModel(in *Model) *Model {
 		NowUnixNs:   in.NowUnixNs,
 		dentries:    cloneDentries(in.dentries),
 		inodes:      cloneInodes(in.inodes),
-		sessions:    make(map[fsmeta.SessionID]fsmeta.SessionRecord, len(in.sessions)),
+		sessions:    make(map[sessionKey]fsmeta.SessionRecord, len(in.sessions)),
 		owners:      make(map[fsmeta.InodeID]fsmeta.SessionRecord, len(in.owners)),
 		snapshots:   make(map[uint64]snapshotState, len(in.snapshots)),
 		snapshotRef: make(map[int]uint64, len(in.snapshotRef)),
@@ -463,14 +463,19 @@ func modelFingerprint(m *Model) string {
 		inode := m.inodes[id]
 		fmt.Fprintf(&b, "i:%d=%s/%d/%d/%d/%x;", id, inode.Type, inode.Size, inode.Mode, inode.LinkCount, inode.OpaqueAttrs)
 	}
-	sessionIDs := make([]fsmeta.SessionID, 0, len(m.sessions))
-	for id := range m.sessions {
-		sessionIDs = append(sessionIDs, id)
+	sessionKeys := make([]sessionKey, 0, len(m.sessions))
+	for key := range m.sessions {
+		sessionKeys = append(sessionKeys, key)
 	}
-	slices.Sort(sessionIDs)
-	for _, id := range sessionIDs {
-		session := m.sessions[id]
-		fmt.Fprintf(&b, "s:%s=%d/%d;", id, session.Inode, session.ExpiresUnixNs)
+	sort.Slice(sessionKeys, func(i, j int) bool {
+		if sessionKeys[i].inode != sessionKeys[j].inode {
+			return sessionKeys[i].inode < sessionKeys[j].inode
+		}
+		return sessionKeys[i].session < sessionKeys[j].session
+	})
+	for _, key := range sessionKeys {
+		session := m.sessions[key]
+		fmt.Fprintf(&b, "s:%d/%s=%d;", key.inode, key.session, session.ExpiresUnixNs)
 	}
 	ownerIDs := make([]fsmeta.InodeID, 0, len(m.owners))
 	for id := range m.owners {

--- a/fsmeta/contract/model.go
+++ b/fsmeta/contract/model.go
@@ -88,6 +88,11 @@ type sessionIndexEntry struct {
 	session bool
 }
 
+type sessionKey struct {
+	inode   fsmeta.InodeID
+	session fsmeta.SessionID
+}
+
 // Model is a sequential oracle for fsmeta namespace semantics. It does not
 // model raftstore, routing, or Percolator internals; it models the user-visible
 // metadata contract those layers must preserve.
@@ -97,7 +102,7 @@ type Model struct {
 	NowUnixNs   int64
 	dentries    map[dentryKey]fsmeta.DentryRecord
 	inodes      map[fsmeta.InodeID]fsmeta.InodeRecord
-	sessions    map[fsmeta.SessionID]fsmeta.SessionRecord
+	sessions    map[sessionKey]fsmeta.SessionRecord
 	owners      map[fsmeta.InodeID]fsmeta.SessionRecord
 	snapshots   map[uint64]snapshotState
 	snapshotRef map[int]uint64
@@ -111,7 +116,7 @@ func NewModel(mount fsmeta.MountID) *Model {
 		NowUnixNs:   1_000_000_000,
 		dentries:    make(map[dentryKey]fsmeta.DentryRecord),
 		inodes:      make(map[fsmeta.InodeID]fsmeta.InodeRecord),
-		sessions:    make(map[fsmeta.SessionID]fsmeta.SessionRecord),
+		sessions:    make(map[sessionKey]fsmeta.SessionRecord),
 		owners:      make(map[fsmeta.InodeID]fsmeta.SessionRecord),
 		snapshots:   make(map[uint64]snapshotState),
 		snapshotRef: make(map[int]uint64),
@@ -398,19 +403,21 @@ func (m *Model) openWriteSession(op Operation) Result {
 	if inode.Type != fsmeta.InodeTypeFile {
 		return Result{Err: fsmeta.ErrInvalidRequest}
 	}
-	if existing, ok := m.sessions[op.Session]; ok && sessionLive(existing, m.NowUnixNs) {
+	key := sessionKey{inode: op.Inode, session: op.Session}
+	if existing, ok := m.sessions[key]; ok && sessionLive(existing, m.NowUnixNs) {
 		return Result{Err: fsmeta.ErrExists}
 	}
 	if owner, ok := m.owners[op.Inode]; ok {
 		if sessionLive(owner, m.NowUnixNs) {
 			return Result{Err: fsmeta.ErrExists}
 		}
-		if current, ok := m.sessions[owner.Session]; ok && current == owner {
-			delete(m.sessions, owner.Session)
+		ownerKey := sessionKey{inode: owner.Inode, session: owner.Session}
+		if current, ok := m.sessions[ownerKey]; ok && current == owner {
+			delete(m.sessions, ownerKey)
 		}
 	}
 	record := fsmeta.SessionRecord{Session: op.Session, Inode: op.Inode, ExpiresUnixNs: op.ExpiresNs}
-	m.sessions[op.Session] = record
+	m.sessions[key] = record
 	m.owners[op.Inode] = record
 	return Result{Session: record}
 }
@@ -419,7 +426,8 @@ func (m *Model) heartbeatSession(op Operation) Result {
 	if op.ExpiresNs <= m.NowUnixNs {
 		return Result{Err: fsmeta.ErrInvalidRequest}
 	}
-	session, ok := m.sessions[op.Session]
+	key := sessionKey{inode: op.Inode, session: op.Session}
+	session, ok := m.sessions[key]
 	if !ok || !sessionLive(session, m.NowUnixNs) || session.Inode != op.Inode {
 		return Result{Err: fsmeta.ErrNotFound}
 	}
@@ -428,17 +436,21 @@ func (m *Model) heartbeatSession(op Operation) Result {
 		return Result{Err: fsmeta.ErrNotFound}
 	}
 	record := fsmeta.SessionRecord{Session: op.Session, Inode: op.Inode, ExpiresUnixNs: op.ExpiresNs}
-	m.sessions[op.Session] = record
+	m.sessions[key] = record
 	m.owners[op.Inode] = record
 	return Result{Session: record}
 }
 
 func (m *Model) closeSession(op Operation) Result {
-	session, ok := m.sessions[op.Session]
+	key := sessionKey{inode: op.Inode, session: op.Session}
+	session, ok := m.sessions[key]
 	if !ok {
 		return Result{Err: fsmeta.ErrNotFound}
 	}
-	delete(m.sessions, op.Session)
+	if session.Inode != op.Inode {
+		return Result{Err: fsmeta.ErrNotFound}
+	}
+	delete(m.sessions, key)
 	if owner, ok := m.owners[session.Inode]; ok && owner.Session == op.Session && owner.Inode == session.Inode {
 		delete(m.owners, session.Inode)
 	}
@@ -452,7 +464,7 @@ func (m *Model) expireSessions(op Operation) Result {
 	}
 	entries := make([]sessionIndexEntry, 0, len(m.sessions)+len(m.owners))
 	for _, record := range m.sessions {
-		key, err := fsmeta.EncodeSessionKey(m.Mount, record.Session)
+		key, err := fsmeta.EncodeSessionKey(m.Mount, record.Inode, record.Session)
 		if err != nil {
 			return Result{Err: err}
 		}
@@ -466,9 +478,9 @@ func (m *Model) expireSessions(op Operation) Result {
 		entries = append(entries, sessionIndexEntry{key: string(key), record: record})
 	}
 	sort.Slice(entries, func(i, j int) bool { return entries[i].key < entries[j].key })
-	deleteSessions := make(map[fsmeta.SessionID]struct{})
+	deleteSessions := make(map[sessionKey]struct{})
 	deleteOwners := make(map[fsmeta.InodeID]struct{})
-	expiredSessions := make(map[fsmeta.SessionID]struct{})
+	expiredSessions := make(map[sessionKey]struct{})
 	visited := uint32(0)
 	for _, entry := range entries {
 		if visited >= limit {
@@ -478,21 +490,22 @@ func (m *Model) expireSessions(op Operation) Result {
 		if sessionLive(entry.record, m.NowUnixNs) {
 			continue
 		}
+		key := sessionKey{inode: entry.record.Inode, session: entry.record.Session}
 		if entry.session {
-			deleteSessions[entry.record.Session] = struct{}{}
+			deleteSessions[key] = struct{}{}
 		} else {
 			deleteOwners[entry.record.Inode] = struct{}{}
 		}
-		if current, ok := m.sessions[entry.record.Session]; ok && current == entry.record {
-			deleteSessions[entry.record.Session] = struct{}{}
-			expiredSessions[entry.record.Session] = struct{}{}
+		if current, ok := m.sessions[key]; ok && current == entry.record {
+			deleteSessions[key] = struct{}{}
+			expiredSessions[key] = struct{}{}
 		}
 		if owner, ok := m.owners[entry.record.Inode]; ok && owner == entry.record {
 			deleteOwners[entry.record.Inode] = struct{}{}
 		}
 	}
-	for session := range deleteSessions {
-		delete(m.sessions, session)
+	for key := range deleteSessions {
+		delete(m.sessions, key)
 	}
 	for inode := range deleteOwners {
 		delete(m.owners, inode)
@@ -547,9 +560,9 @@ func (m *Model) CheckInvariants() error {
 			return fmt.Errorf("inode %d link_count=%d refs=%d", inodeID, inode.LinkCount, refs[inodeID])
 		}
 	}
-	for sessionID, session := range m.sessions {
-		if session.Session != sessionID {
-			return fmt.Errorf("session key/value mismatch key=%s record=%+v", sessionID, session)
+	for key, session := range m.sessions {
+		if session.Session != key.session || session.Inode != key.inode {
+			return fmt.Errorf("session key/value mismatch key=%+v record=%+v", key, session)
 		}
 		if !sessionLive(session, m.NowUnixNs) {
 			continue
@@ -566,7 +579,7 @@ func (m *Model) CheckInvariants() error {
 		if !sessionLive(owner, m.NowUnixNs) {
 			continue
 		}
-		session, ok := m.sessions[owner.Session]
+		session, ok := m.sessions[sessionKey{inode: owner.Inode, session: owner.Session}]
 		if !ok || session.Inode != inodeID {
 			return fmt.Errorf("owner for inode %d missing session %s", inodeID, owner.Session)
 		}

--- a/fsmeta/contract/model_test.go
+++ b/fsmeta/contract/model_test.go
@@ -37,12 +37,13 @@ func TestModelUnlinkKeepsSessionIndexesUntilSessionLifecycleRuns(t *testing.T) {
 
 	require.NoError(t, model.CheckInvariants())
 	require.NotContains(t, model.inodes, fsmeta.InodeID(10))
-	require.Contains(t, model.sessions, fsmeta.SessionID("writer-1"))
+	require.Contains(t, model.sessions, sessionKey{inode: 10, session: "writer-1"})
 	require.Contains(t, model.owners, fsmeta.InodeID(10))
 
 	require.NoError(t, model.Apply(Operation{
 		Kind:    OpCloseSession,
 		Mount:   "vol",
+		Inode:   10,
 		Session: "writer-1",
 	}).Err)
 	require.NoError(t, model.CheckInvariants())
@@ -119,8 +120,8 @@ func TestModelExpireStaleOwnerDoesNotRemoveReusedLiveSession(t *testing.T) {
 	result := model.Apply(Operation{Kind: OpExpireSessions, Mount: "vol", Limit: 16})
 
 	require.NoError(t, result.Err)
-	require.Equal(t, uint64(0), result.Expired)
-	require.Equal(t, fsmeta.InodeID(11), model.sessions["writer-1"].Inode)
+	require.Equal(t, uint64(1), result.Expired)
+	require.Equal(t, fsmeta.InodeID(11), model.sessions[sessionKey{inode: 11, session: "writer-1"}].Inode)
 	require.NotContains(t, model.owners, fsmeta.InodeID(10))
 	require.Contains(t, model.owners, fsmeta.InodeID(11))
 	require.NoError(t, model.CheckInvariants())
@@ -167,8 +168,8 @@ func TestModelOpenWithStaleOwnerDoesNotRemoveReusedLiveSession(t *testing.T) {
 		ExpiresNs: model.NowUnixNs + int64(time.Minute),
 	}).Err)
 
-	require.Equal(t, fsmeta.InodeID(11), model.sessions["writer-1"].Inode)
-	require.Equal(t, fsmeta.InodeID(10), model.sessions["writer-2"].Inode)
+	require.Equal(t, fsmeta.InodeID(11), model.sessions[sessionKey{inode: 11, session: "writer-1"}].Inode)
+	require.Equal(t, fsmeta.InodeID(10), model.sessions[sessionKey{inode: 10, session: "writer-2"}].Inode)
 	require.Equal(t, fsmeta.SessionID("writer-1"), model.owners[11].Session)
 	require.Equal(t, fsmeta.SessionID("writer-2"), model.owners[10].Session)
 	require.NoError(t, model.CheckInvariants())

--- a/fsmeta/contract/script.go
+++ b/fsmeta/contract/script.go
@@ -87,7 +87,7 @@ func chooseOperation(rng *rand.Rand, model *Model, names []string, sessions []fs
 			return lookupOperation(rng, model, names)
 		}
 		session := liveSessions[rng.Intn(len(liveSessions))]
-		return Operation{Kind: OpCloseSession, Mount: model.Mount, Session: session.Session}
+		return Operation{Kind: OpCloseSession, Mount: model.Mount, Inode: session.Inode, Session: session.Session}
 	case 66, 67:
 		return Operation{
 			Kind:      OpAdvanceTime,

--- a/fsmeta/exec/runner.go
+++ b/fsmeta/exec/runner.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"sort"
+	"sync"
 	"sync/atomic"
 	"time"
 
@@ -147,6 +148,8 @@ type atomicFastPathCounters struct {
 	fallbackTotal          atomic.Uint64
 	successTotal           atomic.Uint64
 	consecutiveFallbacks   atomic.Uint64
+	mu                     sync.Mutex
+	fallbacksByAffinity    map[string]uint64
 }
 
 // Option configures an Executor.
@@ -312,7 +315,7 @@ var atomicFastPathKinds = [...]fsmeta.OperationKind{
 func newAtomicFastPathCounters() map[fsmeta.OperationKind]*atomicFastPathCounters {
 	out := make(map[fsmeta.OperationKind]*atomicFastPathCounters, len(atomicFastPathKinds))
 	for _, kind := range atomicFastPathKinds {
-		out[kind] = &atomicFastPathCounters{}
+		out[kind] = &atomicFastPathCounters{fallbacksByAffinity: make(map[string]uint64)}
 	}
 	return out
 }
@@ -446,7 +449,8 @@ func (e *Executor) mutateWithAtomicFastPath(ctx context.Context, kind fsmeta.Ope
 		_, err := e.runner.Mutate(ctx, primary, mutations, startVersion, commitVersion, e.lockTTL)
 		return err
 	}
-	if stats != nil && !stats.allowAttempt() {
+	affinity := atomicFastPathAffinity(primary, mutations)
+	if stats != nil && !stats.allowAttempt(affinity) {
 		stats.skipTotal.Add(1)
 		_, err := e.runner.Mutate(ctx, primary, mutations, startVersion, commitVersion, e.lockTTL)
 		return err
@@ -458,14 +462,13 @@ func (e *Executor) mutateWithAtomicFastPath(ctx context.Context, kind fsmeta.Ope
 	if err != nil || handled {
 		if err == nil && stats != nil {
 			stats.successTotal.Add(1)
-			stats.consecutiveFallbacks.Store(0)
-			stats.backoffSkipTotal.Store(0)
+			stats.recordSuccess(affinity)
 		}
 		return err
 	}
 	if stats != nil {
 		stats.fallbackTotal.Add(1)
-		stats.consecutiveFallbacks.Add(1)
+		stats.recordFallback(affinity)
 	}
 	_, err = e.runner.Mutate(ctx, primary, mutations, startVersion, commitVersion, e.lockTTL)
 	return err
@@ -476,14 +479,64 @@ const (
 	atomicFastPathProbeEvery   = 128
 )
 
-func (s *atomicFastPathCounters) allowAttempt() bool {
-	if s.consecutiveFallbacks.Load() < atomicFastPathBackoffAfter {
+func (s *atomicFastPathCounters) allowAttempt(affinity string) bool {
+	if s == nil {
+		return true
+	}
+	if s.affinityFallbacks(affinity) < atomicFastPathBackoffAfter {
 		return true
 	}
 	// Some plans are only conditionally co-located. Back off after repeated
-	// admission misses, but keep rare probes so a changed placement policy or
-	// key pattern can re-enable the fast path without restarting the gateway.
+	// admission misses for the same placement pattern, but do not let unrelated
+	// patterns force all operations of this kind back onto 2PC.
 	return s.backoffSkipTotal.Add(1)%atomicFastPathProbeEvery == 0
+}
+
+func (s *atomicFastPathCounters) affinityFallbacks(affinity string) uint64 {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.fallbacksByAffinity[affinity]
+}
+
+func (s *atomicFastPathCounters) recordFallback(affinity string) {
+	s.mu.Lock()
+	next := s.fallbacksByAffinity[affinity] + 1
+	s.fallbacksByAffinity[affinity] = next
+	s.mu.Unlock()
+	s.consecutiveFallbacks.Store(next)
+}
+
+func (s *atomicFastPathCounters) recordSuccess(affinity string) {
+	s.mu.Lock()
+	delete(s.fallbacksByAffinity, affinity)
+	s.mu.Unlock()
+	s.consecutiveFallbacks.Store(0)
+}
+
+func atomicFastPathAffinity(primary []byte, mutations []*kvrpcpb.Mutation) string {
+	const virtualShards = 64
+	shards := make([]int, 0, 1+len(mutations))
+	if len(primary) > 0 {
+		shards = append(shards, fsmeta.ShardForUserKey(primary, virtualShards))
+	}
+	for _, mutation := range mutations {
+		if mutation == nil || len(mutation.GetKey()) == 0 {
+			continue
+		}
+		shards = append(shards, fsmeta.ShardForUserKey(mutation.GetKey(), virtualShards))
+	}
+	if len(shards) == 0 {
+		return "empty"
+	}
+	sort.Ints(shards)
+	out := make([]byte, 0, len(shards)*3)
+	for i, shard := range shards {
+		if i > 0 {
+			out = append(out, ',')
+		}
+		out = fmt.Appendf(out, "%02d", shard)
+	}
+	return string(out)
 }
 
 func (e *Executor) mutateWithoutAtomicFastPath(ctx context.Context, kind fsmeta.OperationKind, primary []byte, mutations []*kvrpcpb.Mutation, startVersion, commitVersion uint64) error {
@@ -1126,7 +1179,7 @@ func (e *Executor) OpenWriteSession(ctx context.Context, req fsmeta.OpenWriteSes
 				return fsmeta.ErrExists
 			}
 			predicates = append(predicates, atomicExists(plan.ReadKeys[2]))
-			staleSessionKey, err := fsmeta.EncodeSessionKey(req.Mount, owner.Session)
+			staleSessionKey, err := fsmeta.EncodeSessionKey(req.Mount, owner.Inode, owner.Session)
 			if err != nil {
 				return err
 			}
@@ -1240,6 +1293,9 @@ func (e *Executor) CloseWriteSession(ctx context.Context, req fsmeta.CloseWriteS
 		if !ok {
 			return fsmeta.ErrNotFound
 		}
+		if session.Inode != req.Inode {
+			return fsmeta.ErrNotFound
+		}
 		mutations := []*kvrpcpb.Mutation{{Op: kvrpcpb.Mutation_Delete, Key: cloneBytes(plan.MutateKeys[0])}}
 		ownerKey, err := fsmeta.EncodeInodeSessionKey(req.Mount, session.Inode)
 		if err != nil {
@@ -1277,7 +1333,11 @@ func (e *Executor) ExpireWriteSessions(ctx context.Context, req fsmeta.ExpireWri
 			return err
 		}
 		deletes := make(map[string][]byte)
-		expiredSessions := make(map[fsmeta.SessionID]struct{})
+		type expiredSessionKey struct {
+			inode   fsmeta.InodeID
+			session fsmeta.SessionID
+		}
+		expiredSessions := make(map[expiredSessionKey]struct{})
 		for _, kv := range kvs {
 			if !bytes.HasPrefix(kv.Key, plan.PrimaryKey) {
 				break
@@ -1290,7 +1350,7 @@ func (e *Executor) ExpireWriteSessions(ctx context.Context, req fsmeta.ExpireWri
 				continue
 			}
 			deletes[string(kv.Key)] = cloneBytes(kv.Key)
-			sessionKey, err := fsmeta.EncodeSessionKey(req.Mount, record.Session)
+			sessionKey, err := fsmeta.EncodeSessionKey(req.Mount, record.Inode, record.Session)
 			if err != nil {
 				return err
 			}
@@ -1302,7 +1362,7 @@ func (e *Executor) ExpireWriteSessions(ctx context.Context, req fsmeta.ExpireWri
 				return err
 			} else if ok && bytes.Equal(value, kv.Value) {
 				deletes[string(sessionKey)] = sessionKey
-				expiredSessions[record.Session] = struct{}{}
+				expiredSessions[expiredSessionKey{inode: record.Inode, session: record.Session}] = struct{}{}
 			}
 			if value, ok, err := e.runner.Get(ctx, ownerKey, startVersion); err != nil {
 				return err

--- a/fsmeta/exec/runner_test.go
+++ b/fsmeta/exec/runner_test.go
@@ -868,7 +868,7 @@ func TestExecutorWriteSessionLifecycle(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, fsmeta.SessionRecord{Session: "writer-1", Inode: 22, ExpiresUnixNs: 200}, opened)
 
-	sessionKey, err := fsmeta.EncodeSessionKey("vol", "writer-1")
+	sessionKey, err := fsmeta.EncodeSessionKey("vol", 22, "writer-1")
 	require.NoError(t, err)
 	ownerKey, err := fsmeta.EncodeInodeSessionKey("vol", 22)
 	require.NoError(t, err)
@@ -896,7 +896,7 @@ func TestExecutorWriteSessionLifecycle(t *testing.T) {
 	require.True(t, ok)
 	require.Equal(t, int64(300), stored.ExpiresUnixNs)
 
-	err = executor.CloseWriteSession(context.Background(), fsmeta.CloseWriteSessionRequest{Mount: "vol", Session: "writer-1"})
+	err = executor.CloseWriteSession(context.Background(), fsmeta.CloseWriteSessionRequest{Mount: "vol", Inode: 22, Session: "writer-1"})
 	require.NoError(t, err)
 	require.NotContains(t, runner.data, string(sessionKey))
 	require.NotContains(t, runner.data, string(ownerKey))
@@ -924,7 +924,7 @@ func TestExecutorWriteSessionLifecycleUsesAtomicMutate(t *testing.T) {
 		TTL:     200 * time.Nanosecond,
 	})
 	require.NoError(t, err)
-	err = executor.CloseWriteSession(context.Background(), fsmeta.CloseWriteSessionRequest{Mount: "vol", Session: "writer-1"})
+	err = executor.CloseWriteSession(context.Background(), fsmeta.CloseWriteSessionRequest{Mount: "vol", Inode: 22, Session: "writer-1"})
 	require.NoError(t, err)
 
 	require.Len(t, runner.atomicCalls, 3)
@@ -942,7 +942,7 @@ func TestExecutorOpenWriteSessionSkipsAtomicMutateForStaleSessionCleanup(t *test
 	oldRecord := fsmeta.SessionRecord{Session: "writer-old", Inode: 22, ExpiresUnixNs: 50}
 	oldValue, err := fsmeta.EncodeSessionValue(oldRecord)
 	require.NoError(t, err)
-	oldSessionKey, err := fsmeta.EncodeSessionKey("vol", "writer-old")
+	oldSessionKey, err := fsmeta.EncodeSessionKey("vol", 22, "writer-old")
 	require.NoError(t, err)
 	ownerKey, err := fsmeta.EncodeInodeSessionKey("vol", 22)
 	require.NoError(t, err)
@@ -992,7 +992,7 @@ func TestExecutorWriteSessionRejectsNonPositiveTTL(t *testing.T) {
 func TestExecutorOpenWriteSessionComputesExpiryInsideRetryAttempt(t *testing.T) {
 	runner := newFakeRunner()
 	seedInode(t, runner, "vol", fsmeta.InodeRecord{Inode: 22, Type: fsmeta.InodeTypeFile, LinkCount: 1})
-	sessionKey, err := fsmeta.EncodeSessionKey("vol", "writer-1")
+	sessionKey, err := fsmeta.EncodeSessionKey("vol", 22, "writer-1")
 	require.NoError(t, err)
 	runner.mutateErrs = []error{
 		nokverrors.NewTxnKeyError(&kvrpcpb.KeyError{
@@ -1034,7 +1034,7 @@ func TestExecutorOpenWriteSessionReclaimsExpiredOwner(t *testing.T) {
 	oldRecord := fsmeta.SessionRecord{Session: "writer-old", Inode: 22, ExpiresUnixNs: 50}
 	oldValue, err := fsmeta.EncodeSessionValue(oldRecord)
 	require.NoError(t, err)
-	oldSessionKey, err := fsmeta.EncodeSessionKey("vol", "writer-old")
+	oldSessionKey, err := fsmeta.EncodeSessionKey("vol", 22, "writer-old")
 	require.NoError(t, err)
 	ownerKey, err := fsmeta.EncodeInodeSessionKey("vol", 22)
 	require.NoError(t, err)
@@ -1051,7 +1051,7 @@ func TestExecutorOpenWriteSessionReclaimsExpiredOwner(t *testing.T) {
 	})
 	require.NoError(t, err)
 	require.NotContains(t, runner.data, string(oldSessionKey))
-	newSessionKey, err := fsmeta.EncodeSessionKey("vol", "writer-new")
+	newSessionKey, err := fsmeta.EncodeSessionKey("vol", 22, "writer-new")
 	require.NoError(t, err)
 	require.Contains(t, runner.data, string(newSessionKey))
 	require.Contains(t, runner.data, string(ownerKey))
@@ -1069,7 +1069,7 @@ func TestExecutorOpenWriteSessionDoesNotDeleteReusedLiveSession(t *testing.T) {
 	expiredOwnerKey, err := fsmeta.EncodeInodeSessionKey("vol", expired.Inode)
 	require.NoError(t, err)
 	runner.data[string(expiredOwnerKey)] = expiredValue
-	liveSessionKey, err := fsmeta.EncodeSessionKey("vol", live.Session)
+	liveSessionKey, err := fsmeta.EncodeSessionKey("vol", live.Inode, live.Session)
 	require.NoError(t, err)
 	liveOwnerKey, err := fsmeta.EncodeInodeSessionKey("vol", live.Inode)
 	require.NoError(t, err)
@@ -1121,11 +1121,11 @@ func TestExecutorExpireWriteSessionsDeletesBothIndexes(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, fsmeta.ExpireWriteSessionsResult{Expired: 1}, result)
 
-	expiredSessionKey, err := fsmeta.EncodeSessionKey("vol", expired.Session)
+	expiredSessionKey, err := fsmeta.EncodeSessionKey("vol", expired.Inode, expired.Session)
 	require.NoError(t, err)
 	expiredOwnerKey, err := fsmeta.EncodeInodeSessionKey("vol", expired.Inode)
 	require.NoError(t, err)
-	liveSessionKey, err := fsmeta.EncodeSessionKey("vol", live.Session)
+	liveSessionKey, err := fsmeta.EncodeSessionKey("vol", live.Inode, live.Session)
 	require.NoError(t, err)
 	liveOwnerKey, err := fsmeta.EncodeInodeSessionKey("vol", live.Inode)
 	require.NoError(t, err)
@@ -1133,6 +1133,20 @@ func TestExecutorExpireWriteSessionsDeletesBothIndexes(t *testing.T) {
 	require.NotContains(t, runner.data, string(expiredOwnerKey))
 	require.Contains(t, runner.data, string(liveSessionKey))
 	require.Contains(t, runner.data, string(liveOwnerKey))
+}
+
+func TestExecutorExpireWriteSessionsCountsSessionPerInode(t *testing.T) {
+	runner := newFakeRunner()
+	first := fsmeta.SessionRecord{Session: "writer-reused", Inode: 22, ExpiresUnixNs: 50}
+	second := fsmeta.SessionRecord{Session: "writer-reused", Inode: 23, ExpiresUnixNs: 50}
+	seedSession(t, runner, "vol", first)
+	seedSession(t, runner, "vol", second)
+	executor, err := New(runner, WithClock(func() time.Time { return time.Unix(0, 100) }))
+	require.NoError(t, err)
+
+	result, err := executor.ExpireWriteSessions(context.Background(), fsmeta.ExpireWriteSessionsRequest{Mount: "vol"})
+	require.NoError(t, err)
+	require.Equal(t, fsmeta.ExpireWriteSessionsResult{Expired: 2}, result)
 }
 
 func TestExecutorExpireWriteSessionsDoesNotDeleteReusedLiveSession(t *testing.T) {
@@ -1143,7 +1157,7 @@ func TestExecutorExpireWriteSessionsDoesNotDeleteReusedLiveSession(t *testing.T)
 	require.NoError(t, err)
 	liveValue, err := fsmeta.EncodeSessionValue(live)
 	require.NoError(t, err)
-	sessionKey, err := fsmeta.EncodeSessionKey("vol", live.Session)
+	sessionKey, err := fsmeta.EncodeSessionKey("vol", live.Inode, live.Session)
 	require.NoError(t, err)
 	expiredOwnerKey, err := fsmeta.EncodeInodeSessionKey("vol", expired.Inode)
 	require.NoError(t, err)
@@ -1842,6 +1856,45 @@ func TestExecutorAtomicFastPathBacksOffAfterRepeatedFallback(t *testing.T) {
 	requireAtomicStatUint(t, stats, fsmeta.OperationRename, "backoff_skip_total", 3)
 }
 
+func TestExecutorAtomicFastPathBackoffIsAffinityScoped(t *testing.T) {
+	base := newFakeRunner()
+	runner := &fakeAtomicRunner{fakeRunner: base, handled: false}
+	authority := &fakeAuthorityResolver{same: true}
+	resolver := &fakeMountResolver{records: map[fsmeta.MountID]MountAdmission{
+		"vol": {MountID: "vol", RootInode: fsmeta.RootInode, SchemaVersion: 1},
+	}}
+	executor, err := New(runner, WithMountResolver(resolver), WithSubtreeAuthorityResolver(authority))
+	require.NoError(t, err)
+
+	for i := range atomicFastPathBackoffAfter {
+		oldName := fmt.Sprintf("old-%d", i)
+		newName := fmt.Sprintf("new-%d", i)
+		seedDentry(t, runner.fakeRunner, "vol", 7, oldName, fsmeta.InodeID(100+i))
+		err := executor.Rename(context.Background(), fsmeta.RenameRequest{
+			Mount:      "vol",
+			FromParent: 7,
+			FromName:   oldName,
+			ToParent:   8,
+			ToName:     newName,
+		})
+		require.NoError(t, err)
+	}
+
+	from, to := findDifferentRenameAffinity(t, 7, 8)
+	seedDentry(t, runner.fakeRunner, "vol", from, "other-old", 999)
+	err = executor.Rename(context.Background(), fsmeta.RenameRequest{
+		Mount:      "vol",
+		FromParent: from,
+		FromName:   "other-old",
+		ToParent:   to,
+		ToName:     "other-new",
+	})
+	require.NoError(t, err)
+
+	require.Len(t, runner.atomicCalls, atomicFastPathBackoffAfter+1)
+	requireAtomicStatUint(t, executor.Stats(), fsmeta.OperationRename, "skip_total", 0)
+}
+
 func TestExecutorRenameRejectsCrossAuthority(t *testing.T) {
 	runner := newFakeRunner()
 	seedDentry(t, runner, "vol", 7, "old", 22)
@@ -2009,11 +2062,40 @@ func seedInode(t *testing.T, runner *fakeRunner, mount fsmeta.MountID, record fs
 	runner.data[string(key)] = value
 }
 
+func findDifferentRenameAffinity(t *testing.T, baseFrom, baseTo fsmeta.InodeID) (fsmeta.InodeID, fsmeta.InodeID) {
+	t.Helper()
+	base := renameAffinity(t, baseFrom, baseTo)
+	for from := fsmeta.InodeID(9); from < 256; from++ {
+		for to := fsmeta.InodeID(9); to < 256; to++ {
+			if from == to {
+				continue
+			}
+			if renameAffinity(t, from, to) != base {
+				return from, to
+			}
+		}
+	}
+	t.Fatalf("no distinct rename affinity found")
+	return 0, 0
+}
+
+func renameAffinity(t *testing.T, from, to fsmeta.InodeID) string {
+	t.Helper()
+	source, err := fsmeta.EncodeDentryKey("vol", from, "old")
+	require.NoError(t, err)
+	destination, err := fsmeta.EncodeDentryKey("vol", to, "new")
+	require.NoError(t, err)
+	return atomicFastPathAffinity(source, []*kvrpcpb.Mutation{
+		{Op: kvrpcpb.Mutation_Delete, Key: source},
+		{Op: kvrpcpb.Mutation_Put, Key: destination},
+	})
+}
+
 func seedSession(t *testing.T, runner *fakeRunner, mount fsmeta.MountID, record fsmeta.SessionRecord) {
 	t.Helper()
 	value, err := fsmeta.EncodeSessionValue(record)
 	require.NoError(t, err)
-	sessionKey, err := fsmeta.EncodeSessionKey(mount, record.Session)
+	sessionKey, err := fsmeta.EncodeSessionKey(mount, record.Inode, record.Session)
 	require.NoError(t, err)
 	ownerKey, err := fsmeta.EncodeInodeSessionKey(mount, record.Inode)
 	require.NoError(t, err)

--- a/fsmeta/keys.go
+++ b/fsmeta/keys.go
@@ -3,6 +3,8 @@ package fsmeta
 import (
 	"encoding/binary"
 	"fmt"
+
+	"github.com/feichai0017/NoKV/utils"
 )
 
 // fsmeta key layout:
@@ -19,7 +21,7 @@ import (
 //	  inode   'i' : inode be64
 //	  dentry  'd' : parent inode be64 | name bytes
 //	  chunk   'c' : inode be64 | chunk index be64
-//	  session 's' : session bytes, or 0x00 | inode be64 for writer ownership
+//	  session 's' : inode be64 | 0x01 | session bytes, or inode be64 | 0x00 for writer ownership
 //	  usage   'u' : quota scope inode be64; scope 0 is mount-wide usage
 //
 // Big-endian integer fields preserve numeric order inside each key family.
@@ -123,22 +125,28 @@ func EncodeChunkKey(mount MountID, inode InodeID, chunk ChunkIndex) ([]byte, err
 }
 
 // EncodeSessionKey returns the client/session state key.
-func EncodeSessionKey(mount MountID, session SessionID) ([]byte, error) {
+func EncodeSessionKey(mount MountID, inode InodeID, session SessionID) ([]byte, error) {
+	if err := validateInodeID(inode); err != nil {
+		return nil, err
+	}
 	if err := validateSessionID(session); err != nil {
 		return nil, err
 	}
-	return encodeKey(mount, KeyKindSession, []byte(session))
+	body := make([]byte, 9, 9+len(session))
+	binary.BigEndian.PutUint64(body[:8], uint64(inode))
+	body[8] = 0x01
+	body = append(body, string(session)...)
+	return encodeKey(mount, KeyKindSession, body)
 }
 
 // EncodeInodeSessionKey returns the exclusive writer-owner key for one inode.
-// Session IDs cannot contain NUL, so the 0x00 marker cannot collide with
-// EncodeSessionKey.
 func EncodeInodeSessionKey(mount MountID, inode InodeID) ([]byte, error) {
 	if err := validateInodeID(inode); err != nil {
 		return nil, err
 	}
 	var body [9]byte
-	binary.BigEndian.PutUint64(body[1:], uint64(inode))
+	binary.BigEndian.PutUint64(body[:8], uint64(inode))
+	body[8] = 0x00
 	return encodeKey(mount, KeyKindSession, body[:])
 }
 
@@ -188,6 +196,67 @@ func MountIDOfKey(key []byte) (MountID, bool) {
 func StringMountResolver(key []byte) (string, bool) {
 	mount, ok := MountIDOfKey(key)
 	return string(mount), ok
+}
+
+// ShardForUserKey is the fsmeta physical placement policy used by local DB
+// runtimes. It keeps semantically-related metadata keys on one local shard
+// without teaching the local engine fsmeta's key families.
+func ShardForUserKey(key []byte, shardCount int) int {
+	shardCount = utils.NormalizeShardCount(shardCount)
+	if shardCount <= 1 {
+		return 0
+	}
+	_, pos, err := decodeHeaderParts(key)
+	if err != nil || pos >= len(key) {
+		return utils.ShardForUserKey(key, shardCount)
+	}
+	kind := KeyKind(key[pos])
+	body := key[pos+1:]
+	switch kind {
+	case KeyKindMount:
+		mount, _, err := decodeHeaderParts(key)
+		if err != nil {
+			return utils.ShardForUserKey(key, shardCount)
+		}
+		return utils.ShardForUserKey([]byte(mount), shardCount)
+	case KeyKindInode:
+		if len(body) < 8 {
+			return utils.ShardForUserKey(key, shardCount)
+		}
+		return shardForInodeAffinity(InodeID(binary.BigEndian.Uint64(body[:8])), shardCount)
+	case KeyKindDentry:
+		if len(body) < 8 {
+			return utils.ShardForUserKey(key, shardCount)
+		}
+		parent := InodeID(binary.BigEndian.Uint64(body[:8]))
+		if parent == RootInode && len(body) > 8 {
+			return utils.ShardForUserKey(body[8:], shardCount)
+		}
+		return shardForInodeAffinity(parent, shardCount)
+	case KeyKindChunk:
+		if len(body) < 8 {
+			return utils.ShardForUserKey(key, shardCount)
+		}
+		return shardForInodeAffinity(InodeID(binary.BigEndian.Uint64(body[:8])), shardCount)
+	case KeyKindSession:
+		if len(body) < 9 {
+			return utils.ShardForUserKey(key, shardCount)
+		}
+		return shardForInodeAffinity(InodeID(binary.BigEndian.Uint64(body[:8])), shardCount)
+	case KeyKindUsage:
+		if len(body) < 8 {
+			return utils.ShardForUserKey(key, shardCount)
+		}
+		return shardForInodeAffinity(InodeID(binary.BigEndian.Uint64(body[:8])), shardCount)
+	default:
+		return utils.ShardForUserKey(key, shardCount)
+	}
+}
+
+func shardForInodeAffinity(inode InodeID, shardCount int) int {
+	var body [8]byte
+	binary.BigEndian.PutUint64(body[:], uint64(inode))
+	return utils.ShardForUserKey(body[:], shardCount)
 }
 
 func encodeKey(mount MountID, kind KeyKind, body []byte) ([]byte, error) {

--- a/fsmeta/keys_test.go
+++ b/fsmeta/keys_test.go
@@ -92,6 +92,39 @@ func TestDentryPrefixGroupsDirectoryEntries(t *testing.T) {
 	require.False(t, bytes.HasPrefix(otherMount, prefix))
 }
 
+func TestShardForUserKeyKeepsWorkspaceMutationsLocal(t *testing.T) {
+	const shards = 4
+	createDentry, err := EncodeDentryKey("vol", RootInode, "workspace-a")
+	require.NoError(t, err)
+	targetShard := ShardForUserKey(createDentry, shards)
+
+	inode := findInodeOnShard(t, "vol", targetShard, shards)
+	createInode, err := EncodeInodeKey("vol", inode)
+	require.NoError(t, err)
+	require.Equal(t, targetShard, ShardForUserKey(createInode, shards))
+
+	childA, err := EncodeDentryKey("vol", inode, "scratch")
+	require.NoError(t, err)
+	childB, err := EncodeDentryKey("vol", inode, "checkpoint")
+	require.NoError(t, err)
+	require.Equal(t, targetShard, ShardForUserKey(childA, shards))
+	require.Equal(t, targetShard, ShardForUserKey(childB, shards))
+}
+
+func TestShardForUserKeyKeepsSessionIndexesWithInode(t *testing.T) {
+	const shards = 8
+	session, err := EncodeSessionKey("vol", 42, "writer-1")
+	require.NoError(t, err)
+	owner, err := EncodeInodeSessionKey("vol", 42)
+	require.NoError(t, err)
+	inode, err := EncodeInodeKey("vol", 42)
+	require.NoError(t, err)
+
+	targetShard := ShardForUserKey(inode, shards)
+	require.Equal(t, targetShard, ShardForUserKey(session, shards))
+	require.Equal(t, targetShard, ShardForUserKey(owner, shards))
+}
+
 func TestNameValidationRejectsUnsafePathComponents(t *testing.T) {
 	for _, name := range []string{"", ".", "..", "a/b", "a\x00b"} {
 		_, err := EncodeDentryKey("vol", RootInode, name)
@@ -107,4 +140,17 @@ func TestKeyKindOfRejectsInvalidKeys(t *testing.T) {
 	require.NoError(t, err)
 	_, err = KeyKindOf(key)
 	require.ErrorIs(t, err, ErrInvalidKeyKind)
+}
+
+func findInodeOnShard(t *testing.T, mount MountID, shard int, shardCount int) InodeID {
+	t.Helper()
+	for inode := InodeID(2); inode < 10_000; inode++ {
+		key, err := EncodeInodeKey(mount, inode)
+		require.NoError(t, err)
+		if ShardForUserKey(key, shardCount) == shard {
+			return inode
+		}
+	}
+	t.Fatalf("no inode found for shard %d", shard)
+	return 0
 }

--- a/fsmeta/plan.go
+++ b/fsmeta/plan.go
@@ -149,6 +149,7 @@ type HeartbeatWriteSessionRequest struct {
 
 type CloseWriteSessionRequest struct {
 	Mount   MountID
+	Inode   InodeID
 	Session SessionID
 }
 
@@ -364,7 +365,7 @@ func PlanOpenWriteSession(req OpenWriteSessionRequest) (OperationPlan, error) {
 	if err != nil {
 		return OperationPlan{}, err
 	}
-	session, err := EncodeSessionKey(req.Mount, req.Session)
+	session, err := EncodeSessionKey(req.Mount, req.Inode, req.Session)
 	if err != nil {
 		return OperationPlan{}, err
 	}
@@ -382,7 +383,7 @@ func PlanOpenWriteSession(req OpenWriteSessionRequest) (OperationPlan, error) {
 }
 
 func PlanHeartbeatWriteSession(req HeartbeatWriteSessionRequest) (OperationPlan, error) {
-	session, err := EncodeSessionKey(req.Mount, req.Session)
+	session, err := EncodeSessionKey(req.Mount, req.Inode, req.Session)
 	if err != nil {
 		return OperationPlan{}, err
 	}
@@ -400,7 +401,7 @@ func PlanHeartbeatWriteSession(req HeartbeatWriteSessionRequest) (OperationPlan,
 }
 
 func PlanCloseWriteSession(req CloseWriteSessionRequest) (OperationPlan, error) {
-	session, err := EncodeSessionKey(req.Mount, req.Session)
+	session, err := EncodeSessionKey(req.Mount, req.Inode, req.Session)
 	if err != nil {
 		return OperationPlan{}, err
 	}

--- a/fsmeta/plan_test.go
+++ b/fsmeta/plan_test.go
@@ -229,7 +229,7 @@ func TestPlanOpenWriteSessionTouchesInodeAndSession(t *testing.T) {
 
 	inode, err := EncodeInodeKey("vol", 44)
 	require.NoError(t, err)
-	session, err := EncodeSessionKey("vol", "client-1")
+	session, err := EncodeSessionKey("vol", 44, "client-1")
 	require.NoError(t, err)
 	owner, err := EncodeInodeSessionKey("vol", 44)
 	require.NoError(t, err)

--- a/fsmeta/runtime/raftstore/inode_allocator.go
+++ b/fsmeta/runtime/raftstore/inode_allocator.go
@@ -23,9 +23,9 @@ type IDAllocatorClient interface {
 }
 
 // ShardAffineInodeAllocator prefetches coordinator IDs and returns an inode ID
-// whose inode key hashes to the same local LSM shard as the dentry key when
-// possible. A miss is still correct: Create keeps the existing 1PC safety gate
-// and falls back to Percolator 2PC when local atomicity cannot be proven.
+// whose fsmeta placement shard matches the target dentry when possible. A miss
+// is still correct: Create keeps the existing 1PC safety gate and falls back to
+// Percolator 2PC when local atomicity cannot be proven.
 type ShardAffineInodeAllocator struct {
 	client    IDAllocatorClient
 	shards    int
@@ -175,7 +175,7 @@ func createDentryShard(mount fsmeta.MountID, parent fsmeta.InodeID, name string,
 	if err != nil {
 		return 0, err
 	}
-	return utils.ShardForUserKey(key, shards), nil
+	return fsmeta.ShardForUserKey(key, shards), nil
 }
 
 func createInodeShard(mount fsmeta.MountID, inode fsmeta.InodeID, shards int) (int, error) {
@@ -183,5 +183,5 @@ func createInodeShard(mount fsmeta.MountID, inode fsmeta.InodeID, shards int) (i
 	if err != nil {
 		return 0, err
 	}
-	return utils.ShardForUserKey(key, shards), nil
+	return fsmeta.ShardForUserKey(key, shards), nil
 }

--- a/fsmeta/server/service_test.go
+++ b/fsmeta/server/service_test.go
@@ -376,9 +376,9 @@ func TestGRPCServiceReadDirAndMutationRPCs(t *testing.T) {
 	require.Equal(t, fsmeta.HeartbeatWriteSessionRequest{Mount: "vol", Inode: 42, Session: "writer-1", TTL: 2 * time.Microsecond}, executor.heartbeatReq)
 	require.Equal(t, int64(2000), heartbeatResp.GetSession().GetExpiresUnixNs())
 
-	_, err = client.CloseWriteSession(context.Background(), &fsmetapb.CloseWriteSessionRequest{Mount: "vol", Session: "writer-1"})
+	_, err = client.CloseWriteSession(context.Background(), &fsmetapb.CloseWriteSessionRequest{Mount: "vol", Inode: 42, Session: "writer-1"})
 	require.NoError(t, err)
-	require.Equal(t, fsmeta.CloseWriteSessionRequest{Mount: "vol", Session: "writer-1"}, executor.closeReq)
+	require.Equal(t, fsmeta.CloseWriteSessionRequest{Mount: "vol", Inode: 42, Session: "writer-1"}, executor.closeReq)
 
 	expireResp, err := client.ExpireWriteSessions(context.Background(), &fsmetapb.ExpireWriteSessionsRequest{Mount: "vol", Limit: 64})
 	require.NoError(t, err)

--- a/fsmeta/server/wire.go
+++ b/fsmeta/server/wire.go
@@ -189,6 +189,7 @@ func closeWriteSessionRequestFromProto(req *fsmetapb.CloseWriteSessionRequest) f
 	}
 	return fsmeta.CloseWriteSessionRequest{
 		Mount:   fsmeta.MountID(req.GetMount()),
+		Inode:   fsmeta.InodeID(req.GetInode()),
 		Session: fsmeta.SessionID(req.GetSession()),
 	}
 }

--- a/local/db.go
+++ b/local/db.go
@@ -223,6 +223,7 @@ func (db *DB) startWriteRuntime() {
 		WriteBatchMaxCount: db.opt.WriteBatchMaxCount,
 		WriteBatchMaxSize:  db.opt.WriteBatchMaxSize,
 		WriteBatchWait:     db.opt.WriteBatchWait,
+		UserKeyShardRouter: db.opt.UserKeyShardRouter,
 	}, db)
 	db.pipeline.Start()
 }
@@ -1064,7 +1065,7 @@ func (db *DB) groupInternalEntriesByShard(entries []*kv.Entry) [][]*kv.Entry {
 		if entry == nil {
 			continue
 		}
-		shardID := lsm.ShardForInternalKey(entry.Key, shardCount)
+		shardID := db.shardForInternalKey(entry.Key, shardCount)
 		if len(buckets[shardID]) == 0 {
 			order = append(order, shardID)
 		}
@@ -1075,6 +1076,21 @@ func (db *DB) groupInternalEntriesByShard(entries []*kv.Entry) [][]*kv.Entry {
 		groups = append(groups, buckets[shardID])
 	}
 	return groups
+}
+
+func (db *DB) shardForInternalKey(internalKey []byte, shardCount int) int {
+	if db == nil || db.opt == nil || db.opt.UserKeyShardRouter == nil {
+		return lsm.ShardForInternalKey(internalKey, shardCount)
+	}
+	_, userKey, _, ok := kv.SplitInternalKey(internalKey)
+	if !ok {
+		return 0
+	}
+	shard := db.opt.UserKeyShardRouter(userKey, shardCount)
+	if shard < 0 || shard >= utils.NormalizeShardCount(shardCount) {
+		return utils.ShardForUserKey(userKey, shardCount)
+	}
+	return shard
 }
 
 func releaseEntryGroups(groups [][]*kv.Entry) {

--- a/local/internal/commit/pipeline.go
+++ b/local/internal/commit/pipeline.go
@@ -37,6 +37,7 @@ type Config struct {
 	WriteBatchMaxCount int
 	WriteBatchMaxSize  int64
 	WriteBatchWait     time.Duration
+	UserKeyShardRouter func(userKey []byte, shardCount int) int
 }
 
 // LSM is the narrow LSM surface the pipeline writes through. Implemented
@@ -300,20 +301,19 @@ func (p *Pipeline) dispatcher() {
 			closeAll()
 			return
 		}
-		shardID := shardForBatch(batch, n, &rrFallback)
+		shardID := shardForBatch(batch, n, &rrFallback, p.cfg.UserKeyShardRouter)
 		batch.ShardID = shardID
 		p.dispatch[shardID] <- batch
 	}
 }
 
-// shardForBatch picks the destination shard for a commit batch using
-// per-key affinity: hash the user key of the batch's first entry and
-// mod by the shard count. This keeps every write to the same key on the
-// same shard so percolator's same-startTS lock-on/lock-off and any
-// other "later same-version write wins" pattern stays correct.
+// shardForBatch picks the destination shard for a commit batch using the
+// configured user-key router. The default router hashes the whole user key;
+// fsmeta runtimes can inject a semantic-affinity router so keys that must be
+// atomically mutated together reach one local apply group.
 //
 // Empty batches (no key to hash) round-robin via *rr to keep load even.
-func shardForBatch(batch *CommitBatch, n int, rr *int) int {
+func shardForBatch(batch *CommitBatch, n int, rr *int, router func([]byte, int) int) int {
 	if n <= 1 {
 		return 0
 	}
@@ -330,7 +330,7 @@ func shardForBatch(batch *CommitBatch, n int, rr *int) int {
 				if !ok || len(userKey) == 0 {
 					continue
 				}
-				return utils.ShardForUserKey(userKey, n)
+				return routeUserKeyToShard(userKey, n, router)
 			}
 		}
 	}
@@ -340,6 +340,16 @@ func shardForBatch(batch *CommitBatch, n int, rr *int) int {
 		*rr = 0
 	}
 	return id
+}
+
+func routeUserKeyToShard(userKey []byte, shardCount int, router func([]byte, int) int) int {
+	if router != nil {
+		shard := router(userKey, shardCount)
+		if shard >= 0 && shard < utils.NormalizeShardCount(shardCount) {
+			return shard
+		}
+	}
+	return utils.ShardForUserKey(userKey, shardCount)
 }
 
 // processor runs the per-batch CPU pipeline (collect -> applyRequests ->

--- a/local/internal/commit/pipeline_test.go
+++ b/local/internal/commit/pipeline_test.go
@@ -1,0 +1,41 @@
+package commit
+
+import (
+	"testing"
+
+	"github.com/feichai0017/NoKV/engine/kv"
+	"github.com/feichai0017/NoKV/utils"
+	"github.com/stretchr/testify/require"
+)
+
+func TestShardForBatchUsesConfiguredUserKeyRouter(t *testing.T) {
+	entry := kv.NewEntry(kv.InternalKey(kv.CFDefault, []byte("semantic-key"), 7), []byte("value"))
+	defer entry.DecrRef()
+
+	req := &Request{Entries: []*kv.Entry{entry}}
+	batch := &CommitBatch{Reqs: []*CommitRequest{{Req: req}}}
+	rr := 0
+
+	shard := shardForBatch(batch, 4, &rr, func(userKey []byte, shardCount int) int {
+		require.Equal(t, []byte("semantic-key"), userKey)
+		require.Equal(t, 4, shardCount)
+		return 3
+	})
+
+	require.Equal(t, 3, shard)
+	require.Equal(t, 0, rr)
+}
+
+func TestShardForBatchFallsBackWhenRouterReturnsInvalidShard(t *testing.T) {
+	userKey := []byte("semantic-key")
+	entry := kv.NewEntry(kv.InternalKey(kv.CFDefault, userKey, 7), []byte("value"))
+	defer entry.DecrRef()
+
+	req := &Request{Entries: []*kv.Entry{entry}}
+	batch := &CommitBatch{Reqs: []*CommitRequest{{Req: req}}}
+	rr := 0
+
+	shard := shardForBatch(batch, 4, &rr, func([]byte, int) int { return 99 })
+
+	require.Equal(t, utils.ShardForUserKey(userKey, 4), shard)
+}

--- a/local/options.go
+++ b/local/options.go
@@ -92,7 +92,13 @@ type Options struct {
 	// default; non-power-of-two values are rounded DOWN to the nearest
 	// power of two during Open (e.g. 6 → 4, 12 → 8).
 	LSMShardCount int
-	ManifestSync  bool
+	// UserKeyShardRouter optionally overrides the local data-plane shard for a
+	// user key. Nil keeps the generic full-key hash router. Runtime-specific
+	// routers must be deterministic and must not depend on mutable process
+	// state, because WAL recovery and AtomicMutate admission use the same
+	// placement boundary.
+	UserKeyShardRouter func(userKey []byte, shardCount int) int
+	ManifestSync       bool
 	// ManifestRewriteThreshold triggers a manifest rewrite when the active
 	// MANIFEST file grows beyond this size (bytes). Values <= 0 disable rewrites.
 	ManifestRewriteThreshold int64

--- a/pb/fsmeta/fsmeta.pb.go
+++ b/pb/fsmeta/fsmeta.pb.go
@@ -2715,6 +2715,7 @@ type CloseWriteSessionRequest struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	Mount         string                 `protobuf:"bytes,1,opt,name=mount,proto3" json:"mount,omitempty"`
 	Session       string                 `protobuf:"bytes,2,opt,name=session,proto3" json:"session,omitempty"`
+	Inode         uint64                 `protobuf:"varint,3,opt,name=inode,proto3" json:"inode,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -2761,6 +2762,13 @@ func (x *CloseWriteSessionRequest) GetSession() string {
 		return x.Session
 	}
 	return ""
+}
+
+func (x *CloseWriteSessionRequest) GetInode() uint64 {
+	if x != nil {
+		return x.Inode
+	}
+	return 0
 }
 
 type CloseWriteSessionResponse struct {
@@ -3078,10 +3086,11 @@ const file_fsmeta_fsmeta_proto_rawDesc = "" +
 	"\asession\x18\x03 \x01(\tR\asession\x12\x15\n" +
 	"\x06ttl_ns\x18\x04 \x01(\x04R\x05ttlNs\"X\n" +
 	"\x1dHeartbeatWriteSessionResponse\x127\n" +
-	"\asession\x18\x01 \x01(\v2\x1d.nokv.fsmeta.v1.SessionRecordR\asession\"J\n" +
+	"\asession\x18\x01 \x01(\v2\x1d.nokv.fsmeta.v1.SessionRecordR\asession\"`\n" +
 	"\x18CloseWriteSessionRequest\x12\x14\n" +
 	"\x05mount\x18\x01 \x01(\tR\x05mount\x12\x18\n" +
-	"\asession\x18\x02 \x01(\tR\asession\"\x1b\n" +
+	"\asession\x18\x02 \x01(\tR\asession\x12\x14\n" +
+	"\x05inode\x18\x03 \x01(\x04R\x05inode\"\x1b\n" +
 	"\x19CloseWriteSessionResponse\"H\n" +
 	"\x1aExpireWriteSessionsRequest\x12\x14\n" +
 	"\x05mount\x18\x01 \x01(\tR\x05mount\x12\x14\n" +

--- a/pb/fsmeta/fsmeta.proto
+++ b/pb/fsmeta/fsmeta.proto
@@ -274,6 +274,7 @@ message HeartbeatWriteSessionResponse {
 message CloseWriteSessionRequest {
   string mount = 1;
   string session = 2;
+  uint64 inode = 3;
 }
 
 message CloseWriteSessionResponse {}


### PR DESCRIPTION
## Summary
- add a local UserKeyShardRouter hook and wire fsmeta semantic placement into the store runtime
- make fsmeta session keys inode-affine so session + owner records colocate for AtomicMutate
- scope AtomicMutate fallback backoff by key-affinity pattern instead of operation-wide state
- update fsmeta contract/workload/proto wiring and add placement/router regression tests

## Correctness
- local engine remains a generic KV/LSM engine; fsmeta semantics enter only through a narrow deterministic placement policy
- AtomicMutate safety gate is unchanged: cross-region or cross-local-apply-group operations still fall back to 2PC
- CloseWriteSession is intentionally breaking: request now carries inode and session identity is `(inode, session)`

## Validation
- make fmt
- make lint
- go test ./...
- cd benchmark && go test ./fsmeta ./fsmeta/workload
- Docker Compose fsmeta median benchmark: `benchmark/data/fsmeta/results/fsmeta_compose_median_20260508T135955Z.csv`

## Benchmark evidence
- mixed aggregate: 134.5 ops/s, 0 errors
- checkpoint-storm: 91.1 ops/s, 0 errors
- hotspot-fanin: 61.0 ops/s, 0 errors
- watch-subtree: 180.7 ops/s, 0 errors
- negative-lookup: 1201.4 ops/s, 0 errors
- fast path counters: atomic_success_total=22821, atomic_route_multi_total=0, atomic_local_fallback_total=0


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added inode-aware write session tracking for improved session lifecycle management and concurrent operation handling.
  * Implemented local data placement strategy for better key affinity and performance optimization.

* **Bug Fixes**
  * Enhanced session validation to ensure correct inode association during close operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->