### PR TITLE
Optimize atomic mutate apply fusion

### DIFF
--- a/cmd/nokv/metrics.go
+++ b/cmd/nokv/metrics.go
@@ -130,7 +130,7 @@ func metaRootSnapshot(ctx metaRootExpvarContext) map[string]any {
 func installStorePercolatorExpvar() {
 	storePercolatorOnce.Do(func() {
 		expvar.Publish("nokv_store_percolator", expvar.Func(func() any {
-			return percolator.AtomicMutateStats()
+			return percolator.Stats()
 		}))
 	})
 }

--- a/raftstore/kv/apply.go
+++ b/raftstore/kv/apply.go
@@ -30,7 +30,8 @@ func Apply(db txnstore.Store, latches *latch.Manager, req *raftcmdpb.RaftCmdRequ
 		latches = latch.NewManager(defaultLatchSlots)
 	}
 	resp := &raftcmdpb.RaftCmdResponse{Header: req.Header}
-	for _, r := range req.Requests {
+	for i := 0; i < len(req.Requests); i++ {
+		r := req.Requests[i]
 		if r == nil {
 			continue
 		}
@@ -45,17 +46,49 @@ func Apply(db txnstore.Store, latches *latch.Manager, req *raftcmdpb.RaftCmdRequ
 			}
 			resp.Responses = append(resp.Responses, &raftcmdpb.Response{Cmd: &raftcmdpb.Response_Get{Get: result}})
 		case raftcmdpb.CmdType_CMD_PREWRITE:
-			result := &kvrpcpb.PrewriteResponse{Errors: percolator.Prewrite(db, latches, r.GetPrewrite())}
-			resp.Responses = append(resp.Responses, &raftcmdpb.Response{Cmd: &raftcmdpb.Response_Prewrite{Prewrite: result}})
+			end := collectCommandRun(req.Requests, i, raftcmdpb.CmdType_CMD_PREWRITE)
+			batch := []*kvrpcpb.PrewriteRequest{r.GetPrewrite()}
+			for j := i + 1; j < end; j++ {
+				batch = append(batch, req.Requests[j].GetPrewrite())
+			}
+			for _, errs := range percolator.PrewriteBatch(db, latches, batch) {
+				result := &kvrpcpb.PrewriteResponse{Errors: errs}
+				resp.Responses = append(resp.Responses, &raftcmdpb.Response{Cmd: &raftcmdpb.Response_Prewrite{Prewrite: result}})
+			}
+			i = end - 1
 		case raftcmdpb.CmdType_CMD_COMMIT:
-			err := percolator.Commit(db, latches, r.GetCommit())
-			resp.Responses = append(resp.Responses, &raftcmdpb.Response{Cmd: &raftcmdpb.Response_Commit{Commit: &kvrpcpb.CommitResponse{Error: err}}})
+			end := collectCommandRun(req.Requests, i, raftcmdpb.CmdType_CMD_COMMIT)
+			batch := []*kvrpcpb.CommitRequest{r.GetCommit()}
+			for j := i + 1; j < end; j++ {
+				batch = append(batch, req.Requests[j].GetCommit())
+			}
+			for _, err := range percolator.CommitBatch(db, latches, batch) {
+				resp.Responses = append(resp.Responses, &raftcmdpb.Response{Cmd: &raftcmdpb.Response_Commit{Commit: &kvrpcpb.CommitResponse{Error: err}}})
+			}
+			i = end - 1
 		case raftcmdpb.CmdType_CMD_BATCH_ROLLBACK:
-			err := percolator.BatchRollback(db, latches, r.GetBatchRollback())
-			resp.Responses = append(resp.Responses, &raftcmdpb.Response{Cmd: &raftcmdpb.Response_BatchRollback{BatchRollback: &kvrpcpb.BatchRollbackResponse{Error: err}}})
+			end := collectCommandRun(req.Requests, i, raftcmdpb.CmdType_CMD_BATCH_ROLLBACK)
+			batch := []*kvrpcpb.BatchRollbackRequest{r.GetBatchRollback()}
+			for j := i + 1; j < end; j++ {
+				batch = append(batch, req.Requests[j].GetBatchRollback())
+			}
+			for _, err := range percolator.BatchRollbackBatch(db, latches, batch) {
+				resp.Responses = append(resp.Responses, &raftcmdpb.Response{Cmd: &raftcmdpb.Response_BatchRollback{BatchRollback: &kvrpcpb.BatchRollbackResponse{Error: err}}})
+			}
+			i = end - 1
 		case raftcmdpb.CmdType_CMD_RESOLVE_LOCK:
-			count, err := percolator.ResolveLock(db, latches, r.GetResolveLock())
-			resp.Responses = append(resp.Responses, &raftcmdpb.Response{Cmd: &raftcmdpb.Response_ResolveLock{ResolveLock: &kvrpcpb.ResolveLockResponse{ResolvedLocks: count, Error: err}}})
+			end := collectCommandRun(req.Requests, i, raftcmdpb.CmdType_CMD_RESOLVE_LOCK)
+			batch := []*kvrpcpb.ResolveLockRequest{r.GetResolveLock()}
+			for j := i + 1; j < end; j++ {
+				batch = append(batch, req.Requests[j].GetResolveLock())
+			}
+			for _, result := range percolator.ResolveLockBatch(db, latches, batch) {
+				resp.Responses = append(resp.Responses, &raftcmdpb.Response{Cmd: &raftcmdpb.Response_ResolveLock{ResolveLock: &kvrpcpb.ResolveLockResponse{
+					ResolvedLocks: result.ResolvedLocks,
+					Error:         result.Error,
+				}}})
+			}
+			i = end - 1
 		case raftcmdpb.CmdType_CMD_CHECK_TXN_STATUS:
 			result := percolator.CheckTxnStatus(db, latches, r.GetCheckTxnStatus())
 			resp.Responses = append(resp.Responses, &raftcmdpb.Response{Cmd: &raftcmdpb.Response_CheckTxnStatus{CheckTxnStatus: result}})
@@ -63,12 +96,19 @@ func Apply(db txnstore.Store, latches *latch.Manager, req *raftcmdpb.RaftCmdRequ
 			result := percolator.TxnHeartBeat(db, latches, r.GetTxnHeartBeat())
 			resp.Responses = append(resp.Responses, &raftcmdpb.Response{Cmd: &raftcmdpb.Response_TxnHeartBeat{TxnHeartBeat: result}})
 		case raftcmdpb.CmdType_CMD_TRY_ATOMIC_MUTATE:
-			result := percolator.ApplyAtomicMutate(db, latches, r.GetTryAtomicMutate())
-			resp.Responses = append(resp.Responses, &raftcmdpb.Response{Cmd: &raftcmdpb.Response_TryAtomicMutate{TryAtomicMutate: &kvrpcpb.TryAtomicMutateResponse{
-				Error:                    result.Error,
-				AppliedKeys:              result.AppliedKeys,
-				FallbackToTwoPhaseCommit: result.Fallback,
-			}}})
+			end := collectCommandRun(req.Requests, i, raftcmdpb.CmdType_CMD_TRY_ATOMIC_MUTATE)
+			batch := []*kvrpcpb.TryAtomicMutateRequest{r.GetTryAtomicMutate()}
+			for j := i + 1; j < end; j++ {
+				batch = append(batch, req.Requests[j].GetTryAtomicMutate())
+			}
+			for _, result := range percolator.ApplyAtomicMutateBatch(db, latches, batch) {
+				resp.Responses = append(resp.Responses, &raftcmdpb.Response{Cmd: &raftcmdpb.Response_TryAtomicMutate{TryAtomicMutate: &kvrpcpb.TryAtomicMutateResponse{
+					Error:                    result.Error,
+					AppliedKeys:              result.AppliedKeys,
+					FallbackToTwoPhaseCommit: result.Fallback,
+				}}})
+			}
+			i = end - 1
 		case raftcmdpb.CmdType_CMD_MVCC_MAINTENANCE:
 			result, err := applyMVCCMaintenance(db, r.GetMvccMaintenance())
 			if err != nil {
@@ -86,6 +126,18 @@ func Apply(db txnstore.Store, latches *latch.Manager, req *raftcmdpb.RaftCmdRequ
 		}
 	}
 	return resp, nil
+}
+
+func collectCommandRun(reqs []*raftcmdpb.Request, start int, cmdType raftcmdpb.CmdType) int {
+	end := start + 1
+	for end < len(reqs) {
+		next := reqs[end]
+		if next == nil || next.GetCmdType() != cmdType {
+			break
+		}
+		end++
+	}
+	return end
 }
 
 func applyMVCCMaintenance(db txnstore.Store, req *kvrpcpb.MVCCMaintenanceRequest) (*kvrpcpb.MVCCMaintenanceResponse, error) {

--- a/raftstore/kv/apply_test.go
+++ b/raftstore/kv/apply_test.go
@@ -180,6 +180,71 @@ func TestApplyTryAtomicMutateCommandMaterializesBothKeys(t *testing.T) {
 	require.Equal(t, []byte("attrs"), inode)
 }
 
+func TestApplyTryAtomicMutateBatchFusesLocalApply(t *testing.T) {
+	opt := local.NewDefaultOptions()
+	opt.WorkDir = t.TempDir()
+	opt.LSMShardCount = 1
+	db, err := local.Open(opt)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = db.Close() })
+
+	store := &countingAtomicApplyStore{base: db}
+	resp, err := Apply(store, nil, &raftcmdpb.RaftCmdRequest{
+		Requests: []*raftcmdpb.Request{
+			{
+				CmdType: raftcmdpb.CmdType_CMD_TRY_ATOMIC_MUTATE,
+				Cmd:     &raftcmdpb.Request_TryAtomicMutate{TryAtomicMutate: atomicPutForApplyTest(40, 41, []byte("batched-a"), []byte("va"))},
+			},
+			{
+				CmdType: raftcmdpb.CmdType_CMD_TRY_ATOMIC_MUTATE,
+				Cmd:     &raftcmdpb.Request_TryAtomicMutate{TryAtomicMutate: atomicPutForApplyTest(42, 43, []byte("batched-b"), []byte("vb"))},
+			},
+		},
+	})
+	require.NoError(t, err)
+	require.Len(t, resp.GetResponses(), 2)
+	for _, raftResp := range resp.GetResponses() {
+		atomicResp := raftResp.GetTryAtomicMutate()
+		require.NotNil(t, atomicResp)
+		require.Nil(t, atomicResp.GetError())
+		require.False(t, atomicResp.GetFallbackToTwoPhaseCommit())
+		require.Equal(t, uint64(1), atomicResp.GetAppliedKeys())
+	}
+	require.Equal(t, 1, store.applyCalls)
+	require.Equal(t, []int{6}, store.appliedEntryCounts)
+}
+
+func TestApplyPrewriteBatchFusesLocalApply(t *testing.T) {
+	opt := local.NewDefaultOptions()
+	opt.WorkDir = t.TempDir()
+	db, err := local.Open(opt)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = db.Close() })
+
+	store := &countingAtomicApplyStore{base: db}
+	resp, err := Apply(store, nil, &raftcmdpb.RaftCmdRequest{
+		Requests: []*raftcmdpb.Request{
+			{
+				CmdType: raftcmdpb.CmdType_CMD_PREWRITE,
+				Cmd:     &raftcmdpb.Request_Prewrite{Prewrite: prewriteForApplyTest(50, []byte("prewrite-batched-a"), []byte("va"))},
+			},
+			{
+				CmdType: raftcmdpb.CmdType_CMD_PREWRITE,
+				Cmd:     &raftcmdpb.Request_Prewrite{Prewrite: prewriteForApplyTest(52, []byte("prewrite-batched-b"), []byte("vb"))},
+			},
+		},
+	})
+	require.NoError(t, err)
+	require.Len(t, resp.GetResponses(), 2)
+	for _, raftResp := range resp.GetResponses() {
+		prewriteResp := raftResp.GetPrewrite()
+		require.NotNil(t, prewriteResp)
+		require.Empty(t, prewriteResp.GetErrors())
+	}
+	require.Equal(t, 1, store.applyCalls)
+	require.Equal(t, []int{6}, store.appliedEntryCounts)
+}
+
 func TestApplyTryAtomicMutateCommandFallsBackForCrossShardBatch(t *testing.T) {
 	const shardCount = 4
 
@@ -223,6 +288,54 @@ func TestApplyTryAtomicMutateCommandFallsBackForCrossShardBatch(t *testing.T) {
 		_, _, err := reader.GetValue(key, commitVersion)
 		require.ErrorIs(t, err, utils.ErrKeyNotFound)
 	}
+}
+
+func atomicPutForApplyTest(startVersion, commitVersion uint64, key, value []byte) *kvrpcpb.TryAtomicMutateRequest {
+	return &kvrpcpb.TryAtomicMutateRequest{
+		StartVersion:  startVersion,
+		CommitVersion: commitVersion,
+		Predicates: []*kvrpcpb.AtomicPredicate{
+			{Key: entrykv.SafeCopy(nil, key), Kind: kvrpcpb.AtomicPredicateKind_ATOMIC_PREDICATE_KIND_NOT_EXISTS},
+		},
+		Mutations: []*kvrpcpb.Mutation{
+			{Op: kvrpcpb.Mutation_Put, Key: entrykv.SafeCopy(nil, key), Value: entrykv.SafeCopy(nil, value), AssertionNotExist: true},
+		},
+	}
+}
+
+func prewriteForApplyTest(startVersion uint64, key, value []byte) *kvrpcpb.PrewriteRequest {
+	return &kvrpcpb.PrewriteRequest{
+		Mutations: []*kvrpcpb.Mutation{
+			{Op: kvrpcpb.Mutation_Put, Key: entrykv.SafeCopy(nil, key), Value: entrykv.SafeCopy(nil, value)},
+		},
+		PrimaryLock:  entrykv.SafeCopy(nil, key),
+		StartVersion: startVersion,
+		LockTtl:      1000,
+	}
+}
+
+type countingAtomicApplyStore struct {
+	base               *local.DB
+	applyCalls         int
+	appliedEntryCounts []int
+}
+
+func (s *countingAtomicApplyStore) ApplyInternalEntries(entries []*entrykv.Entry) error {
+	s.applyCalls++
+	s.appliedEntryCounts = append(s.appliedEntryCounts, len(entries))
+	return s.base.ApplyInternalEntries(entries)
+}
+
+func (s *countingAtomicApplyStore) CanApplyInternalEntriesAtomically(entries []*entrykv.Entry) bool {
+	return s.base.CanApplyInternalEntriesAtomically(entries)
+}
+
+func (s *countingAtomicApplyStore) GetInternalEntry(cf entrykv.ColumnFamily, key []byte, version uint64) (*entrykv.Entry, error) {
+	return s.base.GetInternalEntry(cf, key, version)
+}
+
+func (s *countingAtomicApplyStore) NewInternalIterator(opt *index.Options) index.Iterator {
+	return s.base.NewInternalIterator(opt)
 }
 
 func keysWithDifferentDefaultShardsForApplyTest(t *testing.T, shardCount int, version uint64) ([]byte, []byte) {

--- a/txn/percolator/txn.go
+++ b/txn/percolator/txn.go
@@ -28,43 +28,64 @@ import (
 
 // Prewrite applies mutation prewrites for a single region transaction.
 func Prewrite(db txnstore.Store, latches *latch.Manager, req *kvrpcpb.PrewriteRequest) []*kvrpcpb.KeyError {
-	if req == nil {
+	results := PrewriteBatch(db, latches, []*kvrpcpb.PrewriteRequest{req})
+	if len(results) == 0 {
 		return nil
 	}
-	keys := make([][]byte, 0, len(req.Mutations))
-	for _, mut := range req.Mutations {
-		if mut != nil && len(mut.Key) > 0 {
-			keys = append(keys, mut.Key)
-		}
+	return results[0]
+}
+
+// PrewriteBatch applies a raft-entry batch of prewrite requests. It keeps
+// request-level errors independent while fusing local storage apply for
+// non-overlapping requests.
+func PrewriteBatch(db txnstore.Store, latches *latch.Manager, reqs []*kvrpcpb.PrewriteRequest) [][]*kvrpcpb.KeyError {
+	results := make([][]*kvrpcpb.KeyError, len(reqs))
+	keys := make([][]byte, 0)
+	for _, req := range reqs {
+		keys = append(keys, prewriteRequestKeys(req)...)
 	}
 	guard := latches.Acquire(keys)
 	defer guard.Release()
 
 	reader := NewReader(db)
-	var errs []*kvrpcpb.KeyError
-	ops := make([]versionedOp, 0, len(req.Mutations)*3)
-	for _, mut := range req.Mutations {
-		if mut == nil {
+	group := twoPCApplyGroup{}
+	for i, req := range reqs {
+		if req == nil {
 			continue
 		}
-		planned, err := planPrewriteMutation(reader, req, mut)
+		requestKeys := prewriteRequestKeys(req)
+		if group.conflicts(requestKeys) {
+			group.flush(db, func(item twoPCApplyRequest, err *kvrpcpb.KeyError) {
+				if err != nil {
+					results[item.index] = []*kvrpcpb.KeyError{err}
+				}
+			})
+		}
+		var errs []*kvrpcpb.KeyError
+		ops := make([]versionedOp, 0, len(req.Mutations)*3)
+		for _, mut := range req.Mutations {
+			if mut == nil {
+				continue
+			}
+			planned, err := planPrewriteMutation(reader, req, mut)
+			if err != nil {
+				errs = append(errs, err)
+				continue
+			}
+			ops = append(ops, planned...)
+		}
+		if len(errs) > 0 {
+			results[i] = errs
+			continue
+		}
+		group.add(i, requestKeys, ops, 0)
+	}
+	group.flush(db, func(item twoPCApplyRequest, err *kvrpcpb.KeyError) {
 		if err != nil {
-			errs = append(errs, err)
-			continue
+			results[item.index] = []*kvrpcpb.KeyError{err}
 		}
-		ops = append(ops, planned...)
-	}
-	if len(errs) > 0 {
-		return errs
-	}
-	// Prewrite is the lock admission boundary for a region request. Validation
-	// happens for every mutation before storage is touched, so semantic key
-	// errors never hide partial locks. Storage failures are retryable: replaying
-	// the same start_ts observes its own locks and finishes the missing keys.
-	if err := applyVersionedOps(db, ops...); err != nil {
-		return []*kvrpcpb.KeyError{keyErrorRetryable(err)}
-	}
-	return nil
+	})
+	return results
 }
 
 func planPrewriteMutation(reader *Reader, req *kvrpcpb.PrewriteRequest, mut *kvrpcpb.Mutation) ([]versionedOp, *kvrpcpb.KeyError) {
@@ -120,6 +141,19 @@ func planPrewriteMutation(reader *Reader, req *kvrpcpb.PrewriteRequest, mut *kvr
 	return ops, nil
 }
 
+func prewriteRequestKeys(req *kvrpcpb.PrewriteRequest) [][]byte {
+	if req == nil {
+		return nil
+	}
+	keys := make([][]byte, 0, len(req.Mutations))
+	for _, mut := range req.Mutations {
+		if mut != nil && len(mut.Key) > 0 {
+			keys = append(keys, mut.Key)
+		}
+	}
+	return keys
+}
+
 // validateCommitVersion rejects commits that would violate MVCC ordering.
 func validateCommitVersion(StartVersion uint64, CommitVersion uint64) *kvrpcpb.KeyError {
 	if CommitVersion <= StartVersion {
@@ -131,31 +165,60 @@ func validateCommitVersion(StartVersion uint64, CommitVersion uint64) *kvrpcpb.K
 // Commit finalises earlier prewrites by removing locks and writing commit
 // records. A non-nil KeyError is returned when commit should abort.
 func Commit(db txnstore.Store, latches *latch.Manager, req *kvrpcpb.CommitRequest) *kvrpcpb.KeyError {
-	if req == nil {
+	results := CommitBatch(db, latches, []*kvrpcpb.CommitRequest{req})
+	if len(results) == 0 {
 		return nil
 	}
-	if err := validateCommitVersion(req.StartVersion, req.CommitVersion); err != nil {
-		return err
+	return results[0]
+}
+
+// CommitBatch applies a raft-entry batch of commit requests. Percolator still
+// decides each transaction at its primary key; this only reduces local apply
+// fragmentation after raft has already ordered the commit requests.
+func CommitBatch(db txnstore.Store, latches *latch.Manager, reqs []*kvrpcpb.CommitRequest) []*kvrpcpb.KeyError {
+	results := make([]*kvrpcpb.KeyError, len(reqs))
+	keys := make([][]byte, 0)
+	for _, req := range reqs {
+		if req != nil {
+			keys = append(keys, req.Keys...)
+		}
 	}
-	guard := latches.Acquire(req.Keys)
+	guard := latches.Acquire(keys)
 	defer guard.Release()
 
 	reader := NewReader(db)
-	ops := make([]versionedOp, 0, len(req.Keys)*2)
-	for _, key := range req.Keys {
-		planned, err := planCommitKey(reader, key, req.StartVersion, req.CommitVersion)
-		if err != nil {
-			return err
+	group := twoPCApplyGroup{}
+	for i, req := range reqs {
+		if req == nil {
+			continue
 		}
-		ops = append(ops, planned...)
+		if err := validateCommitVersion(req.StartVersion, req.CommitVersion); err != nil {
+			results[i] = err
+			continue
+		}
+		if group.conflicts(req.Keys) {
+			group.flush(db, func(item twoPCApplyRequest, err *kvrpcpb.KeyError) {
+				results[item.index] = err
+			})
+		}
+		ops := make([]versionedOp, 0, len(req.Keys)*2)
+		for _, key := range req.Keys {
+			planned, err := planCommitKey(reader, key, req.StartVersion, req.CommitVersion)
+			if err != nil {
+				results[i] = err
+				break
+			}
+			ops = append(ops, planned...)
+		}
+		if results[i] != nil {
+			continue
+		}
+		group.add(i, req.Keys, ops, 0)
 	}
-	// Commit remains Percolator-idempotent: already committed keys produce no
-	// write op, while residual locks are cleaned with the commit records for the
-	// same key. The DB may fan multi-key requests out by LSM shard affinity.
-	if err := applyVersionedOps(db, ops...); err != nil {
-		return keyErrorRetryable(err)
-	}
-	return nil
+	group.flush(db, func(item twoPCApplyRequest, err *kvrpcpb.KeyError) {
+		results[item.index] = err
+	})
+	return results
 }
 
 // AtomicMutateResult is the local outcome for a region-local 1PC attempt.
@@ -165,20 +228,32 @@ type AtomicMutateResult struct {
 	Fallback    bool
 }
 
-type atomicMutateStatsRegistry struct {
-	applyCalledTotal   atomic.Uint64
-	localFallbackTotal atomic.Uint64
+type statsRegistry struct {
+	applyCalledTotal        atomic.Uint64
+	localFallbackTotal      atomic.Uint64
+	fusedApplyBatchesTotal  atomic.Uint64
+	fusedApplyRequestsTotal atomic.Uint64
+	fusedApplyEntriesTotal  atomic.Uint64
+	twoPCFusedBatchesTotal  atomic.Uint64
+	twoPCFusedRequestsTotal atomic.Uint64
+	twoPCFusedEntriesTotal  atomic.Uint64
 }
 
-var atomicMutateStats atomicMutateStatsRegistry
+var percolatorStats statsRegistry
 
-// AtomicMutateStats returns package-wide server-side 1PC counters. These are
-// deliberately protocol-level counters, so callers can tell whether a request
+// Stats returns package-wide server-side Percolator counters. These are
+// deliberately protocol-level counters, so callers can tell whether requests
 // reached Percolator after client-side region admission.
-func AtomicMutateStats() map[string]any {
+func Stats() map[string]any {
 	return map[string]any{
-		"atomic_apply_called_total":   atomicMutateStats.applyCalledTotal.Load(),
-		"atomic_local_fallback_total": atomicMutateStats.localFallbackTotal.Load(),
+		"atomic_apply_called_total":         percolatorStats.applyCalledTotal.Load(),
+		"atomic_local_fallback_total":       percolatorStats.localFallbackTotal.Load(),
+		"atomic_fused_apply_batches_total":  percolatorStats.fusedApplyBatchesTotal.Load(),
+		"atomic_fused_apply_requests_total": percolatorStats.fusedApplyRequestsTotal.Load(),
+		"atomic_fused_apply_entries_total":  percolatorStats.fusedApplyEntriesTotal.Load(),
+		"two_pc_fused_apply_batches_total":  percolatorStats.twoPCFusedBatchesTotal.Load(),
+		"two_pc_fused_apply_requests_total": percolatorStats.twoPCFusedRequestsTotal.Load(),
+		"two_pc_fused_apply_entries_total":  percolatorStats.twoPCFusedEntriesTotal.Load(),
 	}
 }
 
@@ -190,14 +265,98 @@ func ApplyAtomicMutate(db txnstore.Store, latches *latch.Manager, req *kvrpcpb.T
 	if req == nil {
 		return AtomicMutateResult{}
 	}
+	results := ApplyAtomicMutateBatch(db, latches, []*kvrpcpb.TryAtomicMutateRequest{req})
+	if len(results) == 0 {
+		return AtomicMutateResult{}
+	}
+	return results[0]
+}
+
+// ApplyAtomicMutateBatch applies a raft-entry batch of independent 1PC
+// attempts. It preserves per-request responses and only fuses requests when
+// their combined MVCC entries remain one local atomic apply group.
+func ApplyAtomicMutateBatch(db txnstore.Store, latches *latch.Manager, reqs []*kvrpcpb.TryAtomicMutateRequest) []AtomicMutateResult {
+	results := make([]AtomicMutateResult, len(reqs))
+	if len(reqs) == 0 {
+		return results
+	}
+	prepared := make([]atomicMutatePrepared, len(reqs))
+	var allKeys [][]byte
+	var called uint64
+	for i, req := range reqs {
+		item := prepareAtomicMutate(req)
+		prepared[i] = item
+		results[i] = item.result
+		if !item.eligible {
+			continue
+		}
+		called++
+		allKeys = append(allKeys, item.keys...)
+	}
+	if called == 0 {
+		return results
+	}
+	percolatorStats.applyCalledTotal.Add(called)
+
+	guard := latches.Acquire(allKeys)
+	defer guard.Release()
+
+	planner, hasPlanner := db.(txnstore.AtomicInternalApplyPlanner)
+	group := atomicMutateApplyGroup{}
+	for i, item := range prepared {
+		if !item.eligible {
+			continue
+		}
+		// Overlapping requests must observe raft-log order. Flush before
+		// planning the later request so its predicates see earlier writes.
+		if group.conflicts(item.keys) {
+			group.flush(db, results)
+		}
+		plan, result, ok := planAtomicMutateUnlocked(db, item.req, item.keys)
+		if !ok {
+			results[i] = result
+			continue
+		}
+		if len(plan.entries) == 0 {
+			results[i] = AtomicMutateResult{AppliedKeys: plan.appliedKeys}
+			continue
+		}
+		if !hasPlanner || !planner.CanApplyInternalEntriesAtomically(plan.entries) {
+			percolatorStats.localFallbackTotal.Add(1)
+			releaseEntries(plan.entries)
+			results[i] = AtomicMutateResult{Fallback: true}
+			continue
+		}
+		// A request can be locally atomic by itself while belonging to a
+		// different LSM shard than the current group. Split the group instead
+		// of turning a valid 1PC request into a 2PC fallback.
+		if !group.empty() && !planner.CanApplyInternalEntriesAtomically(group.entriesWith(plan.entries)) {
+			group.flush(db, results)
+		}
+		group.add(i, plan)
+	}
+	group.flush(db, results)
+	return results
+}
+
+type atomicMutatePrepared struct {
+	req      *kvrpcpb.TryAtomicMutateRequest
+	keys     [][]byte
+	eligible bool
+	result   AtomicMutateResult
+}
+
+func prepareAtomicMutate(req *kvrpcpb.TryAtomicMutateRequest) atomicMutatePrepared {
+	if req == nil {
+		return atomicMutatePrepared{}
+	}
 	if err := validateCommitVersion(req.StartVersion, req.CommitVersion); err != nil {
-		return AtomicMutateResult{Error: err}
+		return atomicMutatePrepared{result: AtomicMutateResult{Error: err}}
 	}
 	mutations := req.GetMutations()
 	if len(mutations) == 0 {
-		return AtomicMutateResult{}
+		return atomicMutatePrepared{}
 	}
-	atomicMutateStats.applyCalledTotal.Add(1)
 	keys := make([][]byte, 0, len(mutations)+len(req.GetPredicates()))
 	for _, mut := range mutations {
 		if mut != nil && len(mut.Key) > 0 {
@@ -209,21 +368,29 @@ func ApplyAtomicMutate(db txnstore.Store, latches *latch.Manager, req *kvrpcpb.T
 			keys = append(keys, pred.Key)
 		}
 	}
-	guard := latches.Acquire(keys)
-	defer guard.Release()
+	return atomicMutatePrepared{req: req, keys: keys, eligible: true}
+}
 
+type atomicMutatePlan struct {
+	entries     []*kv.Entry
+	appliedKeys uint64
+	keys        [][]byte
+}
+
+func planAtomicMutateUnlocked(db txnstore.Store, req *kvrpcpb.TryAtomicMutateRequest, keys [][]byte) (atomicMutatePlan, AtomicMutateResult, bool) {
+	mutations := req.GetMutations()
 	reader := NewReader(db)
 	if applied, err := atomicMutateAlreadyApplied(db, reader, req); err != nil {
-		return AtomicMutateResult{Error: keyErrorRetryable(err)}
+		return atomicMutatePlan{}, AtomicMutateResult{Error: keyErrorRetryable(err)}, false
 	} else if applied {
-		return AtomicMutateResult{AppliedKeys: uint64(len(mutations))}
+		return atomicMutatePlan{}, AtomicMutateResult{AppliedKeys: uint64(len(mutations))}, false
 	}
 
 	primary := mutations[0].GetKey()
 	ops := make([]versionedOp, 0, len(mutations)*3)
 	for _, pred := range req.GetPredicates() {
 		if err := validateAtomicPredicate(reader, pred, req.StartVersion); err != nil {
-			return AtomicMutateResult{Error: err}
+			return atomicMutatePlan{}, AtomicMutateResult{Error: err}, false
 		}
 	}
 	for _, mut := range mutations {
@@ -231,43 +398,102 @@ func ApplyAtomicMutate(db txnstore.Store, latches *latch.Manager, req *kvrpcpb.T
 			continue
 		}
 		if err := validateAtomicMutation(mut); err != nil {
-			return AtomicMutateResult{Error: err}
+			return atomicMutatePlan{}, AtomicMutateResult{Error: err}, false
 		}
 		key := mut.GetKey()
 		lock, err := reader.GetLock(key)
 		if err != nil {
-			return AtomicMutateResult{Error: keyErrorRetryable(err)}
+			return atomicMutatePlan{}, AtomicMutateResult{Error: keyErrorRetryable(err)}, false
 		}
 		if lock != nil {
-			return AtomicMutateResult{Error: keyErrorLocked(key, lock)}
+			return atomicMutatePlan{}, AtomicMutateResult{Error: keyErrorLocked(key, lock)}, false
 		}
 		if write, commitTs, err := reader.MostRecentWrite(key); err != nil {
-			return AtomicMutateResult{Error: keyErrorRetryable(err)}
+			return atomicMutatePlan{}, AtomicMutateResult{Error: keyErrorRetryable(err)}, false
 		} else if write != nil && commitTs >= req.StartVersion {
-			return AtomicMutateResult{Error: keyErrorWriteConflict(key, primary, commitTs, write.StartTs, req.StartVersion)}
+			return atomicMutatePlan{}, AtomicMutateResult{Error: keyErrorWriteConflict(key, primary, commitTs, write.StartTs, req.StartVersion)}, false
 		}
 		if mut.GetAssertionNotExist() {
 			exists, err := keyExistsAt(reader, key, req.StartVersion)
 			if err != nil {
-				return AtomicMutateResult{Error: keyErrorRetryable(err)}
+				return atomicMutatePlan{}, AtomicMutateResult{Error: keyErrorRetryable(err)}, false
 			}
 			if exists {
-				return AtomicMutateResult{Error: keyErrorAlreadyExists(key)}
+				return atomicMutatePlan{}, AtomicMutateResult{Error: keyErrorAlreadyExists(key)}, false
 			}
 		}
 		ops = append(ops, committedMutationOps(mut, req.StartVersion, req.CommitVersion)...)
 	}
 	entries := versionedOpsToEntries(ops...)
-	defer releaseEntries(entries)
-	planner, ok := db.(txnstore.AtomicInternalApplyPlanner)
-	if !ok || !planner.CanApplyInternalEntriesAtomically(entries) {
-		atomicMutateStats.localFallbackTotal.Add(1)
-		return AtomicMutateResult{Fallback: true}
+	return atomicMutatePlan{entries: entries, appliedKeys: uint64(len(mutations)), keys: keys}, AtomicMutateResult{}, true
+}
+
+type atomicMutateApplyGroup struct {
+	requests []atomicMutateGroupRequest
+	entries  []*kv.Entry
+	keys     map[string]struct{}
+}
+
+type atomicMutateGroupRequest struct {
+	index       int
+	appliedKeys uint64
+}
+
+func (g *atomicMutateApplyGroup) empty() bool {
+	return g == nil || len(g.requests) == 0
+}
+
+func (g *atomicMutateApplyGroup) conflicts(keys [][]byte) bool {
+	if g == nil || len(g.keys) == 0 {
+		return false
 	}
-	if err := applyVersionedEntries(db, entries); err != nil {
-		return AtomicMutateResult{Error: keyErrorRetryable(err)}
+	for _, key := range keys {
+		if _, ok := g.keys[string(key)]; ok {
+			return true
+		}
 	}
-	return AtomicMutateResult{AppliedKeys: uint64(len(mutations))}
+	return false
+}
+
+func (g *atomicMutateApplyGroup) entriesWith(entries []*kv.Entry) []*kv.Entry {
+	out := make([]*kv.Entry, 0, len(g.entries)+len(entries))
+	out = append(out, g.entries...)
+	out = append(out, entries...)
+	return out
+}
+
+func (g *atomicMutateApplyGroup) add(index int, plan atomicMutatePlan) {
+	g.requests = append(g.requests, atomicMutateGroupRequest{index: index, appliedKeys: plan.appliedKeys})
+	g.entries = append(g.entries, plan.entries...)
+	if g.keys == nil {
+		g.keys = make(map[string]struct{}, len(plan.keys))
+	}
+	for _, key := range plan.keys {
+		g.keys[string(key)] = struct{}{}
+	}
+}
+
+func (g *atomicMutateApplyGroup) flush(db txnstore.Store, results []AtomicMutateResult) {
+	if g == nil || len(g.requests) == 0 {
+		return
+	}
+	defer releaseEntries(g.entries)
+	if len(g.requests) > 1 {
+		percolatorStats.fusedApplyBatchesTotal.Add(1)
+		percolatorStats.fusedApplyRequestsTotal.Add(uint64(len(g.requests)))
+		percolatorStats.fusedApplyEntriesTotal.Add(uint64(len(g.entries)))
+	}
+	err := applyVersionedEntries(db, g.entries)
+	for _, req := range g.requests {
+		if err != nil {
+			results[req.index] = AtomicMutateResult{Error: keyErrorRetryable(err)}
+			continue
+		}
+		results[req.index] = AtomicMutateResult{AppliedKeys: req.appliedKeys}
+	}
+	g.requests = nil
+	g.entries = nil
+	g.keys = nil
 }
 
 func validateAtomicPredicate(reader *Reader, pred *kvrpcpb.AtomicPredicate, startVersion uint64) *kvrpcpb.KeyError {
@@ -386,82 +612,162 @@ func committedMutationOps(mut *kvrpcpb.Mutation, startVersion, commitVersion uin
 
 // BatchRollback rolls back the provided keys for the given start version.
 func BatchRollback(db txnstore.Store, latches *latch.Manager, req *kvrpcpb.BatchRollbackRequest) *kvrpcpb.KeyError {
-	if req == nil {
+	results := BatchRollbackBatch(db, latches, []*kvrpcpb.BatchRollbackRequest{req})
+	if len(results) == 0 {
 		return nil
 	}
-	guard := latches.Acquire(req.Keys)
-	defer guard.Release()
-	reader := NewReader(db)
-	ops := make([]versionedOp, 0, len(req.Keys)*3)
-	for _, key := range req.Keys {
-		planned, err := planRollbackKey(reader, key, req.StartVersion)
-		if err != nil {
-			return err
+	return results[0]
+}
+
+// BatchRollbackBatch applies a raft-entry batch of rollback requests. Rollback
+// remains idempotent per start_ts; this only shares local storage apply for
+// independent rollback records already ordered by raft.
+func BatchRollbackBatch(db txnstore.Store, latches *latch.Manager, reqs []*kvrpcpb.BatchRollbackRequest) []*kvrpcpb.KeyError {
+	results := make([]*kvrpcpb.KeyError, len(reqs))
+	keys := make([][]byte, 0)
+	for _, req := range reqs {
+		if req != nil {
+			keys = append(keys, req.Keys...)
 		}
-		ops = append(ops, planned...)
 	}
-	// Rollback markers and lock tombstones for one key must be planned together;
-	// the DB preserves per-key shard affinity when it persists the internal
-	// entries, and retries keep rollback idempotent.
-	if err := applyVersionedOps(db, ops...); err != nil {
-		return keyErrorRetryable(err)
+	guard := latches.Acquire(keys)
+	defer guard.Release()
+
+	reader := NewReader(db)
+	group := twoPCApplyGroup{}
+	for i, req := range reqs {
+		if req == nil {
+			continue
+		}
+		if group.conflicts(req.Keys) {
+			group.flush(db, func(item twoPCApplyRequest, err *kvrpcpb.KeyError) {
+				results[item.index] = err
+			})
+		}
+		ops := make([]versionedOp, 0, len(req.Keys)*3)
+		for _, key := range req.Keys {
+			planned, err := planRollbackKey(reader, key, req.StartVersion)
+			if err != nil {
+				results[i] = err
+				break
+			}
+			ops = append(ops, planned...)
+		}
+		if results[i] != nil {
+			continue
+		}
+		group.add(i, req.Keys, ops, 0)
 	}
-	return nil
+	group.flush(db, func(item twoPCApplyRequest, err *kvrpcpb.KeyError) {
+		results[item.index] = err
+	})
+	return results
+}
+
+type ResolveLockResult struct {
+	ResolvedLocks uint64
+	Error         *kvrpcpb.KeyError
 }
 
 // ResolveLock resolves locks for the given transaction. commitVersion == 0
 // performs a rollback; otherwise the keys are committed.
 func ResolveLock(db txnstore.Store, latches *latch.Manager, req *kvrpcpb.ResolveLockRequest) (uint64, *kvrpcpb.KeyError) {
-	if req == nil {
+	results := ResolveLockBatch(db, latches, []*kvrpcpb.ResolveLockRequest{req})
+	if len(results) == 0 {
 		return 0, nil
 	}
-	if req.CommitVersion != 0 {
-		if err := validateCommitVersion(req.StartVersion, req.CommitVersion); err != nil {
-			return 0, err
+	return results[0].ResolvedLocks, results[0].Error
+}
+
+// ResolveLockBatch applies a raft-entry batch of lock resolution requests. It
+// preserves resolved-count semantics for every logical request while sharing the
+// local apply when the resolved key sets do not overlap.
+func ResolveLockBatch(db txnstore.Store, latches *latch.Manager, reqs []*kvrpcpb.ResolveLockRequest) []ResolveLockResult {
+	results := make([]ResolveLockResult, len(reqs))
+	keys := make([][]byte, 0)
+	for _, req := range reqs {
+		if req != nil {
+			keys = append(keys, req.Keys...)
 		}
 	}
-	guard := latches.Acquire(req.Keys)
+	guard := latches.Acquire(keys)
 	defer guard.Release()
 
 	reader := NewReader(db)
-	var resolved uint64
-	ops := make([]versionedOp, 0, len(req.Keys)*3)
-	seen := make(map[string]struct{}, len(req.Keys))
-	for _, key := range req.Keys {
-		if len(key) == 0 {
+	group := twoPCApplyGroup{}
+	for i, req := range reqs {
+		if req == nil {
 			continue
 		}
-		keyID := string(key)
-		if _, ok := seen[keyID]; ok {
+		if req.CommitVersion != 0 {
+			if err := validateCommitVersion(req.StartVersion, req.CommitVersion); err != nil {
+				results[i].Error = err
+				continue
+			}
+		}
+		if group.conflicts(req.Keys) {
+			group.flush(db, func(item twoPCApplyRequest, err *kvrpcpb.KeyError) {
+				if err != nil {
+					results[item.index].Error = err
+					return
+				}
+				results[item.index].ResolvedLocks = item.resolvedLocks
+			})
+		}
+		var resolved uint64
+		ops := make([]versionedOp, 0, len(req.Keys)*3)
+		seen := make(map[string]struct{}, len(req.Keys))
+		for _, key := range req.Keys {
+			if len(key) == 0 {
+				continue
+			}
+			keyID := string(key)
+			if _, ok := seen[keyID]; ok {
+				continue
+			}
+			seen[keyID] = struct{}{}
+			lock, err := reader.GetLock(key)
+			if err != nil {
+				results[i].Error = keyErrorRetryable(err)
+				break
+			}
+			if lock == nil || lock.Ts != req.StartVersion {
+				continue
+			}
+			if req.CommitVersion == 0 {
+				planned, err := planRollbackKey(reader, key, req.StartVersion)
+				if err != nil {
+					results[i].Error = err
+					break
+				}
+				ops = append(ops, planned...)
+			} else {
+				planned, err := planCommitKeyWithLock(reader, key, lock, req.CommitVersion)
+				if err != nil {
+					results[i].Error = err
+					break
+				}
+				ops = append(ops, planned...)
+			}
+			resolved++
+		}
+		if results[i].Error != nil {
 			continue
 		}
-		seen[keyID] = struct{}{}
-		lock, err := reader.GetLock(key)
+		if len(ops) == 0 {
+			results[i].ResolvedLocks = resolved
+			continue
+		}
+		group.add(i, req.Keys, ops, resolved)
+	}
+	group.flush(db, func(item twoPCApplyRequest, err *kvrpcpb.KeyError) {
 		if err != nil {
-			return resolved, keyErrorRetryable(err)
+			results[item.index].Error = err
+			return
 		}
-		if lock == nil || lock.Ts != req.StartVersion {
-			continue
-		}
-		if req.CommitVersion == 0 {
-			planned, err := planRollbackKey(reader, key, req.StartVersion)
-			if err != nil {
-				return resolved, err
-			}
-			ops = append(ops, planned...)
-		} else {
-			planned, err := planCommitKeyWithLock(reader, key, lock, req.CommitVersion)
-			if err != nil {
-				return resolved, err
-			}
-			ops = append(ops, planned...)
-		}
-		resolved++
-	}
-	if err := applyVersionedOps(db, ops...); err != nil {
-		return 0, keyErrorRetryable(err)
-	}
-	return resolved, nil
+		results[item.index].ResolvedLocks = item.resolvedLocks
+	})
+	return results
 }
 
 // CheckTxnStatus inspects the primary lock state and optionally rolls back
@@ -752,6 +1058,65 @@ type versionedOp struct {
 	value   []byte
 	meta    byte
 	expires uint64
+}
+
+type twoPCApplyGroup struct {
+	requests []twoPCApplyRequest
+	entries  []*kv.Entry
+	keys     map[string]struct{}
+}
+
+type twoPCApplyRequest struct {
+	index         int
+	resolvedLocks uint64
+}
+
+func (g *twoPCApplyGroup) conflicts(keys [][]byte) bool {
+	if g == nil || len(g.keys) == 0 {
+		return false
+	}
+	for _, key := range keys {
+		if _, ok := g.keys[string(key)]; ok {
+			return true
+		}
+	}
+	return false
+}
+
+func (g *twoPCApplyGroup) add(index int, keys [][]byte, ops []versionedOp, resolvedLocks uint64) {
+	if len(ops) == 0 {
+		return
+	}
+	g.requests = append(g.requests, twoPCApplyRequest{index: index, resolvedLocks: resolvedLocks})
+	g.entries = append(g.entries, versionedOpsToEntries(ops...)...)
+	if g.keys == nil {
+		g.keys = make(map[string]struct{}, len(keys))
+	}
+	for _, key := range keys {
+		g.keys[string(key)] = struct{}{}
+	}
+}
+
+func (g *twoPCApplyGroup) flush(db txnstore.Store, setResult func(twoPCApplyRequest, *kvrpcpb.KeyError)) {
+	if g == nil || len(g.requests) == 0 {
+		return
+	}
+	defer releaseEntries(g.entries)
+	if len(g.requests) > 1 {
+		percolatorStats.twoPCFusedBatchesTotal.Add(1)
+		percolatorStats.twoPCFusedRequestsTotal.Add(uint64(len(g.requests)))
+		percolatorStats.twoPCFusedEntriesTotal.Add(uint64(len(g.entries)))
+	}
+	var keyErr *kvrpcpb.KeyError
+	if err := applyVersionedEntries(db, g.entries); err != nil {
+		keyErr = keyErrorRetryable(err)
+	}
+	for _, req := range g.requests {
+		setResult(req, keyErr)
+	}
+	g.requests = nil
+	g.entries = nil
+	g.keys = nil
 }
 
 func applyVersionedOps(db txnstore.Store, ops ...versionedOp) error {

--- a/txn/percolator/txn_test.go
+++ b/txn/percolator/txn_test.go
@@ -57,6 +57,19 @@ func atomicPutIfAbsentRequest(startVersion, commitVersion uint64, firstKey, firs
 	}
 }
 
+func atomicPutRequest(startVersion, commitVersion uint64, key, value []byte) *kvrpcpb.TryAtomicMutateRequest {
+	return &kvrpcpb.TryAtomicMutateRequest{
+		StartVersion:  startVersion,
+		CommitVersion: commitVersion,
+		Predicates: []*kvrpcpb.AtomicPredicate{
+			{Key: kv.SafeCopy(nil, key), Kind: kvrpcpb.AtomicPredicateKind_ATOMIC_PREDICATE_KIND_NOT_EXISTS},
+		},
+		Mutations: []*kvrpcpb.Mutation{
+			{Op: kvrpcpb.Mutation_Put, Key: kv.SafeCopy(nil, key), Value: kv.SafeCopy(nil, value), AssertionNotExist: true},
+		},
+	}
+}
+
 func atomicMutateStat(t *testing.T, stats map[string]any, key string) uint64 {
 	t.Helper()
 	raw, ok := stats[key]
@@ -159,6 +172,18 @@ func (s *countingStore) NewInternalIterator(opt *index.Options) index.Iterator {
 func (s *countingStore) failNextApply(err error) {
 	s.failApplyErr = err
 	s.failApplyRemaining = 1
+}
+
+type countingAtomicStore struct {
+	*countingStore
+}
+
+func newCountingAtomicStore(base *local.DB) *countingAtomicStore {
+	return &countingAtomicStore{countingStore: newCountingStore(base)}
+}
+
+func (s *countingAtomicStore) CanApplyInternalEntriesAtomically(entries []*kv.Entry) bool {
+	return s.base.CanApplyInternalEntriesAtomically(entries)
 }
 
 type testIterator struct {
@@ -274,16 +299,135 @@ func TestApplyAtomicMutateStatsRecordLocalFallback(t *testing.T) {
 	db := openTestDB(t)
 	store := newCountingStore(db)
 	latches := latch.NewManager(16)
-	before := AtomicMutateStats()
+	before := Stats()
 
 	result := ApplyAtomicMutate(store, latches, atomicPutIfAbsentRequest(20, 21, []byte("dentry"), []byte("ino=42"), []byte("inode"), []byte("attrs")))
 	require.Nil(t, result.Error)
 	require.True(t, result.Fallback)
 	require.Zero(t, store.applyCalls)
 
-	after := AtomicMutateStats()
+	after := Stats()
 	require.Equal(t, atomicMutateStat(t, before, "atomic_apply_called_total")+1, atomicMutateStat(t, after, "atomic_apply_called_total"))
 	require.Equal(t, atomicMutateStat(t, before, "atomic_local_fallback_total")+1, atomicMutateStat(t, after, "atomic_local_fallback_total"))
+}
+
+func TestApplyAtomicMutateBatchFusesIndependentRequests(t *testing.T) {
+	opt := testOptionsForDir(t.TempDir())
+	opt.LSMShardCount = 1
+	db, err := local.Open(opt)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = db.Close() })
+
+	store := newCountingAtomicStore(db)
+	latches := latch.NewManager(16)
+	before := Stats()
+	results := ApplyAtomicMutateBatch(store, latches, []*kvrpcpb.TryAtomicMutateRequest{
+		atomicPutRequest(40, 41, []byte("atomic-batch-a"), []byte("va")),
+		atomicPutRequest(42, 43, []byte("atomic-batch-b"), []byte("vb")),
+	})
+	require.Len(t, results, 2)
+	for _, result := range results {
+		require.Nil(t, result.Error)
+		require.False(t, result.Fallback)
+		require.Equal(t, uint64(1), result.AppliedKeys)
+	}
+	require.Equal(t, 1, store.applyCalls)
+	require.Equal(t, []int{6}, store.appliedEntryCounts)
+
+	reader := NewReader(db)
+	value, _, err := reader.GetValue([]byte("atomic-batch-a"), 50)
+	require.NoError(t, err)
+	require.Equal(t, []byte("va"), value)
+	value, _, err = reader.GetValue([]byte("atomic-batch-b"), 50)
+	require.NoError(t, err)
+	require.Equal(t, []byte("vb"), value)
+
+	after := Stats()
+	require.Equal(t, atomicMutateStat(t, before, "atomic_fused_apply_batches_total")+1, atomicMutateStat(t, after, "atomic_fused_apply_batches_total"))
+	require.Equal(t, atomicMutateStat(t, before, "atomic_fused_apply_requests_total")+2, atomicMutateStat(t, after, "atomic_fused_apply_requests_total"))
+	require.Equal(t, atomicMutateStat(t, before, "atomic_fused_apply_entries_total")+6, atomicMutateStat(t, after, "atomic_fused_apply_entries_total"))
+}
+
+func TestApplyAtomicMutateBatchSplitsDifferentLocalApplyGroups(t *testing.T) {
+	const shardCount = 4
+
+	opt := testOptionsForDir(t.TempDir())
+	opt.LSMShardCount = shardCount
+	db, err := local.Open(opt)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = db.Close() })
+
+	first, second := keysWithAscendingCommitShards(t, shardCount)
+	firstShard := lsm.ShardForInternalKey(kv.InternalKey(kv.CFDefault, first, 50), shardCount)
+	secondShard := lsm.ShardForInternalKey(kv.InternalKey(kv.CFDefault, second, 52), shardCount)
+	require.NotEqual(t, firstShard, secondShard)
+
+	store := newCountingAtomicStore(db)
+	results := ApplyAtomicMutateBatch(store, latch.NewManager(16), []*kvrpcpb.TryAtomicMutateRequest{
+		atomicPutRequest(50, 51, first, []byte("first")),
+		atomicPutRequest(52, 53, second, []byte("second")),
+	})
+	require.Len(t, results, 2)
+	for _, result := range results {
+		require.Nil(t, result.Error)
+		require.False(t, result.Fallback)
+		require.Equal(t, uint64(1), result.AppliedKeys)
+	}
+	require.Equal(t, 2, store.applyCalls)
+	require.Equal(t, []int{3, 3}, store.appliedEntryCounts)
+}
+
+func TestApplyAtomicMutateBatchPreservesOverlappingRequestOrder(t *testing.T) {
+	opt := testOptionsForDir(t.TempDir())
+	opt.LSMShardCount = 1
+	db, err := local.Open(opt)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = db.Close() })
+
+	store := newCountingAtomicStore(db)
+	key := []byte("atomic-overlap")
+	results := ApplyAtomicMutateBatch(store, latch.NewManager(16), []*kvrpcpb.TryAtomicMutateRequest{
+		atomicPutRequest(60, 61, key, []byte("first")),
+		atomicPutRequest(62, 63, key, []byte("second")),
+	})
+	require.Len(t, results, 2)
+	require.Nil(t, results[0].Error)
+	require.Equal(t, uint64(1), results[0].AppliedKeys)
+	require.NotNil(t, results[1].Error)
+	require.NotNil(t, results[1].Error.GetAlreadyExists())
+	require.Equal(t, 1, store.applyCalls)
+
+	value, _, err := NewReader(db).GetValue(key, 70)
+	require.NoError(t, err)
+	require.Equal(t, []byte("first"), value)
+}
+
+func TestApplyAtomicMutateBatchApplyFailureMarksWholeFusedGroup(t *testing.T) {
+	opt := testOptionsForDir(t.TempDir())
+	opt.LSMShardCount = 1
+	db, err := local.Open(opt)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = db.Close() })
+
+	injected := errors.New("fused atomic apply failed")
+	store := newCountingAtomicStore(db)
+	store.failNextApply(injected)
+	results := ApplyAtomicMutateBatch(store, latch.NewManager(16), []*kvrpcpb.TryAtomicMutateRequest{
+		atomicPutRequest(70, 71, []byte("atomic-fail-a"), []byte("va")),
+		atomicPutRequest(72, 73, []byte("atomic-fail-b"), []byte("vb")),
+	})
+	require.Len(t, results, 2)
+	for _, result := range results {
+		require.NotNil(t, result.Error)
+		require.Contains(t, result.Error.GetRetryable(), injected.Error())
+	}
+	require.Equal(t, 1, store.applyCalls)
+
+	reader := NewReader(db)
+	_, _, err = reader.GetValue([]byte("atomic-fail-a"), 80)
+	require.ErrorIs(t, err, utils.ErrKeyNotFound)
+	_, _, err = reader.GetValue([]byte("atomic-fail-b"), 80)
+	require.ErrorIs(t, err, utils.ErrKeyNotFound)
 }
 
 func TestApplyAtomicMutateRejectsExistingDentry(t *testing.T) {
@@ -643,6 +787,186 @@ func TestPrewriteBatchAppliesAllMutationsOnce(t *testing.T) {
 		require.NotNil(t, lock, "key=%s", key)
 		require.Equal(t, uint64(8), lock.Ts)
 	}
+}
+
+func TestPrewriteRequestBatchFusesIndependentRequests(t *testing.T) {
+	db := openTestDB(t)
+	store := newCountingStore(db)
+	latches := latch.NewManager(32)
+	before := Stats()
+
+	results := PrewriteBatch(store, latches, []*kvrpcpb.PrewriteRequest{
+		{
+			Mutations:    []*kvrpcpb.Mutation{{Op: kvrpcpb.Mutation_Put, Key: []byte("prewrite-fused-a"), Value: []byte("va")}},
+			PrimaryLock:  []byte("prewrite-fused-a"),
+			StartVersion: 20,
+			LockTtl:      1000,
+		},
+		{
+			Mutations:    []*kvrpcpb.Mutation{{Op: kvrpcpb.Mutation_Put, Key: []byte("prewrite-fused-b"), Value: []byte("vb")}},
+			PrimaryLock:  []byte("prewrite-fused-b"),
+			StartVersion: 22,
+			LockTtl:      1000,
+		},
+	})
+	require.Len(t, results, 2)
+	require.Empty(t, results[0])
+	require.Empty(t, results[1])
+	require.Equal(t, 1, store.applyCalls)
+	require.Equal(t, []int{6}, store.appliedEntryCounts)
+
+	after := Stats()
+	require.Equal(t, atomicMutateStat(t, before, "two_pc_fused_apply_batches_total")+1, atomicMutateStat(t, after, "two_pc_fused_apply_batches_total"))
+	require.Equal(t, atomicMutateStat(t, before, "two_pc_fused_apply_requests_total")+2, atomicMutateStat(t, after, "two_pc_fused_apply_requests_total"))
+	require.Equal(t, atomicMutateStat(t, before, "two_pc_fused_apply_entries_total")+6, atomicMutateStat(t, after, "two_pc_fused_apply_entries_total"))
+}
+
+func TestPrewriteRequestBatchPreservesOverlappingOrder(t *testing.T) {
+	db := openTestDB(t)
+	store := newCountingStore(db)
+	latches := latch.NewManager(32)
+	key := []byte("prewrite-overlap")
+
+	results := PrewriteBatch(store, latches, []*kvrpcpb.PrewriteRequest{
+		{
+			Mutations:    []*kvrpcpb.Mutation{{Op: kvrpcpb.Mutation_Put, Key: key, Value: []byte("first")}},
+			PrimaryLock:  key,
+			StartVersion: 30,
+			LockTtl:      1000,
+		},
+		{
+			Mutations:    []*kvrpcpb.Mutation{{Op: kvrpcpb.Mutation_Put, Key: key, Value: []byte("second")}},
+			PrimaryLock:  key,
+			StartVersion: 32,
+			LockTtl:      1000,
+		},
+	})
+	require.Len(t, results, 2)
+	require.Empty(t, results[0])
+	require.Len(t, results[1], 1)
+	require.NotNil(t, results[1][0].GetLocked())
+	require.Equal(t, 1, store.applyCalls)
+
+	lock, err := NewReader(db).GetLock(key)
+	require.NoError(t, err)
+	require.NotNil(t, lock)
+	require.Equal(t, uint64(30), lock.Ts)
+}
+
+func TestPrewriteRequestBatchApplyFailureMarksFusedRequests(t *testing.T) {
+	db := openTestDB(t)
+	store := newCountingStore(db)
+	injected := errors.New("fused prewrite apply failed")
+	store.failNextApply(injected)
+	latches := latch.NewManager(32)
+
+	results := PrewriteBatch(store, latches, []*kvrpcpb.PrewriteRequest{
+		{
+			Mutations:    []*kvrpcpb.Mutation{{Op: kvrpcpb.Mutation_Put, Key: []byte("prewrite-fail-a"), Value: []byte("va")}},
+			PrimaryLock:  []byte("prewrite-fail-a"),
+			StartVersion: 40,
+			LockTtl:      1000,
+		},
+		{
+			Mutations:    []*kvrpcpb.Mutation{{Op: kvrpcpb.Mutation_Put, Key: []byte("prewrite-fail-b"), Value: []byte("vb")}},
+			PrimaryLock:  []byte("prewrite-fail-b"),
+			StartVersion: 42,
+			LockTtl:      1000,
+		},
+	})
+	require.Len(t, results, 2)
+	for _, errs := range results {
+		require.Len(t, errs, 1)
+		require.Contains(t, errs[0].GetRetryable(), injected.Error())
+	}
+	require.Equal(t, 1, store.applyCalls)
+
+	reader := NewReader(db)
+	for _, key := range [][]byte{[]byte("prewrite-fail-a"), []byte("prewrite-fail-b")} {
+		lock, err := reader.GetLock(key)
+		require.NoError(t, err)
+		require.Nil(t, lock)
+	}
+}
+
+func TestCommitRequestBatchFusesIndependentRequests(t *testing.T) {
+	db := openTestDB(t)
+	latches := latch.NewManager(32)
+	keys := [][]byte{[]byte("commit-fused-a"), []byte("commit-fused-b")}
+	require.Empty(t, Prewrite(db, latches, &kvrpcpb.PrewriteRequest{
+		Mutations: []*kvrpcpb.Mutation{
+			{Op: kvrpcpb.Mutation_Put, Key: keys[0], Value: []byte("va")},
+			{Op: kvrpcpb.Mutation_Put, Key: keys[1], Value: []byte("vb")},
+		},
+		PrimaryLock:  keys[0],
+		StartVersion: 50,
+		LockTtl:      1000,
+	}))
+
+	store := newCountingStore(db)
+	results := CommitBatch(store, latches, []*kvrpcpb.CommitRequest{
+		{Keys: [][]byte{keys[0]}, StartVersion: 50, CommitVersion: 60},
+		{Keys: [][]byte{keys[1]}, StartVersion: 50, CommitVersion: 60},
+	})
+	require.Len(t, results, 2)
+	require.Nil(t, results[0])
+	require.Nil(t, results[1])
+	require.Equal(t, 1, store.applyCalls)
+	require.Equal(t, []int{4}, store.appliedEntryCounts)
+}
+
+func TestBatchRollbackRequestBatchFusesIndependentRequests(t *testing.T) {
+	db := openTestDB(t)
+	latches := latch.NewManager(32)
+	keys := [][]byte{[]byte("rollback-fused-a"), []byte("rollback-fused-b")}
+	require.Empty(t, Prewrite(db, latches, &kvrpcpb.PrewriteRequest{
+		Mutations: []*kvrpcpb.Mutation{
+			{Op: kvrpcpb.Mutation_Put, Key: keys[0], Value: []byte("va")},
+			{Op: kvrpcpb.Mutation_Put, Key: keys[1], Value: []byte("vb")},
+		},
+		PrimaryLock:  keys[0],
+		StartVersion: 70,
+		LockTtl:      1000,
+	}))
+
+	store := newCountingStore(db)
+	results := BatchRollbackBatch(store, latches, []*kvrpcpb.BatchRollbackRequest{
+		{Keys: [][]byte{keys[0]}, StartVersion: 70},
+		{Keys: [][]byte{keys[1]}, StartVersion: 70},
+	})
+	require.Len(t, results, 2)
+	require.Nil(t, results[0])
+	require.Nil(t, results[1])
+	require.Equal(t, 1, store.applyCalls)
+	require.Equal(t, []int{6}, store.appliedEntryCounts)
+}
+
+func TestResolveLockRequestBatchFusesIndependentRequests(t *testing.T) {
+	db := openTestDB(t)
+	latches := latch.NewManager(32)
+	keys := [][]byte{[]byte("resolve-fused-a"), []byte("resolve-fused-b")}
+	require.Empty(t, Prewrite(db, latches, &kvrpcpb.PrewriteRequest{
+		Mutations: []*kvrpcpb.Mutation{
+			{Op: kvrpcpb.Mutation_Put, Key: keys[0], Value: []byte("va")},
+			{Op: kvrpcpb.Mutation_Put, Key: keys[1], Value: []byte("vb")},
+		},
+		PrimaryLock:  keys[0],
+		StartVersion: 80,
+		LockTtl:      1000,
+	}))
+
+	store := newCountingStore(db)
+	results := ResolveLockBatch(store, latches, []*kvrpcpb.ResolveLockRequest{
+		{Keys: [][]byte{keys[0]}, StartVersion: 80, CommitVersion: 90},
+		{Keys: [][]byte{keys[1]}, StartVersion: 80, CommitVersion: 90},
+	})
+	require.Len(t, results, 2)
+	for _, result := range results {
+		require.Nil(t, result.Error)
+		require.Equal(t, uint64(1), result.ResolvedLocks)
+	}
+	require.Equal(t, 1, store.applyCalls)
+	require.Equal(t, []int{4}, store.appliedEntryCounts)
 }
 
 func TestCommitMissingLock(t *testing.T) {


### PR DESCRIPTION
## Summary
- fuse consecutive `TryAtomicMutate` requests inside one raft apply batch when the combined MVCC entries still fit one local atomic apply group
- extend the same raft-entry apply fusion to 2PC `Prewrite`, `Commit`, `BatchRollback`, and `ResolveLock` requests
- preserve raft request order by flushing before overlapping keys, so later predicates and lock checks observe earlier writes
- keep cross-shard and per-request protocol boundaries intact: 1PC still obeys the existing atomic planner; 2PC remains Percolator-idempotent and retryable on storage failure

## Correctness
- no wire/proto change
- per-request responses keep original order
- overlapping keys force a flush before the later request is planned
- cross-shard 1PC local apply remains split or fallback according to the existing atomic planner
- fused 2PC apply failure returns retryable key errors for affected logical requests, so retries preserve existing idempotency semantics

## Validation
- `make fmt`
- `make lint`
- `go test ./...`
- `go test ./txn/percolator ./raftstore/kv ./cmd/nokv`
- previous clean local Docker Compose fsmeta median before the 2PC extension: 0 errors, mixed aggregate 157.028 ops/s

CI benchmark should be used for apples-to-apples performance comparison against the previous main baseline because local Docker Desktop numbers vary significantly.