### PR TITLE
Batch raftstore write proposals

### DIFF
--- a/cmd/nokv/cmd_meta_root.go
+++ b/cmd/nokv/cmd_meta_root.go
@@ -114,7 +114,7 @@ func runMetaRootCmd(w io.Writer, args []string) error {
 	}
 	defer func() { _ = lis.Close() }()
 
-	grpcServer := grpc.NewServer()
+	grpcServer := grpc.NewServer(rootserver.GRPCServerOptions()...)
 	rootserver.Register(grpcServer, backend)
 
 	installMetaRootExpvar(metaRootExpvarContext{

--- a/cmd/nokv/cmd_serve.go
+++ b/cmd/nokv/cmd_serve.go
@@ -308,6 +308,7 @@ func runServeCmd(w io.Writer, args []string) error {
 		_ = server.Close()
 	}()
 	installStorePercolatorExpvar()
+	installStoreKVExpvar(server.KVStats)
 	metricsLn, err := startExpvarServer(*metricsAddr)
 	if err != nil {
 		return fmt.Errorf("start serve metrics endpoint: %w", err)

--- a/cmd/nokv/metrics.go
+++ b/cmd/nokv/metrics.go
@@ -61,6 +61,8 @@ var (
 	metaRootExpvarOnce     sync.Once
 	metaRootExpvarProvider atomic.Value
 	storePercolatorOnce    sync.Once
+	storeKVExpvarOnce      sync.Once
+	storeKVExpvarProvider  atomic.Value
 )
 
 type metaRootExpvarContext struct {
@@ -126,6 +128,24 @@ func installStorePercolatorExpvar() {
 	storePercolatorOnce.Do(func() {
 		expvar.Publish("nokv_store_percolator", expvar.Func(func() any {
 			return percolator.AtomicMutateStats()
+		}))
+	})
+}
+
+func installStoreKVExpvar(source func() map[string]any) {
+	if source == nil {
+		return
+	}
+	storeKVExpvarProvider.Store(debugSnapshotFunc(func() any {
+		return source()
+	}))
+	storeKVExpvarOnce.Do(func() {
+		expvar.Publish("nokv_store_kv", expvar.Func(func() any {
+			provider, _ := storeKVExpvarProvider.Load().(debugSnapshotFunc)
+			if provider == nil {
+				return map[string]any{}
+			}
+			return provider()
 		}))
 	})
 }

--- a/coordinator/server/service_grant.go
+++ b/coordinator/server/service_grant.go
@@ -524,7 +524,47 @@ func (s *Service) currentRegionLookupRevision() uint64 {
 	if err == nil && snapshot.RootToken.Revision > revision {
 		revision = snapshot.RootToken.Revision
 	}
+	if floor := s.currentRegionLookupGrantFloor(); floor > revision {
+		revision = floor
+	}
 	return revision
+}
+
+func (s *Service) currentRegionLookupGrantFloor() uint64 {
+	if s == nil {
+		return 0
+	}
+	s.grantMu.RLock()
+	view := s.grantView
+	s.grantMu.RUnlock()
+	var floor uint64
+	// Version-bounded duties must be successor-monotone. A restarted
+	// coordinator can rebuild a smaller in-memory descriptor revision than the
+	// ceiling carried by an expired or sealed predecessor, but root will reject
+	// a successor grant that does not cover that predecessor. Keep the requested
+	// region_lookup bound at least as high as every non-inherited predecessor
+	// and currently rooted grant.
+	for _, grant := range view.Grants() {
+		floor = maxUint64(floor, regionLookupRevisionBound(grant.Duties))
+	}
+	for _, retirement := range view.Retirements() {
+		if retirement.InheritedByGrantID != "" {
+			continue
+		}
+		floor = maxUint64(floor, regionLookupRevisionBound(retirement.Bounds))
+	}
+	return floor
+}
+
+func regionLookupRevisionBound(duties []rootproto.DutyGrant) uint64 {
+	var out uint64
+	for _, duty := range duties {
+		if duty.DutyID != rootproto.DutyRegionLookup || duty.Scope.Kind != rootproto.DutyScopeGlobal || duty.Bound.Kind != rootproto.DutyBoundVersion {
+			continue
+		}
+		out = maxUint64(out, duty.Bound.DescriptorRevisionCeiling)
+	}
+	return out
 }
 
 func (s *Service) localGrantDuties() []rootproto.DutyID {

--- a/coordinator/server/service_test.go
+++ b/coordinator/server/service_test.go
@@ -2867,6 +2867,53 @@ func TestServiceGetRegionByKeyRenewsWhenDescriptorOutsideGrant(t *testing.T) {
 	require.Equal(t, 1, store.campaignCalls)
 }
 
+func TestServiceGetRegionByKeyRenewCoversRetiredRegionLookupBound(t *testing.T) {
+	now := time.Unix(100, 0)
+	store := &fakeStorage{
+		leader: true,
+		snapshot: rootview.Snapshot{
+			ActiveGrants: []rootproto.AuthorityGrant{{
+				GrantID:         "c1/region_lookup/10",
+				HolderID:        "c1",
+				ExpiresUnixNano: now.Add(-time.Second).UnixNano(),
+				Era:             10,
+				Duties: []rootproto.DutyGrant{
+					rootproto.NewGlobalVersionDuty(rootproto.DutyRegionLookup, rootproto.AuthorityRootToken{}, 100, 0),
+				},
+			}},
+			RetiredGrants: []rootproto.GrantRetirement{{
+				GrantID:  "c1/region_lookup/9",
+				HolderID: "c1",
+				Era:      9,
+				Mode:     rootproto.GrantRetirementSealedExact,
+				Bounds: []rootproto.DutyGrant{
+					rootproto.NewGlobalVersionDuty(rootproto.DutyRegionLookup, rootproto.AuthorityRootToken{}, 96, 0),
+				},
+			}},
+			Descriptors: map[uint64]topology.Descriptor{
+				11: {RegionID: 11, StartKey: []byte("a"), EndKey: []byte("z"), RootEpoch: 7},
+			},
+			RootToken: rootstorage.TailToken{Revision: 8},
+		},
+	}
+	svc := NewService(catalog.NewCluster(), idalloc.NewIDAllocator(10), tso.NewAllocator(100), store)
+	svc.ConfigureAuthorityGrant("c1", 10*time.Second, 3*time.Second)
+	svc.now = func() time.Time { return now }
+	require.NoError(t, svc.ReloadFromStorage())
+
+	resp, err := svc.GetRegionByKey(context.Background(), &coordpb.GetRegionByKeyRequest{
+		Key:       []byte("m"),
+		Freshness: coordpb.Freshness_FRESHNESS_BEST_EFFORT,
+	})
+	require.NoError(t, err)
+	require.Equal(t, uint64(11), resp.GetRegionDescriptor().GetRegionId())
+	require.Equal(t, 1, store.campaignCalls)
+	renewed, ok := store.snapshot.ActiveGrantFor(rootproto.DutyRegionLookup, rootproto.DutyScope{Kind: rootproto.DutyScopeGlobal})
+	require.True(t, ok)
+	require.Equal(t, uint64(100), regionLookupRevisionBound(renewed.Duties))
+	require.NotEmpty(t, renewed.PredecessorRetirements)
+}
+
 func TestServiceStoreHeartbeatSuppressesOperationsWithoutGrant(t *testing.T) {
 	store := &fakeStorage{
 		leader: true,

--- a/meta/root/client/client.go
+++ b/meta/root/client/client.go
@@ -27,7 +27,10 @@ import (
 	"google.golang.org/grpc/credentials/insecure"
 )
 
-const defaultCallTimeout = 3 * time.Second
+const (
+	defaultCallTimeout            = 3 * time.Second
+	defaultMaxRootRPCMessageBytes = 64 << 20
+)
 
 const errMetadataRootNotLeader = "metadata root not leader"
 
@@ -394,10 +397,23 @@ func dialEndpoint(ctx context.Context, target string, opts ...grpc.DialOption) (
 	if ctx == nil {
 		ctx = context.Background()
 	}
+	dialOpts := make([]grpc.DialOption, 0, len(opts)+2)
 	if len(opts) == 0 {
-		opts = []grpc.DialOption{grpc.WithTransportCredentials(insecure.NewCredentials())}
+		dialOpts = append(dialOpts, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	} else {
+		dialOpts = append(dialOpts, opts...)
 	}
-	conn, err := grpc.NewClient(target, opts...)
+	// Metadata-root checkpoints are compact state, but long-running fsmeta
+	// tests can legitimately grow them past gRPC's 4 MiB default. The root RPC
+	// boundary owns that transport budget so coordinator bootstrap does not
+	// depend on an implicit library limit.
+	dialOpts = append(dialOpts,
+		grpc.WithDefaultCallOptions(
+			grpc.MaxCallRecvMsgSize(defaultMaxRootRPCMessageBytes),
+			grpc.MaxCallSendMsgSize(defaultMaxRootRPCMessageBytes),
+		),
+	)
+	conn, err := grpc.NewClient(target, dialOpts...)
 	if err != nil {
 		return nil, err
 	}

--- a/meta/root/client/client_test.go
+++ b/meta/root/client/client_test.go
@@ -3,16 +3,24 @@ package client
 import (
 	"context"
 	stderrors "errors"
+	"fmt"
+	"net"
 	"strconv"
+	"strings"
 	"testing"
 	"time"
 
 	nokverrors "github.com/feichai0017/NoKV/errors"
+	rootevent "github.com/feichai0017/NoKV/meta/root/event"
+	rootserver "github.com/feichai0017/NoKV/meta/root/server"
+	rootstate "github.com/feichai0017/NoKV/meta/root/state"
 	metapb "github.com/feichai0017/NoKV/pb/meta"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/status"
+	"google.golang.org/grpc/test/bufconn"
 )
 
 func TestRetryableRemoteErrorConnectionClosing(t *testing.T) {
@@ -30,6 +38,69 @@ func TestRetryableRemoteErrorWrappedConnectionClosing(t *testing.T) {
 func clientConnClosingErrForTest() error {
 	//nolint:staticcheck
 	return grpc.ErrClientConnClosing
+}
+
+func TestDialClusterAcceptsLargeRootSnapshot(t *testing.T) {
+	listener := bufconn.Listen(defaultMaxRootRPCMessageBytes)
+	server := grpc.NewServer(rootserver.GRPCServerOptions()...)
+	rootserver.Register(server, largeSnapshotBackend())
+	go func() { _ = server.Serve(listener) }()
+	t.Cleanup(func() {
+		server.Stop()
+		_ = listener.Close()
+	})
+
+	ctx := context.Background()
+	client, err := DialCluster(ctx, map[uint64]string{1: "passthrough:///bufnet"},
+		grpc.WithContextDialer(func(context.Context, string) (net.Conn, error) {
+			return listener.Dial()
+		}),
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = client.Close() })
+
+	snapshot, err := client.Snapshot()
+	require.NoError(t, err)
+	require.Greater(t, len(snapshot.Subtrees), 4_000)
+}
+
+type largeRootBackend struct {
+	snapshot rootstate.Snapshot
+}
+
+func largeSnapshotBackend() *largeRootBackend {
+	subtrees := make(map[string]rootstate.SubtreeAuthority, 5_200)
+	payload := strings.Repeat("x", 1024)
+	for i := range 5_200 {
+		rootInode := uint64(i + 1)
+		id := fmt.Sprintf("bench/%d", rootInode)
+		subtrees[id] = rootstate.SubtreeAuthority{
+			SubtreeID:   id,
+			Mount:       "bench",
+			RootInode:   rootInode,
+			AuthorityID: payload,
+			Era:         1,
+			State:       rootstate.SubtreeAuthorityActive,
+		}
+	}
+	return &largeRootBackend{
+		snapshot: rootstate.Snapshot{
+			Subtrees: subtrees,
+		},
+	}
+}
+
+func (b *largeRootBackend) Snapshot() (rootstate.Snapshot, error) {
+	return rootstate.CloneSnapshot(b.snapshot), nil
+}
+
+func (b *largeRootBackend) Append(context.Context, ...rootevent.Event) (rootstate.CommitInfo, error) {
+	return rootstate.CommitInfo{}, nil
+}
+
+func (b *largeRootBackend) FenceAllocator(context.Context, rootstate.AllocatorKind, uint64) (uint64, error) {
+	return 0, nil
 }
 
 func TestRetryableRemoteErrorMetadataRootNotLeaderIsWriteOnly(t *testing.T) {

--- a/meta/root/server/service.go
+++ b/meta/root/server/service.go
@@ -17,6 +17,8 @@ import (
 	"google.golang.org/grpc"
 )
 
+const defaultMaxRootRPCMessageBytes = 64 << 20
+
 // Backend is the metadata-root authority surface exported over gRPC.
 type Backend interface {
 	Snapshot() (rootstate.Snapshot, error)
@@ -52,6 +54,16 @@ type Service struct {
 // NewService constructs one metadata-root RPC service around backend.
 func NewService(backend Backend) *Service {
 	return &Service{backend: backend}
+}
+
+// GRPCServerOptions returns the production transport budget for metadata-root
+// RPCs. Coordinator bootstrap can transfer a compact checkpoint that is larger
+// than gRPC's 4 MiB default after long-running root workloads.
+func GRPCServerOptions() []grpc.ServerOption {
+	return []grpc.ServerOption{
+		grpc.MaxRecvMsgSize(defaultMaxRootRPCMessageBytes),
+		grpc.MaxSendMsgSize(defaultMaxRootRPCMessageBytes),
+	}
 }
 
 // Register registers one metadata-root RPC service.

--- a/raftstore/kv/service.go
+++ b/raftstore/kv/service.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"time"
 
+	errorpb "github.com/feichai0017/NoKV/pb/error"
 	kvrpcpb "github.com/feichai0017/NoKV/pb/kv"
 	raftcmdpb "github.com/feichai0017/NoKV/pb/raft"
 
@@ -14,12 +15,33 @@ import (
 // Service exposes StoreKV gRPC handlers backed by a raftstore Store.
 type Service struct {
 	kvrpcpb.UnimplementedStoreKVServer
-	store *store.Store
+	store        *store.Store
+	writeBatcher *writeCommandBatcher
 }
 
 // NewService constructs a StoreKV service bound to the provided store.
-func NewService(st *store.Store) *Service {
-	return &Service{store: st}
+func NewService(st *store.Store, opts ...ServiceOption) *Service {
+	options := defaultServiceOptions()
+	for _, opt := range opts {
+		if opt != nil {
+			opt(&options)
+		}
+	}
+	s := &Service{store: st}
+	if options.writeCommandBatchMaxSize > 1 && options.writeCommandBatchMaxWait > 0 {
+		s.writeBatcher = newWriteCommandBatcher(s.propose, options.writeCommandBatchMaxSize, options.writeCommandBatchMaxWait)
+	}
+	return s
+}
+
+// Stats exposes low-cardinality StoreKV service counters for expvar and
+// benchmark artifacts.
+func (s *Service) Stats() map[string]any {
+	if s == nil || s.writeBatcher == nil {
+		var empty *writeCommandBatcher
+		return empty.Stats()
+	}
+	return s.writeBatcher.Stats()
 }
 
 func servicePhysicalTimeMillis() uint64 {
@@ -184,23 +206,16 @@ func (s *Service) Prewrite(ctx context.Context, req *kvrpcpb.KvPrewriteRequest) 
 	if req.GetRequest() == nil {
 		return nil, rpcInvalidArgument("prewrite request missing payload")
 	}
-	resp, err := s.propose(ctx, &raftcmdpb.RaftCmdRequest{
-		Header: header,
-		Requests: []*raftcmdpb.Request{{
-			CmdType: raftcmdpb.CmdType_CMD_PREWRITE,
-			Cmd:     &raftcmdpb.Request_Prewrite{Prewrite: req.GetRequest()},
-		}},
+	first, regionErr, err := s.submitWriteCommand(ctx, header, &raftcmdpb.Request{
+		CmdType: raftcmdpb.CmdType_CMD_PREWRITE,
+		Cmd:     &raftcmdpb.Request_Prewrite{Prewrite: req.GetRequest()},
 	})
 	if err != nil {
-		return nil, rpcStatus(err)
+		return nil, err
 	}
-	out := &kvrpcpb.KvPrewriteResponse{RegionError: resp.GetRegionError()}
+	out := &kvrpcpb.KvPrewriteResponse{RegionError: regionErr}
 	if out.GetRegionError() != nil {
 		return out, nil
-	}
-	first, err := singleRaftResponse("prewrite", resp)
-	if err != nil {
-		return nil, err
 	}
 	if first.GetPrewrite() == nil {
 		return nil, raftPayloadError("prewrite", "missing prewrite payload")
@@ -217,23 +232,16 @@ func (s *Service) Commit(ctx context.Context, req *kvrpcpb.KvCommitRequest) (*kv
 	if req.GetRequest() == nil {
 		return nil, rpcInvalidArgument("commit request missing payload")
 	}
-	resp, err := s.propose(ctx, &raftcmdpb.RaftCmdRequest{
-		Header: header,
-		Requests: []*raftcmdpb.Request{{
-			CmdType: raftcmdpb.CmdType_CMD_COMMIT,
-			Cmd:     &raftcmdpb.Request_Commit{Commit: req.GetRequest()},
-		}},
+	first, regionErr, err := s.submitWriteCommand(ctx, header, &raftcmdpb.Request{
+		CmdType: raftcmdpb.CmdType_CMD_COMMIT,
+		Cmd:     &raftcmdpb.Request_Commit{Commit: req.GetRequest()},
 	})
 	if err != nil {
-		return nil, rpcStatus(err)
+		return nil, err
 	}
-	out := &kvrpcpb.KvCommitResponse{RegionError: resp.GetRegionError()}
+	out := &kvrpcpb.KvCommitResponse{RegionError: regionErr}
 	if out.GetRegionError() != nil {
 		return out, nil
-	}
-	first, err := singleRaftResponse("commit", resp)
-	if err != nil {
-		return nil, err
 	}
 	if first.GetCommit() == nil {
 		return nil, raftPayloadError("commit", "missing commit payload")
@@ -250,23 +258,16 @@ func (s *Service) BatchRollback(ctx context.Context, req *kvrpcpb.KvBatchRollbac
 	if req.GetRequest() == nil {
 		return nil, rpcInvalidArgument("rollback request missing payload")
 	}
-	resp, err := s.propose(ctx, &raftcmdpb.RaftCmdRequest{
-		Header: header,
-		Requests: []*raftcmdpb.Request{{
-			CmdType: raftcmdpb.CmdType_CMD_BATCH_ROLLBACK,
-			Cmd:     &raftcmdpb.Request_BatchRollback{BatchRollback: req.GetRequest()},
-		}},
+	first, regionErr, err := s.submitWriteCommand(ctx, header, &raftcmdpb.Request{
+		CmdType: raftcmdpb.CmdType_CMD_BATCH_ROLLBACK,
+		Cmd:     &raftcmdpb.Request_BatchRollback{BatchRollback: req.GetRequest()},
 	})
 	if err != nil {
-		return nil, rpcStatus(err)
+		return nil, err
 	}
-	out := &kvrpcpb.KvBatchRollbackResponse{RegionError: resp.GetRegionError()}
+	out := &kvrpcpb.KvBatchRollbackResponse{RegionError: regionErr}
 	if out.GetRegionError() != nil {
 		return out, nil
-	}
-	first, err := singleRaftResponse("batch rollback", resp)
-	if err != nil {
-		return nil, err
 	}
 	if first.GetBatchRollback() == nil {
 		return nil, raftPayloadError("batch rollback", "missing batch rollback payload")
@@ -283,23 +284,16 @@ func (s *Service) ResolveLock(ctx context.Context, req *kvrpcpb.KvResolveLockReq
 	if req.GetRequest() == nil {
 		return nil, rpcInvalidArgument("resolve lock request missing payload")
 	}
-	resp, err := s.propose(ctx, &raftcmdpb.RaftCmdRequest{
-		Header: header,
-		Requests: []*raftcmdpb.Request{{
-			CmdType: raftcmdpb.CmdType_CMD_RESOLVE_LOCK,
-			Cmd:     &raftcmdpb.Request_ResolveLock{ResolveLock: req.GetRequest()},
-		}},
+	first, regionErr, err := s.submitWriteCommand(ctx, header, &raftcmdpb.Request{
+		CmdType: raftcmdpb.CmdType_CMD_RESOLVE_LOCK,
+		Cmd:     &raftcmdpb.Request_ResolveLock{ResolveLock: req.GetRequest()},
 	})
 	if err != nil {
-		return nil, rpcStatus(err)
+		return nil, err
 	}
-	out := &kvrpcpb.KvResolveLockResponse{RegionError: resp.GetRegionError()}
+	out := &kvrpcpb.KvResolveLockResponse{RegionError: regionErr}
 	if out.GetRegionError() != nil {
 		return out, nil
-	}
-	first, err := singleRaftResponse("resolve lock", resp)
-	if err != nil {
-		return nil, err
 	}
 	if first.GetResolveLock() == nil {
 		return nil, raftPayloadError("resolve lock", "missing resolve lock payload")
@@ -384,29 +378,43 @@ func (s *Service) TryAtomicMutate(ctx context.Context, req *kvrpcpb.KvTryAtomicM
 	if req.GetRequest() == nil {
 		return nil, rpcInvalidArgument("atomic mutate request missing payload")
 	}
-	resp, err := s.propose(ctx, &raftcmdpb.RaftCmdRequest{
-		Header: header,
-		Requests: []*raftcmdpb.Request{{
-			CmdType: raftcmdpb.CmdType_CMD_TRY_ATOMIC_MUTATE,
-			Cmd:     &raftcmdpb.Request_TryAtomicMutate{TryAtomicMutate: req.GetRequest()},
-		}},
+	first, regionErr, err := s.submitWriteCommand(ctx, header, &raftcmdpb.Request{
+		CmdType: raftcmdpb.CmdType_CMD_TRY_ATOMIC_MUTATE,
+		Cmd:     &raftcmdpb.Request_TryAtomicMutate{TryAtomicMutate: req.GetRequest()},
 	})
 	if err != nil {
-		return nil, rpcStatus(err)
+		return nil, err
 	}
-	out := &kvrpcpb.KvTryAtomicMutateResponse{RegionError: resp.GetRegionError()}
+	out := &kvrpcpb.KvTryAtomicMutateResponse{RegionError: regionErr}
 	if out.GetRegionError() != nil {
 		return out, nil
-	}
-	first, err := singleRaftResponse("atomic mutate", resp)
-	if err != nil {
-		return nil, err
 	}
 	if first.GetTryAtomicMutate() == nil {
 		return nil, raftPayloadError("atomic mutate", "missing atomic mutate payload")
 	}
 	out.Response = first.GetTryAtomicMutate()
 	return out, nil
+}
+
+func (s *Service) submitWriteCommand(ctx context.Context, header *raftcmdpb.CmdHeader, request *raftcmdpb.Request) (*raftcmdpb.Response, *errorpb.RegionError, error) {
+	if s.writeBatcher != nil {
+		return s.writeBatcher.submit(ctx, header, request)
+	}
+	resp, err := s.propose(ctx, &raftcmdpb.RaftCmdRequest{
+		Header:   header,
+		Requests: []*raftcmdpb.Request{request},
+	})
+	if err != nil {
+		return nil, nil, rpcStatus(err)
+	}
+	if regionErr := resp.GetRegionError(); regionErr != nil {
+		return nil, regionErr, nil
+	}
+	first, err := singleRaftResponse(writeCommandName(request.GetCmdType()), resp)
+	if err != nil {
+		return nil, nil, err
+	}
+	return first, nil, nil
 }
 
 func (s *Service) read(ctx context.Context, req *raftcmdpb.RaftCmdRequest) (*raftcmdpb.RaftCmdResponse, error) {

--- a/raftstore/kv/watch.go
+++ b/raftstore/kv/watch.go
@@ -10,6 +10,8 @@ import (
 )
 
 const defaultApplyWatchBuffer = 256
+const defaultApplyWatchMaxKeysPerMessage = 512
+const defaultApplyWatchMaxKeyBytesPerMessage = 512 * 1024
 
 type applyWatchObserver struct {
 	prefix  []byte
@@ -36,22 +38,60 @@ func (o *applyWatchObserver) OnApply(evt storepkg.ApplyEvent) {
 	if len(keys) == 0 {
 		return
 	}
-	out := &kvrpcpb.ApplyWatchEvent{
-		RegionId:      evt.RegionID,
-		Term:          evt.Term,
-		Index:         evt.Index,
-		Source:        applyWatchSourceToProto(evt.Source),
-		CommitVersion: evt.CommitVersion,
-		Keys:          keys,
-	}
-	if out.GetSource() == kvrpcpb.ApplyWatchEventSource_APPLY_WATCH_EVENT_SOURCE_UNSPECIFIED {
+	source := applyWatchSourceToProto(evt.Source)
+	if source == kvrpcpb.ApplyWatchEventSource_APPLY_WATCH_EVENT_SOURCE_UNSPECIFIED {
 		return
 	}
+	// Atomic/proposal batching can make one raft apply event contain thousands
+	// of keys. WatchApply is a streaming boundary, so split the event into
+	// bounded messages with the same raft cursor instead of depending on a large
+	// transport-wide gRPC message limit.
+	for _, chunk := range chunkApplyWatchKeys(keys) {
+		o.enqueue(&kvrpcpb.ApplyWatchEvent{
+			RegionId:      evt.RegionID,
+			Term:          evt.Term,
+			Index:         evt.Index,
+			Source:        source,
+			CommitVersion: evt.CommitVersion,
+			Keys:          chunk,
+		})
+	}
+}
+
+func (o *applyWatchObserver) enqueue(out *kvrpcpb.ApplyWatchEvent) {
 	select {
 	case o.ch <- out:
 	default:
 		o.dropped.Add(1)
 	}
+}
+
+func chunkApplyWatchKeys(keys [][]byte) [][][]byte {
+	if len(keys) == 0 {
+		return nil
+	}
+	chunks := make([][][]byte, 0, (len(keys)+defaultApplyWatchMaxKeysPerMessage-1)/defaultApplyWatchMaxKeysPerMessage)
+	current := make([][]byte, 0, min(len(keys), defaultApplyWatchMaxKeysPerMessage))
+	currentBytes := 0
+	flush := func() {
+		if len(current) == 0 {
+			return
+		}
+		chunks = append(chunks, current)
+		current = make([][]byte, 0, defaultApplyWatchMaxKeysPerMessage)
+		currentBytes = 0
+	}
+	for _, key := range keys {
+		keyBytes := len(key)
+		if len(current) > 0 &&
+			(len(current) >= defaultApplyWatchMaxKeysPerMessage || currentBytes+keyBytes > defaultApplyWatchMaxKeyBytesPerMessage) {
+			flush()
+		}
+		current = append(current, key)
+		currentBytes += keyBytes
+	}
+	flush()
+	return chunks
 }
 
 func (s *Service) WatchApply(req *kvrpcpb.ApplyWatchRequest, stream kvrpcpb.StoreKV_WatchApplyServer) error {

--- a/raftstore/kv/watch_test.go
+++ b/raftstore/kv/watch_test.go
@@ -1,0 +1,45 @@
+package kv
+
+import (
+	"testing"
+
+	storepkg "github.com/feichai0017/NoKV/raftstore/store"
+	"github.com/stretchr/testify/require"
+)
+
+func TestApplyWatchObserverSplitsLargeApplyEvents(t *testing.T) {
+	observer := newApplyWatchObserver(nil)
+	keys := make([][]byte, defaultApplyWatchMaxKeysPerMessage+7)
+	for i := range keys {
+		keys[i] = []byte{byte(i)}
+	}
+
+	observer.OnApply(storepkg.ApplyEvent{
+		RegionID:      7,
+		Term:          2,
+		Index:         11,
+		Source:        storepkg.ApplyEventSourceCommit,
+		CommitVersion: 99,
+		Keys:          keys,
+	})
+
+	first := <-observer.ch
+	second := <-observer.ch
+	require.Len(t, first.GetKeys(), defaultApplyWatchMaxKeysPerMessage)
+	require.Len(t, second.GetKeys(), 7)
+	require.Equal(t, first.GetRegionId(), second.GetRegionId())
+	require.Equal(t, first.GetTerm(), second.GetTerm())
+	require.Equal(t, first.GetIndex(), second.GetIndex())
+	require.Equal(t, first.GetCommitVersion(), second.GetCommitVersion())
+}
+
+func TestChunkApplyWatchKeysSplitsByApproximateKeyBytes(t *testing.T) {
+	large := make([]byte, defaultApplyWatchMaxKeyBytesPerMessage/2+1)
+	keys := [][]byte{large, large, []byte("tail")}
+
+	chunks := chunkApplyWatchKeys(keys)
+
+	require.Len(t, chunks, 2)
+	require.Len(t, chunks[0], 1)
+	require.Len(t, chunks[1], 2)
+}

--- a/raftstore/kv/write_batcher.go
+++ b/raftstore/kv/write_batcher.go
@@ -1,0 +1,371 @@
+package kv
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	errorpb "github.com/feichai0017/NoKV/pb/error"
+	metapb "github.com/feichai0017/NoKV/pb/meta"
+	raftcmdpb "github.com/feichai0017/NoKV/pb/raft"
+)
+
+const (
+	defaultWriteCommandBatchMaxSize = 64
+	defaultWriteCommandBatchMaxWait = 200 * time.Microsecond
+)
+
+var batchedWriteCommandTypes = []raftcmdpb.CmdType{
+	raftcmdpb.CmdType_CMD_PREWRITE,
+	raftcmdpb.CmdType_CMD_COMMIT,
+	raftcmdpb.CmdType_CMD_BATCH_ROLLBACK,
+	raftcmdpb.CmdType_CMD_RESOLVE_LOCK,
+	raftcmdpb.CmdType_CMD_TRY_ATOMIC_MUTATE,
+}
+
+// ServiceOption configures StoreKV service runtime behavior.
+type ServiceOption func(*serviceOptions)
+
+type serviceOptions struct {
+	writeCommandBatchMaxSize int
+	writeCommandBatchMaxWait time.Duration
+}
+
+func defaultServiceOptions() serviceOptions {
+	return serviceOptions{
+		writeCommandBatchMaxSize: defaultWriteCommandBatchMaxSize,
+		writeCommandBatchMaxWait: defaultWriteCommandBatchMaxWait,
+	}
+}
+
+// WithWriteCommandBatch configures StoreKV write-command proposal batching.
+// A maxSize <= 1 or maxWait <= 0 disables batching and preserves direct submit.
+func WithWriteCommandBatch(maxSize int, maxWait time.Duration) ServiceOption {
+	return func(opts *serviceOptions) {
+		opts.writeCommandBatchMaxSize = maxSize
+		opts.writeCommandBatchMaxWait = maxWait
+	}
+}
+
+type writeCommandProposer func(context.Context, *raftcmdpb.RaftCmdRequest) (*raftcmdpb.RaftCmdResponse, error)
+
+type writeCommandBatchKey struct {
+	cmdType          raftcmdpb.CmdType
+	regionID         uint64
+	epochVersion     uint64
+	epochConfVersion uint64
+	storeID          uint64
+	peerID           uint64
+}
+
+type writeCommandBatcher struct {
+	propose writeCommandProposer
+	maxSize int
+	maxWait time.Duration
+
+	mu      sync.Mutex
+	batches map[writeCommandBatchKey]*writeCommandBatch
+	total   writeCommandCounters
+	byCmd   map[raftcmdpb.CmdType]*writeCommandCounters
+}
+
+type writeCommandCounters struct {
+	requestsTotal       atomic.Uint64
+	batchesTotal        atomic.Uint64
+	batchedRequests     atomic.Uint64
+	canceledBeforeFlush atomic.Uint64
+}
+
+type writeCommandBatch struct {
+	header  *raftcmdpb.CmdHeader
+	cmdType raftcmdpb.CmdType
+	items   []*writeCommandBatchItem
+	timer   *time.Timer
+}
+
+type writeCommandBatchItem struct {
+	ctx     context.Context
+	request *raftcmdpb.Request
+	result  chan writeCommandBatchResult
+}
+
+type writeCommandBatchResult struct {
+	regionError *errorpb.RegionError
+	response    *raftcmdpb.Response
+	err         error
+}
+
+func newWriteCommandBatcher(propose writeCommandProposer, maxSize int, maxWait time.Duration) *writeCommandBatcher {
+	if maxSize <= 1 || maxWait <= 0 {
+		return nil
+	}
+	byCmd := make(map[raftcmdpb.CmdType]*writeCommandCounters, len(batchedWriteCommandTypes))
+	for _, cmdType := range batchedWriteCommandTypes {
+		byCmd[cmdType] = &writeCommandCounters{}
+	}
+	return &writeCommandBatcher{
+		propose: propose,
+		maxSize: maxSize,
+		maxWait: maxWait,
+		batches: make(map[writeCommandBatchKey]*writeCommandBatch),
+		byCmd:   byCmd,
+	}
+}
+
+func (b *writeCommandBatcher) submit(ctx context.Context, header *raftcmdpb.CmdHeader, request *raftcmdpb.Request) (*raftcmdpb.Response, *errorpb.RegionError, error) {
+	if b == nil {
+		return nil, nil, errStoreNotInitialized
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if request == nil {
+		return nil, nil, rpcInvalidArgument("write command request missing payload")
+	}
+	if err := ctx.Err(); err != nil {
+		b.addCanceled(request.GetCmdType())
+		return nil, nil, rpcStatus(err)
+	}
+	item := &writeCommandBatchItem{
+		ctx:     ctx,
+		request: request,
+		result:  make(chan writeCommandBatchResult, 1),
+	}
+	cmdType := request.GetCmdType()
+	b.addRequest(cmdType)
+	key := writeBatchKey(header, cmdType)
+	var flush *writeCommandBatch
+
+	b.mu.Lock()
+	batch := b.batches[key]
+	if batch == nil {
+		batch = &writeCommandBatch{
+			header:  cloneCmdHeader(header),
+			cmdType: cmdType,
+			items:   make([]*writeCommandBatchItem, 0, b.maxSize),
+		}
+		b.batches[key] = batch
+		batch.timer = time.AfterFunc(b.maxWait, func() {
+			b.flushKey(key)
+		})
+	}
+	batch.items = append(batch.items, item)
+	if len(batch.items) >= b.maxSize {
+		delete(b.batches, key)
+		if batch.timer != nil {
+			batch.timer.Stop()
+		}
+		flush = batch
+	}
+	b.mu.Unlock()
+
+	if flush != nil {
+		b.flush(flush)
+	}
+
+	select {
+	case result := <-item.result:
+		return result.response, result.regionError, result.err
+	case <-ctx.Done():
+		return nil, nil, rpcStatus(ctx.Err())
+	}
+}
+
+func (b *writeCommandBatcher) flushKey(key writeCommandBatchKey) {
+	b.mu.Lock()
+	batch := b.batches[key]
+	if batch != nil {
+		delete(b.batches, key)
+	}
+	b.mu.Unlock()
+	if batch != nil {
+		b.flush(batch)
+	}
+}
+
+func (b *writeCommandBatcher) flush(batch *writeCommandBatch) {
+	if batch == nil || len(batch.items) == 0 {
+		return
+	}
+	items := make([]*writeCommandBatchItem, 0, len(batch.items))
+	requests := make([]*raftcmdpb.Request, 0, len(batch.items))
+	for _, item := range batch.items {
+		if err := item.ctx.Err(); err != nil {
+			b.addCanceled(batch.cmdType)
+			item.complete(nil, nil, rpcStatus(err))
+			continue
+		}
+		items = append(items, item)
+		requests = append(requests, item.request)
+	}
+	if len(items) == 0 {
+		return
+	}
+	b.addBatch(batch.cmdType, len(items))
+
+	// Each caller has passed admission, but the raft proposal represents all
+	// live items together. Use a detached context so one canceled RPC cannot
+	// abort unrelated requests that share this raft batch.
+	resp, err := b.propose(context.Background(), &raftcmdpb.RaftCmdRequest{
+		Header:   cloneCmdHeader(batch.header),
+		Requests: requests,
+	})
+	if err != nil {
+		err = rpcStatus(err)
+		for _, item := range items {
+			item.complete(nil, nil, err)
+		}
+		return
+	}
+	if regionErr := resp.GetRegionError(); regionErr != nil {
+		for _, item := range items {
+			item.complete(nil, regionErr, nil)
+		}
+		return
+	}
+	if len(resp.GetResponses()) != len(items) {
+		err := raftPayloadError(writeCommandName(batch.cmdType)+" batch", fmt.Sprintf("expected %d raft responses, got %d", len(items), len(resp.GetResponses())))
+		for _, item := range items {
+			item.complete(nil, nil, err)
+		}
+		return
+	}
+	for i, item := range items {
+		if resp.GetResponses()[i] == nil {
+			item.complete(nil, nil, raftPayloadError(writeCommandName(batch.cmdType)+" batch", fmt.Sprintf("missing response %d", i)))
+			continue
+		}
+		item.complete(resp.GetResponses()[i], nil, nil)
+	}
+}
+
+func (i *writeCommandBatchItem) complete(response *raftcmdpb.Response, regionErr *errorpb.RegionError, err error) {
+	i.result <- writeCommandBatchResult{response: response, regionError: regionErr, err: err}
+}
+
+func (b *writeCommandBatcher) addRequest(cmdType raftcmdpb.CmdType) {
+	b.total.requestsTotal.Add(1)
+	if counters := b.commandCounters(cmdType); counters != nil {
+		counters.requestsTotal.Add(1)
+	}
+}
+
+func (b *writeCommandBatcher) addBatch(cmdType raftcmdpb.CmdType, requests int) {
+	b.total.batchesTotal.Add(1)
+	b.total.batchedRequests.Add(uint64(requests))
+	if counters := b.commandCounters(cmdType); counters != nil {
+		counters.batchesTotal.Add(1)
+		counters.batchedRequests.Add(uint64(requests))
+	}
+}
+
+func (b *writeCommandBatcher) addCanceled(cmdType raftcmdpb.CmdType) {
+	b.total.canceledBeforeFlush.Add(1)
+	if counters := b.commandCounters(cmdType); counters != nil {
+		counters.canceledBeforeFlush.Add(1)
+	}
+}
+
+func (b *writeCommandBatcher) commandCounters(cmdType raftcmdpb.CmdType) *writeCommandCounters {
+	if b == nil || b.byCmd == nil {
+		return nil
+	}
+	return b.byCmd[cmdType]
+}
+
+func (b *writeCommandBatcher) Stats() map[string]any {
+	if b == nil {
+		zeroByCmd := make(map[raftcmdpb.CmdType]*writeCommandCounters, len(batchedWriteCommandTypes))
+		for _, cmdType := range batchedWriteCommandTypes {
+			zeroByCmd[cmdType] = &writeCommandCounters{}
+		}
+		return writeCommandStats(&writeCommandCounters{}, zeroByCmd)
+	}
+	return writeCommandStats(&b.total, b.byCmd)
+}
+
+func writeCommandStats(total *writeCommandCounters, byCmd map[raftcmdpb.CmdType]*writeCommandCounters) map[string]any {
+	requestsByCommand := make(map[string]uint64, len(batchedWriteCommandTypes))
+	batchesByCommand := make(map[string]uint64, len(batchedWriteCommandTypes))
+	batchedByCommand := make(map[string]uint64, len(batchedWriteCommandTypes))
+	canceledByCommand := make(map[string]uint64, len(batchedWriteCommandTypes))
+	for _, cmdType := range batchedWriteCommandTypes {
+		name := writeCommandName(cmdType)
+		counters := byCmd[cmdType]
+		if counters == nil {
+			counters = &writeCommandCounters{}
+		}
+		requestsByCommand[name] = counters.requestsTotal.Load()
+		batchesByCommand[name] = counters.batchesTotal.Load()
+		batchedByCommand[name] = counters.batchedRequests.Load()
+		canceledByCommand[name] = counters.canceledBeforeFlush.Load()
+	}
+	return map[string]any{
+		"write_command_batch_requests_total":              total.requestsTotal.Load(),
+		"write_command_batch_batches_total":               total.batchesTotal.Load(),
+		"write_command_batch_batched_requests_total":      total.batchedRequests.Load(),
+		"write_command_batch_canceled_before_flush_total": total.canceledBeforeFlush.Load(),
+		"write_command_batch_requests_by_command":         requestsByCommand,
+		"write_command_batch_batches_by_command":          batchesByCommand,
+		"write_command_batch_batched_requests_by_command": batchedByCommand,
+		"write_command_batch_canceled_by_command":         canceledByCommand,
+	}
+}
+
+func writeBatchKey(header *raftcmdpb.CmdHeader, cmdType raftcmdpb.CmdType) writeCommandBatchKey {
+	if header == nil {
+		return writeCommandBatchKey{cmdType: cmdType}
+	}
+	epoch := header.GetRegionEpoch()
+	return writeCommandBatchKey{
+		cmdType:          cmdType,
+		regionID:         header.GetRegionId(),
+		epochVersion:     epoch.GetVersion(),
+		epochConfVersion: epoch.GetConfVersion(),
+		storeID:          header.GetStoreId(),
+		peerID:           header.GetPeerId(),
+	}
+}
+
+func writeCommandName(cmdType raftcmdpb.CmdType) string {
+	switch cmdType {
+	case raftcmdpb.CmdType_CMD_PREWRITE:
+		return "prewrite"
+	case raftcmdpb.CmdType_CMD_COMMIT:
+		return "commit"
+	case raftcmdpb.CmdType_CMD_BATCH_ROLLBACK:
+		return "batch_rollback"
+	case raftcmdpb.CmdType_CMD_RESOLVE_LOCK:
+		return "resolve_lock"
+	case raftcmdpb.CmdType_CMD_TRY_ATOMIC_MUTATE:
+		return "atomic_mutate"
+	default:
+		return "unknown"
+	}
+}
+
+func cloneCmdHeader(header *raftcmdpb.CmdHeader) *raftcmdpb.CmdHeader {
+	if header == nil {
+		return nil
+	}
+	out := &raftcmdpb.CmdHeader{
+		RegionId:          header.GetRegionId(),
+		PeerId:            header.GetPeerId(),
+		ReadQuorum:        header.GetReadQuorum(),
+		RequestId:         header.GetRequestId(),
+		ReadConsistency:   header.GetReadConsistency(),
+		ReadPreference:    header.GetReadPreference(),
+		MaxStaleReadIndex: header.GetMaxStaleReadIndex(),
+		MaxStaleReadMs:    header.GetMaxStaleReadMs(),
+		StoreId:           header.GetStoreId(),
+	}
+	if epoch := header.GetRegionEpoch(); epoch != nil {
+		out.RegionEpoch = &metapb.RegionEpoch{
+			Version:     epoch.GetVersion(),
+			ConfVersion: epoch.GetConfVersion(),
+		}
+	}
+	return out
+}

--- a/raftstore/kv/write_batcher_test.go
+++ b/raftstore/kv/write_batcher_test.go
@@ -1,0 +1,311 @@
+package kv
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	errorpb "github.com/feichai0017/NoKV/pb/error"
+	kvrpcpb "github.com/feichai0017/NoKV/pb/kv"
+	metapb "github.com/feichai0017/NoKV/pb/meta"
+	raftcmdpb "github.com/feichai0017/NoKV/pb/raft"
+	"github.com/stretchr/testify/require"
+)
+
+type writeBatchTestResult struct {
+	response    *raftcmdpb.Response
+	regionError *errorpb.RegionError
+	err         error
+}
+
+func TestWriteCommandBatcherCoalescesSameHeaderAndCommand(t *testing.T) {
+	var (
+		mu       sync.Mutex
+		proposed []*raftcmdpb.RaftCmdRequest
+	)
+	batcher := newWriteCommandBatcher(func(_ context.Context, req *raftcmdpb.RaftCmdRequest) (*raftcmdpb.RaftCmdResponse, error) {
+		mu.Lock()
+		proposed = append(proposed, req)
+		mu.Unlock()
+		responses := make([]*raftcmdpb.Response, 0, len(req.GetRequests()))
+		for i := range req.GetRequests() {
+			responses = append(responses, writeBatchResponse(req.GetRequests()[i].GetCmdType(), uint64(i+1)))
+		}
+		return &raftcmdpb.RaftCmdResponse{Responses: responses}, nil
+	}, 2, time.Hour)
+
+	first, second := submitTwoWriteCommands(t, batcher, writeBatchTestHeader(7), writeBatchTestHeader(7), writeBatchAtomicRequest("k1"), writeBatchAtomicRequest("k2"))
+	require.ElementsMatch(t, []uint64{1, 2}, []uint64{first.GetTryAtomicMutate().GetAppliedKeys(), second.GetTryAtomicMutate().GetAppliedKeys()})
+
+	mu.Lock()
+	defer mu.Unlock()
+	require.Len(t, proposed, 1)
+	require.Len(t, proposed[0].GetRequests(), 2)
+	require.Equal(t, uint64(1), batcher.Stats()["write_command_batch_batches_total"])
+	require.Equal(t, uint64(2), batcher.Stats()["write_command_batch_batched_requests_total"])
+	require.Equal(t, uint64(1), batcher.Stats()["write_command_batch_batches_by_command"].(map[string]uint64)["atomic_mutate"])
+	require.Equal(t, uint64(2), batcher.Stats()["write_command_batch_batched_requests_by_command"].(map[string]uint64)["atomic_mutate"])
+}
+
+func TestWriteCommandBatcherDoesNotMixCommands(t *testing.T) {
+	var (
+		mu       sync.Mutex
+		proposed []*raftcmdpb.RaftCmdRequest
+	)
+	batcher := newWriteCommandBatcher(func(_ context.Context, req *raftcmdpb.RaftCmdRequest) (*raftcmdpb.RaftCmdResponse, error) {
+		mu.Lock()
+		proposed = append(proposed, req)
+		mu.Unlock()
+		responses := make([]*raftcmdpb.Response, 0, len(req.GetRequests()))
+		for _, request := range req.GetRequests() {
+			responses = append(responses, writeBatchResponse(request.GetCmdType(), 1))
+		}
+		return &raftcmdpb.RaftCmdResponse{Responses: responses}, nil
+	}, 8, time.Millisecond)
+
+	first, second := submitTwoWriteCommands(t, batcher, writeBatchTestHeader(7), writeBatchTestHeader(7), writeBatchPrewriteRequest("k1"), writeBatchCommitRequest("k2"))
+	require.NotNil(t, first.GetPrewrite())
+	require.NotNil(t, second.GetCommit())
+
+	mu.Lock()
+	defer mu.Unlock()
+	require.Len(t, proposed, 2)
+	for _, req := range proposed {
+		require.Len(t, req.GetRequests(), 1)
+	}
+}
+
+func TestWriteCommandBatcherDoesNotMixHeaders(t *testing.T) {
+	var (
+		mu       sync.Mutex
+		proposed []*raftcmdpb.RaftCmdRequest
+	)
+	batcher := newWriteCommandBatcher(func(_ context.Context, req *raftcmdpb.RaftCmdRequest) (*raftcmdpb.RaftCmdResponse, error) {
+		mu.Lock()
+		proposed = append(proposed, req)
+		mu.Unlock()
+		responses := make([]*raftcmdpb.Response, 0, len(req.GetRequests()))
+		for _, request := range req.GetRequests() {
+			responses = append(responses, writeBatchResponse(request.GetCmdType(), 1))
+		}
+		return &raftcmdpb.RaftCmdResponse{Responses: responses}, nil
+	}, 8, time.Millisecond)
+
+	first, second := submitTwoWriteCommands(t, batcher, writeBatchTestHeader(7), writeBatchTestHeader(8), writeBatchAtomicRequest("k1"), writeBatchAtomicRequest("k2"))
+	require.Equal(t, uint64(1), first.GetTryAtomicMutate().GetAppliedKeys())
+	require.Equal(t, uint64(1), second.GetTryAtomicMutate().GetAppliedKeys())
+
+	mu.Lock()
+	defer mu.Unlock()
+	require.Len(t, proposed, 2)
+	for _, req := range proposed {
+		require.Len(t, req.GetRequests(), 1)
+	}
+}
+
+func TestWriteCommandBatcherSkipsCanceledBeforeFlush(t *testing.T) {
+	var proposed atomic.Uint64
+	batcher := newWriteCommandBatcher(func(_ context.Context, req *raftcmdpb.RaftCmdRequest) (*raftcmdpb.RaftCmdResponse, error) {
+		proposed.Add(uint64(len(req.GetRequests())))
+		return &raftcmdpb.RaftCmdResponse{}, nil
+	}, 8, time.Millisecond)
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() {
+		_, _, err := batcher.submit(ctx, writeBatchTestHeader(7), writeBatchAtomicRequest("k1"))
+		done <- err
+	}()
+	cancel()
+	require.Error(t, <-done)
+	time.Sleep(5 * time.Millisecond)
+
+	require.Zero(t, proposed.Load())
+	require.Equal(t, uint64(1), batcher.Stats()["write_command_batch_canceled_before_flush_total"])
+	require.Equal(t, uint64(0), batcher.Stats()["write_command_batch_batches_total"])
+}
+
+func TestWriteCommandBatcherBroadcastsRegionError(t *testing.T) {
+	regionErr := &errorpb.RegionError{RegionNotFound: &errorpb.RegionNotFound{RegionId: 7}}
+	batcher := newWriteCommandBatcher(func(context.Context, *raftcmdpb.RaftCmdRequest) (*raftcmdpb.RaftCmdResponse, error) {
+		return &raftcmdpb.RaftCmdResponse{RegionError: regionErr}, nil
+	}, 2, time.Hour)
+
+	first, second := submitTwoWriteResults(t, batcher, writeBatchTestHeader(7), writeBatchTestHeader(7), writeBatchPrewriteRequest("k1"), writeBatchPrewriteRequest("k2"))
+	require.Same(t, regionErr, first.regionError)
+	require.Same(t, regionErr, second.regionError)
+	require.Nil(t, first.response)
+	require.Nil(t, second.response)
+}
+
+func TestServicePrewriteUsesWriteCommandBatcher(t *testing.T) {
+	var (
+		mu       sync.Mutex
+		proposed []*raftcmdpb.RaftCmdRequest
+	)
+	service := &Service{writeBatcher: newWriteCommandBatcher(func(_ context.Context, req *raftcmdpb.RaftCmdRequest) (*raftcmdpb.RaftCmdResponse, error) {
+		mu.Lock()
+		proposed = append(proposed, req)
+		mu.Unlock()
+		responses := make([]*raftcmdpb.Response, 0, len(req.GetRequests()))
+		for range req.GetRequests() {
+			responses = append(responses, writeBatchResponse(raftcmdpb.CmdType_CMD_PREWRITE, 0))
+		}
+		return &raftcmdpb.RaftCmdResponse{Responses: responses}, nil
+	}, 2, time.Hour)}
+
+	firstCh := make(chan error, 1)
+	secondCh := make(chan error, 1)
+	go func() {
+		_, err := service.Prewrite(context.Background(), writeBatchPrewriteRPC("k1"))
+		firstCh <- err
+	}()
+	go func() {
+		_, err := service.Prewrite(context.Background(), writeBatchPrewriteRPC("k2"))
+		secondCh <- err
+	}()
+	require.NoError(t, receiveError(t, firstCh))
+	require.NoError(t, receiveError(t, secondCh))
+
+	mu.Lock()
+	defer mu.Unlock()
+	require.Len(t, proposed, 1)
+	require.Len(t, proposed[0].GetRequests(), 2)
+	for _, req := range proposed[0].GetRequests() {
+		require.Equal(t, raftcmdpb.CmdType_CMD_PREWRITE, req.GetCmdType())
+	}
+}
+
+func submitTwoWriteCommands(t *testing.T, batcher *writeCommandBatcher, firstHeader, secondHeader *raftcmdpb.CmdHeader, firstRequest, secondRequest *raftcmdpb.Request) (*raftcmdpb.Response, *raftcmdpb.Response) {
+	t.Helper()
+	first, second := submitTwoWriteResults(t, batcher, firstHeader, secondHeader, firstRequest, secondRequest)
+	return first.response, second.response
+}
+
+func submitTwoWriteResults(t *testing.T, batcher *writeCommandBatcher, firstHeader, secondHeader *raftcmdpb.CmdHeader, firstRequest, secondRequest *raftcmdpb.Request) (writeBatchTestResult, writeBatchTestResult) {
+	t.Helper()
+	firstCh := make(chan writeBatchTestResult, 1)
+	secondCh := make(chan writeBatchTestResult, 1)
+	go func() {
+		resp, regionErr, err := batcher.submit(context.Background(), firstHeader, firstRequest)
+		firstCh <- writeBatchTestResult{response: resp, regionError: regionErr, err: err}
+	}()
+	go func() {
+		resp, regionErr, err := batcher.submit(context.Background(), secondHeader, secondRequest)
+		secondCh <- writeBatchTestResult{response: resp, regionError: regionErr, err: err}
+	}()
+	first := receiveWriteBatchResult(t, firstCh)
+	second := receiveWriteBatchResult(t, secondCh)
+	return first, second
+}
+
+func receiveWriteBatchResult(t *testing.T, ch <-chan writeBatchTestResult) writeBatchTestResult {
+	t.Helper()
+	select {
+	case result := <-ch:
+		require.NoError(t, result.err)
+		return result
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for batched write command")
+		return writeBatchTestResult{}
+	}
+}
+
+func receiveError(t *testing.T, ch <-chan error) error {
+	t.Helper()
+	select {
+	case err := <-ch:
+		return err
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for service write command")
+		return nil
+	}
+}
+
+func writeBatchTestHeader(region uint64) *raftcmdpb.CmdHeader {
+	return &raftcmdpb.CmdHeader{
+		RegionId: region,
+		RegionEpoch: &metapb.RegionEpoch{
+			Version:     1,
+			ConfVersion: 1,
+		},
+		StoreId: 1,
+		PeerId:  11,
+	}
+}
+
+func writeBatchTestContext() *kvrpcpb.Context {
+	header := writeBatchTestHeader(7)
+	return &kvrpcpb.Context{
+		RegionId:    header.GetRegionId(),
+		RegionEpoch: header.GetRegionEpoch(),
+		Peer:        &metapb.RegionPeer{StoreId: header.GetStoreId(), PeerId: header.GetPeerId()},
+	}
+}
+
+func writeBatchPrewriteRPC(key string) *kvrpcpb.KvPrewriteRequest {
+	return &kvrpcpb.KvPrewriteRequest{
+		Context: writeBatchTestContext(),
+		Request: &kvrpcpb.PrewriteRequest{
+			PrimaryLock:  []byte(key),
+			StartVersion: 10,
+			Mutations: []*kvrpcpb.Mutation{{
+				Op:    kvrpcpb.Mutation_Put,
+				Key:   []byte(key),
+				Value: []byte("value"),
+			}},
+		},
+	}
+}
+
+func writeBatchPrewriteRequest(key string) *raftcmdpb.Request {
+	return &raftcmdpb.Request{
+		CmdType: raftcmdpb.CmdType_CMD_PREWRITE,
+		Cmd:     &raftcmdpb.Request_Prewrite{Prewrite: &kvrpcpb.PrewriteRequest{PrimaryLock: []byte(key), StartVersion: 10}},
+	}
+}
+
+func writeBatchCommitRequest(key string) *raftcmdpb.Request {
+	return &raftcmdpb.Request{
+		CmdType: raftcmdpb.CmdType_CMD_COMMIT,
+		Cmd:     &raftcmdpb.Request_Commit{Commit: &kvrpcpb.CommitRequest{Keys: [][]byte{[]byte(key)}, StartVersion: 10, CommitVersion: 11}},
+	}
+}
+
+func writeBatchAtomicRequest(key string) *raftcmdpb.Request {
+	return &raftcmdpb.Request{
+		CmdType: raftcmdpb.CmdType_CMD_TRY_ATOMIC_MUTATE,
+		Cmd: &raftcmdpb.Request_TryAtomicMutate{TryAtomicMutate: &kvrpcpb.TryAtomicMutateRequest{
+			StartVersion:  10,
+			CommitVersion: 11,
+			Predicates: []*kvrpcpb.AtomicPredicate{{
+				Key:  []byte(key),
+				Kind: kvrpcpb.AtomicPredicateKind_ATOMIC_PREDICATE_KIND_NOT_EXISTS,
+			}},
+			Mutations: []*kvrpcpb.Mutation{{
+				Op:                kvrpcpb.Mutation_Put,
+				Key:               []byte(key),
+				Value:             []byte("value"),
+				AssertionNotExist: true,
+			}},
+		}},
+	}
+}
+
+func writeBatchResponse(cmdType raftcmdpb.CmdType, value uint64) *raftcmdpb.Response {
+	switch cmdType {
+	case raftcmdpb.CmdType_CMD_PREWRITE:
+		return &raftcmdpb.Response{Cmd: &raftcmdpb.Response_Prewrite{Prewrite: &kvrpcpb.PrewriteResponse{}}}
+	case raftcmdpb.CmdType_CMD_COMMIT:
+		return &raftcmdpb.Response{Cmd: &raftcmdpb.Response_Commit{Commit: &kvrpcpb.CommitResponse{}}}
+	case raftcmdpb.CmdType_CMD_BATCH_ROLLBACK:
+		return &raftcmdpb.Response{Cmd: &raftcmdpb.Response_BatchRollback{BatchRollback: &kvrpcpb.BatchRollbackResponse{}}}
+	case raftcmdpb.CmdType_CMD_RESOLVE_LOCK:
+		return &raftcmdpb.Response{Cmd: &raftcmdpb.Response_ResolveLock{ResolveLock: &kvrpcpb.ResolveLockResponse{}}}
+	case raftcmdpb.CmdType_CMD_TRY_ATOMIC_MUTATE:
+		return &raftcmdpb.Response{Cmd: &raftcmdpb.Response_TryAtomicMutate{TryAtomicMutate: &kvrpcpb.TryAtomicMutateResponse{AppliedKeys: value}}}
+	default:
+		return &raftcmdpb.Response{}
+	}
+}

--- a/raftstore/server/node.go
+++ b/raftstore/server/node.go
@@ -38,6 +38,7 @@ func enableRaftDebugLogging() {
 type Node struct {
 	store           *store.Store
 	transport       *transport.GRPCTransport
+	kvService       *kv.Service
 	mvccMaintenance *storemvcc.MaintenanceWorker
 	mvccGCPlan      *storemvcc.GCPlanner
 	mvccGCPlanTask  *utils.PeriodicTask
@@ -124,6 +125,7 @@ func NewNode(cfg Config) (*Node, error) {
 	node := &Node{
 		store:     st,
 		transport: tr,
+		kvService: kvService,
 	}
 	if sink, ok := cfg.Storage.MVCC.(transportMetricsSink); ok {
 		sink.SetTransportMetricsSource(transport.GRPCMetricsSnapshot)
@@ -168,6 +170,14 @@ func (n *Node) Store() *store.Store {
 		return nil
 	}
 	return n.store
+}
+
+// KVStats returns low-cardinality StoreKV service counters for diagnostics.
+func (n *Node) KVStats() map[string]any {
+	if n == nil || n.kvService == nil {
+		return map[string]any{}
+	}
+	return n.kvService.Stats()
 }
 
 // Transport returns the shared raft/StoreKV gRPC transport.


### PR DESCRIPTION
## Summary
- add StoreKV write-command proposal batching for Prewrite, Commit, BatchRollback, ResolveLock, and TryAtomicMutate
- expose low-cardinality StoreKV batching counters through expvar
- split large WatchApply notifications into bounded streaming messages
- raise metadata-root RPC message limits for large checkpoint snapshots
- keep region-lookup duty grants successor-monotone after coordinator restart

## Correctness notes
- batching is keyed by command type, region, epoch, store, and peer, so 2PC phases are never mixed with each other or with AtomicMutate
- each batched raft response is demultiplexed by request index; region errors are broadcast as raft already defines them
- CheckTxnStatus and TxnHeartBeat stay on direct proposal because they are liveness/recovery paths with service-time injection

## Tests
- make fmt
- make lint
- go test ./...
- go test ./raftstore/kv
- go test ./raftstore/client
- go test ./txn/percolator
- go test ./fsmeta/exec
- go test ./raftstore/server
- cd benchmark && go test ./fsmeta ./fsmeta/workload
