### PR TITLE
Optimize root control-plane hot path

### DIFF
--- a/cmd/nokv/metrics.go
+++ b/cmd/nokv/metrics.go
@@ -118,6 +118,9 @@ func metaRootSnapshot(ctx metaRootExpvarContext) map[string]any {
 		out["is_leader"] = leader.IsLeader()
 		out["leader_id"] = leader.LeaderID()
 	}
+	if stats, ok := ctx.backend.(interface{ Stats() map[string]any }); ok {
+		out["root_metrics"] = stats.Stats()
+	}
 	return out
 }
 

--- a/coordinator/server/service_admission.go
+++ b/coordinator/server/service_admission.go
@@ -46,9 +46,12 @@ func (s *Service) beginDutyAdmission(ctx context.Context, duty rootproto.DutyID)
 		return dutyAdmission{}, translateGrantError(err)
 	}
 	if s.grantInheritanceCandidate() {
+		s.eunomiaMetrics.recordGrantInheritanceSubmitted()
 		if err := s.InheritRetiredGrants(ctx); err != nil {
 			return dutyAdmission{}, err
 		}
+	} else {
+		s.eunomiaMetrics.recordGrantInheritanceSkipped()
 	}
 	admission, err := s.admitDutyFromCachedGrant(duty)
 	if err != nil {
@@ -230,11 +233,28 @@ func (s *Service) admitDutyFromCachedGrant(duty rootproto.DutyID) (dutyAdmission
 	return dutyAdmission{
 		grant:           grant,
 		certificate:     cert,
-		retirements:     append([]rootproto.GrantRetirement(nil), view.retirements...),
+		retirements:     authorityEvidenceRetirements(view.retirements, view.retiredEraFloor),
 		retiredEraFloor: view.retiredEraFloor,
 		duty:            duty,
 		servedUnixNano:  nowUnixNano,
 	}, nil
+}
+
+func authorityEvidenceRetirements(retirements []rootproto.GrantRetirement, retiredEraFloor uint64) []rootproto.GrantRetirement {
+	if len(retirements) == 0 {
+		return nil
+	}
+	out := make([]rootproto.GrantRetirement, 0, len(retirements))
+	for _, retirement := range retirements {
+		// The retired-era floor is the stable verifier contract for inherited
+		// history. Keeping those records in every hot TSO/AllocID reply only
+		// grows the evidence payload without adding a stronger fence.
+		if retirement.InheritedByGrantID != "" && retirement.Era <= retiredEraFloor {
+			continue
+		}
+		out = append(out, retirement)
+	}
+	return out
 }
 
 func (s *Service) validateGateGrant(kind gateKind, duty rootproto.DutyID, grant rootproto.AuthorityGrant) error {

--- a/coordinator/server/service_grant.go
+++ b/coordinator/server/service_grant.go
@@ -356,23 +356,22 @@ func (s *Service) InheritRetiredGrants(ctx context.Context) error {
 	if !s.storage.CanSubmitRootWrites() {
 		return nil
 	}
-	snapshot, err := s.storage.Load()
-	if err != nil {
-		return err
-	}
-	s.refreshCurrentRootSnapshot(snapshot)
 	s.grantMu.RLock()
 	holderID := strings.TrimSpace(s.coordinatorID)
 	s.grantMu.RUnlock()
-	if holderID == "" || !snapshotHasLocalGrant(snapshot, holderID) {
+	if holderID == "" {
 		return nil
 	}
-	pending := make([]string, 0, len(snapshot.RetiredGrants))
-	for _, retirement := range snapshot.RetiredGrants {
-		if retirement.InheritedByGrantID == "" && retirement.GrantID != "" {
-			pending = append(pending, retirement.GrantID)
+	snapshot, ok := s.cachedRootSnapshot()
+	if !ok {
+		var err error
+		snapshot, err = s.storage.Load()
+		if err != nil {
+			return err
 		}
+		s.refreshCurrentRootSnapshot(snapshot)
 	}
+	pending := pendingGrantInheritanceIDs(snapshot, holderID)
 	if len(pending) == 0 {
 		return nil
 	}
@@ -388,14 +387,80 @@ func (s *Service) InheritRetiredGrants(ctx context.Context) error {
 		return err
 	}
 	s.publishEunomiaState(protocolState)
-	return s.reloadAndFenceAllocators(true)
+	// Inheritance only advances the grant lifecycle. Allocator fences and
+	// descriptor state are unchanged, so a full rooted reload would put every
+	// hot TSO/AllocID request back on the checkpoint-read path.
+	return nil
 }
 
 func (s *Service) grantInheritanceCandidate() bool {
 	if s == nil || !s.coordinatorGrantEnabled() || s.storage == nil {
 		return false
 	}
-	return len(s.localActiveAuthorityDuties()) > 0
+	snapshot, ok := s.cachedRootSnapshot()
+	if !ok {
+		return false
+	}
+	s.grantMu.RLock()
+	holderID := strings.TrimSpace(s.coordinatorID)
+	s.grantMu.RUnlock()
+	return len(pendingGrantInheritanceIDs(snapshot, holderID)) > 0
+}
+
+func pendingGrantInheritanceIDs(snapshot rootview.Snapshot, holderID string) []string {
+	holderID = strings.TrimSpace(holderID)
+	if holderID == "" || !snapshotHasLocalGrant(snapshot, holderID) {
+		return nil
+	}
+	grants := localActiveGrants(snapshot, holderID)
+	pending := make([]string, 0, len(snapshot.RetiredGrants))
+	for _, retirement := range snapshot.RetiredGrants {
+		if retirement.InheritedByGrantID == "" && retirement.GrantID != "" && localGrantCoversRetirement(grants, retirement) {
+			pending = append(pending, retirement.GrantID)
+		}
+	}
+	return pending
+}
+
+func localActiveGrants(snapshot rootview.Snapshot, holderID string) []rootproto.AuthorityGrant {
+	holderID = strings.TrimSpace(holderID)
+	if holderID == "" {
+		return nil
+	}
+	out := make([]rootproto.AuthorityGrant, 0, len(snapshot.ActiveGrants))
+	for _, grant := range snapshot.ActiveGrants {
+		if strings.TrimSpace(grant.HolderID) == holderID {
+			out = append(out, grant)
+		}
+	}
+	return out
+}
+
+func localGrantCoversRetirement(grants []rootproto.AuthorityGrant, retirement rootproto.GrantRetirement) bool {
+	for _, grant := range grants {
+		if dutyGrantSetCovers(grant.Duties, retirement.Bounds) {
+			return true
+		}
+	}
+	return false
+}
+
+func dutyGrantSetCovers(grants, required []rootproto.DutyGrant) bool {
+	for _, req := range required {
+		found := false
+		for _, grant := range grants {
+			if grant.DutyID == req.DutyID &&
+				rootproto.ScopeEqual(grant.Scope, req.Scope) &&
+				rootproto.DutyBoundCovers(grant.Bound, req.Bound) {
+				found = true
+				break
+			}
+		}
+		if !found {
+			return false
+		}
+	}
+	return true
 }
 
 func grantInheritanceIgnorable(err error) bool {

--- a/coordinator/server/service_metrics.go
+++ b/coordinator/server/service_metrics.go
@@ -21,6 +21,9 @@ type eunomiaMetrics struct {
 
 	gateDutyAdmissionRejectedTotal atomic.Uint64
 
+	grantInheritanceSkippedTotal   atomic.Uint64
+	grantInheritanceSubmittedTotal atomic.Uint64
+
 	guaranteePrimacyTotal     atomic.Uint64
 	guaranteeInheritanceTotal atomic.Uint64
 	guaranteeSilenceTotal     atomic.Uint64
@@ -33,6 +36,10 @@ func (m *eunomiaMetrics) snapshot() map[string]any {
 		"gate_rejections_total": map[string]any{
 			"duty_admission": m.gateDutyAdmissionRejectedTotal.Load(),
 		},
+		"grant_inheritance_total": map[string]any{
+			"skipped":   m.grantInheritanceSkippedTotal.Load(),
+			"submitted": m.grantInheritanceSubmittedTotal.Load(),
+		},
 		"guarantee_violations_total": map[string]any{
 			"primacy":     m.guaranteePrimacyTotal.Load(),
 			"inheritance": m.guaranteeInheritanceTotal.Load(),
@@ -40,6 +47,14 @@ func (m *eunomiaMetrics) snapshot() map[string]any {
 			"finality":    m.guaranteeFinalityTotal.Load(),
 		},
 	}
+}
+
+func (m *eunomiaMetrics) recordGrantInheritanceSkipped() {
+	m.grantInheritanceSkippedTotal.Add(1)
+}
+
+func (m *eunomiaMetrics) recordGrantInheritanceSubmitted() {
+	m.grantInheritanceSubmittedTotal.Add(1)
 }
 
 func (m *eunomiaMetrics) recordGrantEraTransition(before, after uint64) {

--- a/coordinator/server/service_rootcache.go
+++ b/coordinator/server/service_rootcache.go
@@ -149,6 +149,18 @@ func (s *Service) currentAuthoritySnapshot() rootview.Snapshot {
 	}
 }
 
+func (s *Service) cachedRootSnapshot() (rootview.Snapshot, bool) {
+	if s == nil {
+		return rootview.Snapshot{}, false
+	}
+	s.rootViewMu.RLock()
+	defer s.rootViewMu.RUnlock()
+	if !s.rootView.loaded {
+		return rootview.Snapshot{}, false
+	}
+	return rootview.CloneSnapshot(s.rootView.snapshot), true
+}
+
 func (s *Service) publishEunomiaState(state rootstate.EunomiaState) {
 	if s == nil || !serviceEunomiaStatePresent(state) {
 		return

--- a/coordinator/server/service_test.go
+++ b/coordinator/server/service_test.go
@@ -2589,10 +2589,123 @@ func TestServiceInheritRetiredGrants(t *testing.T) {
 	svc.now = func() time.Time { return time.Unix(0, 200) }
 	require.NoError(t, svc.ReloadFromStorage())
 
+	loadsBefore := store.loadCalls
 	require.NoError(t, svc.InheritRetiredGrants(context.Background()))
 	require.Equal(t, 1, store.reattachCalls)
+	require.Equal(t, loadsBefore, store.loadCalls)
 	require.Equal(t, "c2/2", store.snapshot.RetiredGrants[0].InheritedByGrantID)
 	require.Len(t, store.snapshot.GrantInheritances, 1)
+}
+
+func TestServiceInheritRetiredGrantsSubmitsOnlyCoveredPredecessors(t *testing.T) {
+	allocRetired := rootproto.GrantRetirement{
+		GrantID:  "c1/alloc/1",
+		HolderID: "c1",
+		Era:      1,
+		Mode:     rootproto.GrantRetirementExpiredBound,
+		Bounds:   []rootproto.DutyGrant{rootproto.NewGlobalMonotoneDuty(rootproto.DutyAllocID, 10)},
+	}
+	tsoRetired := rootproto.GrantRetirement{
+		GrantID:  "c1/tso/2",
+		HolderID: "c1",
+		Era:      2,
+		Mode:     rootproto.GrantRetirementExpiredBound,
+		Bounds:   []rootproto.DutyGrant{rootproto.NewGlobalMonotoneDuty(rootproto.DutyTSO, 10)},
+	}
+	store := &fakeStorage{
+		leader: true,
+		snapshot: rootview.Snapshot{
+			ActiveGrants: []rootproto.AuthorityGrant{{
+				GrantID:         "c2/alloc/3",
+				HolderID:        "c2",
+				Era:             3,
+				ExpiresUnixNano: time.Unix(0, 10_000).UnixNano(),
+				Duties:          []rootproto.DutyGrant{rootproto.NewGlobalMonotoneDuty(rootproto.DutyAllocID, 20)},
+			}},
+			RetiredGrants: []rootproto.GrantRetirement{allocRetired, tsoRetired},
+		},
+	}
+	svc := NewService(catalog.NewCluster(), idalloc.NewIDAllocator(10), tso.NewAllocator(100), store)
+	svc.ConfigureAuthorityGrant("c2", 10*time.Second, 3*time.Second)
+	svc.now = func() time.Time { return time.Unix(0, 200) }
+	require.NoError(t, svc.ReloadFromStorage())
+
+	require.NoError(t, svc.InheritRetiredGrants(context.Background()))
+	require.Equal(t, 1, store.reattachCalls)
+	require.Equal(t, "c2/alloc/3", store.snapshot.RetiredGrants[0].InheritedByGrantID)
+	require.Empty(t, store.snapshot.RetiredGrants[1].InheritedByGrantID)
+	require.Len(t, store.snapshot.GrantInheritances, 1)
+	require.Equal(t, allocRetired.GrantID, store.snapshot.GrantInheritances[0].PredecessorGrantID)
+}
+
+func TestServiceDutyAdmissionSkipsInheritanceWhenNoPendingRetirement(t *testing.T) {
+	now := time.Unix(0, 200)
+	grant := rootproto.AuthorityGrant{
+		GrantID:         "c1/1",
+		HolderID:        "c1",
+		Era:             1,
+		ExpiresUnixNano: now.Add(time.Hour).UnixNano(),
+		Duties:          []rootproto.DutyGrant{rootproto.NewGlobalMonotoneDuty(rootproto.DutyAllocID, 100)},
+	}
+	store := &fakeStorage{
+		leader: true,
+		snapshot: rootview.Snapshot{
+			ActiveGrants: []rootproto.AuthorityGrant{grant},
+		},
+	}
+	svc := NewService(catalog.NewCluster(), idalloc.NewIDAllocator(10), tso.NewAllocator(100), store)
+	svc.ConfigureAuthorityGrant("c1", time.Hour, 30*time.Minute)
+	svc.now = func() time.Time { return now }
+	require.NoError(t, svc.ReloadFromStorage())
+	svc.cacheGrantCertificate(testGrantCertificate(grant))
+
+	admission, err := svc.beginDutyAdmission(context.Background(), rootproto.DutyAllocID)
+	require.NoError(t, err)
+	admission.Done()
+	require.Zero(t, store.reattachCalls)
+	require.Equal(t, uint64(1), svc.eunomiaMetrics.grantInheritanceSkippedTotal.Load())
+	require.Equal(t, uint64(0), svc.eunomiaMetrics.grantInheritanceSubmittedTotal.Load())
+}
+
+func TestServiceAuthorityEvidenceUsesRetiredFloorInsteadOfInheritedHistory(t *testing.T) {
+	now := time.Unix(0, 200)
+	retired := rootproto.GrantRetirement{
+		GrantID:            "c0/1",
+		HolderID:           "c0",
+		Era:                1,
+		Mode:               rootproto.GrantRetirementExpiredBound,
+		Bounds:             []rootproto.DutyGrant{rootproto.NewGlobalMonotoneDuty(rootproto.DutyAllocID, 10)},
+		InheritedByGrantID: "c1/2",
+	}
+	grant := rootproto.AuthorityGrant{
+		GrantID:         "c1/2",
+		HolderID:        "c1",
+		Era:             2,
+		ExpiresUnixNano: now.Add(time.Hour).UnixNano(),
+		Duties:          []rootproto.DutyGrant{rootproto.NewGlobalMonotoneDuty(rootproto.DutyAllocID, 100)},
+	}
+	store := &fakeStorage{
+		leader: true,
+		snapshot: rootview.Snapshot{
+			ActiveGrants:    []rootproto.AuthorityGrant{grant},
+			RetiredGrants:   []rootproto.GrantRetirement{retired},
+			RetiredEraFloor: 1,
+		},
+	}
+	svc := NewService(catalog.NewCluster(), idalloc.NewIDAllocator(10), tso.NewAllocator(100), store)
+	svc.ConfigureAuthorityGrant("c1", time.Hour, 30*time.Minute)
+	svc.now = func() time.Time { return now }
+	require.NoError(t, svc.ReloadFromStorage())
+	svc.cacheGrantCertificate(testGrantCertificate(grant))
+
+	admission, err := svc.beginDutyAdmission(context.Background(), rootproto.DutyAllocID)
+	require.NoError(t, err)
+	defer admission.Done()
+	proof, err := admission.authorityEvidence(rootproto.DutyBound{Kind: rootproto.DutyBoundMonotone, MonotoneUpper: 20})
+	require.NoError(t, err)
+	evidence := metawire.RootAuthorityEvidenceFromProto(proof.Evidence)
+	require.Equal(t, uint64(1), evidence.ObservedRetiredEraFloor)
+	require.Empty(t, evidence.ObservedRetirements)
 }
 
 func TestServiceGrantAdmissionSurvivesStaleReloadAfterIssue(t *testing.T) {

--- a/meta/root/replicated/metrics.go
+++ b/meta/root/replicated/metrics.go
@@ -1,0 +1,24 @@
+package replicated
+
+import "sync/atomic"
+
+type metrics struct {
+	observeCacheHitTotal      atomic.Uint64
+	observeCacheMissTotal     atomic.Uint64
+	checkpointLoadTotal       atomic.Uint64
+	committedTailReadTotal    atomic.Uint64
+	observeCacheInvalidations atomic.Uint64
+}
+
+func (m *metrics) snapshot() map[string]any {
+	if m == nil {
+		return map[string]any{}
+	}
+	return map[string]any{
+		"observe_cache_hit_total":           m.observeCacheHitTotal.Load(),
+		"observe_cache_miss_total":          m.observeCacheMissTotal.Load(),
+		"checkpoint_load_total":             m.checkpointLoadTotal.Load(),
+		"committed_tail_read_total":         m.committedTailReadTotal.Load(),
+		"observe_cache_invalidations_total": m.observeCacheInvalidations.Load(),
+	}
+}

--- a/meta/root/replicated/network_virtual_log.go
+++ b/meta/root/replicated/network_virtual_log.go
@@ -13,6 +13,10 @@ func (d *NetworkDriver) ObserveTail(after rootstorage.TailToken) (rootstorage.Ta
 	return d.adapter.observe(after)
 }
 
+func (d *NetworkDriver) ObserveCommitted() (rootstorage.ObservedCommitted, error) {
+	return d.adapter.observeCommitted()
+}
+
 func (d *NetworkDriver) TailNotify() <-chan struct{} {
 	return d.adapter.watchChannel()
 }
@@ -169,4 +173,11 @@ func (d *NetworkDriver) CompactCommitted(stream rootstorage.CommittedTail) error
 
 func (d *NetworkDriver) Size() (int64, error) {
 	return d.adapter.size()
+}
+
+func (d *NetworkDriver) Stats() map[string]any {
+	if d == nil || d.adapter == nil {
+		return map[string]any{}
+	}
+	return d.adapter.stats()
 }

--- a/meta/root/replicated/store.go
+++ b/meta/root/replicated/store.go
@@ -3,8 +3,10 @@ package replicated
 import (
 	"context"
 	"fmt"
+	"maps"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	rootevent "github.com/feichai0017/NoKV/meta/root/event"
@@ -47,6 +49,9 @@ type Store struct {
 	records            []rootstorage.CommittedEvent
 	retainFrom         rootstate.Cursor
 	maxRetainedRecords int
+
+	eunomiaCompactDroppedRetirements  atomic.Uint64
+	eunomiaCompactDroppedInheritances atomic.Uint64
 }
 
 func Open(cfg Config) (*Store, error) {
@@ -56,7 +61,7 @@ func Open(cfg Config) (*Store, error) {
 	if cfg.MaxRetainedRecords <= 0 {
 		cfg.MaxRetainedRecords = defaultRetainedRecords
 	}
-	observed, err := rootstorage.ObserveCommitted(cfg.Driver, 0)
+	observed, err := observeDriverCommitted(cfg.Driver)
 	if err != nil {
 		return nil, err
 	}
@@ -144,7 +149,29 @@ func (s *Store) ObserveCommitted() (rootstorage.ObservedCommitted, error) {
 	if s == nil {
 		return rootstorage.ObservedCommitted{}, nil
 	}
-	return rootstorage.ObserveCommitted(s.driver, 0)
+	return observeDriverCommitted(s.driver)
+}
+
+func observeDriverCommitted(driver Driver) (rootstorage.ObservedCommitted, error) {
+	if observer, ok := driver.(interface {
+		ObserveCommitted() (rootstorage.ObservedCommitted, error)
+	}); ok {
+		return observer.ObserveCommitted()
+	}
+	return rootstorage.ObserveCommitted(driver, 0)
+}
+
+func (s *Store) Stats() map[string]any {
+	if s == nil {
+		return map[string]any{}
+	}
+	out := map[string]any{}
+	if stats, ok := s.driver.(interface{ Stats() map[string]any }); ok {
+		maps.Copy(out, stats.Stats())
+	}
+	out["eunomia_compact_dropped_retirements_total"] = s.eunomiaCompactDroppedRetirements.Load()
+	out["eunomia_compact_dropped_inheritances_total"] = s.eunomiaCompactDroppedInheritances.Load()
+	return out
 }
 
 // WaitForTail waits until the durable committed tail view changes past after.
@@ -261,6 +288,7 @@ func (s *Store) appendLocked(ctx context.Context, events ...rootevent.Event) (ro
 		rootstate.ApplyEventToSnapshot(&snapshot, next, evt)
 		records = append(records, rootstorage.CommittedEvent{Cursor: next, Event: rootevent.CloneEvent(evt)})
 	}
+	snapshot.State = s.compactEunomiaState(snapshot.State)
 	logEnd, err := s.driver.AppendCommitted(ctx, records...)
 	if err != nil {
 		return rootstate.CommitInfo{}, err
@@ -762,10 +790,7 @@ func (s *Store) maybeCompactLocked() {
 		return
 	}
 	plan := rootstorage.PlanTailCompaction(s.records, s.state.LastCommitted, s.maxRetainedRecords)
-	snapshotState := s.state
-	if plan.Compacted {
-		snapshotState = rootstate.CompactEunomiaState(snapshotState)
-	}
+	snapshotState := s.compactEunomiaState(s.state)
 	snapshot := rootstate.Snapshot{
 		State:               snapshotState,
 		Stores:              rootstate.CloneStoreMemberships(s.stores),
@@ -788,6 +813,19 @@ func (s *Store) maybeCompactLocked() {
 	s.state = snapshotState
 	s.records = plan.Tail.Records
 	s.retainFrom = plan.RetainFrom
+}
+
+func (s *Store) compactEunomiaState(state rootstate.State) rootstate.State {
+	compacted := rootstate.CompactEunomiaState(state)
+	if s != nil {
+		if dropped := len(state.RetiredGrants) - len(compacted.RetiredGrants); dropped > 0 {
+			s.eunomiaCompactDroppedRetirements.Add(uint64(dropped))
+		}
+		if dropped := len(state.GrantInheritances) - len(compacted.GrantInheritances); dropped > 0 {
+			s.eunomiaCompactDroppedInheritances.Add(uint64(dropped))
+		}
+	}
+	return compacted
 }
 
 func (s *Store) applyObserved(observed rootstorage.ObservedCommitted) {

--- a/meta/root/replicated/store_test.go
+++ b/meta/root/replicated/store_test.go
@@ -164,6 +164,42 @@ func TestOpenAcceptsDriverConfig(t *testing.T) {
 	require.NotNil(t, store)
 }
 
+func TestReplicatedStoreObserveCommittedUsesDetachedCache(t *testing.T) {
+	stores, drivers, leaderID := openNetworkTestCluster(t, 4)
+	commit, err := stores[leaderID].Append(context.Background(),
+		rootevent.RegionDescriptorPublished(testDescriptor(10, []byte("a"), []byte("z"))),
+	)
+	require.NoError(t, err)
+
+	first, err := stores[leaderID].ObserveCommitted()
+	require.NoError(t, err)
+	first.Checkpoint.Snapshot.State.ClusterEpoch = 999
+
+	second, err := stores[leaderID].ObserveCommitted()
+	require.NoError(t, err)
+	require.Equal(t, commit.State.ClusterEpoch, second.Checkpoint.Snapshot.State.ClusterEpoch)
+
+	stats := drivers[leaderID].Stats()
+	require.GreaterOrEqual(t, metricUint64(stats, "observe_cache_hit_total"), uint64(1))
+	require.GreaterOrEqual(t, metricUint64(stats, "observe_cache_miss_total"), uint64(1))
+}
+
+func TestReplicatedStoreObserveCacheInvalidatesAfterAppend(t *testing.T) {
+	stores, drivers, leaderID := openNetworkTestCluster(t, 4)
+	_, err := stores[leaderID].ObserveCommitted()
+	require.NoError(t, err)
+	before := metricUint64(drivers[leaderID].Stats(), "observe_cache_invalidations_total")
+
+	commit, err := stores[leaderID].Append(context.Background(),
+		rootevent.RegionDescriptorPublished(testDescriptor(11, []byte("a"), []byte("z"))),
+	)
+	require.NoError(t, err)
+	observed, err := stores[leaderID].ObserveCommitted()
+	require.NoError(t, err)
+	require.Equal(t, commit.Cursor, observed.LastCursor())
+	require.Greater(t, metricUint64(drivers[leaderID].Stats(), "observe_cache_invalidations_total"), before)
+}
+
 func TestReplicatedStoreWaitForTailTracksFollowerAdvance(t *testing.T) {
 	stores, _, leaderID := openNetworkTestCluster(t, 4)
 	followerID := uint64(1)
@@ -612,4 +648,9 @@ func testDescriptor(id uint64, start, end []byte) topology.Descriptor {
 	}
 	desc.EnsureHash()
 	return desc
+}
+
+func metricUint64(stats map[string]any, key string) uint64 {
+	value, _ := stats[key].(uint64)
+	return value
 }

--- a/meta/root/replicated/virtual_log_adapter.go
+++ b/meta/root/replicated/virtual_log_adapter.go
@@ -11,10 +11,13 @@ import (
 // replicated protocol driver. Callers must hold the enclosing driver mutex
 // before invoking the mutating helpers.
 type virtualLogAdapter struct {
-	mu       sync.Mutex
-	log      rootstorage.VirtualLog
-	notifyCh chan struct{}
-	latest   rootstorage.TailToken
+	mu         sync.Mutex
+	log        rootstorage.VirtualLog
+	notifyCh   chan struct{}
+	latest     rootstorage.TailToken
+	metrics    metrics
+	cacheValid bool
+	cache      rootstorage.ObservedCommitted
 }
 
 func newVirtualLogAdapter(log rootstorage.VirtualLog) (*virtualLogAdapter, error) {
@@ -32,7 +35,7 @@ func (a *virtualLogAdapter) bootstrap() error {
 	if a == nil || a.log == nil {
 		return nil
 	}
-	observed, err := rootstorage.ObserveCommitted(a.log, 0)
+	observed, err := a.loadObservedLocked(0)
 	if err != nil {
 		return err
 	}
@@ -53,7 +56,7 @@ func (a *virtualLogAdapter) watchChannel() <-chan struct{} {
 func (a *virtualLogAdapter) observe(after rootstorage.TailToken) (rootstorage.TailAdvance, error) {
 	a.mu.Lock()
 	defer a.mu.Unlock()
-	observed, err := rootstorage.ObserveCommitted(a.log, 0)
+	observed, err := a.observeCommittedLocked()
 	if err != nil {
 		return rootstorage.TailAdvance{}, err
 	}
@@ -79,6 +82,8 @@ func (a *virtualLogAdapter) installBootstrap(observed rootstorage.ObservedCommit
 	if err := a.log.InstallBootstrap(observed); err != nil {
 		return err
 	}
+	a.cache = rootstorage.CloneObservedCommitted(observed)
+	a.cacheValid = true
 	a.bump(observed.LastCursor())
 	a.signal()
 	return nil
@@ -93,9 +98,59 @@ func (a *virtualLogAdapter) appendCommitted(ctx context.Context, records []roots
 	if _, err := a.log.AppendCommitted(ctx, records...); err != nil {
 		return err
 	}
+	a.invalidateCacheLocked()
 	a.bump(records[len(records)-1].Cursor)
 	a.signal()
 	return nil
+}
+
+func (a *virtualLogAdapter) observeCommitted() (rootstorage.ObservedCommitted, error) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	return a.observeCommittedLocked()
+}
+
+func (a *virtualLogAdapter) observeCommittedLocked() (rootstorage.ObservedCommitted, error) {
+	if a.cacheValid {
+		a.metrics.observeCacheHitTotal.Add(1)
+		return rootstorage.CloneObservedCommitted(a.cache), nil
+	}
+	a.metrics.observeCacheMissTotal.Add(1)
+	observed, err := a.loadObservedLocked(0)
+	if err != nil {
+		return rootstorage.ObservedCommitted{}, err
+	}
+	a.cache = rootstorage.CloneObservedCommitted(observed)
+	a.cacheValid = true
+	return rootstorage.CloneObservedCommitted(observed), nil
+}
+
+// loadObservedLocked is the only checkpoint+tail read behind the observe
+// cache. All local commit, checkpoint, compaction, and bootstrap publishers
+// invalidate or replace the cache before exposing a newer tail token.
+func (a *virtualLogAdapter) loadObservedLocked(offset int64) (rootstorage.ObservedCommitted, error) {
+	a.metrics.checkpointLoadTotal.Add(1)
+	checkpoint, err := a.log.LoadCheckpoint()
+	if err != nil {
+		return rootstorage.ObservedCommitted{}, err
+	}
+	a.metrics.committedTailReadTotal.Add(1)
+	tail, err := a.log.ReadCommitted(offset)
+	if err != nil {
+		return rootstorage.ObservedCommitted{}, err
+	}
+	return rootstorage.ObservedCommitted{Checkpoint: checkpoint, Tail: tail}, nil
+}
+
+func (a *virtualLogAdapter) invalidateCacheLocked() {
+	if a == nil {
+		return
+	}
+	if a.cacheValid {
+		a.metrics.observeCacheInvalidations.Add(1)
+	}
+	a.cacheValid = false
+	a.cache = rootstorage.ObservedCommitted{}
 }
 
 func (a *virtualLogAdapter) loadCheckpoint() (rootstorage.Checkpoint, error) {
@@ -110,11 +165,8 @@ func (a *virtualLogAdapter) saveCheckpoint(checkpoint rootstorage.Checkpoint) er
 	if err := a.log.SaveCheckpoint(checkpoint); err != nil {
 		return err
 	}
-	observed, err := rootstorage.ObserveCommitted(a.log, 0)
-	if err != nil {
-		return err
-	}
-	a.bump(observed.LastCursor())
+	a.invalidateCacheLocked()
+	a.bump(checkpoint.Snapshot.State.LastCommitted)
 	a.signal()
 	return nil
 }
@@ -131,6 +183,7 @@ func (a *virtualLogAdapter) compactCommitted(stream rootstorage.CommittedTail) e
 	if err := a.log.CompactCommitted(stream); err != nil {
 		return err
 	}
+	a.invalidateCacheLocked()
 	a.bump(stream.TailCursor(a.latest.Cursor))
 	a.signal()
 	return nil
@@ -140,6 +193,13 @@ func (a *virtualLogAdapter) size() (int64, error) {
 	a.mu.Lock()
 	defer a.mu.Unlock()
 	return a.log.Size()
+}
+
+func (a *virtualLogAdapter) stats() map[string]any {
+	if a == nil {
+		return map[string]any{}
+	}
+	return a.metrics.snapshot()
 }
 
 func (a *virtualLogAdapter) bump(cursor rootstate.Cursor) {


### PR DESCRIPTION
## Summary

- cache replicated root `ObserveCommitted` results when the log/checkpoint has not advanced
- compact inherited Eunomia grant history before checkpoint/evidence emission
- avoid hot-path coordinator inheritance writes unless the local active grant can actually cover the pending retirement
- expose root observe/cache and grant-inheritance counters for benchmark/profile evidence

## Correctness

- the observe cache is process-local only; restart recovery still rebuilds from checkpoint and committed log
- append/checkpoint/compact/bootstrap invalidate or refresh the cache
- authority evidence now relies on the retired-era floor instead of carrying already-covered predecessor history
- inheritance submission is filtered by local duty coverage, so unrelated duty retirements do not trigger repeated root writes

## Local validation

- `make lint`
- `go test ./meta/root/... ./coordinator/...`
- `go test ./...`
- `git diff --check`

## Local benchmark evidence

Command:

```bash
NOKV_FSMETA_PROFILE=median NOKV_FSMETA_CAPTURE_PROFILES=1 NOKV_FSMETA_PROFILE_SECONDS=30 ./scripts/run_fsmeta_benchmarks.sh
```

Latest local Docker Compose median result:

- mixed: 132.974 ops/s, 0 errors
- checkpoint-storm: 91.587 ops/s, 0 errors
- hotspot-fanin: 58.118 ops/s, 0 errors
- watch-subtree: 192.044 ops/s, 0 errors
- durable-snapshot: 35.023 ops/s, 0 errors
- negative-lookup: 3893.536 ops/s, 0 errors

Control-plane evidence from the same run:

- coord2 grant inheritance dropped from repeated submissions (`submitted=12468`) to mostly skipped (`submitted=30`, `skipped=11931`) after coverage filtering
- root observe cache showed `observe_cache_hit_total=20870`, `observe_cache_miss_total=476`, `checkpoint_load_total=477`

This is local macOS Docker Compose evidence with profile capture enabled; CI/main long benchmark remains the stable comparison point.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added backend statistics collection and reporting in metrics snapshots.
  * Introduced grant inheritance metrics tracking submitted and skipped operations.

* **Performance Improvements**
  * Implemented caching for committed tail observations to reduce redundant lookups.
  * Optimized grant inheritance filtering based on coverage and retirement bounds.

* **Tests**
  * Enhanced test coverage for grant inheritance, duty admission, and cache behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->