### PR TITLE
Optimize fsmeta placement and key shape routing

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,14 +272,17 @@ All deployment shapes share one configuration file: [`raft_config.example.json`]
     { "store_id": 2, "listen_addr": "127.0.0.1:20171", ... },
     { "store_id": 3, "listen_addr": "127.0.0.1:20172", ... }
   ],
-  "regions": [
-    { "id": 1, "range": [-inf, "m"), "leader": 1, ... },
-    { "id": 2, "range": ["m", +inf), "leader": 2, ... }
-  ]
+  "fsmeta_region_bootstrap": {
+    "mounts": ["default", "fsmeta-bench"],
+    "bucket_count": 16,
+    "region_id_base": 1000,
+    "peer_id_base": 100000,
+    "leader_store_ids": [1, 2, 3]
+  }
 }
 ```
 
-Local scripts, Docker Compose, and all CLI tools consume the same file. Programmatic access: `import "github.com/feichai0017/NoKV/config"` and call `config.LoadFile` / `Validate`.
+Local scripts, Docker Compose, and all CLI tools consume the same file. `nokv-config regions` expands fsmeta bucket bootstrap into ordinary byte-range region descriptors before store seeding; after bootstrap, runtime topology comes from meta-root. Programmatic access: `import "github.com/feichai0017/NoKV/config"` and call `config.LoadFile` / `Validate`.
 
 <br/>
 

--- a/benchmark/fsmeta/fsmeta_bench_test.go
+++ b/benchmark/fsmeta/fsmeta_bench_test.go
@@ -27,7 +27,7 @@ const benchEnvKey = "NOKV_FSMETA_BENCH"
 var (
 	fsmetaAddr            = flag.String("fsmeta_addr", "127.0.0.1:8090", "FSMetadata gRPC endpoint")
 	fsmetaCoordAddr       = flag.String("fsmeta_coordinator_addr", "127.0.0.1:2379", "Coordinator gRPC endpoint for mount bootstrap")
-	fsmetaWorkloads       = flag.String("fsmeta_workloads", "mixed,durable-snapshot,checkpoint-storm,hotspot-fanin,watch-subtree,negative-lookup", "comma-separated workloads: mixed,durable-snapshot,checkpoint-storm,hotspot-fanin,watch-subtree,negative-lookup")
+	fsmetaWorkloads       = flag.String("fsmeta_workloads", "multi-workspace-autoscale,mixed,durable-snapshot,checkpoint-storm,hotspot-fanin,watch-subtree,negative-lookup", "comma-separated workloads: multi-workspace-autoscale,mixed,durable-snapshot,checkpoint-storm,hotspot-fanin,watch-subtree,negative-lookup")
 	fsmetaMount           = flag.String("fsmeta_mount", "fsmeta-bench", "fsmeta mount id")
 	fsmetaClients         = flag.Int("fsmeta_clients", 8, "concurrent clients")
 	fsmetaDirs            = flag.Int("fsmeta_dirs", 16, "checkpoint-storm directory count")
@@ -41,6 +41,7 @@ var (
 	fsmetaGroups          = flag.Int("fsmeta_groups", 4, "mixed workload group directory count")
 	fsmetaEntriesPerGroup = flag.Int("fsmeta_entries_per_group", 8, "mixed workload published entry count per group")
 	fsmetaArtifactsPerRun = flag.Int("fsmeta_artifacts_per_entry", 4, "mixed workload artifact file count per entry; minimum 4")
+	fsmetaWorkspaces      = flag.Int("fsmeta_workspaces", 4, "multi-workspace-autoscale workspace count")
 	fsmetaSessionTTL      = flag.Duration("fsmeta_session_ttl", 5*time.Minute, "mixed writer session TTL")
 	fsmetaStaleSessionTTL = flag.Duration("fsmeta_stale_session_ttl", 2*time.Second, "mixed stale-session cleanup TTL")
 	fsmetaTimeout         = flag.Duration("fsmeta_timeout", 5*time.Minute, "overall benchmark timeout")
@@ -229,6 +230,21 @@ func runBenchmarkWorkload(ctx context.Context, cli workload.Client, workloadName
 			PageLimit:       uint32(*fsmetaPageLimit),
 			SessionTTL:      *fsmetaSessionTTL,
 			StaleSessionTTL: *fsmetaStaleSessionTTL,
+		})
+	case workload.MultiWorkspaceAutoscale:
+		result, err = workload.RunMultiWorkspaceAutoscale(ctx, cli, workload.MultiWorkspaceAutoscaleConfig{
+			MixedConfig: workload.MixedConfig{
+				Mount:           fsmeta.MountID(*fsmetaMount),
+				RunID:           runID,
+				Clients:         *fsmetaClients,
+				Groups:          *fsmetaGroups,
+				EntriesPerGroup: *fsmetaEntriesPerGroup,
+				ArtifactsPerRun: *fsmetaArtifactsPerRun,
+				PageLimit:       uint32(*fsmetaPageLimit),
+				SessionTTL:      *fsmetaSessionTTL,
+				StaleSessionTTL: *fsmetaStaleSessionTTL,
+			},
+			Workspaces: *fsmetaWorkspaces,
 		})
 	default:
 		return workload.Result{}, fmt.Errorf("unknown workload %q", workloadName)

--- a/benchmark/fsmeta/workload/mixed.go
+++ b/benchmark/fsmeta/workload/mixed.go
@@ -46,6 +46,11 @@ type MixedConfig struct {
 	StaleSessionTTL time.Duration
 }
 
+type MultiWorkspaceAutoscaleConfig struct {
+	MixedConfig
+	Workspaces int
+}
+
 type mixedDirs struct {
 	project     fsmeta.InodeID
 	groups      fsmeta.InodeID
@@ -152,6 +157,44 @@ func RunMixed(ctx context.Context, cli Client, cfg MixedConfig) (Result, error) 
 	runStaleSessionCleanup(ctx, native, cfg, dirs.scratch, rec)
 
 	return finishResult(Mixed, cfg.RunID, started, rec.snapshot())
+}
+
+// RunMultiWorkspaceAutoscale runs the mixed workload across several independent
+// workspace roots. It keeps total CI work bounded by dividing groups across
+// workspaces; the goal is to exercise dynamic region placement and leader
+// spread, not to multiply the benchmark size by workspace count.
+func RunMultiWorkspaceAutoscale(ctx context.Context, cli Client, cfg MultiWorkspaceAutoscaleConfig) (Result, error) {
+	cfg = normalizeMultiWorkspaceAutoscaleConfig(cfg)
+	started := time.Now()
+	type workspaceResult struct {
+		samples []Sample
+		err     error
+	}
+	results := make(chan workspaceResult, cfg.Workspaces)
+	var wg sync.WaitGroup
+	for workspace := 0; workspace < cfg.Workspaces; workspace++ {
+		workspace := workspace
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			sub := cfg.MixedConfig
+			sub.RunID = fmt.Sprintf("%s-ws%02d", cfg.RunID, workspace)
+			result, err := RunMixed(ctx, cli, sub)
+			item := workspaceResult{samples: result.Samples, err: err}
+			if err != nil && len(result.Samples) == 0 {
+				item.samples = []Sample{{Operation: "workspace_setup", Error: err.Error()}}
+			}
+			results <- item
+		}()
+	}
+	wg.Wait()
+	close(results)
+
+	var samples []Sample
+	for result := range results {
+		samples = append(samples, result.samples...)
+	}
+	return finishResult(MultiWorkspaceAutoscale, cfg.RunID, started, samples)
 }
 
 func createMixedDirs(ctx context.Context, cli MixedClient, cfg MixedConfig, rec *recorder) (mixedDirs, error) {
@@ -566,6 +609,23 @@ func normalizeMixedConfig(cfg MixedConfig) MixedConfig {
 		cfg.StaleSessionTTL = cfg.SessionTTL
 	}
 	return cfg
+}
+
+func normalizeMultiWorkspaceAutoscaleConfig(cfg MultiWorkspaceAutoscaleConfig) MultiWorkspaceAutoscaleConfig {
+	cfg.MixedConfig = normalizeMixedConfig(cfg.MixedConfig)
+	if cfg.Workspaces <= 0 {
+		cfg.Workspaces = 4
+	}
+	cfg.Clients = max(1, ceilDiv(cfg.Clients, cfg.Workspaces))
+	cfg.Groups = max(1, ceilDiv(cfg.Groups, cfg.Workspaces))
+	return cfg
+}
+
+func ceilDiv(n, d int) int {
+	if d <= 0 {
+		return n
+	}
+	return (n + d - 1) / d
 }
 
 func recordCall(rec *recorder, operation string, fn func() error) error {

--- a/benchmark/fsmeta/workload/mixed_test.go
+++ b/benchmark/fsmeta/workload/mixed_test.go
@@ -25,7 +25,7 @@ type fakeMixedClient struct {
 	reads     []fsmeta.ReadDirRequest
 	next      fsmeta.InodeID
 	version   uint64
-	stream    *fakeWatchStream
+	streams   []*fakeWatchStream
 }
 
 type fakeSessionKey struct {
@@ -42,7 +42,6 @@ func newFakeMixedClient() *fakeMixedClient {
 		versions:  make(map[uint64]struct{}),
 		next:      100,
 		version:   1,
-		stream:    &fakeWatchStream{events: make(chan fsmeta.WatchEvent, 1024)},
 	}
 }
 
@@ -138,8 +137,10 @@ func (c *fakeMixedClient) ReadDirPlus(_ context.Context, req fsmeta.ReadDirReque
 func (c *fakeMixedClient) WatchSubtree(_ context.Context, req fsmeta.WatchRequest) (fsmetaclient.WatchSubscription, error) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	c.stream.prefix = append([]byte(nil), req.KeyPrefix...)
-	return c.stream, nil
+	stream := newFakeWatchStream(1024)
+	stream.prefix = append([]byte(nil), req.KeyPrefix...)
+	c.streams = append(c.streams, stream)
+	return stream, nil
 }
 
 func (c *fakeMixedClient) SnapshotSubtree(_ context.Context, req fsmeta.SnapshotSubtreeRequest) (fsmeta.SnapshotSubtreeToken, error) {
@@ -326,19 +327,26 @@ func (c *retryOpenMixedClient) OpenWriteSession(ctx context.Context, req fsmeta.
 }
 
 func (c *fakeMixedClient) emitDentryEventLocked(mount fsmeta.MountID, entry fsmeta.DentryRecord) {
-	if c.stream == nil {
+	if len(c.streams) == 0 {
 		return
 	}
 	key, err := fsmeta.EncodeDentryKey(mount, entry.Parent, entry.Name)
-	if err != nil || len(c.stream.prefix) > 0 && !bytes.HasPrefix(key, c.stream.prefix) {
+	if err != nil {
 		return
 	}
 	c.version++
-	c.stream.events <- fsmeta.WatchEvent{
+	evt := fsmeta.WatchEvent{
 		Cursor:        fsmeta.WatchCursor{RegionID: 1, Term: 1, Index: c.version},
 		CommitVersion: c.version,
 		Source:        fsmeta.WatchEventSourceCommit,
 		Key:           key,
+	}
+	for _, stream := range c.streams {
+		stream.mu.Lock()
+		if !stream.closed && (len(stream.prefix) == 0 || bytes.HasPrefix(key, stream.prefix)) {
+			stream.events <- evt
+		}
+		stream.mu.Unlock()
 	}
 }
 
@@ -411,6 +419,34 @@ func TestRunMixedCoversFullSurface(t *testing.T) {
 	for version := range versions {
 		require.Contains(t, seen, version)
 	}
+}
+
+func TestRunMultiWorkspaceAutoscaleUsesIndependentWorkspaceRoots(t *testing.T) {
+	cli := newFakeMixedClient()
+	result, err := RunMultiWorkspaceAutoscale(context.Background(), cli, MultiWorkspaceAutoscaleConfig{
+		MixedConfig: MixedConfig{
+			Mount:           "vol",
+			RunID:           "autoscale",
+			Clients:         4,
+			Groups:          4,
+			EntriesPerGroup: 1,
+			ArtifactsPerRun: 4,
+			PageLimit:       8,
+			SessionTTL:      time.Hour,
+			StaleSessionTTL: 2 * time.Millisecond,
+		},
+		Workspaces: 2,
+	})
+	require.NoError(t, err)
+	require.Equal(t, MultiWorkspaceAutoscale, result.Name)
+	require.Zero(t, result.Errors)
+
+	cli.mu.Lock()
+	_, left := cli.dentries[dentryID(fsmeta.RootInode, "mixed-workload-autoscale-ws00")]
+	_, right := cli.dentries[dentryID(fsmeta.RootInode, "mixed-workload-autoscale-ws01")]
+	cli.mu.Unlock()
+	require.True(t, left)
+	require.True(t, right)
 }
 
 func TestWriterSessionOpenUsesFreshLeaseIDAcrossRetry(t *testing.T) {

--- a/benchmark/fsmeta/workload/workload.go
+++ b/benchmark/fsmeta/workload/workload.go
@@ -21,11 +21,12 @@ import (
 )
 
 const (
-	CheckpointStorm = "checkpoint-storm"
-	DurableSnapshot = "durable-snapshot"
-	HotspotFanIn    = "hotspot-fanin"
-	WatchSubtree    = "watch-subtree"
-	NegativeLookup  = "negative-lookup"
+	CheckpointStorm         = "checkpoint-storm"
+	DurableSnapshot         = "durable-snapshot"
+	HotspotFanIn            = "hotspot-fanin"
+	WatchSubtree            = "watch-subtree"
+	NegativeLookup          = "negative-lookup"
+	MultiWorkspaceAutoscale = "multi-workspace-autoscale"
 
 	DriverNativeFSMetadata = "native-fsmeta"
 )

--- a/benchmark/fsmeta/workload/workload_test.go
+++ b/benchmark/fsmeta/workload/workload_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"io"
 	"sync"
 	"testing"
 
@@ -255,7 +256,7 @@ type fakeWatchClient struct {
 func newFakeWatchClient() *fakeWatchClient {
 	return &fakeWatchClient{
 		fakeClient: newFakeClient(),
-		stream:     &fakeWatchStream{events: make(chan fsmeta.WatchEvent, 16)},
+		stream:     newFakeWatchStream(16),
 	}
 }
 
@@ -271,7 +272,12 @@ func (c *fakeWatchClient) Create(ctx context.Context, req fsmeta.CreateRequest) 
 	if err != nil {
 		return fsmeta.CreateResult{}, err
 	}
+	c.stream.mu.Lock()
+	defer c.stream.mu.Unlock()
 	if len(c.stream.prefix) > 0 && !bytes.HasPrefix(key, c.stream.prefix) {
+		return result, nil
+	}
+	if c.stream.closed {
 		return result, nil
 	}
 	c.stream.events <- fsmeta.WatchEvent{
@@ -284,6 +290,8 @@ func (c *fakeWatchClient) Create(ctx context.Context, req fsmeta.CreateRequest) 
 }
 
 func (c *fakeWatchClient) WatchSubtree(_ context.Context, req fsmeta.WatchRequest) (fsmetaclient.WatchSubscription, error) {
+	c.stream.mu.Lock()
+	defer c.stream.mu.Unlock()
 	c.stream.prefix = append([]byte(nil), req.KeyPrefix...)
 	return c.stream, nil
 }
@@ -330,12 +338,22 @@ func (c *fakeSnapshotClient) RetireSnapshotSubtree(_ context.Context, token fsme
 }
 
 type fakeWatchStream struct {
+	mu     sync.Mutex
 	prefix []byte
 	events chan fsmeta.WatchEvent
+	closed bool
+}
+
+func newFakeWatchStream(size int) *fakeWatchStream {
+	return &fakeWatchStream{events: make(chan fsmeta.WatchEvent, size)}
 }
 
 func (s *fakeWatchStream) Recv() (fsmeta.WatchEvent, error) {
-	return <-s.events, nil
+	evt, ok := <-s.events
+	if !ok {
+		return fsmeta.WatchEvent{}, io.EOF
+	}
+	return evt, nil
 }
 
 func (s *fakeWatchStream) ReadyCursor() fsmeta.WatchCursor {
@@ -347,5 +365,11 @@ func (s *fakeWatchStream) Ack(fsmeta.WatchCursor) error {
 }
 
 func (s *fakeWatchStream) Close() error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if !s.closed {
+		close(s.events)
+		s.closed = true
+	}
 	return nil
 }

--- a/cmd/nokv-config/main.go
+++ b/cmd/nokv-config/main.go
@@ -5,13 +5,14 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
-	metaregion "github.com/feichai0017/NoKV/meta/region"
-	rootevent "github.com/feichai0017/NoKV/meta/root/event"
 	"os"
 	"path/filepath"
 	"strings"
 
 	"github.com/feichai0017/NoKV/config"
+	"github.com/feichai0017/NoKV/fsmeta"
+	metaregion "github.com/feichai0017/NoKV/meta/region"
+	rootevent "github.com/feichai0017/NoKV/meta/root/event"
 	localmeta "github.com/feichai0017/NoKV/raftstore/localmeta"
 )
 
@@ -144,11 +145,16 @@ func runRegions(args []string) error {
 		return err
 	}
 
+	regions, err := effectiveRegions(cfg)
+	if err != nil {
+		return err
+	}
+
 	switch strings.ToLower(*format) {
 	case "json":
-		return json.NewEncoder(os.Stdout).Encode(cfg.Regions)
+		return json.NewEncoder(os.Stdout).Encode(regions)
 	case "simple":
-		for _, region := range cfg.Regions {
+		for _, region := range regions {
 			encodedPeers := make([]string, 0, len(region.Peers))
 			for _, peer := range region.Peers {
 				encodedPeers = append(encodedPeers, fmt.Sprintf("%d:%d", peer.StoreID, peer.PeerID))
@@ -167,6 +173,58 @@ func runRegions(args []string) error {
 	default:
 		return fmt.Errorf("unknown format %q", *format)
 	}
+}
+
+func effectiveRegions(cfg *config.File) ([]config.Region, error) {
+	if cfg == nil || cfg.FSMetaRegionBootstrap == nil {
+		return cfg.Regions, nil
+	}
+	return expandFSMetaBootstrapRegions(cfg)
+}
+
+func expandFSMetaBootstrapRegions(cfg *config.File) ([]config.Region, error) {
+	layout := cfg.FSMetaRegionBootstrap
+	mounts := make([]fsmeta.MountID, 0, len(layout.Mounts))
+	for _, mount := range layout.Mounts {
+		mounts = append(mounts, fsmeta.MountID(mount))
+	}
+	ranges, err := fsmeta.PlanBucketPlacement(mounts, layout.BucketCount)
+	if err != nil {
+		return nil, err
+	}
+	leaders := layout.LeaderStoreIDs
+	if len(leaders) == 0 {
+		leaders = make([]uint64, 0, len(cfg.Stores))
+		for _, store := range cfg.Stores {
+			leaders = append(leaders, store.StoreID)
+		}
+	}
+	if len(leaders) == 0 {
+		return nil, fmt.Errorf("config: fsmeta_region_bootstrap requires stores")
+	}
+	regions := make([]config.Region, 0, len(ranges))
+	for i, r := range ranges {
+		regionID := layout.RegionIDBase + uint64(i)
+		peers := make([]config.Peer, 0, len(cfg.Stores))
+		for j, store := range cfg.Stores {
+			peers = append(peers, config.Peer{
+				StoreID: store.StoreID,
+				PeerID:  layout.PeerIDBase + uint64(i*len(cfg.Stores)+j),
+			})
+		}
+		regions = append(regions, config.Region{
+			ID:       regionID,
+			StartKey: string(r.StartKey),
+			EndKey:   string(r.EndKey),
+			Epoch: config.RegionEpoch{
+				Version:     1,
+				ConfVersion: uint64(len(peers)),
+			},
+			Peers:         peers,
+			LeaderStoreID: leaders[i%len(leaders)],
+		})
+	}
+	return regions, nil
 }
 
 func runCoordinator(args []string) error {

--- a/cmd/nokv-config/main_test.go
+++ b/cmd/nokv-config/main_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 
 	"github.com/feichai0017/NoKV/config"
+	"github.com/feichai0017/NoKV/fsmeta"
 	localmeta "github.com/feichai0017/NoKV/raftstore/localmeta"
 	"github.com/stretchr/testify/require"
 )
@@ -61,6 +62,46 @@ func TestRunRegionsJSONFormat(t *testing.T) {
 	var regions []config.Region
 	require.NoError(t, json.Unmarshal([]byte(output), &regions))
 	require.Len(t, regions, 2)
+}
+
+func TestRunRegionsExpandsFSMetaBootstrapLayout(t *testing.T) {
+	cfg := config.File{
+		Stores: []config.Store{
+			{StoreID: 1, Addr: "store-1"},
+			{StoreID: 2, Addr: "store-2"},
+			{StoreID: 3, Addr: "store-3"},
+		},
+		FSMetaRegionBootstrap: &config.FSMetaRegionBootstrap{
+			Mounts:         []string{"fsmeta-bench"},
+			BucketCount:    fsmeta.DefaultAffinityBucketCount,
+			RegionIDBase:   1000,
+			PeerIDBase:     10_000,
+			LeaderStoreIDs: []uint64{1, 2, 3},
+		},
+	}
+	data, err := json.Marshal(cfg)
+	require.NoError(t, err)
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "config.json")
+	require.NoError(t, os.WriteFile(cfgPath, data, 0o600))
+
+	output, err := captureStdout(t, func() error {
+		return runRegions([]string{"--config", cfgPath, "--format", "json"})
+	})
+	require.NoError(t, err)
+	var regions []config.Region
+	require.NoError(t, json.Unmarshal([]byte(output), &regions))
+	require.Len(t, regions, fsmeta.DefaultAffinityBucketCount+2)
+	require.Equal(t, uint64(1000), regions[0].ID)
+	require.Equal(t, uint64(1), regions[0].LeaderStoreID)
+	require.Equal(t, uint64(2), regions[1].LeaderStoreID)
+	require.Len(t, regions[1].Peers, 3)
+	require.Equal(t, uint64(10_003), regions[1].Peers[0].PeerID)
+
+	start, end, err := fsmeta.EncodeBucketRange("fsmeta-bench", 0)
+	require.NoError(t, err)
+	require.Equal(t, start, []byte(regions[1].StartKey))
+	require.Equal(t, end, []byte(regions[1].EndKey))
 }
 
 func TestRunMetaRootSimpleFormat(t *testing.T) {

--- a/cmd/nokv-fsmeta/main.go
+++ b/cmd/nokv-fsmeta/main.go
@@ -37,7 +37,7 @@ func main() {
 		metricsAddr            = flag.String("metrics-addr", "", "optional HTTP address to expose /debug/vars expvar endpoint")
 		negCacheDir            = flag.String("negative-cache-dir", "", "optional slab directory for persistent negative dentry cache")
 		dirPageDir             = flag.String("dirpage-cache-dir", "", "optional slab directory for ReadDirPlus page cache")
-		inodeAffinityShards    = flag.Int("inode-affinity-shards", 4, "local LSM shard count used to choose Create inode IDs that match dentry shard placement")
+		affinityBuckets        = flag.Int("affinity-buckets", fsmeta.DefaultAffinityBucketCount, "fsmeta placement bucket count used to choose Create inode IDs")
 		lockTTL                = flag.Duration("lock-ttl", 0, "Percolator primary-lock TTL for fsmeta mutations; zero uses the fsmeta default")
 		sessionCleanupInterval = flag.Duration("session-cleanup-interval", 30*time.Second, "interval for expired write-session cleanup; choose about half the smallest expected session TTL; negative disables")
 		sessionCleanupLimit    = flag.Uint("session-cleanup-limit", 0, "maximum session records scanned per mount per cleanup pass; zero uses fsmeta default")
@@ -59,7 +59,7 @@ func main() {
 		CoordinatorAddr:        *coordAddr,
 		NegativeCacheDir:       *negCacheDir,
 		DirPageCacheDir:        *dirPageDir,
-		InodeAffinityShards:    *inodeAffinityShards,
+		AffinityBuckets:        *affinityBuckets,
 		LockTTL:                *lockTTL,
 		SessionCleanupInterval: *sessionCleanupInterval,
 		SessionCleanupLimit:    uint32(*sessionCleanupLimit),

--- a/cmd/nokv/cmd_coordinator.go
+++ b/cmd/nokv/cmd_coordinator.go
@@ -20,6 +20,7 @@ import (
 	"github.com/feichai0017/NoKV/coordinator/rootview"
 	coordserver "github.com/feichai0017/NoKV/coordinator/server"
 	"github.com/feichai0017/NoKV/coordinator/tso"
+	"github.com/feichai0017/NoKV/fsmeta"
 	rootproto "github.com/feichai0017/NoKV/meta/root/protocol"
 	rootstorage "github.com/feichai0017/NoKV/meta/root/storage"
 	coordpb "github.com/feichai0017/NoKV/pb/coordinator"
@@ -61,15 +62,17 @@ func runCoordinatorCmd(w io.Writer, args []string) error {
 	if err := fs.Parse(args); err != nil {
 		return err
 	}
+	var cfg *config.File
 	if strings.TrimSpace(*configPath) != "" {
 		scopeNorm := strings.ToLower(strings.TrimSpace(*scope))
 		if scopeNorm != "host" && scopeNorm != "docker" {
 			return fmt.Errorf("invalid coordinator scope %q (expected host|docker)", *scope)
 		}
-		cfg, err := config.LoadFile(strings.TrimSpace(*configPath))
+		loaded, err := config.LoadFile(strings.TrimSpace(*configPath))
 		if err != nil {
 			return fmt.Errorf("coordinator load config %q: %w", strings.TrimSpace(*configPath), err)
 		}
+		cfg = loaded
 		if err := cfg.Validate(); err != nil {
 			return fmt.Errorf("coordinator validate config %q: %w", strings.TrimSpace(*configPath), err)
 		}
@@ -127,6 +130,13 @@ func runCoordinatorCmd(w io.Writer, args []string) error {
 	ids := idalloc.NewIDAllocator(*idStart)
 	tsAlloc := tso.NewAllocator(*tsStart)
 	svc := coordserver.NewService(cluster, ids, tsAlloc, rootStore)
+	if cfg != nil && cfg.FSMetaRegionBootstrap != nil {
+		boundaries, err := fsmetaBootstrapSplitBoundaries(cfg.FSMetaRegionBootstrap)
+		if err != nil {
+			return err
+		}
+		svc.ConfigureSchedulerSplitBoundaries(boundaries)
+	}
 	parsedDuties, err := parseCoordinatorGrantDuties(*grantDuties)
 	if err != nil {
 		return err
@@ -272,6 +282,21 @@ func dutyNames(duties []rootproto.DutyID) []string {
 		out = append(out, rootproto.DutyName(duty))
 	}
 	return out
+}
+
+func fsmetaBootstrapSplitBoundaries(layout *config.FSMetaRegionBootstrap) ([][]byte, error) {
+	if layout == nil {
+		return nil, nil
+	}
+	mounts := make([]fsmeta.MountID, 0, len(layout.Mounts))
+	for _, mount := range layout.Mounts {
+		mounts = append(mounts, fsmeta.MountID(mount))
+	}
+	boundaries, err := fsmeta.BucketSplitBoundaries(mounts, layout.BucketCount)
+	if err != nil {
+		return nil, fmt.Errorf("coordinator build fsmeta split boundaries: %w", err)
+	}
+	return boundaries, nil
 }
 
 func flagPassed(fs *flag.FlagSet, name string) bool {

--- a/cmd/nokv/cmd_serve.go
+++ b/cmd/nokv/cmd_serve.go
@@ -200,7 +200,7 @@ func runServeCmd(w io.Writer, args []string) error {
 	opt.WorkDir = *workDir
 	opt.MemTableEngine = local.MemTableEngineART
 	opt.ControlLogPointerSnapshot = raftstorestats.ControlLogPointers(localMeta.RaftPointerSnapshot)
-	opt.UserKeyShardRouter = fsmeta.ShardForUserKey
+	opt.UserKeyShapeExtractor = fsmeta.UserKeyShape
 	opt.AllowedModes = []workdirmode.Mode{
 		workdirmode.ModeStandalone,
 		workdirmode.ModeSeeded,

--- a/cmd/nokv/metrics.go
+++ b/cmd/nokv/metrics.go
@@ -130,7 +130,7 @@ func metaRootSnapshot(ctx metaRootExpvarContext) map[string]any {
 func installStorePercolatorExpvar() {
 	storePercolatorOnce.Do(func() {
 		expvar.Publish("nokv_store_percolator", expvar.Func(func() any {
-			return percolator.AtomicMutateStats()
+			return percolator.Stats()
 		}))
 	})
 }

--- a/config/config.go
+++ b/config/config.go
@@ -26,13 +26,14 @@ const (
 //     ignored. Runtime topology (splits, merges, peer changes) lives in
 //     meta-root, not here; use `nokv-config regions` to inspect current state.
 type File struct {
-	MaxRetries                 int          `json:"max_retries"`
-	MetaRoot                   *MetaRoot    `json:"meta_root,omitempty"`
-	Coordinator                *Coordinator `json:"coordinator,omitempty"`
-	StoreWorkDirTemplate       string       `json:"store_work_dir_template,omitempty"`
-	StoreDockerWorkDirTemplate string       `json:"store_docker_work_dir_template,omitempty"`
-	Stores                     []Store      `json:"stores"`
-	Regions                    []Region     `json:"regions"`
+	MaxRetries                 int                    `json:"max_retries"`
+	MetaRoot                   *MetaRoot              `json:"meta_root,omitempty"`
+	Coordinator                *Coordinator           `json:"coordinator,omitempty"`
+	StoreWorkDirTemplate       string                 `json:"store_work_dir_template,omitempty"`
+	StoreDockerWorkDirTemplate string                 `json:"store_docker_work_dir_template,omitempty"`
+	Stores                     []Store                `json:"stores"`
+	Regions                    []Region               `json:"regions"`
+	FSMetaRegionBootstrap      *FSMetaRegionBootstrap `json:"fsmeta_region_bootstrap,omitempty"`
 }
 
 // MetaRoot describes the 3-peer replicated meta-root cluster. NoKV only
@@ -109,6 +110,17 @@ type Peer struct {
 	PeerID  uint64 `json:"peer_id"`
 }
 
+// FSMetaRegionBootstrap is a concise bootstrap-only layout that expands to
+// ordinary byte-range regions in nokv-config. Runtime routing still uses rooted
+// region descriptors; this block is not consulted after fresh store seeding.
+type FSMetaRegionBootstrap struct {
+	Mounts         []string `json:"mounts"`
+	BucketCount    int      `json:"bucket_count"`
+	RegionIDBase   uint64   `json:"region_id_base"`
+	PeerIDBase     uint64   `json:"peer_id_base"`
+	LeaderStoreIDs []uint64 `json:"leader_store_ids,omitempty"`
+}
+
 // LoadFile parses a config file from disk.
 func LoadFile(path string) (*File, error) {
 	data, err := os.ReadFile(path)
@@ -162,6 +174,48 @@ func (f *File) Validate() error {
 			if _, ok := storeIDs[peer.StoreID]; !ok {
 				return fmt.Errorf("config: region %d references unknown store %d", region.ID, peer.StoreID)
 			}
+		}
+	}
+	if err := f.validateFSMetaRegionBootstrap(storeIDs); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (f *File) validateFSMetaRegionBootstrap(storeIDs map[uint64]struct{}) error {
+	if f == nil || f.FSMetaRegionBootstrap == nil {
+		return nil
+	}
+	layout := f.FSMetaRegionBootstrap
+	if len(f.Regions) != 0 {
+		return fmt.Errorf("config: fsmeta_region_bootstrap cannot be combined with explicit regions")
+	}
+	if len(layout.Mounts) == 0 {
+		return fmt.Errorf("config: fsmeta_region_bootstrap.mounts is required")
+	}
+	if layout.BucketCount <= 0 || layout.BucketCount > 1<<16 {
+		return fmt.Errorf("config: fsmeta_region_bootstrap.bucket_count out of range")
+	}
+	if layout.RegionIDBase == 0 || layout.PeerIDBase == 0 {
+		return fmt.Errorf("config: fsmeta_region_bootstrap region_id_base and peer_id_base must be > 0")
+	}
+	if len(storeIDs) == 0 {
+		return fmt.Errorf("config: fsmeta_region_bootstrap requires stores")
+	}
+	mounts := make(map[string]struct{}, len(layout.Mounts))
+	for _, mount := range layout.Mounts {
+		mount = strings.TrimSpace(mount)
+		if mount == "" {
+			return fmt.Errorf("config: fsmeta_region_bootstrap mount cannot be empty")
+		}
+		if _, dup := mounts[mount]; dup {
+			return fmt.Errorf("config: fsmeta_region_bootstrap duplicate mount %q", mount)
+		}
+		mounts[mount] = struct{}{}
+	}
+	for _, storeID := range layout.LeaderStoreIDs {
+		if _, ok := storeIDs[storeID]; !ok {
+			return fmt.Errorf("config: fsmeta_region_bootstrap leader store %d missing from stores", storeID)
 		}
 	}
 	return nil

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -161,6 +161,26 @@ func TestValidatePeerUnknownStore(t *testing.T) {
 	}
 }
 
+func TestValidateFSMetaRegionBootstrap(t *testing.T) {
+	cfg := &File{
+		Stores: []Store{{StoreID: 1, Addr: "x"}},
+		FSMetaRegionBootstrap: &FSMetaRegionBootstrap{
+			Mounts:       []string{"default"},
+			BucketCount:  16,
+			RegionIDBase: 1000,
+			PeerIDBase:   10_000,
+		},
+	}
+	if err := cfg.Validate(); err != nil {
+		t.Fatalf("validate fsmeta bootstrap: %v", err)
+	}
+
+	cfg.Regions = []Region{{ID: 1}}
+	if err := cfg.Validate(); err == nil {
+		t.Fatalf("expected explicit region conflict")
+	}
+}
+
 func TestValidateStoreWorkDirTemplateRequiresID(t *testing.T) {
 	cfg := &File{
 		StoreWorkDirTemplate: "/var/lib/nokv-store",

--- a/coordinator/catalog/store_view.go
+++ b/coordinator/catalog/store_view.go
@@ -8,15 +8,27 @@ import (
 
 // StoreStats captures store-level heartbeat data tracked by Coordinator views.
 type StoreStats struct {
-	StoreID           uint64    `json:"store_id"`
-	ClientAddr        string    `json:"client_addr,omitempty"`
-	RaftAddr          string    `json:"raft_addr,omitempty"`
-	RegionNum         uint64    `json:"region_num"`
-	LeaderNum         uint64    `json:"leader_num"`
-	Capacity          uint64    `json:"capacity"`
-	Available         uint64    `json:"available"`
-	DroppedOperations uint64    `json:"dropped_operations"`
-	UpdatedAt         time.Time `json:"updated_at"`
+	StoreID           uint64        `json:"store_id"`
+	ClientAddr        string        `json:"client_addr,omitempty"`
+	RaftAddr          string        `json:"raft_addr,omitempty"`
+	RegionNum         uint64        `json:"region_num"`
+	LeaderNum         uint64        `json:"leader_num"`
+	Capacity          uint64        `json:"capacity"`
+	Available         uint64        `json:"available"`
+	DroppedOperations uint64        `json:"dropped_operations"`
+	UpdatedAt         time.Time     `json:"updated_at"`
+	RegionStats       []RegionStats `json:"region_stats,omitempty"`
+}
+
+type RegionStats struct {
+	RegionID            uint64 `json:"region_id"`
+	ReadQPS             uint64 `json:"read_qps"`
+	WriteQPS            uint64 `json:"write_qps"`
+	WriteBytesPerSecond uint64 `json:"write_bytes_per_sec"`
+	ApproxRegionBytes   uint64 `json:"approx_region_bytes"`
+	AtomicMutateQPS     uint64 `json:"atomic_mutate_qps"`
+	LeaderStoreID       uint64 `json:"leader_store_id,omitempty"`
+	PendingAdmin        bool   `json:"pending_admin,omitempty"`
 }
 
 // StoreHealthView is the disposable control-plane view of store heartbeats.
@@ -41,6 +53,7 @@ func (v *StoreHealthView) UpsertAt(stats StoreStats, now time.Time) error {
 		return ErrInvalidStoreID
 	}
 	stats.UpdatedAt = now
+	stats.RegionStats = cloneRegionStats(stats.RegionStats)
 	v.mu.Lock()
 	v.stores[stats.StoreID] = stats
 	v.mu.Unlock()
@@ -64,6 +77,7 @@ func (v *StoreHealthView) Get(storeID uint64) (StoreStats, bool) {
 	v.mu.RLock()
 	defer v.mu.RUnlock()
 	stats, ok := v.stores[storeID]
+	stats.RegionStats = cloneRegionStats(stats.RegionStats)
 	return stats, ok
 }
 
@@ -74,9 +88,19 @@ func (v *StoreHealthView) Snapshot() []StoreStats {
 	v.mu.RLock()
 	out := make([]StoreStats, 0, len(v.stores))
 	for _, st := range v.stores {
+		st.RegionStats = cloneRegionStats(st.RegionStats)
 		out = append(out, st)
 	}
 	v.mu.RUnlock()
 	sort.Slice(out, func(i, j int) bool { return out[i].StoreID < out[j].StoreID })
+	return out
+}
+
+func cloneRegionStats(in []RegionStats) []RegionStats {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make([]RegionStats, len(in))
+	copy(out, in)
 	return out
 }

--- a/coordinator/client/client.go
+++ b/coordinator/client/client.go
@@ -66,9 +66,13 @@ type grpcEndpoint struct {
 	coord coordpb.CoordinatorClient
 }
 
-const maxAuthorityMissRetryRounds = 3
-const defaultAuthorityClockSkewAllowance = time.Second
-const defaultAuthorityMaxReplyAge = 30 * time.Second
+const (
+	maxAuthorityMissRetryRounds        = 8
+	authorityMissRetryBackoff          = 20 * time.Millisecond
+	authorityMissRetryMaxBackoff       = 120 * time.Millisecond
+	defaultAuthorityClockSkewAllowance = time.Second
+	defaultAuthorityMaxReplyAge        = 30 * time.Second
+)
 
 type GRPCClientOptions struct {
 	VerifierStore               AuthorityVerifierStore
@@ -215,35 +219,35 @@ func (c *GRPCClient) StoreHeartbeat(ctx context.Context, req *coordpb.StoreHeart
 
 // RegionLiveness forwards region liveness heartbeat RPC.
 func (c *GRPCClient) RegionLiveness(ctx context.Context, req *coordpb.RegionLivenessRequest) (*coordpb.RegionLivenessResponse, error) {
-	return invokeRPCValidated(c, retryableRead, func(coord coordpb.CoordinatorClient) (*coordpb.RegionLivenessResponse, error) {
+	return invokeRPCValidated(ctx, c, retryableRead, func(coord coordpb.CoordinatorClient) (*coordpb.RegionLivenessResponse, error) {
 		return coord.RegionLiveness(ctx, req)
 	}, nil)
 }
 
 // PublishRootEvent forwards explicit rooted event RPC.
 func (c *GRPCClient) PublishRootEvent(ctx context.Context, req *coordpb.PublishRootEventRequest) (*coordpb.PublishRootEventResponse, error) {
-	return invokeRPCValidated(c, retryableWrite, func(coord coordpb.CoordinatorClient) (*coordpb.PublishRootEventResponse, error) {
+	return invokeRPCValidated(ctx, c, retryableWrite, func(coord coordpb.CoordinatorClient) (*coordpb.PublishRootEventResponse, error) {
 		return coord.PublishRootEvent(ctx, req)
 	}, nil)
 }
 
 // ListTransitions returns the rooted pending transition view.
 func (c *GRPCClient) ListTransitions(ctx context.Context, req *coordpb.ListTransitionsRequest) (*coordpb.ListTransitionsResponse, error) {
-	return invokeRPCValidated(c, retryableRead, func(coord coordpb.CoordinatorClient) (*coordpb.ListTransitionsResponse, error) {
+	return invokeRPCValidated(ctx, c, retryableRead, func(coord coordpb.CoordinatorClient) (*coordpb.ListTransitionsResponse, error) {
 		return coord.ListTransitions(ctx, req)
 	}, nil)
 }
 
 // AssessRootEvent evaluates one rooted transition event without mutating truth.
 func (c *GRPCClient) AssessRootEvent(ctx context.Context, req *coordpb.AssessRootEventRequest) (*coordpb.AssessRootEventResponse, error) {
-	return invokeRPCValidated(c, retryableRead, func(coord coordpb.CoordinatorClient) (*coordpb.AssessRootEventResponse, error) {
+	return invokeRPCValidated(ctx, c, retryableRead, func(coord coordpb.CoordinatorClient) (*coordpb.AssessRootEventResponse, error) {
 		return coord.AssessRootEvent(ctx, req)
 	}, nil)
 }
 
 // RemoveRegion forwards region removal RPC.
 func (c *GRPCClient) RemoveRegion(ctx context.Context, req *coordpb.RemoveRegionRequest) (*coordpb.RemoveRegionResponse, error) {
-	return invokeRPCValidated(c, retryableWrite, func(coord coordpb.CoordinatorClient) (*coordpb.RemoveRegionResponse, error) {
+	return invokeRPCValidated(ctx, c, retryableWrite, func(coord coordpb.CoordinatorClient) (*coordpb.RemoveRegionResponse, error) {
 		return coord.RemoveRegion(ctx, req)
 	}, nil)
 }
@@ -253,7 +257,7 @@ func (c *GRPCClient) GetRegionByKey(ctx context.Context, req *coordpb.GetRegionB
 	// Region lookup is a metadata authority read: standby coordinators can
 	// reject it with grant-not-held, so it must fail over like TSO/AllocID even
 	// though the RPC does not mutate user metadata.
-	return invokeDutyRPCValidated(c, rootproto.DutyRegionLookup, retryableWrite, func(coord coordpb.CoordinatorClient) (*coordpb.GetRegionByKeyResponse, error) {
+	return invokeDutyRPCValidated(ctx, c, rootproto.DutyRegionLookup, retryableWrite, func(coord coordpb.CoordinatorClient) (*coordpb.GetRegionByKeyResponse, error) {
 		return coord.GetRegionByKey(ctx, req)
 	}, func(resp *coordpb.GetRegionByKeyResponse) error {
 		return c.validateGetRegionByKeyResponse(req, resp)
@@ -262,44 +266,44 @@ func (c *GRPCClient) GetRegionByKey(ctx context.Context, req *coordpb.GetRegionB
 
 // GetStore returns the current runtime endpoint for one store.
 func (c *GRPCClient) GetStore(ctx context.Context, req *coordpb.GetStoreRequest) (*coordpb.GetStoreResponse, error) {
-	return invokeRPCValidated(c, retryableRead, func(coord coordpb.CoordinatorClient) (*coordpb.GetStoreResponse, error) {
+	return invokeRPCValidated(ctx, c, retryableRead, func(coord coordpb.CoordinatorClient) (*coordpb.GetStoreResponse, error) {
 		return coord.GetStore(ctx, req)
 	}, validateGetStoreResponse)
 }
 
 // ListStores returns the current runtime store registry snapshot.
 func (c *GRPCClient) ListStores(ctx context.Context, req *coordpb.ListStoresRequest) (*coordpb.ListStoresResponse, error) {
-	return invokeRPCValidated(c, retryableRead, func(coord coordpb.CoordinatorClient) (*coordpb.ListStoresResponse, error) {
+	return invokeRPCValidated(ctx, c, retryableRead, func(coord coordpb.CoordinatorClient) (*coordpb.ListStoresResponse, error) {
 		return coord.ListStores(ctx, req)
 	}, validateListStoresResponse)
 }
 
 func (c *GRPCClient) GetMount(ctx context.Context, req *coordpb.GetMountRequest) (*coordpb.GetMountResponse, error) {
-	return invokeRPCValidated(c, retryableRead, func(coord coordpb.CoordinatorClient) (*coordpb.GetMountResponse, error) {
+	return invokeRPCValidated(ctx, c, retryableRead, func(coord coordpb.CoordinatorClient) (*coordpb.GetMountResponse, error) {
 		return coord.GetMount(ctx, req)
 	}, validateGetMountResponse)
 }
 
 func (c *GRPCClient) ListMounts(ctx context.Context, req *coordpb.ListMountsRequest) (*coordpb.ListMountsResponse, error) {
-	return invokeRPCValidated(c, retryableRead, func(coord coordpb.CoordinatorClient) (*coordpb.ListMountsResponse, error) {
+	return invokeRPCValidated(ctx, c, retryableRead, func(coord coordpb.CoordinatorClient) (*coordpb.ListMountsResponse, error) {
 		return coord.ListMounts(ctx, req)
 	}, validateListMountsResponse)
 }
 
 func (c *GRPCClient) ListSubtreeAuthorities(ctx context.Context, req *coordpb.ListSubtreeAuthoritiesRequest) (*coordpb.ListSubtreeAuthoritiesResponse, error) {
-	return invokeRPCValidated(c, retryableRead, func(coord coordpb.CoordinatorClient) (*coordpb.ListSubtreeAuthoritiesResponse, error) {
+	return invokeRPCValidated(ctx, c, retryableRead, func(coord coordpb.CoordinatorClient) (*coordpb.ListSubtreeAuthoritiesResponse, error) {
 		return coord.ListSubtreeAuthorities(ctx, req)
 	}, validateListSubtreeAuthoritiesResponse)
 }
 
 func (c *GRPCClient) GetQuotaFence(ctx context.Context, req *coordpb.GetQuotaFenceRequest) (*coordpb.GetQuotaFenceResponse, error) {
-	return invokeRPCValidated(c, retryableRead, func(coord coordpb.CoordinatorClient) (*coordpb.GetQuotaFenceResponse, error) {
+	return invokeRPCValidated(ctx, c, retryableRead, func(coord coordpb.CoordinatorClient) (*coordpb.GetQuotaFenceResponse, error) {
 		return coord.GetQuotaFence(ctx, req)
 	}, validateGetQuotaFenceResponse)
 }
 
 func (c *GRPCClient) ListQuotaFences(ctx context.Context, req *coordpb.ListQuotaFencesRequest) (*coordpb.ListQuotaFencesResponse, error) {
-	return invokeRPCValidated(c, retryableRead, func(coord coordpb.CoordinatorClient) (*coordpb.ListQuotaFencesResponse, error) {
+	return invokeRPCValidated(ctx, c, retryableRead, func(coord coordpb.CoordinatorClient) (*coordpb.ListQuotaFencesResponse, error) {
 		return coord.ListQuotaFences(ctx, req)
 	}, validateListQuotaFencesResponse)
 }
@@ -332,7 +336,7 @@ func (c *GRPCClient) WatchRootEvents(ctx context.Context, req *coordpb.WatchRoot
 
 // AllocID forwards ID allocation RPC.
 func (c *GRPCClient) AllocID(ctx context.Context, req *coordpb.AllocIDRequest) (*coordpb.AllocIDResponse, error) {
-	return invokeDutyRPCValidated(c, rootproto.DutyAllocID, retryableWrite, func(coord coordpb.CoordinatorClient) (*coordpb.AllocIDResponse, error) {
+	return invokeDutyRPCValidated(ctx, c, rootproto.DutyAllocID, retryableWrite, func(coord coordpb.CoordinatorClient) (*coordpb.AllocIDResponse, error) {
 		return coord.AllocID(ctx, req)
 	}, func(resp *coordpb.AllocIDResponse) error {
 		return c.validateAllocIDResponse(req, resp)
@@ -341,7 +345,7 @@ func (c *GRPCClient) AllocID(ctx context.Context, req *coordpb.AllocIDRequest) (
 
 // Tso forwards TSO allocation RPC.
 func (c *GRPCClient) Tso(ctx context.Context, req *coordpb.TsoRequest) (*coordpb.TsoResponse, error) {
-	return invokeDutyRPCValidated(c, rootproto.DutyTSO, retryableWrite, func(coord coordpb.CoordinatorClient) (*coordpb.TsoResponse, error) {
+	return invokeDutyRPCValidated(ctx, c, rootproto.DutyTSO, retryableWrite, func(coord coordpb.CoordinatorClient) (*coordpb.TsoResponse, error) {
 		return coord.Tso(ctx, req)
 	}, func(resp *coordpb.TsoResponse) error {
 		return c.validateTSOResponse(req, resp)
@@ -454,11 +458,11 @@ func (c *GRPCClient) markPreferredForDuty(duty rootproto.DutyID, addr string) {
 	}
 }
 
-func invokeRPCValidated[T any](c *GRPCClient, retryable func(error) bool, call func(coord coordpb.CoordinatorClient) (T, error), validate func(T) error) (T, error) {
-	return invokeDutyRPCValidated(c, "", retryable, call, validate)
+func invokeRPCValidated[T any](ctx context.Context, c *GRPCClient, retryable func(error) bool, call func(coord coordpb.CoordinatorClient) (T, error), validate func(T) error) (T, error) {
+	return invokeDutyRPCValidated(ctx, c, "", retryable, call, validate)
 }
 
-func invokeDutyRPCValidated[T any](c *GRPCClient, duty rootproto.DutyID, retryable func(error) bool, call func(coord coordpb.CoordinatorClient) (T, error), validate func(T) error) (T, error) {
+func invokeDutyRPCValidated[T any](ctx context.Context, c *GRPCClient, duty rootproto.DutyID, retryable func(error) bool, call func(coord coordpb.CoordinatorClient) (T, error), validate func(T) error) (T, error) {
 	var zero T
 	if c == nil {
 		return zero, errNoReachableAddress
@@ -470,9 +474,14 @@ func invokeDutyRPCValidated[T any](c *GRPCClient, duty rootproto.DutyID, retryab
 			return zero, errNoReachableAddress
 		}
 		// Not-leader / grant-not-held replies mean the client reached a coordinator,
-		// but not the current authority. If every endpoint misses authority, retry
-		// the whole set briefly so root write access and grant ownership can converge.
+		// but not the current authority. A holder can also be briefly unavailable
+		// during root grant renewal or allocator persistence. In both cases retry
+		// the whole endpoint set as a unit so a standby rejection from the last
+		// endpoint does not mask a converging holder.
 		allAuthorityMiss := true
+		allRetryable := true
+		roundConverging := true
+		var lastNonAuthorityErr error
 		for i, endpoint := range endpoints {
 			resp, err := call(endpoint.coord)
 			if err == nil && validate != nil {
@@ -485,15 +494,32 @@ func invokeDutyRPCValidated[T any](c *GRPCClient, duty rootproto.DutyID, retryab
 			lastErr = err
 			if !isAuthorityMiss(err) {
 				allAuthorityMiss = false
+				lastNonAuthorityErr = err
 			}
-			if i == len(endpoints)-1 || !retryable(err) {
-				if allAuthorityMiss && retryable(err) && round+1 < maxAuthorityMissRetryRounds {
-					break
-				}
+			if !isDutyConvergenceError(err) {
+				roundConverging = false
+			}
+			if !retryable(err) {
 				return zero, err
 			}
+			if i == len(endpoints)-1 && roundConverging && round+1 < maxAuthorityMissRetryRounds {
+				if waitErr := waitAuthorityMissRetry(ctx, round); waitErr != nil {
+					return zero, waitErr
+				}
+				break
+			}
+			allRetryable = allRetryable && retryable(err)
 		}
-		if !allAuthorityMiss {
+		if !allRetryable {
+			if lastNonAuthorityErr != nil {
+				return zero, lastNonAuthorityErr
+			}
+			return zero, lastErr
+		}
+		if !allAuthorityMiss && (!roundConverging || round+1 >= maxAuthorityMissRetryRounds) {
+			if lastNonAuthorityErr != nil {
+				return zero, lastNonAuthorityErr
+			}
 			return zero, lastErr
 		}
 	}
@@ -501,6 +527,44 @@ func invokeDutyRPCValidated[T any](c *GRPCClient, duty rootproto.DutyID, retryab
 		lastErr = errNoReachableAddress
 	}
 	return zero, lastErr
+}
+
+func isDutyConvergenceError(err error) bool {
+	if isAuthorityMiss(err) {
+		return true
+	}
+	switch nokverrors.KindOf(err) {
+	case nokverrors.KindUnavailable, nokverrors.KindRetryable, nokverrors.KindStaleEpoch:
+		return true
+	default:
+		return false
+	}
+}
+
+func waitAuthorityMissRetry(ctx context.Context, round int) error {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	// All endpoints missing the same duty usually means root grant issue,
+	// renewal, or route-view publication is still converging. Back off within
+	// the caller's deadline instead of leaking that short authority gap to the
+	// metadata operation.
+	backoff := authorityMissRetryBackoff
+	for range round {
+		if backoff >= authorityMissRetryMaxBackoff/2 {
+			backoff = authorityMissRetryMaxBackoff
+			break
+		}
+		backoff *= 2
+	}
+	timer := time.NewTimer(backoff)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-timer.C:
+		return nil
+	}
 }
 
 func retryableRead(err error) bool {
@@ -533,9 +597,8 @@ type witnessEraFloor struct {
 }
 
 type metadataAttachedFloor struct {
-	hasCurrentToken    bool
-	currentToken       *coordpb.RootToken
-	descriptorRevision uint64
+	hasCurrentToken bool
+	currentToken    *coordpb.RootToken
 }
 
 type metadataWitnessExpectation struct {
@@ -905,16 +968,6 @@ func (c *GRPCClient) advanceAttachedMetadataFloor(resp *coordpb.GetRegionByKeyRe
 			errInvalidWitness,
 		)
 	}
-	if c.metadataAttached.descriptorRevision != 0 &&
-		resp.GetDescriptorRevision() != 0 &&
-		resp.GetDescriptorRevision() < c.metadataAttached.descriptorRevision {
-		return fmt.Errorf(
-			"%w: get_region_by_key era=0 descriptor_revision=%d attached_floor=%d",
-			errInvalidWitness,
-			resp.GetDescriptorRevision(),
-			c.metadataAttached.descriptorRevision,
-		)
-	}
 	storeState, err := c.loadVerifierStateLocked(rootproto.DutyRegionLookup)
 	if err != nil {
 		return err
@@ -926,27 +979,10 @@ func (c *GRPCClient) advanceAttachedMetadataFloor(resp *coordpb.GetRegionByKeyRe
 			errInvalidWitness,
 		)
 	}
-	if storeState.MaxDescriptorRevision != 0 &&
-		resp.GetDescriptorRevision() != 0 &&
-		resp.GetDescriptorRevision() < storeState.MaxDescriptorRevision {
-		return fmt.Errorf(
-			"%w: get_region_by_key era=0 descriptor_revision=%d durable_floor=%d",
-			errInvalidWitness,
-			resp.GetDescriptorRevision(),
-			storeState.MaxDescriptorRevision,
-		)
-	}
-
 	if currentToken != nil {
 		c.metadataAttached.currentToken = proto.Clone(currentToken).(*coordpb.RootToken)
 		c.metadataAttached.hasCurrentToken = true
 		storeState.MaxRootToken = authorityRootTokenFromCoordProto(currentToken)
-	}
-	if resp.GetDescriptorRevision() > c.metadataAttached.descriptorRevision {
-		c.metadataAttached.descriptorRevision = resp.GetDescriptorRevision()
-	}
-	if resp.GetDescriptorRevision() > storeState.MaxDescriptorRevision {
-		storeState.MaxDescriptorRevision = resp.GetDescriptorRevision()
 	}
 	if err := c.saveVerifierStateLocked(storeState); err != nil {
 		return err
@@ -966,17 +1002,14 @@ func (c *GRPCClient) advanceMetadataVerifierRootFloor(resp *coordpb.GetRegionByK
 		!metadataRootTokenSatisfied(currentToken, authorityRootTokenToCoordProto(storeState.MaxRootToken)) {
 		return fmt.Errorf("%w: get_region_by_key current_root_token regressed behind durable verifier floor", errInvalidWitness)
 	}
-	if storeState.MaxDescriptorRevision != 0 &&
-		resp.GetDescriptorRevision() != 0 &&
-		resp.GetDescriptorRevision() < storeState.MaxDescriptorRevision {
-		return fmt.Errorf("%w: get_region_by_key descriptor_revision=%d durable_floor=%d", errInvalidWitness, resp.GetDescriptorRevision(), storeState.MaxDescriptorRevision)
-	}
 	if currentToken != nil {
 		storeState.MaxRootToken = authorityRootTokenFromCoordProto(currentToken)
 	}
-	if resp.GetDescriptorRevision() > storeState.MaxDescriptorRevision {
-		storeState.MaxDescriptorRevision = resp.GetDescriptorRevision()
-	}
+	// DescriptorRevision is the returned region descriptor's own root epoch.
+	// Different bucket regions can validly carry lower root epochs than a
+	// previously observed hot region, so only the root token is a global durable
+	// floor. Per-request descriptor_revision checks stay in
+	// validateGetRegionByKeyResponse.
 	return c.saveVerifierStateLocked(storeState)
 }
 

--- a/coordinator/client/client_test.go
+++ b/coordinator/client/client_test.go
@@ -596,6 +596,79 @@ func TestGRPCClientRetriesTSOAfterFullGrantMissRound(t *testing.T) {
 	require.Equal(t, "passthrough:///holder", cli.orderedEndpointsForDuty(rootproto.DutyTSO)[0].addr)
 }
 
+func TestGRPCClientRetriesDutyRoundWhenHolderTemporarilyUnavailable(t *testing.T) {
+	grantErr := grantNotHeldErrorForTest()
+	servers := map[string]*scriptedCoordinatorServer{
+		"holder": {
+			tsoErrors: []error{status.Error(codes.Unavailable, "holder is renewing grant")},
+			tsoResponses: []*coordpb.TsoResponse{{
+				Timestamp:        400,
+				Count:            1,
+				Era:              4,
+				ConsumedFrontier: 400,
+			}},
+		},
+		"standby": {
+			tsoErrors: []error{grantErr},
+		},
+	}
+	cli := newScriptedCoordinatorClient(t, []string{"holder", "standby"}, servers)
+
+	resp, err := cli.Tso(context.Background(), &coordpb.TsoRequest{Count: 1})
+	require.NoError(t, err)
+	require.Equal(t, uint64(400), resp.GetTimestamp())
+	require.Equal(t, 2, servers["holder"].tsoCalls)
+	require.Equal(t, 1, servers["standby"].tsoCalls)
+	require.Equal(t, "passthrough:///holder", cli.orderedEndpointsForDuty(rootproto.DutyTSO)[0].addr)
+}
+
+func TestGRPCClientRetriesStaleWitnessAcrossDutyRounds(t *testing.T) {
+	servers := map[string]*scriptedCoordinatorServer{
+		"holder": {
+			tsoResponses: []*coordpb.TsoResponse{
+				{
+					Timestamp:               500,
+					Count:                   1,
+					Era:                     5,
+					ConsumedFrontier:        500,
+					ObservedRetiredEraFloor: 5,
+				},
+				{
+					Timestamp:        501,
+					Count:            1,
+					Era:              6,
+					ConsumedFrontier: 501,
+				},
+			},
+		},
+	}
+	cli := newScriptedCoordinatorClient(t, []string{"holder"}, servers)
+
+	resp, err := cli.Tso(context.Background(), &coordpb.TsoRequest{Count: 1})
+	require.NoError(t, err)
+	require.Equal(t, uint64(501), resp.GetTimestamp())
+	require.Equal(t, 2, servers["holder"].tsoCalls)
+}
+
+func TestGRPCClientAuthorityMissRetryHonorsContext(t *testing.T) {
+	grantErr := grantNotHeldErrorForTest()
+	servers := map[string]*scriptedCoordinatorServer{
+		"standby": {
+			tsoErrors: []error{
+				grantErr, grantErr, grantErr, grantErr,
+				grantErr, grantErr, grantErr, grantErr,
+			},
+		},
+	}
+	cli := newScriptedCoordinatorClient(t, []string{"standby"}, servers)
+	ctx, cancel := context.WithTimeout(context.Background(), time.Millisecond)
+	defer cancel()
+
+	_, err := cli.Tso(ctx, &coordpb.TsoRequest{Count: 1})
+	require.ErrorIs(t, err, context.DeadlineExceeded)
+	require.Equal(t, 1, servers["standby"].tsoCalls)
+}
+
 func TestGRPCClientRejectsInvalidAllocWitness(t *testing.T) {
 	cli := newScriptedCoordinatorClient(t, []string{"alloc-invalid"}, map[string]*scriptedCoordinatorServer{
 		"alloc-invalid": {
@@ -782,6 +855,64 @@ func TestGRPCClientAcceptsValidMetadataWitness(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, resp)
 	require.Equal(t, uint64(11), resp.GetRegionDescriptor().GetRegionId())
+}
+
+func TestGRPCClientAcceptsLowerDescriptorRevisionFromDifferentRegion(t *testing.T) {
+	cli := newScriptedCoordinatorClient(t, []string{"metadata-valid"}, map[string]*scriptedCoordinatorServer{
+		"metadata-valid": {
+			getResponses: []*coordpb.GetRegionByKeyResponse{
+				{
+					RegionDescriptor:           &metapb.RegionDescriptor{RegionId: 21, RootEpoch: 100},
+					ServedRootToken:            &coordpb.RootToken{Term: 2, Index: 100, Revision: 100},
+					CurrentRootToken:           &coordpb.RootToken{Term: 2, Index: 101, Revision: 101},
+					ServedFreshness:            coordpb.Freshness_FRESHNESS_BOUNDED,
+					RootLag:                    1,
+					CatchUpState:               coordpb.CatchUpState_CATCH_UP_STATE_LAGGING,
+					DescriptorRevision:         100,
+					RequiredDescriptorRevision: 1,
+					Era:                        7,
+					ServingClass:               coordpb.ServingClass_SERVING_CLASS_BOUNDED_STALE,
+					SyncHealth:                 coordpb.SyncHealth_SYNC_HEALTH_LAGGING,
+				},
+				{
+					RegionDescriptor:           &metapb.RegionDescriptor{RegionId: 22, RootEpoch: 12},
+					ServedRootToken:            &coordpb.RootToken{Term: 2, Index: 101, Revision: 101},
+					CurrentRootToken:           &coordpb.RootToken{Term: 2, Index: 102, Revision: 102},
+					ServedFreshness:            coordpb.Freshness_FRESHNESS_BOUNDED,
+					RootLag:                    1,
+					CatchUpState:               coordpb.CatchUpState_CATCH_UP_STATE_LAGGING,
+					DescriptorRevision:         12,
+					RequiredDescriptorRevision: 1,
+					Era:                        7,
+					ServingClass:               coordpb.ServingClass_SERVING_CLASS_BOUNDED_STALE,
+					SyncHealth:                 coordpb.SyncHealth_SYNC_HEALTH_LAGGING,
+				},
+			},
+		},
+	})
+
+	resp, err := cli.GetRegionByKey(context.Background(), &coordpb.GetRegionByKeyRequest{
+		Key:                        []byte("hot-bucket"),
+		Freshness:                  coordpb.Freshness_FRESHNESS_BOUNDED,
+		RequiredRootToken:          &coordpb.RootToken{Term: 2, Index: 100, Revision: 100},
+		RequiredDescriptorRevision: 1,
+		MaxRootLag:                 proto.Uint64(2),
+	})
+	require.NoError(t, err)
+	require.Equal(t, uint64(21), resp.GetRegionDescriptor().GetRegionId())
+
+	// Region descriptor revisions are per-region root epochs. A later lookup
+	// for a colder bucket can return a lower descriptor revision while still
+	// carrying a monotone current root token and valid region-lookup evidence.
+	resp, err = cli.GetRegionByKey(context.Background(), &coordpb.GetRegionByKeyRequest{
+		Key:                        []byte("cold-bucket"),
+		Freshness:                  coordpb.Freshness_FRESHNESS_BOUNDED,
+		RequiredRootToken:          &coordpb.RootToken{Term: 2, Index: 101, Revision: 101},
+		RequiredDescriptorRevision: 1,
+		MaxRootLag:                 proto.Uint64(2),
+	})
+	require.NoError(t, err)
+	require.Equal(t, uint64(22), resp.GetRegionDescriptor().GetRegionId())
 }
 
 func TestGRPCClientRetriesStaleMetadataWitnessEraAcrossEndpoints(t *testing.T) {
@@ -1192,21 +1323,15 @@ func TestValidateAuthorityEvidenceRejectsMissingServedTime(t *testing.T) {
 }
 
 func TestGRPCClientRejectsReplyAtObservedSealFloor(t *testing.T) {
-	cli := newScriptedCoordinatorClient(t, []string{"mixed"}, map[string]*scriptedCoordinatorServer{
-		"mixed": {
-			allocResponses: []*coordpb.AllocIDResponse{
-				{
-					FirstId:                 100,
-					Count:                   1,
-					Era:                     2,
-					ConsumedFrontier:        100,
-					ObservedRetiredEraFloor: 2,
-				},
-			},
-		},
+	cli := &GRPCClient{verifierStore: NewMemoryAuthorityVerifierStore(), verifierClusterID: "test"}
+	err := cli.validateAllocIDResponse(&coordpb.AllocIDRequest{Count: 1}, &coordpb.AllocIDResponse{
+		FirstId:                 100,
+		Count:                   1,
+		Era:                     2,
+		ConsumedFrontier:        100,
+		ObservedRetiredEraFloor: 2,
+		AuthorityEvidence:       defaultAuthorityEvidence(rootproto.DutyAllocID, rootproto.DutyBound{Kind: rootproto.DutyBoundMonotone, MonotoneUpper: 100}, 2, 2),
 	})
-
-	_, err := cli.AllocID(context.Background(), &coordpb.AllocIDRequest{Count: 1})
 	require.Error(t, err)
 	require.True(t, IsStaleWitnessEra(err))
 	require.Contains(t, err.Error(), "retired_floor=2")

--- a/coordinator/scheduling/planner.go
+++ b/coordinator/scheduling/planner.go
@@ -7,29 +7,589 @@
 package scheduling
 
 import (
+	"bytes"
+	"sort"
+	"sync"
+
 	"github.com/feichai0017/NoKV/coordinator/catalog"
 	metaregion "github.com/feichai0017/NoKV/meta/region"
 	"github.com/feichai0017/NoKV/meta/topology"
+	metawire "github.com/feichai0017/NoKV/meta/wire"
 	coordpb "github.com/feichai0017/NoKV/pb/coordinator"
 )
 
-// PlanStoreOperations builds lightweight control-plane operations for the
-// heartbeat source store. The current policy only balances raft leaders; richer
-// replica repair, drain, placement, and hotspot policies should plug in here
-// instead of growing coordinator/server.
+const (
+	defaultHotRegionWriteQPS      uint64 = 2_000
+	defaultHotRegionWriteBytesPS  uint64 = 8 << 20
+	defaultColdRegionWriteQPS     uint64 = 10
+	defaultColdRegionReadQPS      uint64 = 10
+	defaultMergeMaxApproxBytes    uint64 = 128 << 20
+	defaultHotRegionWindows              = 3
+	defaultColdRegionWindows             = 5
+	defaultSchedulerCooldownTicks uint64 = 3
+	defaultMaxOperationsPerStore         = 1
+)
+
+type PlanOptions struct {
+	HotRegionWriteQPS     uint64
+	HotRegionWriteBytesPS uint64
+	ColdRegionWriteQPS    uint64
+	ColdRegionReadQPS     uint64
+	MergeMaxApproxBytes   uint64
+	NextID                func() (uint64, bool)
+	SplitKey              func(topology.Descriptor) ([]byte, bool)
+	HotRegionWindows      int
+	ColdRegionWindows     int
+	CooldownTicks         uint64
+	MaxOperationsPerStore int
+}
+
+type Planner struct {
+	mu       sync.Mutex
+	opts     PlanOptions
+	tick     uint64
+	hot      map[uint64]int
+	cold     map[regionPair]int
+	cooldown map[uint64]uint64
+}
+
+type regionPair struct {
+	left  uint64
+	right uint64
+}
+
+func NewPlanner(opts PlanOptions) *Planner {
+	return &Planner{
+		opts:     normalizeOptions(opts, true),
+		hot:      make(map[uint64]int),
+		cold:     make(map[regionPair]int),
+		cooldown: make(map[uint64]uint64),
+	}
+}
+
+func (p *Planner) ConfigureOptions(opts PlanOptions) {
+	if p == nil {
+		return
+	}
+	p.mu.Lock()
+	p.opts = mergeOptions(p.opts, opts)
+	p.mu.Unlock()
+}
+
+// PlanStoreOperations builds bounded control-plane operations for the heartbeat
+// source store. The ordering is deliberate: leader transfer is cheapest and
+// does not disturb route epochs, while split and merge mutate rooted topology.
 func PlanStoreOperations(heartbeatStoreID uint64, snapshot catalog.ClusterSnapshot) []*coordpb.SchedulerOperation {
+	return PlanStoreOperationsWithOptions(heartbeatStoreID, snapshot, PlanOptions{})
+}
+
+func PlanStoreOperationsWithOptions(heartbeatStoreID uint64, snapshot catalog.ClusterSnapshot, opts PlanOptions) []*coordpb.SchedulerOperation {
+	return planStoreOperationsImmediate(heartbeatStoreID, snapshot, normalizeOptions(opts, false))
+}
+
+func (p *Planner) PlanStoreOperationsWithOptions(heartbeatStoreID uint64, snapshot catalog.ClusterSnapshot, opts PlanOptions) []*coordpb.SchedulerOperation {
+	if p == nil {
+		return PlanStoreOperationsWithOptions(heartbeatStoreID, snapshot, opts)
+	}
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.tick++
+	merged := mergeOptions(p.opts, opts)
+	p.prune(snapshot)
+	return p.plan(heartbeatStoreID, snapshot, merged)
+}
+
+func planStoreOperationsImmediate(heartbeatStoreID uint64, snapshot catalog.ClusterSnapshot, opts PlanOptions) []*coordpb.SchedulerOperation {
 	if heartbeatStoreID == 0 || len(snapshot.Stores) < 2 {
 		return nil
 	}
+	if op, ok := planLeaderTransfer(heartbeatStoreID, snapshot); ok {
+		return []*coordpb.SchedulerOperation{op}
+	}
+	if op, ok := planHotRegionSplit(heartbeatStoreID, snapshot, opts); ok {
+		return []*coordpb.SchedulerOperation{op}
+	}
+	if op, ok := planColdRegionMerge(heartbeatStoreID, snapshot, opts); ok {
+		return []*coordpb.SchedulerOperation{op}
+	}
+	return nil
+}
+
+func (p *Planner) plan(heartbeatStoreID uint64, snapshot catalog.ClusterSnapshot, opts PlanOptions) []*coordpb.SchedulerOperation {
+	if heartbeatStoreID == 0 || len(snapshot.Stores) < 2 {
+		return nil
+	}
+	maxOps := opts.MaxOperationsPerStore
+	if maxOps <= 0 {
+		maxOps = defaultMaxOperationsPerStore
+	}
+	ops := make([]*coordpb.SchedulerOperation, 0, maxOps)
+	if op, ok := planLeaderTransfer(heartbeatStoreID, snapshot); ok && !p.operationInCooldown(op) {
+		ops = append(ops, op)
+		p.markOperationCooldown(op, opts.CooldownTicks)
+		return ops
+	}
+	if op, ok := p.planHotRegionSplit(heartbeatStoreID, snapshot, opts); ok {
+		ops = append(ops, op)
+		p.markOperationCooldown(op, opts.CooldownTicks)
+		return ops
+	}
+	if op, ok := p.planColdRegionMerge(heartbeatStoreID, snapshot, opts); ok {
+		ops = append(ops, op)
+		p.markOperationCooldown(op, opts.CooldownTicks)
+		return ops
+	}
+	return nil
+}
+
+func normalizeOptions(opts PlanOptions, stateful bool) PlanOptions {
+	if opts.HotRegionWriteQPS == 0 {
+		opts.HotRegionWriteQPS = defaultHotRegionWriteQPS
+	}
+	if opts.HotRegionWriteBytesPS == 0 {
+		opts.HotRegionWriteBytesPS = defaultHotRegionWriteBytesPS
+	}
+	if opts.ColdRegionWriteQPS == 0 {
+		opts.ColdRegionWriteQPS = defaultColdRegionWriteQPS
+	}
+	if opts.ColdRegionReadQPS == 0 {
+		opts.ColdRegionReadQPS = defaultColdRegionReadQPS
+	}
+	if opts.MergeMaxApproxBytes == 0 {
+		opts.MergeMaxApproxBytes = defaultMergeMaxApproxBytes
+	}
+	if opts.SplitKey == nil {
+		opts.SplitKey = midpointSplitKey
+	}
+	if opts.HotRegionWindows <= 0 {
+		if stateful {
+			opts.HotRegionWindows = defaultHotRegionWindows
+		} else {
+			opts.HotRegionWindows = 1
+		}
+	}
+	if opts.ColdRegionWindows <= 0 {
+		if stateful {
+			opts.ColdRegionWindows = defaultColdRegionWindows
+		} else {
+			opts.ColdRegionWindows = 1
+		}
+	}
+	if opts.CooldownTicks == 0 && stateful {
+		opts.CooldownTicks = defaultSchedulerCooldownTicks
+	}
+	if opts.MaxOperationsPerStore <= 0 {
+		opts.MaxOperationsPerStore = defaultMaxOperationsPerStore
+	}
+	return opts
+}
+
+func mergeOptions(base, override PlanOptions) PlanOptions {
+	out := base
+	if override.HotRegionWriteQPS != 0 {
+		out.HotRegionWriteQPS = override.HotRegionWriteQPS
+	}
+	if override.HotRegionWriteBytesPS != 0 {
+		out.HotRegionWriteBytesPS = override.HotRegionWriteBytesPS
+	}
+	if override.ColdRegionWriteQPS != 0 {
+		out.ColdRegionWriteQPS = override.ColdRegionWriteQPS
+	}
+	if override.ColdRegionReadQPS != 0 {
+		out.ColdRegionReadQPS = override.ColdRegionReadQPS
+	}
+	if override.MergeMaxApproxBytes != 0 {
+		out.MergeMaxApproxBytes = override.MergeMaxApproxBytes
+	}
+	if override.NextID != nil {
+		out.NextID = override.NextID
+	}
+	if override.SplitKey != nil {
+		out.SplitKey = override.SplitKey
+	}
+	if override.HotRegionWindows != 0 {
+		out.HotRegionWindows = override.HotRegionWindows
+	}
+	if override.ColdRegionWindows != 0 {
+		out.ColdRegionWindows = override.ColdRegionWindows
+	}
+	if override.CooldownTicks != 0 {
+		out.CooldownTicks = override.CooldownTicks
+	}
+	if override.MaxOperationsPerStore != 0 {
+		out.MaxOperationsPerStore = override.MaxOperationsPerStore
+	}
+	return normalizeOptions(out, true)
+}
+
+func planLeaderTransfer(heartbeatStoreID uint64, snapshot catalog.ClusterSnapshot) (*coordpb.SchedulerOperation, bool) {
 	src, dst, ok := selectLeaderRebalancePair(snapshot.Stores, heartbeatStoreID)
 	if !ok {
-		return nil
+		return nil, false
 	}
-	op, ok := chooseLeaderTransferOperation(snapshot.Regions, src.StoreID, dst.StoreID)
+	return chooseLeaderTransferOperation(snapshot.Regions, src.StoreID, dst.StoreID)
+}
+
+func planHotRegionSplit(heartbeatStoreID uint64, snapshot catalog.ClusterSnapshot, opts PlanOptions) (*coordpb.SchedulerOperation, bool) {
+	if opts.NextID == nil {
+		return nil, false
+	}
+	stats := regionStatsByID(snapshot.Stores)
+	for _, region := range snapshot.Regions {
+		desc := region.Descriptor
+		stat := stats[desc.RegionID]
+		if stat.RegionID == 0 || stat.PendingAdmin || stat.LeaderStoreID != heartbeatStoreID {
+			continue
+		}
+		if stat.WriteQPS < opts.HotRegionWriteQPS && stat.WriteBytesPerSecond < opts.HotRegionWriteBytesPS {
+			continue
+		}
+		splitKey, ok := opts.SplitKey(desc)
+		if !ok || !splitKeyInsideParent(desc, splitKey) {
+			continue
+		}
+		child, ok := buildSplitChild(desc, splitKey, opts.NextID)
+		if !ok {
+			continue
+		}
+		return &coordpb.SchedulerOperation{
+			Type:       coordpb.SchedulerOperationType_SCHEDULER_OPERATION_TYPE_SPLIT_REGION,
+			RegionId:   desc.RegionID,
+			SplitKey:   splitKey,
+			SplitChild: metawire.DescriptorToProto(child),
+		}, true
+	}
+	return nil, false
+}
+
+func planColdRegionMerge(heartbeatStoreID uint64, snapshot catalog.ClusterSnapshot, opts PlanOptions) (*coordpb.SchedulerOperation, bool) {
+	stats := regionStatsByID(snapshot.Stores)
+	regions := append([]catalog.RegionInfo(nil), snapshot.Regions...)
+	sortRegionsByStart(regions)
+	for i := 0; i+1 < len(regions); i++ {
+		left := regions[i].Descriptor
+		right := regions[i+1].Descriptor
+		leftStat := stats[left.RegionID]
+		rightStat := stats[right.RegionID]
+		if leftStat.RegionID == 0 || rightStat.RegionID == 0 {
+			continue
+		}
+		if leftStat.PendingAdmin || rightStat.PendingAdmin {
+			continue
+		}
+		if leftStat.LeaderStoreID != heartbeatStoreID {
+			continue
+		}
+		if !bytes.Equal(left.EndKey, right.StartKey) || !samePeers(left.Peers, right.Peers) {
+			continue
+		}
+		if leftStat.WriteQPS > opts.ColdRegionWriteQPS || rightStat.WriteQPS > opts.ColdRegionWriteQPS ||
+			leftStat.ReadQPS > opts.ColdRegionReadQPS || rightStat.ReadQPS > opts.ColdRegionReadQPS {
+			continue
+		}
+		if leftStat.ApproxRegionBytes == 0 && rightStat.ApproxRegionBytes == 0 {
+			continue
+		}
+		if leftStat.ApproxRegionBytes+rightStat.ApproxRegionBytes > opts.MergeMaxApproxBytes {
+			continue
+		}
+		return &coordpb.SchedulerOperation{
+			Type:           coordpb.SchedulerOperationType_SCHEDULER_OPERATION_TYPE_MERGE_REGION,
+			RegionId:       left.RegionID,
+			SourceRegionId: right.RegionID,
+		}, true
+	}
+	return nil, false
+}
+
+func (p *Planner) planHotRegionSplit(heartbeatStoreID uint64, snapshot catalog.ClusterSnapshot, opts PlanOptions) (*coordpb.SchedulerOperation, bool) {
+	stats := regionStatsByID(snapshot.Stores)
+	for _, region := range snapshot.Regions {
+		desc := region.Descriptor
+		stat := stats[desc.RegionID]
+		if !hotSplitCandidate(heartbeatStoreID, desc, stat, opts) || p.regionInCooldown(desc.RegionID) {
+			p.hot[desc.RegionID] = 0
+			continue
+		}
+		p.hot[desc.RegionID]++
+		if p.hot[desc.RegionID] < opts.HotRegionWindows {
+			continue
+		}
+		op, ok := buildHotRegionSplitOperation(desc, opts)
+		if !ok {
+			continue
+		}
+		p.hot[desc.RegionID] = 0
+		return op, true
+	}
+	return nil, false
+}
+
+func (p *Planner) planColdRegionMerge(heartbeatStoreID uint64, snapshot catalog.ClusterSnapshot, opts PlanOptions) (*coordpb.SchedulerOperation, bool) {
+	stats := regionStatsByID(snapshot.Stores)
+	regions := append([]catalog.RegionInfo(nil), snapshot.Regions...)
+	sortRegionsByStart(regions)
+	for i := 0; i+1 < len(regions); i++ {
+		left := regions[i].Descriptor
+		right := regions[i+1].Descriptor
+		pair := regionPair{left: left.RegionID, right: right.RegionID}
+		if !coldMergeCandidate(heartbeatStoreID, left, right, stats[left.RegionID], stats[right.RegionID], opts) ||
+			p.regionInCooldown(left.RegionID) || p.regionInCooldown(right.RegionID) {
+			p.cold[pair] = 0
+			continue
+		}
+		p.cold[pair]++
+		if p.cold[pair] < opts.ColdRegionWindows {
+			continue
+		}
+		p.cold[pair] = 0
+		return buildColdRegionMergeOperation(left, right), true
+	}
+	return nil, false
+}
+
+func hotSplitCandidate(heartbeatStoreID uint64, desc topology.Descriptor, stat catalog.RegionStats, opts PlanOptions) bool {
+	if stat.RegionID == 0 || stat.PendingAdmin || stat.LeaderStoreID != heartbeatStoreID {
+		return false
+	}
+	return stat.WriteQPS >= opts.HotRegionWriteQPS || stat.WriteBytesPerSecond >= opts.HotRegionWriteBytesPS
+}
+
+func buildHotRegionSplitOperation(desc topology.Descriptor, opts PlanOptions) (*coordpb.SchedulerOperation, bool) {
+	if opts.NextID == nil {
+		return nil, false
+	}
+	splitKey, ok := opts.SplitKey(desc)
+	if !ok || !splitKeyInsideParent(desc, splitKey) {
+		return nil, false
+	}
+	child, ok := buildSplitChild(desc, splitKey, opts.NextID)
 	if !ok {
-		return nil
+		return nil, false
 	}
-	return []*coordpb.SchedulerOperation{op}
+	return &coordpb.SchedulerOperation{
+		Type:       coordpb.SchedulerOperationType_SCHEDULER_OPERATION_TYPE_SPLIT_REGION,
+		RegionId:   desc.RegionID,
+		SplitKey:   splitKey,
+		SplitChild: metawire.DescriptorToProto(child),
+	}, true
+}
+
+func coldMergeCandidate(heartbeatStoreID uint64, left, right topology.Descriptor, leftStat, rightStat catalog.RegionStats, opts PlanOptions) bool {
+	if leftStat.RegionID == 0 || rightStat.RegionID == 0 {
+		return false
+	}
+	if leftStat.PendingAdmin || rightStat.PendingAdmin {
+		return false
+	}
+	if leftStat.LeaderStoreID != heartbeatStoreID {
+		return false
+	}
+	if !bytes.Equal(left.EndKey, right.StartKey) || !samePeers(left.Peers, right.Peers) {
+		return false
+	}
+	if leftStat.WriteQPS > opts.ColdRegionWriteQPS || rightStat.WriteQPS > opts.ColdRegionWriteQPS ||
+		leftStat.ReadQPS > opts.ColdRegionReadQPS || rightStat.ReadQPS > opts.ColdRegionReadQPS {
+		return false
+	}
+	if leftStat.ApproxRegionBytes == 0 && rightStat.ApproxRegionBytes == 0 {
+		return false
+	}
+	return leftStat.ApproxRegionBytes+rightStat.ApproxRegionBytes <= opts.MergeMaxApproxBytes
+}
+
+func buildColdRegionMergeOperation(left, right topology.Descriptor) *coordpb.SchedulerOperation {
+	return &coordpb.SchedulerOperation{
+		Type:           coordpb.SchedulerOperationType_SCHEDULER_OPERATION_TYPE_MERGE_REGION,
+		RegionId:       left.RegionID,
+		SourceRegionId: right.RegionID,
+	}
+}
+
+func (p *Planner) operationInCooldown(op *coordpb.SchedulerOperation) bool {
+	if op == nil {
+		return false
+	}
+	switch op.GetType() {
+	case coordpb.SchedulerOperationType_SCHEDULER_OPERATION_TYPE_LEADER_TRANSFER,
+		coordpb.SchedulerOperationType_SCHEDULER_OPERATION_TYPE_SPLIT_REGION:
+		return p.regionInCooldown(op.GetRegionId())
+	case coordpb.SchedulerOperationType_SCHEDULER_OPERATION_TYPE_MERGE_REGION:
+		return p.regionInCooldown(op.GetRegionId()) || p.regionInCooldown(op.GetSourceRegionId())
+	default:
+		return false
+	}
+}
+
+func (p *Planner) markOperationCooldown(op *coordpb.SchedulerOperation, cooldownTicks uint64) {
+	if op == nil || cooldownTicks == 0 {
+		return
+	}
+	until := p.tick + cooldownTicks
+	p.cooldown[op.GetRegionId()] = until
+	if op.GetSourceRegionId() != 0 {
+		p.cooldown[op.GetSourceRegionId()] = until
+	}
+}
+
+func (p *Planner) regionInCooldown(regionID uint64) bool {
+	if regionID == 0 {
+		return false
+	}
+	return p.cooldown[regionID] > p.tick
+}
+
+func (p *Planner) prune(snapshot catalog.ClusterSnapshot) {
+	active := make(map[uint64]struct{}, len(snapshot.Regions))
+	for _, region := range snapshot.Regions {
+		active[region.Descriptor.RegionID] = struct{}{}
+	}
+	for regionID := range p.hot {
+		if _, ok := active[regionID]; !ok {
+			delete(p.hot, regionID)
+		}
+	}
+	for pair := range p.cold {
+		if _, ok := active[pair.left]; !ok {
+			delete(p.cold, pair)
+			continue
+		}
+		if _, ok := active[pair.right]; !ok {
+			delete(p.cold, pair)
+		}
+	}
+	for regionID, until := range p.cooldown {
+		if _, ok := active[regionID]; !ok || until <= p.tick {
+			delete(p.cooldown, regionID)
+		}
+	}
+}
+
+func SplitKeyFromBoundaries(boundaries [][]byte) func(topology.Descriptor) ([]byte, bool) {
+	clean := make([][]byte, 0, len(boundaries))
+	for _, boundary := range boundaries {
+		if len(boundary) == 0 {
+			continue
+		}
+		clean = append(clean, append([]byte(nil), boundary...))
+	}
+	sort.Slice(clean, func(i, j int) bool { return bytes.Compare(clean[i], clean[j]) < 0 })
+	return func(desc topology.Descriptor) ([]byte, bool) {
+		candidates := make([][]byte, 0, len(clean))
+		for _, boundary := range clean {
+			if splitKeyInsideParent(desc, boundary) {
+				candidates = append(candidates, boundary)
+			}
+		}
+		if len(candidates) == 0 {
+			return nil, false
+		}
+		return append([]byte(nil), candidates[len(candidates)/2]...), true
+	}
+}
+
+func buildSplitChild(parent topology.Descriptor, splitKey []byte, nextID func() (uint64, bool)) (topology.Descriptor, bool) {
+	regionID, ok := nextID()
+	if !ok || regionID == 0 {
+		return topology.Descriptor{}, false
+	}
+	child := parent.Clone()
+	child.RegionID = regionID
+	child.StartKey = append([]byte(nil), splitKey...)
+	child.EndKey = append([]byte(nil), parent.EndKey...)
+	child.Hash = nil
+	child.Lineage = nil
+	child.Peers = make([]metaregion.Peer, 0, len(parent.Peers))
+	for _, peer := range parent.Peers {
+		peerID, ok := nextID()
+		if !ok || peerID == 0 {
+			return topology.Descriptor{}, false
+		}
+		child.Peers = append(child.Peers, metaregion.Peer{StoreID: peer.StoreID, PeerID: peerID})
+	}
+	child.EnsureHash()
+	return child, true
+}
+
+func splitKeyInsideParent(parent topology.Descriptor, splitKey []byte) bool {
+	if len(splitKey) == 0 {
+		return false
+	}
+	if bytes.Compare(splitKey, parent.StartKey) <= 0 {
+		return false
+	}
+	return len(parent.EndKey) == 0 || bytes.Compare(splitKey, parent.EndKey) < 0
+}
+
+func regionStatsByID(stores []catalog.StoreStats) map[uint64]catalog.RegionStats {
+	out := make(map[uint64]catalog.RegionStats)
+	for _, store := range stores {
+		for _, stat := range store.RegionStats {
+			if stat.RegionID == 0 {
+				continue
+			}
+			current := out[stat.RegionID]
+			current.RegionID = stat.RegionID
+			current.ReadQPS += stat.ReadQPS
+			current.WriteQPS += stat.WriteQPS
+			current.WriteBytesPerSecond += stat.WriteBytesPerSecond
+			current.ApproxRegionBytes += stat.ApproxRegionBytes
+			current.AtomicMutateQPS += stat.AtomicMutateQPS
+			current.PendingAdmin = current.PendingAdmin || stat.PendingAdmin
+			if stat.LeaderStoreID != 0 {
+				current.LeaderStoreID = stat.LeaderStoreID
+			}
+			out[stat.RegionID] = current
+		}
+	}
+	return out
+}
+
+func sortRegionsByStart(regions []catalog.RegionInfo) {
+	for i := 1; i < len(regions); i++ {
+		current := regions[i]
+		j := i - 1
+		for ; j >= 0 && bytes.Compare(regions[j].Descriptor.StartKey, current.Descriptor.StartKey) > 0; j-- {
+			regions[j+1] = regions[j]
+		}
+		regions[j+1] = current
+	}
+}
+
+func samePeers(a, b []metaregion.Peer) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i].StoreID != b[i].StoreID {
+			return false
+		}
+	}
+	return true
+}
+
+func midpointSplitKey(desc topology.Descriptor) ([]byte, bool) {
+	start, end := desc.StartKey, desc.EndKey
+	if len(start) == 0 || len(end) == 0 || bytes.Compare(start, end) >= 0 {
+		return nil, false
+	}
+	maxLen := max(len(start), len(end))
+	left := make([]byte, maxLen+1)
+	right := make([]byte, maxLen+1)
+	copy(left, start)
+	copy(right, end)
+	var carry uint16
+	mid := make([]byte, len(left))
+	for i := len(left) - 1; i >= 0; i-- {
+		sum := uint16(left[i]) + uint16(right[i]) + carry*256
+		mid[i] = byte(sum / 2)
+		carry = sum % 2
+	}
+	mid = bytes.TrimRight(mid, "\x00")
+	if len(mid) == 0 || bytes.Compare(mid, start) <= 0 || bytes.Compare(mid, end) >= 0 {
+		return nil, false
+	}
+	return mid, true
 }
 
 func selectLeaderRebalancePair(stores []catalog.StoreStats, heartbeatStoreID uint64) (catalog.StoreStats, catalog.StoreStats, bool) {
@@ -52,8 +612,6 @@ func selectLeaderRebalancePair(stores []catalog.StoreStats, heartbeatStoreID uin
 	if heartbeatStoreID != src.StoreID {
 		return catalog.StoreStats{}, catalog.StoreStats{}, false
 	}
-	// Require at least two leaders of skew before scheduling. One-leader skew
-	// is common during startup and would otherwise produce noisy transfers.
 	if src.LeaderNum <= dst.LeaderNum+1 {
 		return catalog.StoreStats{}, catalog.StoreStats{}, false
 	}
@@ -64,14 +622,11 @@ func chooseLeaderTransferOperation(regions []catalog.RegionInfo, srcStoreID, dst
 	if srcStoreID == 0 || dstStoreID == 0 {
 		return nil, false
 	}
-	// Prefer regions whose first peer belongs to the source store; this aligns
-	// with common bootstrap ordering and increases chance of immediate success.
 	for _, region := range regions {
 		if op, ok := buildLeaderTransfer(region.Descriptor, srcStoreID, dstStoreID, true); ok {
 			return op, true
 		}
 	}
-	// Fallback to any region that has peers on both stores.
 	for _, region := range regions {
 		if op, ok := buildLeaderTransfer(region.Descriptor, srcStoreID, dstStoreID, false); ok {
 			return op, true

--- a/coordinator/scheduling/planner_test.go
+++ b/coordinator/scheduling/planner_test.go
@@ -97,6 +97,259 @@ func TestPlanStoreOperationsSkipsRegionsWithoutTargetPeer(t *testing.T) {
 	require.Nil(t, ops)
 }
 
+func TestPlanStoreOperationsSplitsHotBoundedRegion(t *testing.T) {
+	ids := []uint64{1000, 1001, 1002}
+	nextID := func() (uint64, bool) {
+		if len(ids) == 0 {
+			return 0, false
+		}
+		id := ids[0]
+		ids = ids[1:]
+		return id, true
+	}
+	ops := PlanStoreOperationsWithOptions(1,
+		catalog.ClusterSnapshot{
+			Stores: []catalog.StoreStats{
+				{StoreID: 1, LeaderNum: 1, RegionStats: []catalog.RegionStats{{RegionID: 100, WriteQPS: 100, LeaderStoreID: 1}}},
+				{StoreID: 2, LeaderNum: 1},
+			},
+			Regions: []catalog.RegionInfo{
+				{Descriptor: testDescriptor(100, []metaregion.Peer{{StoreID: 1, PeerID: 101}, {StoreID: 2, PeerID: 201}})},
+			},
+		},
+		PlanOptions{
+			HotRegionWriteQPS: 10,
+			NextID:            nextID,
+			SplitKey: func(desc topology.Descriptor) ([]byte, bool) {
+				return []byte("m"), true
+			},
+		},
+	)
+
+	require.Len(t, ops, 1)
+	op := ops[0]
+	require.Equal(t, coordpb.SchedulerOperationType_SCHEDULER_OPERATION_TYPE_SPLIT_REGION, op.GetType())
+	require.Equal(t, uint64(100), op.GetRegionId())
+	require.Equal(t, []byte("m"), op.GetSplitKey())
+	require.Equal(t, uint64(1000), op.GetSplitChild().GetRegionId())
+	require.Equal(t, []byte("m"), op.GetSplitChild().GetStartKey())
+	require.Equal(t, []byte("z"), op.GetSplitChild().GetEndKey())
+	require.Equal(t, uint64(1001), op.GetSplitChild().GetPeers()[0].GetPeerId())
+	require.Equal(t, uint64(1002), op.GetSplitChild().GetPeers()[1].GetPeerId())
+}
+
+func TestPlanStoreOperationsSkipsHotSingleBoundaryRegionWithoutSplitKey(t *testing.T) {
+	ops := PlanStoreOperationsWithOptions(1,
+		catalog.ClusterSnapshot{
+			Stores: []catalog.StoreStats{
+				{StoreID: 1, LeaderNum: 1, RegionStats: []catalog.RegionStats{{RegionID: 100, WriteQPS: 100, LeaderStoreID: 1}}},
+				{StoreID: 2, LeaderNum: 1},
+			},
+			Regions: []catalog.RegionInfo{
+				{Descriptor: topology.Descriptor{
+					RegionID: 100,
+					StartKey: []byte("a"),
+					Peers:    []metaregion.Peer{{StoreID: 1, PeerID: 101}, {StoreID: 2, PeerID: 201}},
+					State:    metaregion.ReplicaStateRunning,
+				}},
+			},
+		},
+		PlanOptions{
+			HotRegionWriteQPS: 10,
+			NextID: func() (uint64, bool) {
+				return 1000, true
+			},
+		},
+	)
+
+	require.Nil(t, ops)
+}
+
+func TestPlanStoreOperationsRejectsInvalidSplitKey(t *testing.T) {
+	ids := []uint64{1000, 1001, 1002}
+	nextID := func() (uint64, bool) {
+		if len(ids) == 0 {
+			return 0, false
+		}
+		id := ids[0]
+		ids = ids[1:]
+		return id, true
+	}
+	ops := PlanStoreOperationsWithOptions(1,
+		catalog.ClusterSnapshot{
+			Stores: []catalog.StoreStats{
+				{StoreID: 1, LeaderNum: 1, RegionStats: []catalog.RegionStats{{RegionID: 100, WriteQPS: 100, LeaderStoreID: 1}}},
+				{StoreID: 2, LeaderNum: 1},
+			},
+			Regions: []catalog.RegionInfo{
+				{Descriptor: testDescriptor(100, []metaregion.Peer{{StoreID: 1, PeerID: 101}, {StoreID: 2, PeerID: 201}})},
+			},
+		},
+		PlanOptions{
+			HotRegionWriteQPS: 10,
+			NextID:            nextID,
+			SplitKey: func(topology.Descriptor) ([]byte, bool) {
+				return []byte("z"), true
+			},
+		},
+	)
+
+	require.Nil(t, ops)
+}
+
+func TestPlanStoreOperationsMergesColdAdjacentRegions(t *testing.T) {
+	left := testDescriptor(100, []metaregion.Peer{{StoreID: 1, PeerID: 101}, {StoreID: 2, PeerID: 201}})
+	left.StartKey = []byte("a")
+	left.EndKey = []byte("m")
+	right := testDescriptor(101, []metaregion.Peer{{StoreID: 1, PeerID: 102}, {StoreID: 2, PeerID: 202}})
+	right.StartKey = []byte("m")
+	right.EndKey = []byte("z")
+
+	ops := PlanStoreOperationsWithOptions(1,
+		catalog.ClusterSnapshot{
+			Stores: []catalog.StoreStats{
+				{StoreID: 1, LeaderNum: 1, RegionStats: []catalog.RegionStats{
+					{RegionID: 100, ReadQPS: 1, WriteQPS: 1, ApproxRegionBytes: 1024, LeaderStoreID: 1},
+					{RegionID: 101, ReadQPS: 1, WriteQPS: 1, ApproxRegionBytes: 1024, LeaderStoreID: 1},
+				}},
+				{StoreID: 2, LeaderNum: 1},
+			},
+			Regions: []catalog.RegionInfo{{Descriptor: right}, {Descriptor: left}},
+		},
+		PlanOptions{},
+	)
+
+	require.Len(t, ops, 1)
+	require.Equal(t, coordpb.SchedulerOperationType_SCHEDULER_OPERATION_TYPE_MERGE_REGION, ops[0].GetType())
+	require.Equal(t, uint64(100), ops[0].GetRegionId())
+	require.Equal(t, uint64(101), ops[0].GetSourceRegionId())
+}
+
+func TestPlanStoreOperationsSkipsMergeWithPendingAdmin(t *testing.T) {
+	left := testDescriptor(100, []metaregion.Peer{{StoreID: 1, PeerID: 101}, {StoreID: 2, PeerID: 201}})
+	left.StartKey = []byte("a")
+	left.EndKey = []byte("m")
+	right := testDescriptor(101, []metaregion.Peer{{StoreID: 1, PeerID: 102}, {StoreID: 2, PeerID: 202}})
+	right.StartKey = []byte("m")
+	right.EndKey = []byte("z")
+
+	ops := PlanStoreOperationsWithOptions(1,
+		catalog.ClusterSnapshot{
+			Stores: []catalog.StoreStats{
+				{StoreID: 1, LeaderNum: 1, RegionStats: []catalog.RegionStats{
+					{RegionID: 100, ApproxRegionBytes: 1024, LeaderStoreID: 1},
+					{RegionID: 101, ApproxRegionBytes: 1024, LeaderStoreID: 1, PendingAdmin: true},
+				}},
+				{StoreID: 2, LeaderNum: 1},
+			},
+			Regions: []catalog.RegionInfo{{Descriptor: left}, {Descriptor: right}},
+		},
+		PlanOptions{},
+	)
+
+	require.Nil(t, ops)
+}
+
+func TestPlannerRequiresConsecutiveHotWindowsAndAppliesCooldown(t *testing.T) {
+	ids := []uint64{1000, 1001, 1002}
+	nextID := func() (uint64, bool) {
+		if len(ids) == 0 {
+			return 0, false
+		}
+		id := ids[0]
+		ids = ids[1:]
+		return id, true
+	}
+	planner := NewPlanner(PlanOptions{
+		HotRegionWriteQPS: 10,
+		HotRegionWindows:  2,
+		CooldownTicks:     2,
+		NextID:            nextID,
+		SplitKey: func(topology.Descriptor) ([]byte, bool) {
+			return []byte("m"), true
+		},
+	})
+	snapshot := catalog.ClusterSnapshot{
+		Stores: []catalog.StoreStats{
+			{StoreID: 1, LeaderNum: 1, RegionStats: []catalog.RegionStats{{RegionID: 100, WriteQPS: 100, LeaderStoreID: 1}}},
+			{StoreID: 2, LeaderNum: 1},
+		},
+		Regions: []catalog.RegionInfo{
+			{Descriptor: testDescriptor(100, []metaregion.Peer{{StoreID: 1, PeerID: 101}, {StoreID: 2, PeerID: 201}})},
+		},
+	}
+
+	require.Nil(t, planner.PlanStoreOperationsWithOptions(1, snapshot, PlanOptions{}))
+	ops := planner.PlanStoreOperationsWithOptions(1, snapshot, PlanOptions{})
+	require.Len(t, ops, 1)
+	require.Equal(t, coordpb.SchedulerOperationType_SCHEDULER_OPERATION_TYPE_SPLIT_REGION, ops[0].GetType())
+	require.Nil(t, planner.PlanStoreOperationsWithOptions(1, snapshot, PlanOptions{}))
+}
+
+func TestPlannerUsesConfiguredBoundarySplitKey(t *testing.T) {
+	ids := []uint64{1000, 1001, 1002}
+	nextID := func() (uint64, bool) {
+		if len(ids) == 0 {
+			return 0, false
+		}
+		id := ids[0]
+		ids = ids[1:]
+		return id, true
+	}
+	planner := NewPlanner(PlanOptions{
+		HotRegionWriteQPS: 10,
+		HotRegionWindows:  1,
+		CooldownTicks:     1,
+		NextID:            nextID,
+		SplitKey:          SplitKeyFromBoundaries([][]byte{[]byte("b"), []byte("m"), []byte("x")}),
+	})
+	ops := planner.PlanStoreOperationsWithOptions(1,
+		catalog.ClusterSnapshot{
+			Stores: []catalog.StoreStats{
+				{StoreID: 1, LeaderNum: 1, RegionStats: []catalog.RegionStats{{RegionID: 100, WriteQPS: 100, LeaderStoreID: 1}}},
+				{StoreID: 2, LeaderNum: 1},
+			},
+			Regions: []catalog.RegionInfo{
+				{Descriptor: testDescriptor(100, []metaregion.Peer{{StoreID: 1, PeerID: 101}, {StoreID: 2, PeerID: 201}})},
+			},
+		},
+		PlanOptions{},
+	)
+
+	require.Len(t, ops, 1)
+	require.Equal(t, []byte("m"), ops[0].GetSplitKey())
+}
+
+func TestPlannerRequiresConsecutiveColdWindows(t *testing.T) {
+	planner := NewPlanner(PlanOptions{
+		ColdRegionReadQPS:  10,
+		ColdRegionWriteQPS: 10,
+		ColdRegionWindows:  2,
+		CooldownTicks:      1,
+	})
+	left := testDescriptor(100, []metaregion.Peer{{StoreID: 1, PeerID: 101}, {StoreID: 2, PeerID: 201}})
+	left.StartKey = []byte("a")
+	left.EndKey = []byte("m")
+	right := testDescriptor(101, []metaregion.Peer{{StoreID: 1, PeerID: 102}, {StoreID: 2, PeerID: 202}})
+	right.StartKey = []byte("m")
+	right.EndKey = []byte("z")
+	snapshot := catalog.ClusterSnapshot{
+		Stores: []catalog.StoreStats{
+			{StoreID: 1, LeaderNum: 1, RegionStats: []catalog.RegionStats{
+				{RegionID: 100, ReadQPS: 1, WriteQPS: 1, ApproxRegionBytes: 1024, LeaderStoreID: 1},
+				{RegionID: 101, ReadQPS: 1, WriteQPS: 1, ApproxRegionBytes: 1024, LeaderStoreID: 1},
+			}},
+			{StoreID: 2, LeaderNum: 1},
+		},
+		Regions: []catalog.RegionInfo{{Descriptor: left}, {Descriptor: right}},
+	}
+
+	require.Nil(t, planner.PlanStoreOperationsWithOptions(1, snapshot, PlanOptions{}))
+	ops := planner.PlanStoreOperationsWithOptions(1, snapshot, PlanOptions{})
+	require.Len(t, ops, 1)
+	require.Equal(t, coordpb.SchedulerOperationType_SCHEDULER_OPERATION_TYPE_MERGE_REGION, ops[0].GetType())
+}
+
 func testDescriptor(regionID uint64, peers []metaregion.Peer) topology.Descriptor {
 	desc := topology.Descriptor{
 		RegionID: regionID,

--- a/coordinator/server/service.go
+++ b/coordinator/server/service.go
@@ -26,6 +26,7 @@ import (
 	"github.com/feichai0017/NoKV/coordinator/catalog"
 	"github.com/feichai0017/NoKV/coordinator/idalloc"
 	"github.com/feichai0017/NoKV/coordinator/rootview"
+	"github.com/feichai0017/NoKV/coordinator/scheduling"
 	"github.com/feichai0017/NoKV/coordinator/tso"
 	rootproto "github.com/feichai0017/NoKV/meta/root/protocol"
 	coordpb "github.com/feichai0017/NoKV/pb/coordinator"
@@ -74,6 +75,7 @@ type Service struct {
 	lastRootReload    int64
 	lastRootError     string
 	eunomiaMetrics    eunomiaMetrics
+	scheduler         *scheduling.Planner
 }
 
 type authorityServingState uint8
@@ -227,6 +229,7 @@ func NewService(cluster *catalog.Cluster, ids *idalloc.IDAllocator, tsAlloc *tso
 		idWindowSize:  defaultAllocatorWindowSize,
 		tsoWindowSize: defaultAllocatorWindowSize,
 		now:           time.Now,
+		scheduler:     scheduling.NewPlanner(scheduling.PlanOptions{}),
 	}
 	svc.storeHeartbeatTTL.Store(int64(defaultStoreHeartbeatTTL))
 	return svc

--- a/coordinator/server/service_gateway.go
+++ b/coordinator/server/service_gateway.go
@@ -38,6 +38,7 @@ func (s *Service) StoreHeartbeat(ctx context.Context, req *coordpb.StoreHeartbea
 		Capacity:          req.GetCapacity(),
 		Available:         req.GetAvailable(),
 		DroppedOperations: req.GetDroppedOperations(),
+		RegionStats:       regionStatsFromPB(req.GetRegionStats()),
 	})
 	if err != nil {
 		if errors.Is(err, catalog.ErrInvalidStoreID) {
@@ -58,6 +59,29 @@ func (s *Service) StoreHeartbeat(ctx context.Context, req *coordpb.StoreHeartbea
 		Accepted:   true,
 		Operations: operations,
 	}, nil
+}
+
+func regionStatsFromPB(in []*coordpb.RegionRuntimeStats) []catalog.RegionStats {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make([]catalog.RegionStats, 0, len(in))
+	for _, stat := range in {
+		if stat == nil || stat.GetRegionId() == 0 {
+			continue
+		}
+		out = append(out, catalog.RegionStats{
+			RegionID:            stat.GetRegionId(),
+			ReadQPS:             stat.GetReadQps(),
+			WriteQPS:            stat.GetWriteQps(),
+			WriteBytesPerSecond: stat.GetWriteBytesPerSec(),
+			ApproxRegionBytes:   stat.GetApproxRegionBytes(),
+			AtomicMutateQPS:     stat.GetAtomicMutateQps(),
+			LeaderStoreID:       stat.GetLeaderStoreId(),
+			PendingAdmin:        stat.GetPendingAdmin(),
+		})
+	}
+	return out
 }
 
 // GetStore returns the current runtime endpoint for one store.

--- a/coordinator/server/service_grant.go
+++ b/coordinator/server/service_grant.go
@@ -37,7 +37,7 @@ func (s *Service) requireRootWriteAccess() error {
 
 func (s *Service) grantScopedStoreOperations(ctx context.Context, storeID uint64) []*coordpb.SchedulerOperation {
 	if s == nil || !s.coordinatorGrantEnabled() {
-		return s.storeControlOperations(storeID)
+		return s.storeControlOperations(ctx, storeID)
 	}
 	if s.storage != nil && !s.storage.CanSubmitRootWrites() {
 		return nil
@@ -45,14 +45,50 @@ func (s *Service) grantScopedStoreOperations(ctx context.Context, storeID uint64
 	if err := s.ensureGrant(ctx, rootproto.DutyRegionLookup); err != nil {
 		return nil
 	}
-	return s.storeControlOperations(storeID)
+	return s.storeControlOperations(ctx, storeID)
 }
 
-func (s *Service) storeControlOperations(storeID uint64) []*coordpb.SchedulerOperation {
+func (s *Service) storeControlOperations(ctx context.Context, storeID uint64) []*coordpb.SchedulerOperation {
 	if s == nil || s.cluster == nil || storeID == 0 {
 		return nil
 	}
-	return scheduling.PlanStoreOperations(storeID, s.cluster.Snapshot())
+	opts := scheduling.PlanOptions{
+		NextID: s.schedulerNextID(ctx),
+	}
+	if s.scheduler != nil {
+		return s.scheduler.PlanStoreOperationsWithOptions(storeID, s.cluster.Snapshot(), opts)
+	}
+	return scheduling.PlanStoreOperationsWithOptions(storeID, s.cluster.Snapshot(), opts)
+}
+
+func (s *Service) ConfigureSchedulerSplitBoundaries(boundaries [][]byte) {
+	if s == nil {
+		return
+	}
+	if s.scheduler == nil {
+		s.scheduler = scheduling.NewPlanner(scheduling.PlanOptions{})
+	}
+	s.scheduler.ConfigureOptions(scheduling.PlanOptions{
+		SplitKey: scheduling.SplitKeyFromBoundaries(boundaries),
+	})
+}
+
+func (s *Service) schedulerNextID(ctx context.Context) func() (uint64, bool) {
+	return func() (uint64, bool) {
+		if s == nil {
+			return 0, false
+		}
+		if s.coordinatorGrantEnabled() {
+			if err := s.ensureGrant(ctx, rootproto.DutyAllocID); err != nil {
+				return 0, false
+			}
+		}
+		id, err := s.reserveIDs(ctx, 1)
+		if err != nil {
+			return 0, false
+		}
+		return id, true
+	}
 }
 
 // RunGrantLoop keeps the local coordinator grant renewed while ctx
@@ -584,11 +620,11 @@ func (s *Service) grantDutyRequest(duty rootproto.DutyID) (rootproto.DutyGrant, 
 }
 
 func (s *Service) currentRegionLookupRevision() uint64 {
+	// RegionLookup grants fence route descriptors, not every root-log event.
+	// Using the root token revision here makes a grant self-invalidating:
+	// issuing the grant appends a root event, advances the root token, and then
+	// immediately forces another renewal even though no descriptor changed.
 	revision := s.currentDescriptorRevision()
-	snapshot, err := s.currentRootSnapshot()
-	if err == nil && snapshot.RootToken.Revision > revision {
-		revision = snapshot.RootToken.Revision
-	}
 	if floor := s.currentRegionLookupGrantFloor(); floor > revision {
 		revision = floor
 	}

--- a/coordinator/server/service_test.go
+++ b/coordinator/server/service_test.go
@@ -96,6 +96,23 @@ func TestTranslateGrantContextErrors(t *testing.T) {
 	}
 }
 
+func TestRegionLookupGrantRevisionIgnoresRootOnlyEvents(t *testing.T) {
+	cluster := catalog.NewCluster()
+	desc := testDescriptor(11, []byte("a"), []byte("z"), metaregion.Epoch{Version: 1, ConfVersion: 1}, nil)
+	desc.RootEpoch = 7
+	require.NoError(t, cluster.PublishRootEvent(rootevent.RegionBootstrapped(desc)))
+	storage := &fakeStorage{snapshot: rootview.Snapshot{
+		RootToken: rootstorage.TailToken{
+			Cursor:   rootstate.Cursor{Term: 1, Index: 100},
+			Revision: 100,
+		},
+		Descriptors: map[uint64]topology.Descriptor{desc.RegionID: desc},
+	}}
+	svc := NewService(cluster, idalloc.NewIDAllocator(1), tso.NewAllocator(1), storage)
+
+	require.Equal(t, uint64(7), svc.currentRegionLookupRevision())
+}
+
 func (f *fakeStorage) protocolState() rootstate.EunomiaState {
 	return rootstate.EunomiaState{
 		ActiveGrants:      append([]rootproto.AuthorityGrant(nil), f.snapshot.ActiveGrants...),

--- a/coordinator/storecontrol/client.go
+++ b/coordinator/storecontrol/client.go
@@ -116,6 +116,7 @@ func (s *CoordinatorClient) StoreHeartbeat(ctx context.Context, stats StoreStats
 		Available:         stats.Available,
 		DroppedOperations: stats.DroppedOperations,
 		LeaderRegionIds:   stats.LeaderRegionIDs,
+		RegionStats:       regionStatsToPB(stats.RegionStats),
 	})
 	if err != nil {
 		s.recordError("StoreHeartbeat", err)
@@ -166,9 +167,52 @@ func fromPBOperation(op *coordpb.SchedulerOperation) (Operation, bool) {
 			Source: op.GetSourcePeerId(),
 			Target: op.GetTargetPeerId(),
 		}, true
+	case coordpb.SchedulerOperationType_SCHEDULER_OPERATION_TYPE_SPLIT_REGION:
+		child := metawire.DescriptorFromProto(op.GetSplitChild())
+		if op.GetRegionId() == 0 || len(op.GetSplitKey()) == 0 || child.RegionID == 0 {
+			return Operation{}, false
+		}
+		return Operation{
+			Type:       OperationSplitRegion,
+			Region:     op.GetRegionId(),
+			SplitKey:   append([]byte(nil), op.GetSplitKey()...),
+			SplitChild: child,
+		}, true
+	case coordpb.SchedulerOperationType_SCHEDULER_OPERATION_TYPE_MERGE_REGION:
+		if op.GetRegionId() == 0 || op.GetSourceRegionId() == 0 {
+			return Operation{}, false
+		}
+		return Operation{
+			Type:         OperationMergeRegion,
+			Region:       op.GetRegionId(),
+			SourceRegion: op.GetSourceRegionId(),
+		}, true
 	default:
 		return Operation{}, false
 	}
+}
+
+func regionStatsToPB(in []RegionStats) []*coordpb.RegionRuntimeStats {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make([]*coordpb.RegionRuntimeStats, 0, len(in))
+	for _, stat := range in {
+		if stat.RegionID == 0 {
+			continue
+		}
+		out = append(out, &coordpb.RegionRuntimeStats{
+			RegionId:          stat.RegionID,
+			ReadQps:           stat.ReadQPS,
+			WriteQps:          stat.WriteQPS,
+			WriteBytesPerSec:  stat.WriteBytesPerSecond,
+			ApproxRegionBytes: stat.ApproxRegionBytes,
+			AtomicMutateQps:   stat.AtomicMutateQPS,
+			LeaderStoreId:     stat.LeaderStoreID,
+			PendingAdmin:      stat.PendingAdmin,
+		})
+	}
+	return out
 }
 
 // Close closes the coordinator client if present.

--- a/coordinator/storecontrol/client_test.go
+++ b/coordinator/storecontrol/client_test.go
@@ -176,6 +176,16 @@ func TestClientForwardsAndPlans(t *testing.T) {
 		Available:         800,
 		DroppedOperations: 7,
 		LeaderRegionIDs:   []uint64{10, 12},
+		RegionStats: []RegionStats{{
+			RegionID:            10,
+			ReadQPS:             11,
+			WriteQPS:            12,
+			WriteBytesPerSecond: 13,
+			ApproxRegionBytes:   14,
+			AtomicMutateQPS:     15,
+			LeaderStoreID:       1,
+			PendingAdmin:        true,
+		}},
 	})
 
 	require.Len(t, coord.livenessReqs, 1)
@@ -184,6 +194,10 @@ func TestClientForwardsAndPlans(t *testing.T) {
 	require.Equal(t, uint64(1), coord.storeReqs[0].GetStoreId())
 	require.Equal(t, uint64(7), coord.storeReqs[0].GetDroppedOperations())
 	require.Equal(t, []uint64{10, 12}, coord.storeReqs[0].GetLeaderRegionIds())
+	require.Len(t, coord.storeReqs[0].GetRegionStats(), 1)
+	require.Equal(t, uint64(10), coord.storeReqs[0].GetRegionStats()[0].GetRegionId())
+	require.Equal(t, uint64(12), coord.storeReqs[0].GetRegionStats()[0].GetWriteQps())
+	require.True(t, coord.storeReqs[0].GetRegionStats()[0].GetPendingAdmin())
 
 	require.Len(t, ops, 1)
 	require.Equal(t, OperationLeaderTransfer, ops[0].Type)
@@ -288,6 +302,27 @@ func TestFromPBOperationValidation(t *testing.T) {
 	})
 	require.True(t, ok)
 	require.Equal(t, OperationLeaderTransfer, op.Type)
+
+	child := testDescriptor(2, []byte("m"), []byte("z"), metaregion.Epoch{Version: 1, ConfVersion: 1}, nil)
+	op, ok = fromPBOperation(&coordpb.SchedulerOperation{
+		Type:       coordpb.SchedulerOperationType_SCHEDULER_OPERATION_TYPE_SPLIT_REGION,
+		RegionId:   1,
+		SplitKey:   []byte("m"),
+		SplitChild: metawire.DescriptorToProto(child),
+	})
+	require.True(t, ok)
+	require.Equal(t, OperationSplitRegion, op.Type)
+	require.Equal(t, []byte("m"), op.SplitKey)
+	require.Equal(t, uint64(2), op.SplitChild.RegionID)
+
+	op, ok = fromPBOperation(&coordpb.SchedulerOperation{
+		Type:           coordpb.SchedulerOperationType_SCHEDULER_OPERATION_TYPE_MERGE_REGION,
+		RegionId:       1,
+		SourceRegionId: 2,
+	})
+	require.True(t, ok)
+	require.Equal(t, OperationMergeRegion, op.Type)
+	require.Equal(t, uint64(2), op.SourceRegion)
 }
 
 func testDescriptor(id uint64, start, end []byte, epoch metaregion.Epoch, peers []metaregion.Peer) topology.Descriptor {

--- a/coordinator/storecontrol/types.go
+++ b/coordinator/storecontrol/types.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	rootevent "github.com/feichai0017/NoKV/meta/root/event"
+	"github.com/feichai0017/NoKV/meta/topology"
 )
 
 // StoreStats captures minimal store-level heartbeat information.
@@ -19,19 +20,37 @@ type StoreStats struct {
 	// LeaderRegionIDs enumerates the regions for which this store is the
 	// local raft leader at snapshot time. The coordinator uses this to
 	// populate its region directory view with per-region leadership.
-	LeaderRegionIDs   []uint64  `json:"leader_region_ids,omitempty"`
-	Capacity          uint64    `json:"capacity"`
-	Available         uint64    `json:"available"`
-	DroppedOperations uint64    `json:"dropped_operations"`
-	UpdatedAt         time.Time `json:"updated_at"`
+	LeaderRegionIDs   []uint64      `json:"leader_region_ids,omitempty"`
+	Capacity          uint64        `json:"capacity"`
+	Available         uint64        `json:"available"`
+	DroppedOperations uint64        `json:"dropped_operations"`
+	UpdatedAt         time.Time     `json:"updated_at"`
+	RegionStats       []RegionStats `json:"region_stats,omitempty"`
+}
+
+// RegionStats carries low-cardinality per-region load over the store-control
+// heartbeat. It is scheduling input only; region descriptors remain rooted
+// truth and must not be inferred from this telemetry.
+type RegionStats struct {
+	RegionID            uint64 `json:"region_id"`
+	ReadQPS             uint64 `json:"read_qps"`
+	WriteQPS            uint64 `json:"write_qps"`
+	WriteBytesPerSecond uint64 `json:"write_bytes_per_sec"`
+	ApproxRegionBytes   uint64 `json:"approx_region_bytes"`
+	AtomicMutateQPS     uint64 `json:"atomic_mutate_qps"`
+	LeaderStoreID       uint64 `json:"leader_store_id,omitempty"`
+	PendingAdmin        bool   `json:"pending_admin,omitempty"`
 }
 
 // Operation represents a control-plane decision to be executed by store runtime.
 type Operation struct {
-	Type   OperationType
-	Region uint64
-	Source uint64
-	Target uint64
+	Type         OperationType
+	Region       uint64
+	Source       uint64
+	Target       uint64
+	SplitKey     []byte
+	SplitChild   topology.Descriptor
+	SourceRegion uint64
 }
 
 // OperationType identifies one store-control operation kind.
@@ -40,12 +59,18 @@ type OperationType uint8
 const (
 	OperationNone OperationType = iota
 	OperationLeaderTransfer
+	OperationSplitRegion
+	OperationMergeRegion
 )
 
 func (t OperationType) String() string {
 	switch t {
 	case OperationLeaderTransfer:
 		return "leader-transfer"
+	case OperationSplitRegion:
+		return "split-region"
+	case OperationMergeRegion:
+		return "merge-region"
 	default:
 		return "none"
 	}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -312,6 +312,7 @@ services:
       - "--coordinator-addr=nokv-coordinator-1:2379,nokv-coordinator-2:2379,nokv-coordinator-3:2379"
       - "--negative-cache-dir=/var/lib/nokv/negative-cache"
       - "--dirpage-cache-dir=/var/lib/nokv/dirpage-cache"
+      - "--affinity-buckets=16"
       - "--metrics-addr=0.0.0.0:9400"
     volumes:
       - fsmeta-negative-cache:/var/lib/nokv/negative-cache

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -260,10 +260,10 @@ The RPC request/response shape is intentionally close to TinyKV/TiKV so the MVCC
 - **Timestamps**: clients must supply `startVersion`/`commitVersion`. For distributed demos, use Coordinator (`nokv coordinator`) to obtain globally increasing values before calling `TwoPhaseCommit`.
 - **Bootstrap helpers**: `scripts/dev/cluster.sh --config raft_config.example.json` builds the binaries, seeds local peer catalogs via `nokv-config catalog`, launches the 3 meta-root peers + coordinator, and starts the stores declared in the config.
 
-**Example (two regions)**
-1. Regions `[a,m)` and `[m,+∞)`, each led by a different store.
-2. `Mutate(ctx, primary="alfa", mutations, startTs, commitTs, ttl)` prewrites and commits across the relevant regions.
-3. `Get/Scan` retries automatically if the leader changes.
+**Example (fsmeta bucket regions)**
+1. `raft_config.example.json` declares `fsmeta_region_bootstrap` for the default mounts.
+2. `nokv-config regions` expands that declaration into ordinary byte ranges, with one range per fsmeta affinity bucket plus gap ranges.
+3. `Mutate(ctx, primary, mutations, startTs, commitTs, ttl)` still sees only region descriptors and retries on stale epochs or leader changes.
 4. See `raftstore/server/node_test.go` for a full end-to-end example using real `server.Node` instances.
 
 ---

--- a/docs/config.md
+++ b/docs/config.md
@@ -117,9 +117,9 @@ them is a common deployment mistake, so be explicit:
 | Layer | Keys | Lifecycle | Source of truth |
 |---|---|---|---|
 | **Address directory** | `meta_root.peers`, `coordinator`, `stores`, `store_work_dir_template`, `max_retries` | Read on **every** CLI invocation. Keep in sync with deployed containers/hosts. | **This file is the source of truth.** Nothing else knows where to dial. |
-| **Bootstrap seed** | `regions` | Read **only** on first startup by `scripts/ops/bootstrap.sh`. Once a store has `CURRENT`, bootstrap skips it. | After first bootstrap, **meta-root** owns the runtime region topology. Inspect with `nokv-config regions`. |
+| **Bootstrap seed** | `regions` or `fsmeta_region_bootstrap` | Read **only** on first startup by `scripts/ops/bootstrap.sh`. Once a store has `CURRENT`, bootstrap skips it. | After first bootstrap, **meta-root** owns the runtime region topology. Inspect with `nokv-config regions`. |
 
-Consequence: editing `regions` after bootstrap is a no-op for running
+Consequence: editing bootstrap ranges after bootstrap is a no-op for running
 clusters. Editing addresses is effective on the next CLI invocation
 (restart / docker compose up).
 
@@ -164,12 +164,13 @@ a source of defaults:
       "docker_listen_addr": "0.0.0.0:20160",
       "docker_addr": "nokv-store-1:20160" }
   ],
-  "regions": [
-    { "id": 1, "start_key": "", "end_key": "m",
-      "epoch": { "version": 1, "conf_version": 1 },
-      "peers": [{ "store_id": 1, "peer_id": 101 }],
-      "leader_store_id": 1 }
-  ]
+  "fsmeta_region_bootstrap": {
+    "mounts": ["default", "fsmeta-bench"],
+    "bucket_count": 16,
+    "region_id_base": 1000,
+    "peer_id_base": 100000,
+    "leader_store_ids": [1, 2, 3]
+  }
 }
 ```
 
@@ -193,6 +194,10 @@ a source of defaults:
   Empty or `"-"` means unbounded.
 - **`leader_store_id`** is bootstrap metadata only. Runtime routing comes
   from coordinator (`GetRegionByKey`), never from this field.
+- **`fsmeta_region_bootstrap`** is mutually exclusive with explicit `regions`.
+  It expands to continuous byte-range regions: gap ranges plus one range per
+  fsmeta mount/bucket. This keeps the store/coordinator layer generic while
+  giving fsmeta workloads stable locality and round-robin bootstrap leaders.
 
 ### CLI integration
 

--- a/fsmeta/client/client.go
+++ b/fsmeta/client/client.go
@@ -411,7 +411,10 @@ func translateRPCError(err error) error {
 		}
 		return fmt.Errorf("%w: %v", fsmeta.ErrNotFound, err)
 	case codes.OutOfRange:
-		return fmt.Errorf("%w: %v", fsmeta.ErrWatchCursorExpired, err)
+		if fsmetaReason(err) == reasonWatchCursorExpired {
+			return fmt.Errorf("%w: %v", fsmeta.ErrWatchCursorExpired, err)
+		}
+		return err
 	case codes.FailedPrecondition:
 		switch fsmetaReason(err) {
 		case reasonMountRetired:

--- a/fsmeta/client/errors_test.go
+++ b/fsmeta/client/errors_test.go
@@ -1,10 +1,13 @@
 package client
 
 import (
+	"errors"
 	"testing"
 
 	nokverrors "github.com/feichai0017/NoKV/errors"
+	"github.com/feichai0017/NoKV/fsmeta"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
 )
 
 func TestClientErrorsExposeStableKinds(t *testing.T) {
@@ -24,4 +27,17 @@ func TestClientErrorsExposeStableKinds(t *testing.T) {
 	require.Equal(t, nokverrors.KindProtocolViolation, nokverrors.KindOf(errWatchEventBeforeReady))
 	require.Equal(t, nokverrors.KindUnavailable, nokverrors.KindOf(errConnectionNotReady))
 	require.True(t, nokverrors.Retryable(errConnectionNotReady))
+}
+
+func TestTranslateRPCErrorOnlyMapsWatchReasonToCursorExpired(t *testing.T) {
+	stale := nokverrors.RPCStatusError(nokverrors.KindStaleEpoch, codes.OutOfRange, "stale route", nil)
+	got := translateRPCError(stale)
+	require.False(t, errors.Is(got, fsmeta.ErrWatchCursorExpired))
+	require.Equal(t, nokverrors.KindStaleEpoch, nokverrors.KindOf(got))
+
+	watch := nokverrors.RPCStatusError(nokverrors.KindStaleEpoch, codes.OutOfRange, "watch cursor expired", map[string]string{
+		fsmetaReasonMetadata: reasonWatchCursorExpired,
+	})
+	got = translateRPCError(watch)
+	require.ErrorIs(t, got, fsmeta.ErrWatchCursorExpired)
 }

--- a/fsmeta/exec/runner.go
+++ b/fsmeta/exec/runner.go
@@ -1648,7 +1648,7 @@ func (e *Executor) reserveQuota(ctx context.Context, changes []QuotaChange, star
 }
 
 func (e *Executor) reserveReadVersion(ctx context.Context) (uint64, error) {
-	return e.runner.ReserveTimestamp(ctx, 1)
+	return e.reserveTimestampWithRetry(ctx, 1, maxReadContentionRetries, &e.readRetriesTotal, &e.readRetryExhaustedTotal)
 }
 
 func (e *Executor) readVersion(ctx context.Context, snapshotVersion uint64) (uint64, error) {
@@ -1676,11 +1676,41 @@ func (e *Executor) readVersion(ctx context.Context, snapshotVersion uint64) (uin
 // speculative commit_ts is detected at commit time, never silently accepted.
 // CommitTsExpired is retried transparently by withTxnRetry below.
 func (e *Executor) reserveTxnVersions(ctx context.Context) (uint64, uint64, error) {
-	startVersion, err := e.runner.ReserveTimestamp(ctx, 2)
+	startVersion, err := e.reserveTimestampWithRetry(ctx, 2, maxTxnContentionRetries, &e.txnRetriesTotal, &e.txnRetryExhaustedTotal)
 	if err != nil {
 		return 0, 0, err
 	}
 	return startVersion, startVersion + 1, nil
+}
+
+func (e *Executor) reserveTimestampWithRetry(ctx context.Context, count uint64, maxRetries int, retryTotal, exhaustedTotal *atomic.Uint64) (uint64, error) {
+	var last error
+	for attempt := 0; attempt <= maxRetries; attempt++ {
+		version, err := e.runner.ReserveTimestamp(ctx, count)
+		if err == nil {
+			return version, nil
+		}
+		if !nokverrors.Retryable(err) {
+			return 0, err
+		}
+		last = err
+		if attempt == maxRetries {
+			if exhaustedTotal != nil {
+				exhaustedTotal.Add(1)
+			}
+			break
+		}
+		if retryTotal != nil {
+			retryTotal.Add(1)
+		}
+		// Coordinator duty handoff can reject a timestamp request with stale
+		// evidence before any fsmeta mutation has started. Retrying here keeps
+		// transient authority churn below the namespace API boundary.
+		if err := waitTxnContentionRetryDelay(ctx, txnContentionRetryDelay(attempt)); err != nil {
+			return 0, err
+		}
+	}
+	return 0, last
 }
 
 func (e *Executor) withTxnRetry(ctx context.Context, run func(startVersion, commitVersion uint64) error) error {

--- a/fsmeta/exec/runner.go
+++ b/fsmeta/exec/runner.go
@@ -1328,47 +1328,63 @@ func (e *Executor) ExpireWriteSessions(ctx context.Context, req fsmeta.ExpireWri
 	now := e.clock().UnixNano()
 	var expired uint64
 	if err := e.withTxnRetry(ctx, func(startVersion, commitVersion uint64) error {
-		kvs, err := e.runner.Scan(ctx, plan.StartKey, plan.Limit, startVersion)
-		if err != nil {
-			return err
-		}
 		deletes := make(map[string][]byte)
 		type expiredSessionKey struct {
 			inode   fsmeta.InodeID
 			session fsmeta.SessionID
 		}
 		expiredSessions := make(map[expiredSessionKey]struct{})
-		for _, kv := range kvs {
-			if !bytes.HasPrefix(kv.Key, plan.PrimaryKey) {
+		remaining := plan.Limit
+		for _, scanPrefix := range plan.ReadPrefixes {
+			if remaining == 0 {
 				break
 			}
-			record, err := fsmeta.DecodeSessionValue(kv.Value)
+			kvs, err := e.runner.Scan(ctx, scanPrefix, remaining, startVersion)
 			if err != nil {
 				return err
 			}
-			if sessionLive(record, now) {
-				continue
+			var matched uint32
+			for _, kv := range kvs {
+				if !bytes.HasPrefix(kv.Key, scanPrefix) {
+					break
+				}
+				matched++
+				kind, err := fsmeta.KeyKindOf(kv.Key)
+				if err != nil {
+					return err
+				}
+				if kind != fsmeta.KeyKindSession {
+					continue
+				}
+				record, err := fsmeta.DecodeSessionValue(kv.Value)
+				if err != nil {
+					return err
+				}
+				if sessionLive(record, now) {
+					continue
+				}
+				deletes[string(kv.Key)] = cloneBytes(kv.Key)
+				sessionKey, err := fsmeta.EncodeSessionKey(req.Mount, record.Inode, record.Session)
+				if err != nil {
+					return err
+				}
+				ownerKey, err := fsmeta.EncodeInodeSessionKey(req.Mount, record.Inode)
+				if err != nil {
+					return err
+				}
+				if value, ok, err := e.runner.Get(ctx, sessionKey, startVersion); err != nil {
+					return err
+				} else if ok && bytes.Equal(value, kv.Value) {
+					deletes[string(sessionKey)] = sessionKey
+					expiredSessions[expiredSessionKey{inode: record.Inode, session: record.Session}] = struct{}{}
+				}
+				if value, ok, err := e.runner.Get(ctx, ownerKey, startVersion); err != nil {
+					return err
+				} else if ok && bytes.Equal(value, kv.Value) {
+					deletes[string(ownerKey)] = ownerKey
+				}
 			}
-			deletes[string(kv.Key)] = cloneBytes(kv.Key)
-			sessionKey, err := fsmeta.EncodeSessionKey(req.Mount, record.Inode, record.Session)
-			if err != nil {
-				return err
-			}
-			ownerKey, err := fsmeta.EncodeInodeSessionKey(req.Mount, record.Inode)
-			if err != nil {
-				return err
-			}
-			if value, ok, err := e.runner.Get(ctx, sessionKey, startVersion); err != nil {
-				return err
-			} else if ok && bytes.Equal(value, kv.Value) {
-				deletes[string(sessionKey)] = sessionKey
-				expiredSessions[expiredSessionKey{inode: record.Inode, session: record.Session}] = struct{}{}
-			}
-			if value, ok, err := e.runner.Get(ctx, ownerKey, startVersion); err != nil {
-				return err
-			} else if ok && bytes.Equal(value, kv.Value) {
-				deletes[string(ownerKey)] = ownerKey
-			}
+			remaining -= matched
 		}
 		if len(deletes) == 0 {
 			expired = 0
@@ -1679,19 +1695,17 @@ func (e *Executor) withTxnRetry(ctx context.Context, run func(startVersion, comm
 		if err == nil {
 			return nil
 		}
-		if !isRetryableTxnContention(err) {
+		if !isRetryableTxnAttempt(err) {
 			return translateMutateError(err)
 		}
 		last = err
-		if !canRetryTxnContention(attempt, started, err, e.lockTTL) {
+		if !canRetryTxnAttempt(attempt, started, err, e.lockTTL) {
 			e.txnRetryExhaustedTotal.Add(1)
 			break
 		}
-		// A live Percolator lock may survive ordinary RPC and raft scheduling
-		// jitter, especially when a close and session-cleanup delete touch the
-		// same lease key. fsmeta write APIs should absorb that transient
-		// contention up to the advertised lock TTL instead of returning MVCC
-		// lock details.
+		// A live Percolator lock or a coordinator/region route refresh can race
+		// with the same semantic fsmeta operation. Retrying at this boundary
+		// keeps transient MVCC and route churn below the API contract.
 		e.txnRetriesTotal.Add(1)
 		delay := txnContentionRetryDelay(attempt)
 		if budget := txnRetryBudget(err, e.lockTTL); budget > 0 {
@@ -1720,7 +1734,7 @@ func (e *Executor) withReadRetry(ctx context.Context, snapshotVersion uint64, ru
 		if err == nil {
 			return nil
 		}
-		if !isRetryableTxnContention(err) {
+		if !isRetryableReadAttempt(err) {
 			return err
 		}
 		last = err
@@ -1728,9 +1742,9 @@ func (e *Executor) withReadRetry(ctx context.Context, snapshotVersion uint64, ru
 			e.readRetryExhaustedTotal.Add(1)
 			break
 		}
-		// ReadDir and ReadDirPlus may race with live Percolator locks from
-		// concurrent namespace mutation. Retrying keeps the external API at the
-		// fsmeta level instead of leaking a transient MVCC lock to callers.
+		// ReadDir and ReadDirPlus may race with live Percolator locks or region
+		// route refresh. Retrying keeps the external API at the fsmeta level
+		// instead of leaking transient storage details to callers.
 		e.readRetriesTotal.Add(1)
 		if err := waitTxnContentionRetryDelay(ctx, txnContentionRetryDelay(attempt)); err != nil {
 			return err
@@ -1739,7 +1753,7 @@ func (e *Executor) withReadRetry(ctx context.Context, snapshotVersion uint64, ru
 	return last
 }
 
-func canRetryTxnContention(attempt int, started time.Time, err error, fallbackLockTTL uint64) bool {
+func canRetryTxnAttempt(attempt int, started time.Time, err error, fallbackLockTTL uint64) bool {
 	if budget := txnRetryBudget(err, fallbackLockTTL); budget > 0 {
 		return time.Since(started) < budget
 	}
@@ -1926,4 +1940,23 @@ func translateMutateError(err error) error {
 
 func isRetryableTxnContention(err error) bool {
 	return nokverrors.IsTxnContention(err)
+}
+
+func isRetryableTxnAttempt(err error) bool {
+	return isRetryableTxnContention(err) || isRetryableRouteRefresh(err)
+}
+
+func isRetryableReadAttempt(err error) bool {
+	return isRetryableTxnContention(err) || isRetryableRouteRefresh(err)
+}
+
+func isRetryableRouteRefresh(err error) bool {
+	switch nokverrors.KindOf(err) {
+	case nokverrors.KindRouteUnavailable,
+		nokverrors.KindRegionRouting,
+		nokverrors.KindStaleEpoch:
+		return true
+	default:
+		return false
+	}
 }

--- a/fsmeta/exec/runner_test.go
+++ b/fsmeta/exec/runner_test.go
@@ -1334,6 +1334,30 @@ func TestExecutorRetriesLostTxnLock(t *testing.T) {
 	require.Equal(t, uint64(0), executor.Stats()["txn_retry_exhausted_total"])
 }
 
+func TestExecutorRetriesRouteUnavailable(t *testing.T) {
+	runner := newFakeRunner()
+	runner.mutateErrs = []error{
+		nokverrors.New(nokverrors.KindRouteUnavailable, "route lookup refreshing"),
+		nil,
+	}
+	allocator := &fakeInodeAllocator{ids: []fsmeta.InodeID{22}}
+	executor, err := New(runner, WithInodeAllocator(allocator))
+	require.NoError(t, err)
+
+	_, err = executor.Create(context.Background(), fsmeta.CreateRequest{
+		Mount:  "vol",
+		Parent: fsmeta.RootInode,
+		Name:   "file",
+		Attrs:  fsmeta.CreateAttrs{Type: fsmeta.InodeTypeFile},
+	})
+	require.NoError(t, err)
+	require.Len(t, runner.mutations, 1)
+	require.Equal(t, 1, allocator.calls)
+	require.Equal(t, uint64(5), runner.nextTS)
+	require.Equal(t, uint64(1), executor.Stats()["txn_retries_total"])
+	require.Equal(t, uint64(0), executor.Stats()["txn_retry_exhausted_total"])
+}
+
 func TestExecutorRetriesLockedTxnContention(t *testing.T) {
 	runner := newFakeRunner()
 	runner.mutateErrs = []error{
@@ -1408,8 +1432,8 @@ func TestTxnContentionRetryPolicyUsesLockTTLAfterFixedAttempts(t *testing.T) {
 	budget := txnRetryBudget(lockErr, defaultLockTTL)
 
 	require.Equal(t, 5*time.Second+txnContentionRetryMaxBackoff, budget)
-	require.True(t, canRetryTxnContention(maxTxnContentionRetries+8, time.Now(), lockErr, defaultLockTTL))
-	require.False(t, canRetryTxnContention(maxTxnContentionRetries+8, time.Now().Add(-budget-time.Millisecond), lockErr, defaultLockTTL))
+	require.True(t, canRetryTxnAttempt(maxTxnContentionRetries+8, time.Now(), lockErr, defaultLockTTL))
+	require.False(t, canRetryTxnAttempt(maxTxnContentionRetries+8, time.Now().Add(-budget-time.Millisecond), lockErr, defaultLockTTL))
 }
 
 func TestTxnContentionRetryPolicyKeepsCountBoundForNonLockConflicts(t *testing.T) {
@@ -1422,8 +1446,8 @@ func TestTxnContentionRetryPolicyKeepsCountBoundForNonLockConflicts(t *testing.T
 	}}}
 
 	require.Zero(t, txnRetryBudget(writeConflictErr, defaultLockTTL))
-	require.True(t, canRetryTxnContention(maxTxnContentionRetries-1, time.Now(), writeConflictErr, defaultLockTTL))
-	require.False(t, canRetryTxnContention(maxTxnContentionRetries, time.Now(), writeConflictErr, defaultLockTTL))
+	require.True(t, canRetryTxnAttempt(maxTxnContentionRetries-1, time.Now(), writeConflictErr, defaultLockTTL))
+	require.False(t, canRetryTxnAttempt(maxTxnContentionRetries, time.Now(), writeConflictErr, defaultLockTTL))
 }
 
 func TestTxnRetryBudgetFallsBackWhenLockDetailsAreUnavailable(t *testing.T) {
@@ -1438,7 +1462,7 @@ func TestTxnRetryBudgetCoversPercolatorRetryableStartTSLoss(t *testing.T) {
 	}}}
 
 	require.Equal(t, 50*time.Millisecond+txnContentionRetryMaxBackoff, txnRetryBudget(err, 50))
-	require.True(t, canRetryTxnContention(maxTxnContentionRetries+1, time.Now(), err, 50))
+	require.True(t, canRetryTxnAttempt(maxTxnContentionRetries+1, time.Now(), err, 50))
 }
 
 func TestExecutorRetriesWriteConflict(t *testing.T) {

--- a/fsmeta/exec/runner_test.go
+++ b/fsmeta/exec/runner_test.go
@@ -26,6 +26,7 @@ type fakeRunner struct {
 	batchVersions       []uint64
 	scanErrs            []error
 	batchErrs           []error
+	timestampErrs       []error
 	mutateErr           error
 	mutateErrs          []error
 	actualCommitVersion uint64
@@ -203,6 +204,13 @@ func newFakeRunner() *fakeRunner {
 func (r *fakeRunner) ReserveTimestamp(_ context.Context, count uint64) (uint64, error) {
 	if count == 0 {
 		return 0, errors.New("zero timestamp reservation")
+	}
+	if len(r.timestampErrs) > 0 {
+		err := r.timestampErrs[0]
+		r.timestampErrs = r.timestampErrs[1:]
+		if err != nil {
+			return 0, err
+		}
 	}
 	first := r.nextTS
 	r.nextTS += count
@@ -464,6 +472,39 @@ func TestExecutorCreateAndLookup(t *testing.T) {
 	require.Len(t, runner.mutations[0], 2)
 	require.True(t, runner.mutations[0][0].GetAssertionNotExist())
 	require.True(t, runner.mutations[0][1].GetAssertionNotExist())
+}
+
+func TestExecutorRetriesTimestampAuthorityRefreshBeforeMutate(t *testing.T) {
+	runner := newFakeRunner()
+	runner.timestampErrs = []error{nokverrors.New(nokverrors.KindStaleEpoch, "coordinator client: stale witness era")}
+	executor, err := New(runner, WithInodeAllocator(&fakeInodeAllocator{ids: []fsmeta.InodeID{22}}))
+	require.NoError(t, err)
+
+	_, err = executor.Create(context.Background(), fsmeta.CreateRequest{
+		Mount:  "vol",
+		Parent: fsmeta.RootInode,
+		Name:   "file",
+		Attrs:  fsmeta.CreateAttrs{Type: fsmeta.InodeTypeFile},
+	})
+
+	require.NoError(t, err)
+	require.Empty(t, runner.timestampErrs)
+	require.Len(t, runner.mutations, 1)
+	requireStatUint(t, executor.Stats(), "txn_retries_total", 1)
+}
+
+func TestExecutorRetriesReadTimestampAuthorityRefresh(t *testing.T) {
+	runner := newFakeRunner()
+	runner.timestampErrs = []error{nokverrors.New(nokverrors.KindStaleEpoch, "coordinator client: stale witness era")}
+	executor, err := New(runner)
+	require.NoError(t, err)
+
+	version, err := executor.GetReadVersion(context.Background(), fsmeta.ReadVersionRequest{Mount: "vol"})
+
+	require.NoError(t, err)
+	require.NotZero(t, version)
+	require.Empty(t, runner.timestampErrs)
+	requireStatUint(t, executor.Stats(), "read_retries_total", 1)
 }
 
 func TestExecutorCreateRequiresInodeAllocator(t *testing.T) {

--- a/fsmeta/keys.go
+++ b/fsmeta/keys.go
@@ -4,6 +4,7 @@ import (
 	"encoding/binary"
 	"fmt"
 
+	localdb "github.com/feichai0017/NoKV/local"
 	"github.com/feichai0017/NoKV/utils"
 )
 
@@ -14,6 +15,7 @@ import (
 //	  version  = 0x01
 //	  mount_len uvarint
 //	  mount bytes
+//	  affinity_bucket be16
 //	  kind byte
 //
 //	kind bodies:
@@ -28,6 +30,14 @@ import (
 var keyMagic = []byte{'f', 's', 'm', 0}
 
 const keySchemaVersion byte = 1
+
+const (
+	DefaultAffinityBucketCount = 16
+	RootAffinityBucket         = AffinityBucket(0)
+	encodedBucketBytes         = 2
+)
+
+type AffinityBucket uint16
 
 // KeyKind classifies one fsmeta key family.
 type KeyKind byte
@@ -62,7 +72,7 @@ func (k KeyKind) String() string {
 
 // EncodeMountKey returns the mount-level metadata record key.
 func EncodeMountKey(mount MountID) ([]byte, error) {
-	return encodeKey(mount, KeyKindMount, nil)
+	return encodeKey(mount, RootAffinityBucket, KeyKindMount, nil)
 }
 
 // EncodeMountPrefix returns the common key prefix for one mount. All fsmeta
@@ -81,6 +91,25 @@ func EncodeMountKeyRange(mount MountID) (start, end []byte, err error) {
 	return start, prefixUpperBound(start), nil
 }
 
+// EncodeBucketPrefix returns the key prefix for one mount-local affinity
+// bucket. Coordinator placement can split these byte ranges without learning
+// fsmeta's record families.
+func EncodeBucketPrefix(mount MountID, bucket AffinityBucket) ([]byte, error) {
+	prefix, err := encodeMountPrefix(mount)
+	if err != nil {
+		return nil, err
+	}
+	return appendBucket(prefix, bucket), nil
+}
+
+func EncodeBucketRange(mount MountID, bucket AffinityBucket) (start, end []byte, err error) {
+	start, err = EncodeBucketPrefix(mount, bucket)
+	if err != nil {
+		return nil, nil, err
+	}
+	return start, prefixUpperBound(start), nil
+}
+
 // EncodeInodeKey returns the inode attribute record key.
 func EncodeInodeKey(mount MountID, inode InodeID) ([]byte, error) {
 	if err := validateInodeID(inode); err != nil {
@@ -88,7 +117,7 @@ func EncodeInodeKey(mount MountID, inode InodeID) ([]byte, error) {
 	}
 	var body [8]byte
 	binary.BigEndian.PutUint64(body[:], uint64(inode))
-	return encodeKey(mount, KeyKindInode, body[:])
+	return encodeKey(mount, BucketForInodeID(inode), KeyKindInode, body[:])
 }
 
 // EncodeDentryPrefix returns the scan prefix for entries directly under parent.
@@ -98,7 +127,7 @@ func EncodeDentryPrefix(mount MountID, parent InodeID) ([]byte, error) {
 	}
 	var body [8]byte
 	binary.BigEndian.PutUint64(body[:], uint64(parent))
-	return encodeKey(mount, KeyKindDentry, body[:])
+	return encodeKey(mount, BucketForInodeID(parent), KeyKindDentry, body[:])
 }
 
 // EncodeDentryKey returns the dentry record key for parent/name.
@@ -121,7 +150,7 @@ func EncodeChunkKey(mount MountID, inode InodeID, chunk ChunkIndex) ([]byte, err
 	var body [16]byte
 	binary.BigEndian.PutUint64(body[:8], uint64(inode))
 	binary.BigEndian.PutUint64(body[8:], uint64(chunk))
-	return encodeKey(mount, KeyKindChunk, body[:])
+	return encodeKey(mount, BucketForInodeID(inode), KeyKindChunk, body[:])
 }
 
 // EncodeSessionKey returns the client/session state key.
@@ -136,7 +165,15 @@ func EncodeSessionKey(mount MountID, inode InodeID, session SessionID) ([]byte, 
 	binary.BigEndian.PutUint64(body[:8], uint64(inode))
 	body[8] = 0x01
 	body = append(body, string(session)...)
-	return encodeKey(mount, KeyKindSession, body)
+	return encodeKey(mount, BucketForInodeID(inode), KeyKindSession, body)
+}
+
+// EncodeSessionBucketPrefix returns the prefix for all session records in one
+// mount-local affinity bucket. Maintenance scanners use this bucket-local
+// prefix instead of the mount prefix so routed scans stay inside real fsmeta
+// data ranges.
+func EncodeSessionBucketPrefix(mount MountID, bucket AffinityBucket) ([]byte, error) {
+	return encodeKey(mount, bucket, KeyKindSession, nil)
 }
 
 // EncodeInodeSessionKey returns the exclusive writer-owner key for one inode.
@@ -147,13 +184,7 @@ func EncodeInodeSessionKey(mount MountID, inode InodeID) ([]byte, error) {
 	var body [9]byte
 	binary.BigEndian.PutUint64(body[:8], uint64(inode))
 	body[8] = 0x00
-	return encodeKey(mount, KeyKindSession, body[:])
-}
-
-// EncodeSessionPrefix returns the scan prefix covering both session IDs and
-// inode owner records for one mount.
-func EncodeSessionPrefix(mount MountID) ([]byte, error) {
-	return encodeKey(mount, KeyKindSession, nil)
+	return encodeKey(mount, BucketForInodeID(inode), KeyKindSession, body[:])
 }
 
 // EncodeUsageKey returns a quota usage/counter key. Scope 0 is mount-wide;
@@ -161,7 +192,7 @@ func EncodeSessionPrefix(mount MountID) ([]byte, error) {
 func EncodeUsageKey(mount MountID, scope InodeID) ([]byte, error) {
 	var body [8]byte
 	binary.BigEndian.PutUint64(body[:], uint64(scope))
-	return encodeKey(mount, KeyKindUsage, body[:])
+	return encodeKey(mount, BucketForInodeID(scope), KeyKindUsage, body[:])
 }
 
 // KeyKindOf returns the kind byte encoded in a fsmeta key.
@@ -191,11 +222,50 @@ func MountIDOfKey(key []byte) (MountID, bool) {
 	return mount, true
 }
 
+func BucketOfKey(key []byte) (AffinityBucket, bool) {
+	_, pos, err := decodeMountPrefix(key)
+	if err != nil || len(key)-pos < encodedBucketBytes+1 {
+		return 0, false
+	}
+	return AffinityBucket(binary.BigEndian.Uint16(key[pos : pos+encodedBucketBytes])), true
+}
+
 // StringMountResolver adapts fsmeta keys to raftstore MVCC GC mount-scoped
 // retention policy.
 func StringMountResolver(key []byte) (string, bool) {
 	mount, ok := MountIDOfKey(key)
 	return string(mount), ok
+}
+
+// UserKeyShape exposes fsmeta key shape to the local engine without making the
+// engine import fsmeta. The shape keeps all keys in one mount-local affinity
+// bucket on the same local shard and gives prefix bloom filters record-family
+// prefixes that match the current key layout.
+func UserKeyShape(key []byte) localdb.UserKeyShape {
+	_, bucketPos, err := decodeMountPrefix(key)
+	if err != nil || len(key)-bucketPos < encodedBucketBytes+1 {
+		return localdb.UserKeyShape{}
+	}
+	kindPos := bucketPos + encodedBucketBytes
+	kind := KeyKind(key[kindPos])
+	bodyPos := kindPos + 1
+	shape := localdb.UserKeyShape{
+		LocalityPrefix: key[:kindPos],
+		ShardKey:       key[:kindPos],
+		Family:         byte(kind),
+	}
+	switch kind {
+	case KeyKindMount:
+		shape.BloomPrefix = key[:bodyPos]
+	case KeyKindInode, KeyKindDentry, KeyKindChunk, KeyKindSession, KeyKindUsage:
+		if len(key) < bodyPos+8 {
+			return localdb.UserKeyShape{}
+		}
+		shape.BloomPrefix = key[:bodyPos+8]
+	default:
+		return localdb.UserKeyShape{}
+	}
+	return shape
 }
 
 // ShardForUserKey is the fsmeta physical placement policy used by local DB
@@ -206,64 +276,39 @@ func ShardForUserKey(key []byte, shardCount int) int {
 	if shardCount <= 1 {
 		return 0
 	}
-	_, pos, err := decodeHeaderParts(key)
-	if err != nil || pos >= len(key) {
-		return utils.ShardForUserKey(key, shardCount)
+	shape := UserKeyShape(key)
+	if len(shape.ShardKey) > 0 {
+		return utils.ShardForUserKey(shape.ShardKey, shardCount)
 	}
-	kind := KeyKind(key[pos])
-	body := key[pos+1:]
-	switch kind {
-	case KeyKindMount:
-		mount, _, err := decodeHeaderParts(key)
-		if err != nil {
-			return utils.ShardForUserKey(key, shardCount)
-		}
-		return utils.ShardForUserKey([]byte(mount), shardCount)
-	case KeyKindInode:
-		if len(body) < 8 {
-			return utils.ShardForUserKey(key, shardCount)
-		}
-		return shardForInodeAffinity(InodeID(binary.BigEndian.Uint64(body[:8])), shardCount)
-	case KeyKindDentry:
-		if len(body) < 8 {
-			return utils.ShardForUserKey(key, shardCount)
-		}
-		parent := InodeID(binary.BigEndian.Uint64(body[:8]))
-		if parent == RootInode && len(body) > 8 {
-			return utils.ShardForUserKey(body[8:], shardCount)
-		}
-		return shardForInodeAffinity(parent, shardCount)
-	case KeyKindChunk:
-		if len(body) < 8 {
-			return utils.ShardForUserKey(key, shardCount)
-		}
-		return shardForInodeAffinity(InodeID(binary.BigEndian.Uint64(body[:8])), shardCount)
-	case KeyKindSession:
-		if len(body) < 9 {
-			return utils.ShardForUserKey(key, shardCount)
-		}
-		return shardForInodeAffinity(InodeID(binary.BigEndian.Uint64(body[:8])), shardCount)
-	case KeyKindUsage:
-		if len(body) < 8 {
-			return utils.ShardForUserKey(key, shardCount)
-		}
-		return shardForInodeAffinity(InodeID(binary.BigEndian.Uint64(body[:8])), shardCount)
-	default:
-		return utils.ShardForUserKey(key, shardCount)
+	if len(shape.LocalityPrefix) > 0 {
+		return utils.ShardForUserKey(shape.LocalityPrefix, shardCount)
 	}
+	return utils.ShardForUserKey(key, shardCount)
 }
 
-func shardForInodeAffinity(inode InodeID, shardCount int) int {
+func BucketForInodeID(inode InodeID) AffinityBucket {
+	if inode == RootInode {
+		return RootAffinityBucket
+	}
 	var body [8]byte
 	binary.BigEndian.PutUint64(body[:], uint64(inode))
-	return utils.ShardForUserKey(body[:], shardCount)
+	return AffinityBucket(utils.ShardForUserKey(body[:], DefaultAffinityBucketCount))
 }
 
-func encodeKey(mount MountID, kind KeyKind, body []byte) ([]byte, error) {
+func ChooseWorkspaceBucket(mount MountID, name string) AffinityBucket {
+	key := make([]byte, 0, len(mount)+1+len(name))
+	key = append(key, string(mount)...)
+	key = append(key, 0)
+	key = append(key, name...)
+	return AffinityBucket(utils.ShardForUserKey(key, DefaultAffinityBucketCount))
+}
+
+func encodeKey(mount MountID, bucket AffinityBucket, kind KeyKind, body []byte) ([]byte, error) {
 	out, err := encodeMountPrefix(mount)
 	if err != nil {
 		return nil, err
 	}
+	out = appendBucket(out, bucket)
 	out = append(out, byte(kind))
 	out = append(out, body...)
 	return out, nil
@@ -281,6 +326,12 @@ func encodeMountPrefix(mount MountID) ([]byte, error) {
 	return out, nil
 }
 
+func appendBucket(out []byte, bucket AffinityBucket) []byte {
+	var buf [encodedBucketBytes]byte
+	binary.BigEndian.PutUint16(buf[:], uint16(bucket))
+	return append(out, buf[:]...)
+}
+
 func prefixUpperBound(prefix []byte) []byte {
 	out := append([]byte(nil), prefix...)
 	for i := len(out) - 1; i >= 0; i-- {
@@ -293,6 +344,17 @@ func prefixUpperBound(prefix []byte) []byte {
 }
 
 func decodeHeaderParts(key []byte) (MountID, int, error) {
+	mount, pos, err := decodeMountPrefix(key)
+	if err != nil {
+		return "", 0, err
+	}
+	if len(key)-pos < encodedBucketBytes+1 {
+		return "", 0, ErrInvalidKey
+	}
+	return mount, pos + encodedBucketBytes, nil
+}
+
+func decodeMountPrefix(key []byte) (MountID, int, error) {
 	if len(key) < len(keyMagic)+2 {
 		return "", 0, ErrInvalidKey
 	}

--- a/fsmeta/keys_test.go
+++ b/fsmeta/keys_test.go
@@ -12,7 +12,7 @@ func TestKeyLayoutStable(t *testing.T) {
 	key, err := EncodeInodeKey("vol", 42)
 	require.NoError(t, err)
 
-	require.Equal(t, "66736d000103766f6c69000000000000002a", hex.EncodeToString(key))
+	require.Equal(t, "66736d000103766f6c000769000000000000002a", hex.EncodeToString(key))
 
 	kind, err := KeyKindOf(key)
 	require.NoError(t, err)
@@ -43,6 +43,28 @@ func TestAuxiliaryKeyEncoders(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, KeyKindChunk, kind)
 	require.Equal(t, "chunk", kind.String())
+}
+
+func TestBucketPrefixAndRangeCoverOneAffinityBucket(t *testing.T) {
+	start, end, err := EncodeBucketRange("vol", 3)
+	require.NoError(t, err)
+	require.NotEmpty(t, end)
+
+	var inBucket InodeID
+	for inode := InodeID(2); inode < 10_000; inode++ {
+		if BucketForInodeID(inode) == 3 {
+			inBucket = inode
+			break
+		}
+	}
+	require.NotZero(t, inBucket)
+	key, err := EncodeInodeKey("vol", inBucket)
+	require.NoError(t, err)
+	require.GreaterOrEqual(t, bytes.Compare(key, start), 0)
+	require.Less(t, bytes.Compare(key, end), 0)
+	bucket, ok := BucketOfKey(key)
+	require.True(t, ok)
+	require.Equal(t, AffinityBucket(3), bucket)
 }
 
 func TestMountPrefixAndRangeCoverOnlyOneMount(t *testing.T) {
@@ -96,19 +118,82 @@ func TestShardForUserKeyKeepsWorkspaceMutationsLocal(t *testing.T) {
 	const shards = 4
 	createDentry, err := EncodeDentryKey("vol", RootInode, "workspace-a")
 	require.NoError(t, err)
-	targetShard := ShardForUserKey(createDentry, shards)
+	rootBucket, ok := BucketOfKey(createDentry)
+	require.True(t, ok)
+	require.Equal(t, RootAffinityBucket, rootBucket)
 
-	inode := findInodeOnShard(t, "vol", targetShard, shards)
+	targetBucket := ChooseWorkspaceBucket("vol", "workspace-a")
+	inode := findInodeOnBucket(t, "vol", targetBucket)
 	createInode, err := EncodeInodeKey("vol", inode)
 	require.NoError(t, err)
-	require.Equal(t, targetShard, ShardForUserKey(createInode, shards))
 
 	childA, err := EncodeDentryKey("vol", inode, "scratch")
 	require.NoError(t, err)
 	childB, err := EncodeDentryKey("vol", inode, "checkpoint")
 	require.NoError(t, err)
-	require.Equal(t, targetShard, ShardForUserKey(childA, shards))
-	require.Equal(t, targetShard, ShardForUserKey(childB, shards))
+	require.Equal(t, ShardForUserKey(createInode, shards), ShardForUserKey(childA, shards))
+	require.Equal(t, ShardForUserKey(createInode, shards), ShardForUserKey(childB, shards))
+}
+
+func TestUserKeyShapeExtractsAffinityAndBloomPrefixes(t *testing.T) {
+	const mount MountID = "vol"
+	const inode InodeID = 42
+
+	bucketPrefix, err := EncodeBucketPrefix(mount, BucketForInodeID(inode))
+	require.NoError(t, err)
+
+	dentryPrefix, err := EncodeDentryPrefix(mount, inode)
+	require.NoError(t, err)
+	dentry, err := EncodeDentryKey(mount, inode, "checkpoint")
+	require.NoError(t, err)
+	dentryShape := UserKeyShape(dentry)
+	require.Equal(t, bucketPrefix, dentryShape.LocalityPrefix)
+	require.Equal(t, bucketPrefix, dentryShape.ShardKey)
+	require.Equal(t, byte(KeyKindDentry), dentryShape.Family)
+	require.Equal(t, dentryPrefix, dentryShape.BloomPrefix)
+
+	session, err := EncodeSessionKey(mount, inode, "writer-1")
+	require.NoError(t, err)
+	owner, err := EncodeInodeSessionKey(mount, inode)
+	require.NoError(t, err)
+	sessionShape := UserKeyShape(session)
+	require.Equal(t, bucketPrefix, sessionShape.LocalityPrefix)
+	require.Equal(t, byte(KeyKindSession), sessionShape.Family)
+	require.Equal(t, owner[:len(owner)-1], sessionShape.BloomPrefix)
+
+	inodeKey, err := EncodeInodeKey(mount, inode)
+	require.NoError(t, err)
+	inodeShape := UserKeyShape(inodeKey)
+	require.Equal(t, bucketPrefix, inodeShape.LocalityPrefix)
+	require.Equal(t, inodeKey, inodeShape.BloomPrefix)
+}
+
+func TestShardForUserKeyUsesShapeLocalityAcrossFamilies(t *testing.T) {
+	const shards = 4
+	const mount MountID = "vol"
+	inode := findInodeOnBucket(t, mount, 7)
+	keys := make([][]byte, 0, 5)
+
+	inodeKey, err := EncodeInodeKey(mount, inode)
+	require.NoError(t, err)
+	keys = append(keys, inodeKey)
+	dentry, err := EncodeDentryKey(mount, inode, "scratch")
+	require.NoError(t, err)
+	keys = append(keys, dentry)
+	chunk, err := EncodeChunkKey(mount, inode, 3)
+	require.NoError(t, err)
+	keys = append(keys, chunk)
+	session, err := EncodeSessionKey(mount, inode, "writer-1")
+	require.NoError(t, err)
+	keys = append(keys, session)
+	usage, err := EncodeUsageKey(mount, inode)
+	require.NoError(t, err)
+	keys = append(keys, usage)
+
+	target := ShardForUserKey(keys[0], shards)
+	for _, key := range keys[1:] {
+		require.Equal(t, target, ShardForUserKey(key, shards))
+	}
 }
 
 func TestShardForUserKeyKeepsSessionIndexesWithInode(t *testing.T) {
@@ -136,21 +221,23 @@ func TestKeyKindOfRejectsInvalidKeys(t *testing.T) {
 	_, err := KeyKindOf([]byte("not-fsmeta"))
 	require.ErrorIs(t, err, ErrInvalidKey)
 
-	key, err := encodeKey("vol", KeyKind('x'), []byte("body"))
+	key, err := encodeKey("vol", RootAffinityBucket, KeyKind('x'), []byte("body"))
 	require.NoError(t, err)
 	_, err = KeyKindOf(key)
 	require.ErrorIs(t, err, ErrInvalidKeyKind)
 }
 
-func findInodeOnShard(t *testing.T, mount MountID, shard int, shardCount int) InodeID {
+func findInodeOnBucket(t *testing.T, mount MountID, bucket AffinityBucket) InodeID {
 	t.Helper()
 	for inode := InodeID(2); inode < 10_000; inode++ {
 		key, err := EncodeInodeKey(mount, inode)
 		require.NoError(t, err)
-		if ShardForUserKey(key, shardCount) == shard {
+		got, ok := BucketOfKey(key)
+		require.True(t, ok)
+		if got == bucket {
 			return inode
 		}
 	}
-	t.Fatalf("no inode found for shard %d", shard)
+	t.Fatalf("no inode found for bucket %d", bucket)
 	return 0
 }

--- a/fsmeta/placement.go
+++ b/fsmeta/placement.go
@@ -1,0 +1,98 @@
+package fsmeta
+
+import (
+	"bytes"
+	"fmt"
+	"sort"
+)
+
+// PlacementRange describes one bootstrap byte range. Bucket ranges are fsmeta
+// locality ranges; gap ranges keep the whole keyspace covered without teaching
+// raftstore or coordinator about fsmeta record families.
+type PlacementRange struct {
+	StartKey []byte
+	EndKey   []byte
+	Mount    MountID
+	Bucket   AffinityBucket
+	Bucketed bool
+}
+
+// PlanBucketPlacement returns continuous byte ranges that isolate each
+// mount-local affinity bucket while preserving full keyspace coverage.
+func PlanBucketPlacement(mounts []MountID, bucketCount int) ([]PlacementRange, error) {
+	if bucketCount <= 0 || bucketCount > 1<<16 {
+		return nil, fmt.Errorf("%w: affinity bucket count out of range", ErrInvalidRequest)
+	}
+	buckets := make([]PlacementRange, 0, len(mounts)*bucketCount)
+	seen := make(map[MountID]struct{}, len(mounts))
+	for _, mount := range mounts {
+		if _, ok := seen[mount]; ok {
+			return nil, fmt.Errorf("%w: duplicate mount %q", ErrInvalidRequest, mount)
+		}
+		seen[mount] = struct{}{}
+		for bucket := range bucketCount {
+			start, end, err := EncodeBucketRange(mount, AffinityBucket(bucket))
+			if err != nil {
+				return nil, err
+			}
+			buckets = append(buckets, PlacementRange{
+				StartKey: start,
+				EndKey:   end,
+				Mount:    mount,
+				Bucket:   AffinityBucket(bucket),
+				Bucketed: true,
+			})
+		}
+	}
+	sort.Slice(buckets, func(i, j int) bool {
+		return bytes.Compare(buckets[i].StartKey, buckets[j].StartKey) < 0
+	})
+
+	out := make([]PlacementRange, 0, len(buckets)*2+1)
+	var cursor []byte
+	for _, bucket := range buckets {
+		if len(cursor) == 0 {
+			if len(bucket.StartKey) > 0 {
+				out = append(out, PlacementRange{
+					StartKey: nil,
+					EndKey:   append([]byte(nil), bucket.StartKey...),
+				})
+			}
+		} else {
+			cmp := bytes.Compare(cursor, bucket.StartKey)
+			if cmp > 0 {
+				return nil, fmt.Errorf("%w: overlapping fsmeta bucket ranges", ErrInvalidRequest)
+			}
+			if cmp < 0 {
+				out = append(out, PlacementRange{
+					StartKey: append([]byte(nil), cursor...),
+					EndKey:   append([]byte(nil), bucket.StartKey...),
+				})
+			}
+		}
+		out = append(out, bucket)
+		cursor = append([]byte(nil), bucket.EndKey...)
+	}
+	out = append(out, PlacementRange{
+		StartKey: append([]byte(nil), cursor...),
+		EndKey:   nil,
+	})
+	return out, nil
+}
+
+// BucketSplitBoundaries returns byte boundaries that can split fsmeta bootstrap
+// ranges without cutting through one affinity bucket.
+func BucketSplitBoundaries(mounts []MountID, bucketCount int) ([][]byte, error) {
+	ranges, err := PlanBucketPlacement(mounts, bucketCount)
+	if err != nil {
+		return nil, err
+	}
+	boundaries := make([][]byte, 0, len(ranges)-1)
+	for _, r := range ranges[1:] {
+		if len(r.StartKey) == 0 {
+			continue
+		}
+		boundaries = append(boundaries, append([]byte(nil), r.StartKey...))
+	}
+	return boundaries, nil
+}

--- a/fsmeta/placement_test.go
+++ b/fsmeta/placement_test.go
@@ -1,0 +1,65 @@
+package fsmeta
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestPlanBucketPlacementReturnsContinuousRanges(t *testing.T) {
+	ranges, err := PlanBucketPlacement([]MountID{"default", "fsmeta-bench"}, DefaultAffinityBucketCount)
+	require.NoError(t, err)
+	require.Len(t, ranges, DefaultAffinityBucketCount*2+3)
+
+	for i := 0; i+1 < len(ranges); i++ {
+		require.Equal(t, ranges[i].EndKey, ranges[i+1].StartKey)
+		if len(ranges[i].EndKey) != 0 {
+			require.Less(t, bytes.Compare(ranges[i].StartKey, ranges[i].EndKey), 0)
+		}
+	}
+	require.Empty(t, ranges[0].StartKey)
+	require.Empty(t, ranges[len(ranges)-1].EndKey)
+}
+
+func TestPlanBucketPlacementKeepsBucketKeysInsideBucketRange(t *testing.T) {
+	ranges, err := PlanBucketPlacement([]MountID{"vol"}, DefaultAffinityBucketCount)
+	require.NoError(t, err)
+
+	var bucketRange PlacementRange
+	for _, r := range ranges {
+		if r.Bucketed && r.Bucket == 7 {
+			bucketRange = r
+			break
+		}
+	}
+	require.True(t, bucketRange.Bucketed)
+
+	inode := findInodeOnBucket(t, "vol", 7)
+	key, err := EncodeInodeKey("vol", inode)
+	require.NoError(t, err)
+	require.GreaterOrEqual(t, bytes.Compare(key, bucketRange.StartKey), 0)
+	require.Less(t, bytes.Compare(key, bucketRange.EndKey), 0)
+}
+
+func TestPlanBucketPlacementRejectsInvalidInput(t *testing.T) {
+	_, err := PlanBucketPlacement([]MountID{"vol"}, 0)
+	require.ErrorIs(t, err, ErrInvalidRequest)
+
+	_, err = PlanBucketPlacement([]MountID{"vol", "vol"}, DefaultAffinityBucketCount)
+	require.ErrorIs(t, err, ErrInvalidRequest)
+}
+
+func TestBucketSplitBoundariesUseBucketEdges(t *testing.T) {
+	boundaries, err := BucketSplitBoundaries([]MountID{"vol"}, 4)
+	require.NoError(t, err)
+	require.Len(t, boundaries, 5)
+
+	bucket0, _, err := EncodeBucketRange("vol", 0)
+	require.NoError(t, err)
+	require.Equal(t, bucket0, boundaries[0])
+
+	_, bucket3End, err := EncodeBucketRange("vol", 3)
+	require.NoError(t, err)
+	require.Equal(t, bucket3End, boundaries[4])
+}

--- a/fsmeta/plan.go
+++ b/fsmeta/plan.go
@@ -419,17 +419,21 @@ func PlanExpireWriteSessions(req ExpireWriteSessionsRequest) (OperationPlan, err
 	if err != nil {
 		return OperationPlan{}, err
 	}
-	prefix, err := EncodeSessionPrefix(req.Mount)
-	if err != nil {
-		return OperationPlan{}, err
+	prefixes := make([][]byte, 0, DefaultAffinityBucketCount)
+	for bucket := range DefaultAffinityBucketCount {
+		prefix, err := EncodeSessionBucketPrefix(req.Mount, AffinityBucket(bucket))
+		if err != nil {
+			return OperationPlan{}, err
+		}
+		prefixes = append(prefixes, prefix)
 	}
 	return OperationPlan{
 		Kind:         OperationExpireSessions,
 		Mount:        req.Mount,
-		PrimaryKey:   cloneBytes(prefix),
-		StartKey:     cloneBytes(prefix),
+		PrimaryKey:   cloneBytes(prefixes[0]),
+		StartKey:     cloneBytes(prefixes[0]),
 		Limit:        limit,
-		ReadPrefixes: cloneKeySet(prefix),
+		ReadPrefixes: cloneKeySet(prefixes...),
 	}, nil
 }
 

--- a/fsmeta/plan_test.go
+++ b/fsmeta/plan_test.go
@@ -54,6 +54,35 @@ func TestPlanReadDirDefaultsLimit(t *testing.T) {
 	require.Equal(t, DefaultReadDirLimit, plan.Limit)
 }
 
+func TestPlanExpireWriteSessionsScansSessionBuckets(t *testing.T) {
+	plan, err := PlanExpireWriteSessions(ExpireWriteSessionsRequest{
+		Mount: "vol",
+		Limit: 32,
+	})
+	require.NoError(t, err)
+
+	first, err := EncodeSessionBucketPrefix("vol", 0)
+	require.NoError(t, err)
+	last, err := EncodeSessionBucketPrefix("vol", AffinityBucket(DefaultAffinityBucketCount-1))
+	require.NoError(t, err)
+	mountPrefix, err := EncodeMountPrefix("vol")
+	require.NoError(t, err)
+
+	require.Equal(t, OperationExpireSessions, plan.Kind)
+	require.Equal(t, first, plan.PrimaryKey)
+	require.Equal(t, first, plan.StartKey)
+	require.Equal(t, uint32(32), plan.Limit)
+	require.Len(t, plan.ReadPrefixes, DefaultAffinityBucketCount)
+	require.Equal(t, first, plan.ReadPrefixes[0])
+	require.Equal(t, last, plan.ReadPrefixes[len(plan.ReadPrefixes)-1])
+	for _, prefix := range plan.ReadPrefixes {
+		require.True(t, bytes.HasPrefix(prefix, mountPrefix))
+		kind, err := KeyKindOf(prefix)
+		require.NoError(t, err)
+		require.Equal(t, KeyKindSession, kind)
+	}
+}
+
 func TestPlanReadDirStartAfterBecomesInclusiveSeekKey(t *testing.T) {
 	plan, err := PlanReadDir(ReadDirRequest{
 		Mount:      "vol",

--- a/fsmeta/runtime/raftstore/inode_allocator.go
+++ b/fsmeta/runtime/raftstore/inode_allocator.go
@@ -11,8 +11,8 @@ import (
 )
 
 const (
-	defaultInodeAllocBatchSize = 256
-	defaultInodeAffinityShards = 4
+	defaultInodeAllocBatchSize  = 256
+	defaultInodeAffinityBuckets = fsmeta.DefaultAffinityBucketCount
 )
 
 // IDAllocatorClient is the rooted coordinator ID surface used by fsmeta. The
@@ -23,12 +23,12 @@ type IDAllocatorClient interface {
 }
 
 // ShardAffineInodeAllocator prefetches coordinator IDs and returns an inode ID
-// whose fsmeta placement shard matches the target dentry when possible. A miss
-// is still correct: Create keeps the existing 1PC safety gate and falls back to
-// Percolator 2PC when local atomicity cannot be proven.
+// whose fsmeta affinity bucket matches the target workspace when possible. A
+// miss is still correct: Create keeps the existing 1PC safety gate and falls
+// back to Percolator 2PC when local atomicity cannot be proven.
 type ShardAffineInodeAllocator struct {
 	client    IDAllocatorClient
-	shards    int
+	buckets   int
 	batchSize uint64
 
 	mu    sync.Mutex
@@ -52,10 +52,10 @@ func NewShardAffineInodeAllocatorWithBatch(client IDAllocatorClient, shardCount 
 	if batchSize == 0 {
 		return nil, errInodeAllocBatchRequired
 	}
-	shards := utils.NormalizeShardCount(shardCount)
+	buckets := max(utils.NormalizeShardCount(shardCount), fsmeta.DefaultAffinityBucketCount)
 	return &ShardAffineInodeAllocator{
 		client:    client,
-		shards:    shards,
+		buckets:   buckets,
 		batchSize: batchSize,
 		pools:     make(map[fsmeta.MountID][][]fsmeta.InodeID),
 	}, nil
@@ -65,13 +65,13 @@ func (a *ShardAffineInodeAllocator) AllocateCreateInode(ctx context.Context, mou
 	if a == nil {
 		return 0, errIDAllocatorClientRequired
 	}
-	target, err := createDentryShard(mount, parent, name, a.shards)
+	target, err := createDentryBucket(mount, parent, name)
 	if err != nil {
 		return 0, err
 	}
 	a.mu.Lock()
 	defer a.mu.Unlock()
-	if inode, ok := a.popShardLocked(mount, target); ok {
+	if inode, ok := a.popBucketLocked(mount, target); ok {
 		a.total.Add(1)
 		a.affinityHit.Add(1)
 		return inode, nil
@@ -79,7 +79,7 @@ func (a *ShardAffineInodeAllocator) AllocateCreateInode(ctx context.Context, mou
 	if err := a.refillLocked(ctx, mount); err != nil {
 		return 0, err
 	}
-	if inode, ok := a.popShardLocked(mount, target); ok {
+	if inode, ok := a.popBucketLocked(mount, target); ok {
 		a.total.Add(1)
 		a.affinityHit.Add(1)
 		return inode, nil
@@ -130,58 +130,70 @@ func (a *ShardAffineInodeAllocator) refillLocked(ctx context.Context, mount fsme
 		if id < first || fsmeta.InodeID(id) <= fsmeta.RootInode {
 			continue
 		}
-		shard, err := createInodeShard(mount, fsmeta.InodeID(id), a.shards)
+		bucket, err := createInodeBucket(mount, fsmeta.InodeID(id))
 		if err != nil {
 			return err
 		}
-		pool[shard] = append(pool[shard], fsmeta.InodeID(id))
+		pool[bucket] = append(pool[bucket], fsmeta.InodeID(id))
 		a.reservedTotal.Add(1)
 	}
 	return nil
 }
 
 func (a *ShardAffineInodeAllocator) ensurePoolsLocked(mount fsmeta.MountID) [][]fsmeta.InodeID {
-	if pool := a.pools[mount]; len(pool) == a.shards {
+	if pool := a.pools[mount]; len(pool) == a.buckets {
 		return pool
 	}
-	pool := make([][]fsmeta.InodeID, a.shards)
+	pool := make([][]fsmeta.InodeID, a.buckets)
 	a.pools[mount] = pool
 	return pool
 }
 
-func (a *ShardAffineInodeAllocator) popShardLocked(mount fsmeta.MountID, shard int) (fsmeta.InodeID, bool) {
+func (a *ShardAffineInodeAllocator) popBucketLocked(mount fsmeta.MountID, bucket fsmeta.AffinityBucket) (fsmeta.InodeID, bool) {
 	pool := a.ensurePoolsLocked(mount)
-	if shard < 0 || shard >= len(pool) || len(pool[shard]) == 0 {
+	idx := int(bucket)
+	if idx < 0 || idx >= len(pool) || len(pool[idx]) == 0 {
 		return 0, false
 	}
-	last := len(pool[shard]) - 1
-	inode := pool[shard][last]
-	pool[shard] = pool[shard][:last]
+	last := len(pool[idx]) - 1
+	inode := pool[idx][last]
+	pool[idx] = pool[idx][:last]
 	return inode, true
 }
 
 func (a *ShardAffineInodeAllocator) popAnyLocked(mount fsmeta.MountID) (fsmeta.InodeID, bool) {
 	pool := a.ensurePoolsLocked(mount)
-	for shard := range pool {
-		if inode, ok := a.popShardLocked(mount, shard); ok {
+	for bucket := range pool {
+		if inode, ok := a.popBucketLocked(mount, fsmeta.AffinityBucket(bucket)); ok {
 			return inode, true
 		}
 	}
 	return 0, false
 }
 
-func createDentryShard(mount fsmeta.MountID, parent fsmeta.InodeID, name string, shards int) (int, error) {
+func createDentryBucket(mount fsmeta.MountID, parent fsmeta.InodeID, name string) (fsmeta.AffinityBucket, error) {
+	if parent == fsmeta.RootInode {
+		return fsmeta.ChooseWorkspaceBucket(mount, name), nil
+	}
 	key, err := fsmeta.EncodeDentryKey(mount, parent, name)
 	if err != nil {
 		return 0, err
 	}
-	return fsmeta.ShardForUserKey(key, shards), nil
+	bucket, ok := fsmeta.BucketOfKey(key)
+	if !ok {
+		return 0, fsmeta.ErrInvalidKey
+	}
+	return bucket, nil
 }
 
-func createInodeShard(mount fsmeta.MountID, inode fsmeta.InodeID, shards int) (int, error) {
+func createInodeBucket(mount fsmeta.MountID, inode fsmeta.InodeID) (fsmeta.AffinityBucket, error) {
 	key, err := fsmeta.EncodeInodeKey(mount, inode)
 	if err != nil {
 		return 0, err
 	}
-	return fsmeta.ShardForUserKey(key, shards), nil
+	bucket, ok := fsmeta.BucketOfKey(key)
+	if !ok {
+		return 0, fsmeta.ErrInvalidKey
+	}
+	return bucket, nil
 }

--- a/fsmeta/runtime/raftstore/inode_allocator_test.go
+++ b/fsmeta/runtime/raftstore/inode_allocator_test.go
@@ -60,16 +60,16 @@ func TestShardAffineInodeAllocatorSkipsRootInode(t *testing.T) {
 	require.Equal(t, uint64(3), alloc.Stats()["inode_alloc_reserved_total"])
 }
 
-func TestShardAffineInodeAllocatorChoosesDentryShard(t *testing.T) {
+func TestShardAffineInodeAllocatorChoosesWorkspaceBucket(t *testing.T) {
 	client := &fakeAllocIDClient{next: 2}
-	alloc, err := NewShardAffineInodeAllocatorWithBatch(client, 4, 64)
+	alloc, err := NewShardAffineInodeAllocatorWithBatch(client, fsmeta.DefaultAffinityBucketCount, 64)
 	require.NoError(t, err)
 
 	inode, err := alloc.AllocateCreateInode(context.Background(), "vol", fsmeta.RootInode, "aligned")
 	require.NoError(t, err)
-	want, err := createDentryShard("vol", fsmeta.RootInode, "aligned", 4)
+	want, err := createDentryBucket("vol", fsmeta.RootInode, "aligned")
 	require.NoError(t, err)
-	got, err := createInodeShard("vol", inode, 4)
+	got, err := createInodeBucket("vol", inode)
 	require.NoError(t, err)
 	require.Equal(t, want, got)
 	require.Equal(t, uint64(1), alloc.Stats()["inode_alloc_affinity_hit_total"])
@@ -78,7 +78,7 @@ func TestShardAffineInodeAllocatorChoosesDentryShard(t *testing.T) {
 
 func TestShardAffineInodeAllocatorReturnsUniqueConcurrentIDs(t *testing.T) {
 	client := &fakeAllocIDClient{next: 2}
-	alloc, err := NewShardAffineInodeAllocatorWithBatch(client, 4, 16)
+	alloc, err := NewShardAffineInodeAllocatorWithBatch(client, fsmeta.DefaultAffinityBucketCount, 16)
 	require.NoError(t, err)
 
 	const workers = 64
@@ -109,7 +109,7 @@ func TestShardAffineInodeAllocatorReturnsUniqueConcurrentIDs(t *testing.T) {
 
 func TestShardAffineInodeAllocatorPropagatesAllocIDError(t *testing.T) {
 	want := errors.New("root unavailable")
-	alloc, err := NewShardAffineInodeAllocatorWithBatch(&fakeAllocIDClient{err: want}, 4, 8)
+	alloc, err := NewShardAffineInodeAllocatorWithBatch(&fakeAllocIDClient{err: want}, fsmeta.DefaultAffinityBucketCount, 8)
 	require.NoError(t, err)
 
 	_, err = alloc.AllocateCreateInode(context.Background(), "vol", fsmeta.RootInode, "file")
@@ -117,20 +117,20 @@ func TestShardAffineInodeAllocatorPropagatesAllocIDError(t *testing.T) {
 }
 
 func TestShardAffineInodeAllocatorMissStillReturnsUsableID(t *testing.T) {
-	target, err := createDentryShard("vol", fsmeta.RootInode, "file", 4)
+	target, err := createDentryBucket("vol", fsmeta.RootInode, "file")
 	require.NoError(t, err)
 	var candidate fsmeta.InodeID
 	for id := fsmeta.InodeID(2); id < 10_000; id++ {
-		shard, err := createInodeShard("vol", id, 4)
+		bucket, err := createInodeBucket("vol", id)
 		require.NoError(t, err)
-		if shard != target {
+		if bucket != target {
 			candidate = id
 			break
 		}
 	}
 	require.NotZero(t, candidate)
 	client := &fakeAllocIDClient{fixed: []*coordpb.AllocIDResponse{{FirstId: uint64(candidate), Count: 1}}}
-	alloc, err := NewShardAffineInodeAllocatorWithBatch(client, 4, 1)
+	alloc, err := NewShardAffineInodeAllocatorWithBatch(client, fsmeta.DefaultAffinityBucketCount, 1)
 	require.NoError(t, err)
 
 	inode, err := alloc.AllocateCreateInode(context.Background(), "vol", fsmeta.RootInode, "file")

--- a/fsmeta/runtime/raftstore/open.go
+++ b/fsmeta/runtime/raftstore/open.go
@@ -58,10 +58,10 @@ type Options struct {
 	// invalidated by fsmeta mutations.
 	DirPageCacheDir string
 
-	// InodeAffinityShards must match the store-side LSM shard count for Create
-	// to choose IDs that can hit the region-local 1PC apply group. Mismatch is
-	// safe because the percolator fallback gate remains authoritative.
-	InodeAffinityShards int
+	// AffinityBuckets is the fsmeta key-placement bucket count used when
+	// choosing Create inode IDs. The local engine receives only generic key
+	// shape hints; this value belongs to fsmeta placement policy.
+	AffinityBuckets int
 }
 
 // Runtime is a complete fsmeta runtime backed by the NoKV raftstore. It owns
@@ -135,11 +135,11 @@ func Open(ctx context.Context, opts Options) (*Runtime, error) {
 		_ = coord.Close()
 		return nil, fmt.Errorf("init runner: %w", err)
 	}
-	shards := opts.InodeAffinityShards
-	if shards == 0 {
-		shards = defaultInodeAffinityShards
+	buckets := opts.AffinityBuckets
+	if buckets == 0 {
+		buckets = defaultInodeAffinityBuckets
 	}
-	inodes, err := NewShardAffineInodeAllocator(coord, shards)
+	inodes, err := NewShardAffineInodeAllocator(coord, buckets)
 	if err != nil {
 		_ = kv.Close()
 		_ = coord.Close()

--- a/fsmeta/server/errors.go
+++ b/fsmeta/server/errors.go
@@ -40,9 +40,6 @@ func rpcError(err error) error {
 	if err == nil {
 		return nil
 	}
-	if _, ok := status.FromError(err); ok {
-		return err
-	}
 	switch {
 	case errors.Is(err, context.Canceled):
 		return nokverrors.RPCStatusError(nokverrors.KindAborted, codes.Canceled, err.Error(), map[string]string{
@@ -52,10 +49,19 @@ func rpcError(err error) error {
 		return nokverrors.RPCStatusError(nokverrors.KindUnavailable, codes.DeadlineExceeded, err.Error(), map[string]string{
 			fsmetaReasonMetadata: reasonContextDeadline,
 		})
-	default:
-		kind := nokverrors.KindOf(err)
-		return nokverrors.RPCStatusError(kind, rpcCodeForKind(kind), err.Error(), fsmetaErrorMetadata(err))
 	}
+	var carrier nokverrors.KindCarrier
+	if errors.As(err, &carrier) {
+		kind := nokverrors.KindOf(err)
+		if kind != nokverrors.KindUnknown {
+			return nokverrors.RPCStatusError(kind, rpcCodeForKind(kind), err.Error(), fsmetaErrorMetadata(err))
+		}
+	}
+	if _, ok := status.FromError(err); ok {
+		return err
+	}
+	kind := nokverrors.KindOf(err)
+	return nokverrors.RPCStatusError(kind, rpcCodeForKind(kind), err.Error(), fsmetaErrorMetadata(err))
 }
 
 func rpcInvalidArgument(message string) error {

--- a/fsmeta/server/errors_test.go
+++ b/fsmeta/server/errors_test.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"fmt"
 	"testing"
 
 	nokverrors "github.com/feichai0017/NoKV/errors"
@@ -25,4 +26,33 @@ func TestRPCCodeForKind(t *testing.T) {
 func TestRPCErrorPassesThroughStatusErrors(t *testing.T) {
 	err := status.Error(codes.NotFound, "already mapped")
 	require.Same(t, err, rpcError(err))
+}
+
+func TestRPCErrorPreservesOuterStableKindOverWrappedStatus(t *testing.T) {
+	err := testKindWrap{
+		kind: nokverrors.KindRouteUnavailable,
+		err:  status.Error(codes.FailedPrecondition, "required descriptor revision not satisfied"),
+	}
+
+	got := rpcError(err)
+
+	require.Equal(t, codes.Unavailable, status.Code(got))
+	require.Equal(t, nokverrors.KindRouteUnavailable, nokverrors.KindOf(got))
+}
+
+type testKindWrap struct {
+	kind nokverrors.Kind
+	err  error
+}
+
+func (e testKindWrap) Error() string {
+	return fmt.Sprintf("wrapped: %v", e.err)
+}
+
+func (e testKindWrap) Unwrap() error {
+	return e.err
+}
+
+func (e testKindWrap) ErrorKind() nokverrors.Kind {
+	return e.kind
 }

--- a/local/db.go
+++ b/local/db.go
@@ -223,7 +223,7 @@ func (db *DB) startWriteRuntime() {
 		WriteBatchMaxCount: db.opt.WriteBatchMaxCount,
 		WriteBatchMaxSize:  db.opt.WriteBatchMaxSize,
 		WriteBatchWait:     db.opt.WriteBatchWait,
-		UserKeyShardRouter: db.opt.UserKeyShardRouter,
+		UserKeyShardKey:    db.userKeyShardKey,
 	}, db)
 	db.pipeline.Start()
 }
@@ -1079,18 +1079,25 @@ func (db *DB) groupInternalEntriesByShard(entries []*kv.Entry) [][]*kv.Entry {
 }
 
 func (db *DB) shardForInternalKey(internalKey []byte, shardCount int) int {
-	if db == nil || db.opt == nil || db.opt.UserKeyShardRouter == nil {
-		return lsm.ShardForInternalKey(internalKey, shardCount)
-	}
 	_, userKey, _, ok := kv.SplitInternalKey(internalKey)
-	if !ok {
+	if !ok || len(userKey) == 0 {
 		return 0
 	}
-	shard := db.opt.UserKeyShardRouter(userKey, shardCount)
-	if shard < 0 || shard >= utils.NormalizeShardCount(shardCount) {
-		return utils.ShardForUserKey(userKey, shardCount)
+	return utils.ShardForUserKey(db.userKeyShardKeyOrUserKey(userKey), shardCount)
+}
+
+func (db *DB) userKeyShardKey(userKey []byte) []byte {
+	if db == nil || db.opt == nil || db.opt.UserKeyShapeExtractor == nil {
+		return nil
 	}
-	return shard
+	return db.opt.UserKeyShapeExtractor(userKey).shardKey()
+}
+
+func (db *DB) userKeyShardKeyOrUserKey(userKey []byte) []byte {
+	if key := db.userKeyShardKey(userKey); len(key) > 0 {
+		return key
+	}
+	return userKey
 }
 
 func releaseEntryGroups(groups [][]*kv.Entry) {

--- a/local/db_test.go
+++ b/local/db_test.go
@@ -252,8 +252,22 @@ func TestNewDefaultOptionsExposeConcreteCompactionDefaults(t *testing.T) {
 	require.LessOrEqual(t, opt.CompactionResumeTrigger, opt.CompactionSlowdownTrigger)
 	require.Greater(t, opt.LandingCompactBatchSize, 0)
 	require.Greater(t, opt.LandingBacklogMergeScore, 0.0)
-	require.NotNil(t, opt.PrefixExtractor)
+	require.Nil(t, opt.UserKeyShapeExtractor)
 	require.Greater(t, opt.CompactionTombstoneWeight, 0.0)
+}
+
+func TestLSMPrefixExtractorUsesUserKeyShape(t *testing.T) {
+	opt := NewDefaultOptions()
+	opt.UserKeyShapeExtractor = func(userKey []byte) UserKeyShape {
+		require.Equal(t, []byte("user-key"), userKey)
+		return UserKeyShape{BloomPrefix: []byte("bloom-prefix")}
+	}
+	cfg := &lsm.Options{}
+
+	opt.applyLSMSharedOptions(cfg)
+
+	require.NotNil(t, cfg.PrefixExtractor)
+	require.Equal(t, []byte("bloom-prefix"), cfg.PrefixExtractor([]byte("user-key")))
 }
 
 func TestNewDefaultOptionsExposeConcreteBatchDefaults(t *testing.T) {

--- a/local/internal/commit/pipeline.go
+++ b/local/internal/commit/pipeline.go
@@ -37,7 +37,7 @@ type Config struct {
 	WriteBatchMaxCount int
 	WriteBatchMaxSize  int64
 	WriteBatchWait     time.Duration
-	UserKeyShardRouter func(userKey []byte, shardCount int) int
+	UserKeyShardKey    func(userKey []byte) []byte
 }
 
 // LSM is the narrow LSM surface the pipeline writes through. Implemented
@@ -301,19 +301,19 @@ func (p *Pipeline) dispatcher() {
 			closeAll()
 			return
 		}
-		shardID := shardForBatch(batch, n, &rrFallback, p.cfg.UserKeyShardRouter)
+		shardID := shardForBatch(batch, n, &rrFallback, p.cfg.UserKeyShardKey)
 		batch.ShardID = shardID
 		p.dispatch[shardID] <- batch
 	}
 }
 
 // shardForBatch picks the destination shard for a commit batch using the
-// configured user-key router. The default router hashes the whole user key;
-// fsmeta runtimes can inject a semantic-affinity router so keys that must be
-// atomically mutated together reach one local apply group.
+// configured semantic shard key. The default router hashes the whole user key;
+// runtimes can expose a stable locality key so related records reach one local
+// apply group without the commit package knowing their higher-level schema.
 //
 // Empty batches (no key to hash) round-robin via *rr to keep load even.
-func shardForBatch(batch *CommitBatch, n int, rr *int, router func([]byte, int) int) int {
+func shardForBatch(batch *CommitBatch, n int, rr *int, shardKey func([]byte) []byte) int {
 	if n <= 1 {
 		return 0
 	}
@@ -330,7 +330,7 @@ func shardForBatch(batch *CommitBatch, n int, rr *int, router func([]byte, int) 
 				if !ok || len(userKey) == 0 {
 					continue
 				}
-				return routeUserKeyToShard(userKey, n, router)
+				return routeUserKeyToShard(userKey, n, shardKey)
 			}
 		}
 	}
@@ -342,11 +342,10 @@ func shardForBatch(batch *CommitBatch, n int, rr *int, router func([]byte, int) 
 	return id
 }
 
-func routeUserKeyToShard(userKey []byte, shardCount int, router func([]byte, int) int) int {
-	if router != nil {
-		shard := router(userKey, shardCount)
-		if shard >= 0 && shard < utils.NormalizeShardCount(shardCount) {
-			return shard
+func routeUserKeyToShard(userKey []byte, shardCount int, shardKey func([]byte) []byte) int {
+	if shardKey != nil {
+		if key := shardKey(userKey); len(key) > 0 {
+			return utils.ShardForUserKey(key, shardCount)
 		}
 	}
 	return utils.ShardForUserKey(userKey, shardCount)

--- a/local/internal/commit/pipeline_test.go
+++ b/local/internal/commit/pipeline_test.go
@@ -1,6 +1,7 @@
 package commit
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/feichai0017/NoKV/engine/kv"
@@ -8,7 +9,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestShardForBatchUsesConfiguredUserKeyRouter(t *testing.T) {
+func TestShardForBatchUsesConfiguredShardKey(t *testing.T) {
 	entry := kv.NewEntry(kv.InternalKey(kv.CFDefault, []byte("semantic-key"), 7), []byte("value"))
 	defer entry.DecrRef()
 
@@ -16,17 +17,17 @@ func TestShardForBatchUsesConfiguredUserKeyRouter(t *testing.T) {
 	batch := &CommitBatch{Reqs: []*CommitRequest{{Req: req}}}
 	rr := 0
 
-	shard := shardForBatch(batch, 4, &rr, func(userKey []byte, shardCount int) int {
+	shardKey := keyForShard(t, 4, 3)
+	shard := shardForBatch(batch, 4, &rr, func(userKey []byte) []byte {
 		require.Equal(t, []byte("semantic-key"), userKey)
-		require.Equal(t, 4, shardCount)
-		return 3
+		return shardKey
 	})
 
 	require.Equal(t, 3, shard)
 	require.Equal(t, 0, rr)
 }
 
-func TestShardForBatchFallsBackWhenRouterReturnsInvalidShard(t *testing.T) {
+func TestShardForBatchFallsBackWhenShardKeyIsEmpty(t *testing.T) {
 	userKey := []byte("semantic-key")
 	entry := kv.NewEntry(kv.InternalKey(kv.CFDefault, userKey, 7), []byte("value"))
 	defer entry.DecrRef()
@@ -35,7 +36,19 @@ func TestShardForBatchFallsBackWhenRouterReturnsInvalidShard(t *testing.T) {
 	batch := &CommitBatch{Reqs: []*CommitRequest{{Req: req}}}
 	rr := 0
 
-	shard := shardForBatch(batch, 4, &rr, func([]byte, int) int { return 99 })
+	shard := shardForBatch(batch, 4, &rr, func([]byte) []byte { return nil })
 
 	require.Equal(t, utils.ShardForUserKey(userKey, 4), shard)
+}
+
+func keyForShard(t *testing.T, shards int, target int) []byte {
+	t.Helper()
+	for i := range 10_000 {
+		key := fmt.Appendf(nil, "shard-key-%d", i)
+		if utils.ShardForUserKey(key, shards) == target {
+			return key
+		}
+	}
+	t.Fatalf("no key found for shard %d", target)
+	return nil
 }

--- a/local/keyshape.go
+++ b/local/keyshape.go
@@ -1,0 +1,31 @@
+package local
+
+// UserKeyShape describes runtime-derived key structure that the local engine
+// can use without importing higher-level metadata packages. Shape data is not
+// persisted; it only guides shard routing and SST prefix bloom construction.
+type UserKeyShape struct {
+	// LocalityPrefix groups keys that should share one local apply group.
+	LocalityPrefix []byte
+	// BloomPrefix is the prefix stored in SST prefix bloom filters.
+	BloomPrefix []byte
+	// ShardKey is the exact byte sequence used for local shard routing. When
+	// empty, LocalityPrefix is used; when both are empty the full user key is
+	// hashed by the generic router.
+	ShardKey []byte
+	// Family is a low-cardinality key-family marker for diagnostics.
+	Family byte
+}
+
+// UserKeyShapeExtractor returns the shape for one user key. Returned slices may
+// alias userKey and are consumed synchronously by the caller. The extractor
+// must be deterministic and must not depend on process-local mutable state
+// because WAL recovery and AtomicMutate admission use the same local apply
+// boundary.
+type UserKeyShapeExtractor func(userKey []byte) UserKeyShape
+
+func (s UserKeyShape) shardKey() []byte {
+	if len(s.ShardKey) > 0 {
+		return s.ShardKey
+	}
+	return s.LocalityPrefix
+}

--- a/local/options.go
+++ b/local/options.go
@@ -1,7 +1,6 @@
 package local
 
 import (
-	"encoding/binary"
 	"time"
 
 	lsmpkg "github.com/feichai0017/NoKV/engine/lsm"
@@ -92,13 +91,11 @@ type Options struct {
 	// default; non-power-of-two values are rounded DOWN to the nearest
 	// power of two during Open (e.g. 6 → 4, 12 → 8).
 	LSMShardCount int
-	// UserKeyShardRouter optionally overrides the local data-plane shard for a
-	// user key. Nil keeps the generic full-key hash router. Runtime-specific
-	// routers must be deterministic and must not depend on mutable process
-	// state, because WAL recovery and AtomicMutate admission use the same
-	// placement boundary.
-	UserKeyShardRouter func(userKey []byte, shardCount int) int
-	ManifestSync       bool
+	// UserKeyShapeExtractor optionally exposes runtime-derived key structure to
+	// local storage. Nil keeps generic full-key hashing and disables semantic
+	// prefix bloom filters.
+	UserKeyShapeExtractor UserKeyShapeExtractor
+	ManifestSync          bool
 	// ManifestRewriteThreshold triggers a manifest rewrite when the active
 	// MANIFEST file grows beyond this size (bytes). Values <= 0 disable rewrites.
 	ManifestRewriteThreshold int64
@@ -125,10 +122,6 @@ type Options struct {
 	BlockCacheBytes int64
 	// IndexCacheBytes bounds the in-memory budget for decoded SSTable indexes.
 	IndexCacheBytes int64
-	// PrefixExtractor enables SST prefix bloom filters. Nil disables prefix
-	// bloom creation. The default extractor recognizes NoKV native metadata
-	// keys and returns nil for unrelated user keys.
-	PrefixExtractor lsmpkg.PrefixExtractor
 	// BlockCompression controls SST data-block compression.
 	BlockCompression lsmpkg.BlockCompression
 
@@ -293,7 +286,6 @@ func NewDefaultOptions() *Options {
 		MaxBatchSize:                  defaultWriteBatchMaxSize,
 		BlockCacheBytes:               lsmpkg.DefaultBlockCacheBytes,
 		IndexCacheBytes:               lsmpkg.DefaultIndexCacheBytes,
-		PrefixExtractor:               nativeMetadataPrefix,
 		BlockCompression:              lsmpkg.DefaultBlockCompression,
 		SyncWrites:                    false,
 		ManifestSync:                  false,
@@ -413,7 +405,7 @@ func (opt *Options) applyLSMSharedOptions(dst *lsmpkg.Options) {
 	dst.CompactionValueAlertThreshold = opt.CompactionValueAlertThreshold
 	dst.BlockCacheBytes = opt.BlockCacheBytes
 	dst.IndexCacheBytes = opt.IndexCacheBytes
-	dst.PrefixExtractor = opt.PrefixExtractor
+	dst.PrefixExtractor = opt.lsmPrefixExtractor()
 	dst.BlockCompression = opt.BlockCompression
 	dst.NegativeCachePersistent = opt.NegativeCachePersistent
 	dst.NegativeCacheSlabMaxSize = opt.NegativeCacheSlabMaxSize
@@ -444,44 +436,17 @@ func (opt *Options) copyNormalizedLSMOptions(src *lsmpkg.Options) {
 	opt.CompactionValueAlertThreshold = src.CompactionValueAlertThreshold
 	opt.BlockCacheBytes = src.BlockCacheBytes
 	opt.IndexCacheBytes = src.IndexCacheBytes
-	opt.PrefixExtractor = src.PrefixExtractor
 	opt.BlockCompression = src.BlockCompression
 	opt.NegativeCachePersistent = src.NegativeCachePersistent
 	opt.NegativeCacheSlabMaxSize = src.NegativeCacheSlabMaxSize
 }
 
-func nativeMetadataPrefix(key []byte) []byte {
-	const (
-		magicLen = 4
-		version  = byte(1)
-	)
-	if len(key) < magicLen+3 {
+func (opt *Options) lsmPrefixExtractor() lsmpkg.PrefixExtractor {
+	if opt == nil || opt.UserKeyShapeExtractor == nil {
 		return nil
 	}
-	if key[0] != 'f' || key[1] != 's' || key[2] != 'm' || key[3] != 0 || key[4] != version {
-		return nil
-	}
-	pos := magicLen + 1
-	mountLen, n := binary.Uvarint(key[pos:])
-	if n <= 0 {
-		return nil
-	}
-	pos += n
-	if mountLen == 0 || uint64(len(key)-pos) < mountLen+1 {
-		return nil
-	}
-	pos += int(mountLen)
-	kindPos := pos
-	pos++
-	switch key[kindPos] {
-	case 'd', 'c':
-		if len(key) < pos+8 {
-			return nil
-		}
-		return key[:pos+8]
-	case 'i', 'm', 's', 'u':
-		return key[:pos]
-	default:
-		return nil
+	return func(userKey []byte) []byte {
+		shape := opt.UserKeyShapeExtractor(userKey)
+		return shape.BloomPrefix
 	}
 }

--- a/pb/coordinator/coordinator.pb.go
+++ b/pb/coordinator/coordinator.pb.go
@@ -179,6 +179,8 @@ type SchedulerOperationType int32
 const (
 	SchedulerOperationType_SCHEDULER_OPERATION_TYPE_NONE            SchedulerOperationType = 0
 	SchedulerOperationType_SCHEDULER_OPERATION_TYPE_LEADER_TRANSFER SchedulerOperationType = 1
+	SchedulerOperationType_SCHEDULER_OPERATION_TYPE_SPLIT_REGION    SchedulerOperationType = 2
+	SchedulerOperationType_SCHEDULER_OPERATION_TYPE_MERGE_REGION    SchedulerOperationType = 3
 )
 
 // Enum value maps for SchedulerOperationType.
@@ -186,10 +188,14 @@ var (
 	SchedulerOperationType_name = map[int32]string{
 		0: "SCHEDULER_OPERATION_TYPE_NONE",
 		1: "SCHEDULER_OPERATION_TYPE_LEADER_TRANSFER",
+		2: "SCHEDULER_OPERATION_TYPE_SPLIT_REGION",
+		3: "SCHEDULER_OPERATION_TYPE_MERGE_REGION",
 	}
 	SchedulerOperationType_value = map[string]int32{
 		"SCHEDULER_OPERATION_TYPE_NONE":            0,
 		"SCHEDULER_OPERATION_TYPE_LEADER_TRANSFER": 1,
+		"SCHEDULER_OPERATION_TYPE_SPLIT_REGION":    2,
+		"SCHEDULER_OPERATION_TYPE_MERGE_REGION":    3,
 	}
 )
 
@@ -791,7 +797,8 @@ type StoreHeartbeatRequest struct {
 	// raft_addr is the raft transport address used by operators and future
 	// transport-aware scheduling. The first implementation usually matches
 	// client_addr because NoKV currently shares one gRPC transport.
-	RaftAddr      string `protobuf:"bytes,9,opt,name=raft_addr,json=raftAddr,proto3" json:"raft_addr,omitempty"`
+	RaftAddr      string                `protobuf:"bytes,9,opt,name=raft_addr,json=raftAddr,proto3" json:"raft_addr,omitempty"`
+	RegionStats   []*RegionRuntimeStats `protobuf:"bytes,10,rep,name=region_stats,json=regionStats,proto3" json:"region_stats,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -889,6 +896,113 @@ func (x *StoreHeartbeatRequest) GetRaftAddr() string {
 	return ""
 }
 
+func (x *StoreHeartbeatRequest) GetRegionStats() []*RegionRuntimeStats {
+	if x != nil {
+		return x.RegionStats
+	}
+	return nil
+}
+
+type RegionRuntimeStats struct {
+	state             protoimpl.MessageState `protogen:"open.v1"`
+	RegionId          uint64                 `protobuf:"varint,1,opt,name=region_id,json=regionId,proto3" json:"region_id,omitempty"`
+	ReadQps           uint64                 `protobuf:"varint,2,opt,name=read_qps,json=readQps,proto3" json:"read_qps,omitempty"`
+	WriteQps          uint64                 `protobuf:"varint,3,opt,name=write_qps,json=writeQps,proto3" json:"write_qps,omitempty"`
+	WriteBytesPerSec  uint64                 `protobuf:"varint,4,opt,name=write_bytes_per_sec,json=writeBytesPerSec,proto3" json:"write_bytes_per_sec,omitempty"`
+	ApproxRegionBytes uint64                 `protobuf:"varint,5,opt,name=approx_region_bytes,json=approxRegionBytes,proto3" json:"approx_region_bytes,omitempty"`
+	AtomicMutateQps   uint64                 `protobuf:"varint,6,opt,name=atomic_mutate_qps,json=atomicMutateQps,proto3" json:"atomic_mutate_qps,omitempty"`
+	LeaderStoreId     uint64                 `protobuf:"varint,7,opt,name=leader_store_id,json=leaderStoreId,proto3" json:"leader_store_id,omitempty"`
+	PendingAdmin      bool                   `protobuf:"varint,8,opt,name=pending_admin,json=pendingAdmin,proto3" json:"pending_admin,omitempty"`
+	unknownFields     protoimpl.UnknownFields
+	sizeCache         protoimpl.SizeCache
+}
+
+func (x *RegionRuntimeStats) Reset() {
+	*x = RegionRuntimeStats{}
+	mi := &file_coordinator_coordinator_proto_msgTypes[1]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *RegionRuntimeStats) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*RegionRuntimeStats) ProtoMessage() {}
+
+func (x *RegionRuntimeStats) ProtoReflect() protoreflect.Message {
+	mi := &file_coordinator_coordinator_proto_msgTypes[1]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use RegionRuntimeStats.ProtoReflect.Descriptor instead.
+func (*RegionRuntimeStats) Descriptor() ([]byte, []int) {
+	return file_coordinator_coordinator_proto_rawDescGZIP(), []int{1}
+}
+
+func (x *RegionRuntimeStats) GetRegionId() uint64 {
+	if x != nil {
+		return x.RegionId
+	}
+	return 0
+}
+
+func (x *RegionRuntimeStats) GetReadQps() uint64 {
+	if x != nil {
+		return x.ReadQps
+	}
+	return 0
+}
+
+func (x *RegionRuntimeStats) GetWriteQps() uint64 {
+	if x != nil {
+		return x.WriteQps
+	}
+	return 0
+}
+
+func (x *RegionRuntimeStats) GetWriteBytesPerSec() uint64 {
+	if x != nil {
+		return x.WriteBytesPerSec
+	}
+	return 0
+}
+
+func (x *RegionRuntimeStats) GetApproxRegionBytes() uint64 {
+	if x != nil {
+		return x.ApproxRegionBytes
+	}
+	return 0
+}
+
+func (x *RegionRuntimeStats) GetAtomicMutateQps() uint64 {
+	if x != nil {
+		return x.AtomicMutateQps
+	}
+	return 0
+}
+
+func (x *RegionRuntimeStats) GetLeaderStoreId() uint64 {
+	if x != nil {
+		return x.LeaderStoreId
+	}
+	return 0
+}
+
+func (x *RegionRuntimeStats) GetPendingAdmin() bool {
+	if x != nil {
+		return x.PendingAdmin
+	}
+	return false
+}
+
 type StoreInfo struct {
 	state                 protoimpl.MessageState `protogen:"open.v1"`
 	StoreId               uint64                 `protobuf:"varint,1,opt,name=store_id,json=storeId,proto3" json:"store_id,omitempty"`
@@ -907,7 +1021,7 @@ type StoreInfo struct {
 
 func (x *StoreInfo) Reset() {
 	*x = StoreInfo{}
-	mi := &file_coordinator_coordinator_proto_msgTypes[1]
+	mi := &file_coordinator_coordinator_proto_msgTypes[2]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -919,7 +1033,7 @@ func (x *StoreInfo) String() string {
 func (*StoreInfo) ProtoMessage() {}
 
 func (x *StoreInfo) ProtoReflect() protoreflect.Message {
-	mi := &file_coordinator_coordinator_proto_msgTypes[1]
+	mi := &file_coordinator_coordinator_proto_msgTypes[2]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -932,7 +1046,7 @@ func (x *StoreInfo) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use StoreInfo.ProtoReflect.Descriptor instead.
 func (*StoreInfo) Descriptor() ([]byte, []int) {
-	return file_coordinator_coordinator_proto_rawDescGZIP(), []int{1}
+	return file_coordinator_coordinator_proto_rawDescGZIP(), []int{2}
 }
 
 func (x *StoreInfo) GetStoreId() uint64 {
@@ -1014,7 +1128,7 @@ type GetStoreRequest struct {
 
 func (x *GetStoreRequest) Reset() {
 	*x = GetStoreRequest{}
-	mi := &file_coordinator_coordinator_proto_msgTypes[2]
+	mi := &file_coordinator_coordinator_proto_msgTypes[3]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1026,7 +1140,7 @@ func (x *GetStoreRequest) String() string {
 func (*GetStoreRequest) ProtoMessage() {}
 
 func (x *GetStoreRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_coordinator_coordinator_proto_msgTypes[2]
+	mi := &file_coordinator_coordinator_proto_msgTypes[3]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1039,7 +1153,7 @@ func (x *GetStoreRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetStoreRequest.ProtoReflect.Descriptor instead.
 func (*GetStoreRequest) Descriptor() ([]byte, []int) {
-	return file_coordinator_coordinator_proto_rawDescGZIP(), []int{2}
+	return file_coordinator_coordinator_proto_rawDescGZIP(), []int{3}
 }
 
 func (x *GetStoreRequest) GetStoreId() uint64 {
@@ -1059,7 +1173,7 @@ type GetStoreResponse struct {
 
 func (x *GetStoreResponse) Reset() {
 	*x = GetStoreResponse{}
-	mi := &file_coordinator_coordinator_proto_msgTypes[3]
+	mi := &file_coordinator_coordinator_proto_msgTypes[4]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1071,7 +1185,7 @@ func (x *GetStoreResponse) String() string {
 func (*GetStoreResponse) ProtoMessage() {}
 
 func (x *GetStoreResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_coordinator_coordinator_proto_msgTypes[3]
+	mi := &file_coordinator_coordinator_proto_msgTypes[4]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1084,7 +1198,7 @@ func (x *GetStoreResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetStoreResponse.ProtoReflect.Descriptor instead.
 func (*GetStoreResponse) Descriptor() ([]byte, []int) {
-	return file_coordinator_coordinator_proto_rawDescGZIP(), []int{3}
+	return file_coordinator_coordinator_proto_rawDescGZIP(), []int{4}
 }
 
 func (x *GetStoreResponse) GetStore() *StoreInfo {
@@ -1109,7 +1223,7 @@ type ListStoresRequest struct {
 
 func (x *ListStoresRequest) Reset() {
 	*x = ListStoresRequest{}
-	mi := &file_coordinator_coordinator_proto_msgTypes[4]
+	mi := &file_coordinator_coordinator_proto_msgTypes[5]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1121,7 +1235,7 @@ func (x *ListStoresRequest) String() string {
 func (*ListStoresRequest) ProtoMessage() {}
 
 func (x *ListStoresRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_coordinator_coordinator_proto_msgTypes[4]
+	mi := &file_coordinator_coordinator_proto_msgTypes[5]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1134,7 +1248,7 @@ func (x *ListStoresRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListStoresRequest.ProtoReflect.Descriptor instead.
 func (*ListStoresRequest) Descriptor() ([]byte, []int) {
-	return file_coordinator_coordinator_proto_rawDescGZIP(), []int{4}
+	return file_coordinator_coordinator_proto_rawDescGZIP(), []int{5}
 }
 
 type ListStoresResponse struct {
@@ -1146,7 +1260,7 @@ type ListStoresResponse struct {
 
 func (x *ListStoresResponse) Reset() {
 	*x = ListStoresResponse{}
-	mi := &file_coordinator_coordinator_proto_msgTypes[5]
+	mi := &file_coordinator_coordinator_proto_msgTypes[6]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1158,7 +1272,7 @@ func (x *ListStoresResponse) String() string {
 func (*ListStoresResponse) ProtoMessage() {}
 
 func (x *ListStoresResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_coordinator_coordinator_proto_msgTypes[5]
+	mi := &file_coordinator_coordinator_proto_msgTypes[6]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1171,7 +1285,7 @@ func (x *ListStoresResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListStoresResponse.ProtoReflect.Descriptor instead.
 func (*ListStoresResponse) Descriptor() ([]byte, []int) {
-	return file_coordinator_coordinator_proto_rawDescGZIP(), []int{5}
+	return file_coordinator_coordinator_proto_rawDescGZIP(), []int{6}
 }
 
 func (x *ListStoresResponse) GetStores() []*StoreInfo {
@@ -1195,7 +1309,7 @@ type MountInfo struct {
 
 func (x *MountInfo) Reset() {
 	*x = MountInfo{}
-	mi := &file_coordinator_coordinator_proto_msgTypes[6]
+	mi := &file_coordinator_coordinator_proto_msgTypes[7]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1207,7 +1321,7 @@ func (x *MountInfo) String() string {
 func (*MountInfo) ProtoMessage() {}
 
 func (x *MountInfo) ProtoReflect() protoreflect.Message {
-	mi := &file_coordinator_coordinator_proto_msgTypes[6]
+	mi := &file_coordinator_coordinator_proto_msgTypes[7]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1220,7 +1334,7 @@ func (x *MountInfo) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use MountInfo.ProtoReflect.Descriptor instead.
 func (*MountInfo) Descriptor() ([]byte, []int) {
-	return file_coordinator_coordinator_proto_rawDescGZIP(), []int{6}
+	return file_coordinator_coordinator_proto_rawDescGZIP(), []int{7}
 }
 
 func (x *MountInfo) GetMountId() string {
@@ -1274,7 +1388,7 @@ type GetMountRequest struct {
 
 func (x *GetMountRequest) Reset() {
 	*x = GetMountRequest{}
-	mi := &file_coordinator_coordinator_proto_msgTypes[7]
+	mi := &file_coordinator_coordinator_proto_msgTypes[8]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1286,7 +1400,7 @@ func (x *GetMountRequest) String() string {
 func (*GetMountRequest) ProtoMessage() {}
 
 func (x *GetMountRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_coordinator_coordinator_proto_msgTypes[7]
+	mi := &file_coordinator_coordinator_proto_msgTypes[8]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1299,7 +1413,7 @@ func (x *GetMountRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetMountRequest.ProtoReflect.Descriptor instead.
 func (*GetMountRequest) Descriptor() ([]byte, []int) {
-	return file_coordinator_coordinator_proto_rawDescGZIP(), []int{7}
+	return file_coordinator_coordinator_proto_rawDescGZIP(), []int{8}
 }
 
 func (x *GetMountRequest) GetMountId() string {
@@ -1319,7 +1433,7 @@ type GetMountResponse struct {
 
 func (x *GetMountResponse) Reset() {
 	*x = GetMountResponse{}
-	mi := &file_coordinator_coordinator_proto_msgTypes[8]
+	mi := &file_coordinator_coordinator_proto_msgTypes[9]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1331,7 +1445,7 @@ func (x *GetMountResponse) String() string {
 func (*GetMountResponse) ProtoMessage() {}
 
 func (x *GetMountResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_coordinator_coordinator_proto_msgTypes[8]
+	mi := &file_coordinator_coordinator_proto_msgTypes[9]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1344,7 +1458,7 @@ func (x *GetMountResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetMountResponse.ProtoReflect.Descriptor instead.
 func (*GetMountResponse) Descriptor() ([]byte, []int) {
-	return file_coordinator_coordinator_proto_rawDescGZIP(), []int{8}
+	return file_coordinator_coordinator_proto_rawDescGZIP(), []int{9}
 }
 
 func (x *GetMountResponse) GetMount() *MountInfo {
@@ -1369,7 +1483,7 @@ type ListMountsRequest struct {
 
 func (x *ListMountsRequest) Reset() {
 	*x = ListMountsRequest{}
-	mi := &file_coordinator_coordinator_proto_msgTypes[9]
+	mi := &file_coordinator_coordinator_proto_msgTypes[10]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1381,7 +1495,7 @@ func (x *ListMountsRequest) String() string {
 func (*ListMountsRequest) ProtoMessage() {}
 
 func (x *ListMountsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_coordinator_coordinator_proto_msgTypes[9]
+	mi := &file_coordinator_coordinator_proto_msgTypes[10]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1394,7 +1508,7 @@ func (x *ListMountsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListMountsRequest.ProtoReflect.Descriptor instead.
 func (*ListMountsRequest) Descriptor() ([]byte, []int) {
-	return file_coordinator_coordinator_proto_rawDescGZIP(), []int{9}
+	return file_coordinator_coordinator_proto_rawDescGZIP(), []int{10}
 }
 
 type ListMountsResponse struct {
@@ -1406,7 +1520,7 @@ type ListMountsResponse struct {
 
 func (x *ListMountsResponse) Reset() {
 	*x = ListMountsResponse{}
-	mi := &file_coordinator_coordinator_proto_msgTypes[10]
+	mi := &file_coordinator_coordinator_proto_msgTypes[11]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1418,7 +1532,7 @@ func (x *ListMountsResponse) String() string {
 func (*ListMountsResponse) ProtoMessage() {}
 
 func (x *ListMountsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_coordinator_coordinator_proto_msgTypes[10]
+	mi := &file_coordinator_coordinator_proto_msgTypes[11]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1431,7 +1545,7 @@ func (x *ListMountsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListMountsResponse.ProtoReflect.Descriptor instead.
 func (*ListMountsResponse) Descriptor() ([]byte, []int) {
-	return file_coordinator_coordinator_proto_rawDescGZIP(), []int{10}
+	return file_coordinator_coordinator_proto_rawDescGZIP(), []int{11}
 }
 
 func (x *ListMountsResponse) GetMounts() []*MountInfo {
@@ -1465,7 +1579,7 @@ type SubtreeAuthorityInfo struct {
 
 func (x *SubtreeAuthorityInfo) Reset() {
 	*x = SubtreeAuthorityInfo{}
-	mi := &file_coordinator_coordinator_proto_msgTypes[11]
+	mi := &file_coordinator_coordinator_proto_msgTypes[12]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1477,7 +1591,7 @@ func (x *SubtreeAuthorityInfo) String() string {
 func (*SubtreeAuthorityInfo) ProtoMessage() {}
 
 func (x *SubtreeAuthorityInfo) ProtoReflect() protoreflect.Message {
-	mi := &file_coordinator_coordinator_proto_msgTypes[11]
+	mi := &file_coordinator_coordinator_proto_msgTypes[12]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1490,7 +1604,7 @@ func (x *SubtreeAuthorityInfo) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SubtreeAuthorityInfo.ProtoReflect.Descriptor instead.
 func (*SubtreeAuthorityInfo) Descriptor() ([]byte, []int) {
-	return file_coordinator_coordinator_proto_rawDescGZIP(), []int{11}
+	return file_coordinator_coordinator_proto_rawDescGZIP(), []int{12}
 }
 
 func (x *SubtreeAuthorityInfo) GetSubtreeId() string {
@@ -1613,7 +1727,7 @@ type ListSubtreeAuthoritiesRequest struct {
 
 func (x *ListSubtreeAuthoritiesRequest) Reset() {
 	*x = ListSubtreeAuthoritiesRequest{}
-	mi := &file_coordinator_coordinator_proto_msgTypes[12]
+	mi := &file_coordinator_coordinator_proto_msgTypes[13]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1625,7 +1739,7 @@ func (x *ListSubtreeAuthoritiesRequest) String() string {
 func (*ListSubtreeAuthoritiesRequest) ProtoMessage() {}
 
 func (x *ListSubtreeAuthoritiesRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_coordinator_coordinator_proto_msgTypes[12]
+	mi := &file_coordinator_coordinator_proto_msgTypes[13]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1638,7 +1752,7 @@ func (x *ListSubtreeAuthoritiesRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListSubtreeAuthoritiesRequest.ProtoReflect.Descriptor instead.
 func (*ListSubtreeAuthoritiesRequest) Descriptor() ([]byte, []int) {
-	return file_coordinator_coordinator_proto_rawDescGZIP(), []int{12}
+	return file_coordinator_coordinator_proto_rawDescGZIP(), []int{13}
 }
 
 type ListSubtreeAuthoritiesResponse struct {
@@ -1650,7 +1764,7 @@ type ListSubtreeAuthoritiesResponse struct {
 
 func (x *ListSubtreeAuthoritiesResponse) Reset() {
 	*x = ListSubtreeAuthoritiesResponse{}
-	mi := &file_coordinator_coordinator_proto_msgTypes[13]
+	mi := &file_coordinator_coordinator_proto_msgTypes[14]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1662,7 +1776,7 @@ func (x *ListSubtreeAuthoritiesResponse) String() string {
 func (*ListSubtreeAuthoritiesResponse) ProtoMessage() {}
 
 func (x *ListSubtreeAuthoritiesResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_coordinator_coordinator_proto_msgTypes[13]
+	mi := &file_coordinator_coordinator_proto_msgTypes[14]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1675,7 +1789,7 @@ func (x *ListSubtreeAuthoritiesResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListSubtreeAuthoritiesResponse.ProtoReflect.Descriptor instead.
 func (*ListSubtreeAuthoritiesResponse) Descriptor() ([]byte, []int) {
-	return file_coordinator_coordinator_proto_rawDescGZIP(), []int{13}
+	return file_coordinator_coordinator_proto_rawDescGZIP(), []int{14}
 }
 
 func (x *ListSubtreeAuthoritiesResponse) GetSubtrees() []*SubtreeAuthorityInfo {
@@ -1697,7 +1811,7 @@ type QuotaSubject struct {
 
 func (x *QuotaSubject) Reset() {
 	*x = QuotaSubject{}
-	mi := &file_coordinator_coordinator_proto_msgTypes[14]
+	mi := &file_coordinator_coordinator_proto_msgTypes[15]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1709,7 +1823,7 @@ func (x *QuotaSubject) String() string {
 func (*QuotaSubject) ProtoMessage() {}
 
 func (x *QuotaSubject) ProtoReflect() protoreflect.Message {
-	mi := &file_coordinator_coordinator_proto_msgTypes[14]
+	mi := &file_coordinator_coordinator_proto_msgTypes[15]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1722,7 +1836,7 @@ func (x *QuotaSubject) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use QuotaSubject.ProtoReflect.Descriptor instead.
 func (*QuotaSubject) Descriptor() ([]byte, []int) {
-	return file_coordinator_coordinator_proto_rawDescGZIP(), []int{14}
+	return file_coordinator_coordinator_proto_rawDescGZIP(), []int{15}
 }
 
 func (x *QuotaSubject) GetMountId() string {
@@ -1753,7 +1867,7 @@ type QuotaFenceInfo struct {
 
 func (x *QuotaFenceInfo) Reset() {
 	*x = QuotaFenceInfo{}
-	mi := &file_coordinator_coordinator_proto_msgTypes[15]
+	mi := &file_coordinator_coordinator_proto_msgTypes[16]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1765,7 +1879,7 @@ func (x *QuotaFenceInfo) String() string {
 func (*QuotaFenceInfo) ProtoMessage() {}
 
 func (x *QuotaFenceInfo) ProtoReflect() protoreflect.Message {
-	mi := &file_coordinator_coordinator_proto_msgTypes[15]
+	mi := &file_coordinator_coordinator_proto_msgTypes[16]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1778,7 +1892,7 @@ func (x *QuotaFenceInfo) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use QuotaFenceInfo.ProtoReflect.Descriptor instead.
 func (*QuotaFenceInfo) Descriptor() ([]byte, []int) {
-	return file_coordinator_coordinator_proto_rawDescGZIP(), []int{15}
+	return file_coordinator_coordinator_proto_rawDescGZIP(), []int{16}
 }
 
 func (x *QuotaFenceInfo) GetSubject() *QuotaSubject {
@@ -1832,7 +1946,7 @@ type GetQuotaFenceRequest struct {
 
 func (x *GetQuotaFenceRequest) Reset() {
 	*x = GetQuotaFenceRequest{}
-	mi := &file_coordinator_coordinator_proto_msgTypes[16]
+	mi := &file_coordinator_coordinator_proto_msgTypes[17]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1844,7 +1958,7 @@ func (x *GetQuotaFenceRequest) String() string {
 func (*GetQuotaFenceRequest) ProtoMessage() {}
 
 func (x *GetQuotaFenceRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_coordinator_coordinator_proto_msgTypes[16]
+	mi := &file_coordinator_coordinator_proto_msgTypes[17]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1857,7 +1971,7 @@ func (x *GetQuotaFenceRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetQuotaFenceRequest.ProtoReflect.Descriptor instead.
 func (*GetQuotaFenceRequest) Descriptor() ([]byte, []int) {
-	return file_coordinator_coordinator_proto_rawDescGZIP(), []int{16}
+	return file_coordinator_coordinator_proto_rawDescGZIP(), []int{17}
 }
 
 func (x *GetQuotaFenceRequest) GetSubject() *QuotaSubject {
@@ -1877,7 +1991,7 @@ type GetQuotaFenceResponse struct {
 
 func (x *GetQuotaFenceResponse) Reset() {
 	*x = GetQuotaFenceResponse{}
-	mi := &file_coordinator_coordinator_proto_msgTypes[17]
+	mi := &file_coordinator_coordinator_proto_msgTypes[18]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1889,7 +2003,7 @@ func (x *GetQuotaFenceResponse) String() string {
 func (*GetQuotaFenceResponse) ProtoMessage() {}
 
 func (x *GetQuotaFenceResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_coordinator_coordinator_proto_msgTypes[17]
+	mi := &file_coordinator_coordinator_proto_msgTypes[18]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1902,7 +2016,7 @@ func (x *GetQuotaFenceResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetQuotaFenceResponse.ProtoReflect.Descriptor instead.
 func (*GetQuotaFenceResponse) Descriptor() ([]byte, []int) {
-	return file_coordinator_coordinator_proto_rawDescGZIP(), []int{17}
+	return file_coordinator_coordinator_proto_rawDescGZIP(), []int{18}
 }
 
 func (x *GetQuotaFenceResponse) GetFence() *QuotaFenceInfo {
@@ -1927,7 +2041,7 @@ type ListQuotaFencesRequest struct {
 
 func (x *ListQuotaFencesRequest) Reset() {
 	*x = ListQuotaFencesRequest{}
-	mi := &file_coordinator_coordinator_proto_msgTypes[18]
+	mi := &file_coordinator_coordinator_proto_msgTypes[19]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1939,7 +2053,7 @@ func (x *ListQuotaFencesRequest) String() string {
 func (*ListQuotaFencesRequest) ProtoMessage() {}
 
 func (x *ListQuotaFencesRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_coordinator_coordinator_proto_msgTypes[18]
+	mi := &file_coordinator_coordinator_proto_msgTypes[19]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1952,7 +2066,7 @@ func (x *ListQuotaFencesRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListQuotaFencesRequest.ProtoReflect.Descriptor instead.
 func (*ListQuotaFencesRequest) Descriptor() ([]byte, []int) {
-	return file_coordinator_coordinator_proto_rawDescGZIP(), []int{18}
+	return file_coordinator_coordinator_proto_rawDescGZIP(), []int{19}
 }
 
 type ListQuotaFencesResponse struct {
@@ -1964,7 +2078,7 @@ type ListQuotaFencesResponse struct {
 
 func (x *ListQuotaFencesResponse) Reset() {
 	*x = ListQuotaFencesResponse{}
-	mi := &file_coordinator_coordinator_proto_msgTypes[19]
+	mi := &file_coordinator_coordinator_proto_msgTypes[20]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1976,7 +2090,7 @@ func (x *ListQuotaFencesResponse) String() string {
 func (*ListQuotaFencesResponse) ProtoMessage() {}
 
 func (x *ListQuotaFencesResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_coordinator_coordinator_proto_msgTypes[19]
+	mi := &file_coordinator_coordinator_proto_msgTypes[20]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1989,7 +2103,7 @@ func (x *ListQuotaFencesResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListQuotaFencesResponse.ProtoReflect.Descriptor instead.
 func (*ListQuotaFencesResponse) Descriptor() ([]byte, []int) {
-	return file_coordinator_coordinator_proto_rawDescGZIP(), []int{19}
+	return file_coordinator_coordinator_proto_rawDescGZIP(), []int{20}
 }
 
 func (x *ListQuotaFencesResponse) GetFences() []*QuotaFenceInfo {
@@ -2008,7 +2122,7 @@ type WatchRootEventsRequest struct {
 
 func (x *WatchRootEventsRequest) Reset() {
 	*x = WatchRootEventsRequest{}
-	mi := &file_coordinator_coordinator_proto_msgTypes[20]
+	mi := &file_coordinator_coordinator_proto_msgTypes[21]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2020,7 +2134,7 @@ func (x *WatchRootEventsRequest) String() string {
 func (*WatchRootEventsRequest) ProtoMessage() {}
 
 func (x *WatchRootEventsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_coordinator_coordinator_proto_msgTypes[20]
+	mi := &file_coordinator_coordinator_proto_msgTypes[21]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2033,7 +2147,7 @@ func (x *WatchRootEventsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use WatchRootEventsRequest.ProtoReflect.Descriptor instead.
 func (*WatchRootEventsRequest) Descriptor() ([]byte, []int) {
-	return file_coordinator_coordinator_proto_rawDescGZIP(), []int{20}
+	return file_coordinator_coordinator_proto_rawDescGZIP(), []int{21}
 }
 
 func (x *WatchRootEventsRequest) GetAfter() *meta.RootTailToken {
@@ -2054,7 +2168,7 @@ type WatchRootEventsResponse struct {
 
 func (x *WatchRootEventsResponse) Reset() {
 	*x = WatchRootEventsResponse{}
-	mi := &file_coordinator_coordinator_proto_msgTypes[21]
+	mi := &file_coordinator_coordinator_proto_msgTypes[22]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2066,7 +2180,7 @@ func (x *WatchRootEventsResponse) String() string {
 func (*WatchRootEventsResponse) ProtoMessage() {}
 
 func (x *WatchRootEventsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_coordinator_coordinator_proto_msgTypes[21]
+	mi := &file_coordinator_coordinator_proto_msgTypes[22]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2079,7 +2193,7 @@ func (x *WatchRootEventsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use WatchRootEventsResponse.ProtoReflect.Descriptor instead.
 func (*WatchRootEventsResponse) Descriptor() ([]byte, []int) {
-	return file_coordinator_coordinator_proto_rawDescGZIP(), []int{21}
+	return file_coordinator_coordinator_proto_rawDescGZIP(), []int{22}
 }
 
 func (x *WatchRootEventsResponse) GetToken() *meta.RootTailToken {
@@ -2104,18 +2218,21 @@ func (x *WatchRootEventsResponse) GetBootstrapRequired() bool {
 }
 
 type SchedulerOperation struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	Type          SchedulerOperationType `protobuf:"varint,1,opt,name=type,proto3,enum=nokv.coordinator.v1.SchedulerOperationType" json:"type,omitempty"`
-	RegionId      uint64                 `protobuf:"varint,2,opt,name=region_id,json=regionId,proto3" json:"region_id,omitempty"`
-	SourcePeerId  uint64                 `protobuf:"varint,3,opt,name=source_peer_id,json=sourcePeerId,proto3" json:"source_peer_id,omitempty"`
-	TargetPeerId  uint64                 `protobuf:"varint,4,opt,name=target_peer_id,json=targetPeerId,proto3" json:"target_peer_id,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	state          protoimpl.MessageState `protogen:"open.v1"`
+	Type           SchedulerOperationType `protobuf:"varint,1,opt,name=type,proto3,enum=nokv.coordinator.v1.SchedulerOperationType" json:"type,omitempty"`
+	RegionId       uint64                 `protobuf:"varint,2,opt,name=region_id,json=regionId,proto3" json:"region_id,omitempty"`
+	SourcePeerId   uint64                 `protobuf:"varint,3,opt,name=source_peer_id,json=sourcePeerId,proto3" json:"source_peer_id,omitempty"`
+	TargetPeerId   uint64                 `protobuf:"varint,4,opt,name=target_peer_id,json=targetPeerId,proto3" json:"target_peer_id,omitempty"`
+	SplitKey       []byte                 `protobuf:"bytes,5,opt,name=split_key,json=splitKey,proto3" json:"split_key,omitempty"`
+	SplitChild     *meta.RegionDescriptor `protobuf:"bytes,6,opt,name=split_child,json=splitChild,proto3" json:"split_child,omitempty"`
+	SourceRegionId uint64                 `protobuf:"varint,7,opt,name=source_region_id,json=sourceRegionId,proto3" json:"source_region_id,omitempty"`
+	unknownFields  protoimpl.UnknownFields
+	sizeCache      protoimpl.SizeCache
 }
 
 func (x *SchedulerOperation) Reset() {
 	*x = SchedulerOperation{}
-	mi := &file_coordinator_coordinator_proto_msgTypes[22]
+	mi := &file_coordinator_coordinator_proto_msgTypes[23]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2127,7 +2244,7 @@ func (x *SchedulerOperation) String() string {
 func (*SchedulerOperation) ProtoMessage() {}
 
 func (x *SchedulerOperation) ProtoReflect() protoreflect.Message {
-	mi := &file_coordinator_coordinator_proto_msgTypes[22]
+	mi := &file_coordinator_coordinator_proto_msgTypes[23]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2140,7 +2257,7 @@ func (x *SchedulerOperation) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SchedulerOperation.ProtoReflect.Descriptor instead.
 func (*SchedulerOperation) Descriptor() ([]byte, []int) {
-	return file_coordinator_coordinator_proto_rawDescGZIP(), []int{22}
+	return file_coordinator_coordinator_proto_rawDescGZIP(), []int{23}
 }
 
 func (x *SchedulerOperation) GetType() SchedulerOperationType {
@@ -2171,6 +2288,27 @@ func (x *SchedulerOperation) GetTargetPeerId() uint64 {
 	return 0
 }
 
+func (x *SchedulerOperation) GetSplitKey() []byte {
+	if x != nil {
+		return x.SplitKey
+	}
+	return nil
+}
+
+func (x *SchedulerOperation) GetSplitChild() *meta.RegionDescriptor {
+	if x != nil {
+		return x.SplitChild
+	}
+	return nil
+}
+
+func (x *SchedulerOperation) GetSourceRegionId() uint64 {
+	if x != nil {
+		return x.SourceRegionId
+	}
+	return 0
+}
+
 type StoreHeartbeatResponse struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	Accepted      bool                   `protobuf:"varint,1,opt,name=accepted,proto3" json:"accepted,omitempty"`
@@ -2181,7 +2319,7 @@ type StoreHeartbeatResponse struct {
 
 func (x *StoreHeartbeatResponse) Reset() {
 	*x = StoreHeartbeatResponse{}
-	mi := &file_coordinator_coordinator_proto_msgTypes[23]
+	mi := &file_coordinator_coordinator_proto_msgTypes[24]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2193,7 +2331,7 @@ func (x *StoreHeartbeatResponse) String() string {
 func (*StoreHeartbeatResponse) ProtoMessage() {}
 
 func (x *StoreHeartbeatResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_coordinator_coordinator_proto_msgTypes[23]
+	mi := &file_coordinator_coordinator_proto_msgTypes[24]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2206,7 +2344,7 @@ func (x *StoreHeartbeatResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use StoreHeartbeatResponse.ProtoReflect.Descriptor instead.
 func (*StoreHeartbeatResponse) Descriptor() ([]byte, []int) {
-	return file_coordinator_coordinator_proto_rawDescGZIP(), []int{23}
+	return file_coordinator_coordinator_proto_rawDescGZIP(), []int{24}
 }
 
 func (x *StoreHeartbeatResponse) GetAccepted() bool {
@@ -2232,7 +2370,7 @@ type RegionLivenessRequest struct {
 
 func (x *RegionLivenessRequest) Reset() {
 	*x = RegionLivenessRequest{}
-	mi := &file_coordinator_coordinator_proto_msgTypes[24]
+	mi := &file_coordinator_coordinator_proto_msgTypes[25]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2244,7 +2382,7 @@ func (x *RegionLivenessRequest) String() string {
 func (*RegionLivenessRequest) ProtoMessage() {}
 
 func (x *RegionLivenessRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_coordinator_coordinator_proto_msgTypes[24]
+	mi := &file_coordinator_coordinator_proto_msgTypes[25]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2257,7 +2395,7 @@ func (x *RegionLivenessRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RegionLivenessRequest.ProtoReflect.Descriptor instead.
 func (*RegionLivenessRequest) Descriptor() ([]byte, []int) {
-	return file_coordinator_coordinator_proto_rawDescGZIP(), []int{24}
+	return file_coordinator_coordinator_proto_rawDescGZIP(), []int{25}
 }
 
 func (x *RegionLivenessRequest) GetRegionId() uint64 {
@@ -2276,7 +2414,7 @@ type RegionLivenessResponse struct {
 
 func (x *RegionLivenessResponse) Reset() {
 	*x = RegionLivenessResponse{}
-	mi := &file_coordinator_coordinator_proto_msgTypes[25]
+	mi := &file_coordinator_coordinator_proto_msgTypes[26]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2288,7 +2426,7 @@ func (x *RegionLivenessResponse) String() string {
 func (*RegionLivenessResponse) ProtoMessage() {}
 
 func (x *RegionLivenessResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_coordinator_coordinator_proto_msgTypes[25]
+	mi := &file_coordinator_coordinator_proto_msgTypes[26]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2301,7 +2439,7 @@ func (x *RegionLivenessResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RegionLivenessResponse.ProtoReflect.Descriptor instead.
 func (*RegionLivenessResponse) Descriptor() ([]byte, []int) {
-	return file_coordinator_coordinator_proto_rawDescGZIP(), []int{25}
+	return file_coordinator_coordinator_proto_rawDescGZIP(), []int{26}
 }
 
 func (x *RegionLivenessResponse) GetAccepted() bool {
@@ -2323,7 +2461,7 @@ type PublishRootEventRequest struct {
 
 func (x *PublishRootEventRequest) Reset() {
 	*x = PublishRootEventRequest{}
-	mi := &file_coordinator_coordinator_proto_msgTypes[26]
+	mi := &file_coordinator_coordinator_proto_msgTypes[27]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2335,7 +2473,7 @@ func (x *PublishRootEventRequest) String() string {
 func (*PublishRootEventRequest) ProtoMessage() {}
 
 func (x *PublishRootEventRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_coordinator_coordinator_proto_msgTypes[26]
+	mi := &file_coordinator_coordinator_proto_msgTypes[27]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2348,7 +2486,7 @@ func (x *PublishRootEventRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PublishRootEventRequest.ProtoReflect.Descriptor instead.
 func (*PublishRootEventRequest) Descriptor() ([]byte, []int) {
-	return file_coordinator_coordinator_proto_rawDescGZIP(), []int{26}
+	return file_coordinator_coordinator_proto_rawDescGZIP(), []int{27}
 }
 
 func (x *PublishRootEventRequest) GetEvent() *meta.RootEvent {
@@ -2379,7 +2517,7 @@ type PublishRootEventResponse struct {
 
 func (x *PublishRootEventResponse) Reset() {
 	*x = PublishRootEventResponse{}
-	mi := &file_coordinator_coordinator_proto_msgTypes[27]
+	mi := &file_coordinator_coordinator_proto_msgTypes[28]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2391,7 +2529,7 @@ func (x *PublishRootEventResponse) String() string {
 func (*PublishRootEventResponse) ProtoMessage() {}
 
 func (x *PublishRootEventResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_coordinator_coordinator_proto_msgTypes[27]
+	mi := &file_coordinator_coordinator_proto_msgTypes[28]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2404,7 +2542,7 @@ func (x *PublishRootEventResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PublishRootEventResponse.ProtoReflect.Descriptor instead.
 func (*PublishRootEventResponse) Descriptor() ([]byte, []int) {
-	return file_coordinator_coordinator_proto_rawDescGZIP(), []int{27}
+	return file_coordinator_coordinator_proto_rawDescGZIP(), []int{28}
 }
 
 func (x *PublishRootEventResponse) GetAccepted() bool {
@@ -2440,7 +2578,7 @@ type TransitionEntry struct {
 
 func (x *TransitionEntry) Reset() {
 	*x = TransitionEntry{}
-	mi := &file_coordinator_coordinator_proto_msgTypes[28]
+	mi := &file_coordinator_coordinator_proto_msgTypes[29]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2452,7 +2590,7 @@ func (x *TransitionEntry) String() string {
 func (*TransitionEntry) ProtoMessage() {}
 
 func (x *TransitionEntry) ProtoReflect() protoreflect.Message {
-	mi := &file_coordinator_coordinator_proto_msgTypes[28]
+	mi := &file_coordinator_coordinator_proto_msgTypes[29]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2465,7 +2603,7 @@ func (x *TransitionEntry) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use TransitionEntry.ProtoReflect.Descriptor instead.
 func (*TransitionEntry) Descriptor() ([]byte, []int) {
-	return file_coordinator_coordinator_proto_rawDescGZIP(), []int{28}
+	return file_coordinator_coordinator_proto_rawDescGZIP(), []int{29}
 }
 
 func (x *TransitionEntry) GetKey() uint64 {
@@ -2542,7 +2680,7 @@ type TransitionAssessment struct {
 
 func (x *TransitionAssessment) Reset() {
 	*x = TransitionAssessment{}
-	mi := &file_coordinator_coordinator_proto_msgTypes[29]
+	mi := &file_coordinator_coordinator_proto_msgTypes[30]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2554,7 +2692,7 @@ func (x *TransitionAssessment) String() string {
 func (*TransitionAssessment) ProtoMessage() {}
 
 func (x *TransitionAssessment) ProtoReflect() protoreflect.Message {
-	mi := &file_coordinator_coordinator_proto_msgTypes[29]
+	mi := &file_coordinator_coordinator_proto_msgTypes[30]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2567,7 +2705,7 @@ func (x *TransitionAssessment) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use TransitionAssessment.ProtoReflect.Descriptor instead.
 func (*TransitionAssessment) Descriptor() ([]byte, []int) {
-	return file_coordinator_coordinator_proto_rawDescGZIP(), []int{29}
+	return file_coordinator_coordinator_proto_rawDescGZIP(), []int{30}
 }
 
 func (x *TransitionAssessment) GetKey() uint64 {
@@ -2627,7 +2765,7 @@ type ListTransitionsRequest struct {
 
 func (x *ListTransitionsRequest) Reset() {
 	*x = ListTransitionsRequest{}
-	mi := &file_coordinator_coordinator_proto_msgTypes[30]
+	mi := &file_coordinator_coordinator_proto_msgTypes[31]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2639,7 +2777,7 @@ func (x *ListTransitionsRequest) String() string {
 func (*ListTransitionsRequest) ProtoMessage() {}
 
 func (x *ListTransitionsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_coordinator_coordinator_proto_msgTypes[30]
+	mi := &file_coordinator_coordinator_proto_msgTypes[31]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2652,7 +2790,7 @@ func (x *ListTransitionsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListTransitionsRequest.ProtoReflect.Descriptor instead.
 func (*ListTransitionsRequest) Descriptor() ([]byte, []int) {
-	return file_coordinator_coordinator_proto_rawDescGZIP(), []int{30}
+	return file_coordinator_coordinator_proto_rawDescGZIP(), []int{31}
 }
 
 type ListTransitionsResponse struct {
@@ -2664,7 +2802,7 @@ type ListTransitionsResponse struct {
 
 func (x *ListTransitionsResponse) Reset() {
 	*x = ListTransitionsResponse{}
-	mi := &file_coordinator_coordinator_proto_msgTypes[31]
+	mi := &file_coordinator_coordinator_proto_msgTypes[32]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2676,7 +2814,7 @@ func (x *ListTransitionsResponse) String() string {
 func (*ListTransitionsResponse) ProtoMessage() {}
 
 func (x *ListTransitionsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_coordinator_coordinator_proto_msgTypes[31]
+	mi := &file_coordinator_coordinator_proto_msgTypes[32]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2689,7 +2827,7 @@ func (x *ListTransitionsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ListTransitionsResponse.ProtoReflect.Descriptor instead.
 func (*ListTransitionsResponse) Descriptor() ([]byte, []int) {
-	return file_coordinator_coordinator_proto_rawDescGZIP(), []int{31}
+	return file_coordinator_coordinator_proto_rawDescGZIP(), []int{32}
 }
 
 func (x *ListTransitionsResponse) GetEntries() []*TransitionEntry {
@@ -2708,7 +2846,7 @@ type AssessRootEventRequest struct {
 
 func (x *AssessRootEventRequest) Reset() {
 	*x = AssessRootEventRequest{}
-	mi := &file_coordinator_coordinator_proto_msgTypes[32]
+	mi := &file_coordinator_coordinator_proto_msgTypes[33]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2720,7 +2858,7 @@ func (x *AssessRootEventRequest) String() string {
 func (*AssessRootEventRequest) ProtoMessage() {}
 
 func (x *AssessRootEventRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_coordinator_coordinator_proto_msgTypes[32]
+	mi := &file_coordinator_coordinator_proto_msgTypes[33]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2733,7 +2871,7 @@ func (x *AssessRootEventRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AssessRootEventRequest.ProtoReflect.Descriptor instead.
 func (*AssessRootEventRequest) Descriptor() ([]byte, []int) {
-	return file_coordinator_coordinator_proto_rawDescGZIP(), []int{32}
+	return file_coordinator_coordinator_proto_rawDescGZIP(), []int{33}
 }
 
 func (x *AssessRootEventRequest) GetEvent() *meta.RootEvent {
@@ -2752,7 +2890,7 @@ type AssessRootEventResponse struct {
 
 func (x *AssessRootEventResponse) Reset() {
 	*x = AssessRootEventResponse{}
-	mi := &file_coordinator_coordinator_proto_msgTypes[33]
+	mi := &file_coordinator_coordinator_proto_msgTypes[34]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2764,7 +2902,7 @@ func (x *AssessRootEventResponse) String() string {
 func (*AssessRootEventResponse) ProtoMessage() {}
 
 func (x *AssessRootEventResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_coordinator_coordinator_proto_msgTypes[33]
+	mi := &file_coordinator_coordinator_proto_msgTypes[34]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2777,7 +2915,7 @@ func (x *AssessRootEventResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AssessRootEventResponse.ProtoReflect.Descriptor instead.
 func (*AssessRootEventResponse) Descriptor() ([]byte, []int) {
-	return file_coordinator_coordinator_proto_rawDescGZIP(), []int{33}
+	return file_coordinator_coordinator_proto_rawDescGZIP(), []int{34}
 }
 
 func (x *AssessRootEventResponse) GetAssessment() *TransitionAssessment {
@@ -2797,7 +2935,7 @@ type RemoveRegionRequest struct {
 
 func (x *RemoveRegionRequest) Reset() {
 	*x = RemoveRegionRequest{}
-	mi := &file_coordinator_coordinator_proto_msgTypes[34]
+	mi := &file_coordinator_coordinator_proto_msgTypes[35]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2809,7 +2947,7 @@ func (x *RemoveRegionRequest) String() string {
 func (*RemoveRegionRequest) ProtoMessage() {}
 
 func (x *RemoveRegionRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_coordinator_coordinator_proto_msgTypes[34]
+	mi := &file_coordinator_coordinator_proto_msgTypes[35]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2822,7 +2960,7 @@ func (x *RemoveRegionRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RemoveRegionRequest.ProtoReflect.Descriptor instead.
 func (*RemoveRegionRequest) Descriptor() ([]byte, []int) {
-	return file_coordinator_coordinator_proto_rawDescGZIP(), []int{34}
+	return file_coordinator_coordinator_proto_rawDescGZIP(), []int{35}
 }
 
 func (x *RemoveRegionRequest) GetRegionId() uint64 {
@@ -2848,7 +2986,7 @@ type RemoveRegionResponse struct {
 
 func (x *RemoveRegionResponse) Reset() {
 	*x = RemoveRegionResponse{}
-	mi := &file_coordinator_coordinator_proto_msgTypes[35]
+	mi := &file_coordinator_coordinator_proto_msgTypes[36]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2860,7 +2998,7 @@ func (x *RemoveRegionResponse) String() string {
 func (*RemoveRegionResponse) ProtoMessage() {}
 
 func (x *RemoveRegionResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_coordinator_coordinator_proto_msgTypes[35]
+	mi := &file_coordinator_coordinator_proto_msgTypes[36]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2873,7 +3011,7 @@ func (x *RemoveRegionResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RemoveRegionResponse.ProtoReflect.Descriptor instead.
 func (*RemoveRegionResponse) Descriptor() ([]byte, []int) {
-	return file_coordinator_coordinator_proto_rawDescGZIP(), []int{35}
+	return file_coordinator_coordinator_proto_rawDescGZIP(), []int{36}
 }
 
 func (x *RemoveRegionResponse) GetRemoved() bool {
@@ -2897,7 +3035,7 @@ type RootToken struct {
 
 func (x *RootToken) Reset() {
 	*x = RootToken{}
-	mi := &file_coordinator_coordinator_proto_msgTypes[36]
+	mi := &file_coordinator_coordinator_proto_msgTypes[37]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2909,7 +3047,7 @@ func (x *RootToken) String() string {
 func (*RootToken) ProtoMessage() {}
 
 func (x *RootToken) ProtoReflect() protoreflect.Message {
-	mi := &file_coordinator_coordinator_proto_msgTypes[36]
+	mi := &file_coordinator_coordinator_proto_msgTypes[37]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2922,7 +3060,7 @@ func (x *RootToken) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RootToken.ProtoReflect.Descriptor instead.
 func (*RootToken) Descriptor() ([]byte, []int) {
-	return file_coordinator_coordinator_proto_rawDescGZIP(), []int{36}
+	return file_coordinator_coordinator_proto_rawDescGZIP(), []int{37}
 }
 
 func (x *RootToken) GetTerm() uint64 {
@@ -2965,7 +3103,7 @@ type GetRegionByKeyRequest struct {
 
 func (x *GetRegionByKeyRequest) Reset() {
 	*x = GetRegionByKeyRequest{}
-	mi := &file_coordinator_coordinator_proto_msgTypes[37]
+	mi := &file_coordinator_coordinator_proto_msgTypes[38]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2977,7 +3115,7 @@ func (x *GetRegionByKeyRequest) String() string {
 func (*GetRegionByKeyRequest) ProtoMessage() {}
 
 func (x *GetRegionByKeyRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_coordinator_coordinator_proto_msgTypes[37]
+	mi := &file_coordinator_coordinator_proto_msgTypes[38]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2990,7 +3128,7 @@ func (x *GetRegionByKeyRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetRegionByKeyRequest.ProtoReflect.Descriptor instead.
 func (*GetRegionByKeyRequest) Descriptor() ([]byte, []int) {
-	return file_coordinator_coordinator_proto_rawDescGZIP(), []int{37}
+	return file_coordinator_coordinator_proto_rawDescGZIP(), []int{38}
 }
 
 func (x *GetRegionByKeyRequest) GetKey() []byte {
@@ -3069,7 +3207,7 @@ type GetRegionByKeyResponse struct {
 
 func (x *GetRegionByKeyResponse) Reset() {
 	*x = GetRegionByKeyResponse{}
-	mi := &file_coordinator_coordinator_proto_msgTypes[38]
+	mi := &file_coordinator_coordinator_proto_msgTypes[39]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3081,7 +3219,7 @@ func (x *GetRegionByKeyResponse) String() string {
 func (*GetRegionByKeyResponse) ProtoMessage() {}
 
 func (x *GetRegionByKeyResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_coordinator_coordinator_proto_msgTypes[38]
+	mi := &file_coordinator_coordinator_proto_msgTypes[39]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3094,7 +3232,7 @@ func (x *GetRegionByKeyResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetRegionByKeyResponse.ProtoReflect.Descriptor instead.
 func (*GetRegionByKeyResponse) Descriptor() ([]byte, []int) {
-	return file_coordinator_coordinator_proto_rawDescGZIP(), []int{38}
+	return file_coordinator_coordinator_proto_rawDescGZIP(), []int{39}
 }
 
 func (x *GetRegionByKeyResponse) GetRegionDescriptor() *meta.RegionDescriptor {
@@ -3218,7 +3356,7 @@ type AllocIDRequest struct {
 
 func (x *AllocIDRequest) Reset() {
 	*x = AllocIDRequest{}
-	mi := &file_coordinator_coordinator_proto_msgTypes[39]
+	mi := &file_coordinator_coordinator_proto_msgTypes[40]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3230,7 +3368,7 @@ func (x *AllocIDRequest) String() string {
 func (*AllocIDRequest) ProtoMessage() {}
 
 func (x *AllocIDRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_coordinator_coordinator_proto_msgTypes[39]
+	mi := &file_coordinator_coordinator_proto_msgTypes[40]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3243,7 +3381,7 @@ func (x *AllocIDRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AllocIDRequest.ProtoReflect.Descriptor instead.
 func (*AllocIDRequest) Descriptor() ([]byte, []int) {
-	return file_coordinator_coordinator_proto_rawDescGZIP(), []int{39}
+	return file_coordinator_coordinator_proto_rawDescGZIP(), []int{40}
 }
 
 func (x *AllocIDRequest) GetCount() uint64 {
@@ -3269,7 +3407,7 @@ type AllocIDResponse struct {
 
 func (x *AllocIDResponse) Reset() {
 	*x = AllocIDResponse{}
-	mi := &file_coordinator_coordinator_proto_msgTypes[40]
+	mi := &file_coordinator_coordinator_proto_msgTypes[41]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3281,7 +3419,7 @@ func (x *AllocIDResponse) String() string {
 func (*AllocIDResponse) ProtoMessage() {}
 
 func (x *AllocIDResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_coordinator_coordinator_proto_msgTypes[40]
+	mi := &file_coordinator_coordinator_proto_msgTypes[41]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3294,7 +3432,7 @@ func (x *AllocIDResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AllocIDResponse.ProtoReflect.Descriptor instead.
 func (*AllocIDResponse) Descriptor() ([]byte, []int) {
-	return file_coordinator_coordinator_proto_rawDescGZIP(), []int{40}
+	return file_coordinator_coordinator_proto_rawDescGZIP(), []int{41}
 }
 
 func (x *AllocIDResponse) GetFirstId() uint64 {
@@ -3348,7 +3486,7 @@ type TsoRequest struct {
 
 func (x *TsoRequest) Reset() {
 	*x = TsoRequest{}
-	mi := &file_coordinator_coordinator_proto_msgTypes[41]
+	mi := &file_coordinator_coordinator_proto_msgTypes[42]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3360,7 +3498,7 @@ func (x *TsoRequest) String() string {
 func (*TsoRequest) ProtoMessage() {}
 
 func (x *TsoRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_coordinator_coordinator_proto_msgTypes[41]
+	mi := &file_coordinator_coordinator_proto_msgTypes[42]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3373,7 +3511,7 @@ func (x *TsoRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use TsoRequest.ProtoReflect.Descriptor instead.
 func (*TsoRequest) Descriptor() ([]byte, []int) {
-	return file_coordinator_coordinator_proto_rawDescGZIP(), []int{41}
+	return file_coordinator_coordinator_proto_rawDescGZIP(), []int{42}
 }
 
 func (x *TsoRequest) GetCount() uint64 {
@@ -3399,7 +3537,7 @@ type TsoResponse struct {
 
 func (x *TsoResponse) Reset() {
 	*x = TsoResponse{}
-	mi := &file_coordinator_coordinator_proto_msgTypes[42]
+	mi := &file_coordinator_coordinator_proto_msgTypes[43]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3411,7 +3549,7 @@ func (x *TsoResponse) String() string {
 func (*TsoResponse) ProtoMessage() {}
 
 func (x *TsoResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_coordinator_coordinator_proto_msgTypes[42]
+	mi := &file_coordinator_coordinator_proto_msgTypes[43]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3424,7 +3562,7 @@ func (x *TsoResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use TsoResponse.ProtoReflect.Descriptor instead.
 func (*TsoResponse) Descriptor() ([]byte, []int) {
-	return file_coordinator_coordinator_proto_rawDescGZIP(), []int{42}
+	return file_coordinator_coordinator_proto_rawDescGZIP(), []int{43}
 }
 
 func (x *TsoResponse) GetTimestamp() uint64 {
@@ -3473,7 +3611,7 @@ var File_coordinator_coordinator_proto protoreflect.FileDescriptor
 
 const file_coordinator_coordinator_proto_rawDesc = "" +
 	"\n" +
-	"\x1dcoordinator/coordinator.proto\x12\x13nokv.coordinator.v1\x1a\x15meta/descriptor.proto\x1a\x0fmeta/root.proto\"\xc3\x02\n" +
+	"\x1dcoordinator/coordinator.proto\x12\x13nokv.coordinator.v1\x1a\x15meta/descriptor.proto\x1a\x0fmeta/root.proto\"\x8f\x03\n" +
 	"\x15StoreHeartbeatRequest\x12\x19\n" +
 	"\bstore_id\x18\x01 \x01(\x04R\astoreId\x12\x1d\n" +
 	"\n" +
@@ -3486,7 +3624,18 @@ const file_coordinator_coordinator_proto_rawDesc = "" +
 	"\x11leader_region_ids\x18\a \x03(\x04R\x0fleaderRegionIds\x12\x1f\n" +
 	"\vclient_addr\x18\b \x01(\tR\n" +
 	"clientAddr\x12\x1b\n" +
-	"\traft_addr\x18\t \x01(\tR\braftAddr\"\xfb\x02\n" +
+	"\traft_addr\x18\t \x01(\tR\braftAddr\x12J\n" +
+	"\fregion_stats\x18\n" +
+	" \x03(\v2'.nokv.coordinator.v1.RegionRuntimeStatsR\vregionStats\"\xc1\x02\n" +
+	"\x12RegionRuntimeStats\x12\x1b\n" +
+	"\tregion_id\x18\x01 \x01(\x04R\bregionId\x12\x19\n" +
+	"\bread_qps\x18\x02 \x01(\x04R\areadQps\x12\x1b\n" +
+	"\twrite_qps\x18\x03 \x01(\x04R\bwriteQps\x12-\n" +
+	"\x13write_bytes_per_sec\x18\x04 \x01(\x04R\x10writeBytesPerSec\x12.\n" +
+	"\x13approx_region_bytes\x18\x05 \x01(\x04R\x11approxRegionBytes\x12*\n" +
+	"\x11atomic_mutate_qps\x18\x06 \x01(\x04R\x0fatomicMutateQps\x12&\n" +
+	"\x0fleader_store_id\x18\a \x01(\x04R\rleaderStoreId\x12#\n" +
+	"\rpending_admin\x18\b \x01(\bR\fpendingAdmin\"\xfb\x02\n" +
 	"\tStoreInfo\x12\x19\n" +
 	"\bstore_id\x18\x01 \x01(\x04R\astoreId\x12\x1f\n" +
 	"\vclient_addr\x18\x02 \x01(\tR\n" +
@@ -3576,12 +3725,16 @@ const file_coordinator_coordinator_proto_rawDesc = "" +
 	"\x17WatchRootEventsResponse\x121\n" +
 	"\x05token\x18\x01 \x01(\v2\x1b.nokv.meta.v1.RootTailTokenR\x05token\x128\n" +
 	"\x06events\x18\x02 \x03(\v2 .nokv.meta.v1.RootCommittedEventR\x06events\x12-\n" +
-	"\x12bootstrap_required\x18\x03 \x01(\bR\x11bootstrapRequired\"\xbe\x01\n" +
+	"\x12bootstrap_required\x18\x03 \x01(\bR\x11bootstrapRequired\"\xc6\x02\n" +
 	"\x12SchedulerOperation\x12?\n" +
 	"\x04type\x18\x01 \x01(\x0e2+.nokv.coordinator.v1.SchedulerOperationTypeR\x04type\x12\x1b\n" +
 	"\tregion_id\x18\x02 \x01(\x04R\bregionId\x12$\n" +
 	"\x0esource_peer_id\x18\x03 \x01(\x04R\fsourcePeerId\x12$\n" +
-	"\x0etarget_peer_id\x18\x04 \x01(\x04R\ftargetPeerId\"}\n" +
+	"\x0etarget_peer_id\x18\x04 \x01(\x04R\ftargetPeerId\x12\x1b\n" +
+	"\tsplit_key\x18\x05 \x01(\fR\bsplitKey\x12?\n" +
+	"\vsplit_child\x18\x06 \x01(\v2\x1e.nokv.meta.v1.RegionDescriptorR\n" +
+	"splitChild\x12(\n" +
+	"\x10source_region_id\x18\a \x01(\x04R\x0esourceRegionId\"}\n" +
 	"\x16StoreHeartbeatResponse\x12\x1a\n" +
 	"\baccepted\x18\x01 \x01(\bR\baccepted\x12G\n" +
 	"\n" +
@@ -3696,10 +3849,12 @@ const file_coordinator_coordinator_proto_rawDesc = "" +
 	"\x15SubtreeAuthorityState\x12#\n" +
 	"\x1fSUBTREE_AUTHORITY_STATE_UNKNOWN\x10\x00\x12\"\n" +
 	"\x1eSUBTREE_AUTHORITY_STATE_ACTIVE\x10\x01\x12#\n" +
-	"\x1fSUBTREE_AUTHORITY_STATE_HANDOFF\x10\x02*i\n" +
+	"\x1fSUBTREE_AUTHORITY_STATE_HANDOFF\x10\x02*\xbf\x01\n" +
 	"\x16SchedulerOperationType\x12!\n" +
 	"\x1dSCHEDULER_OPERATION_TYPE_NONE\x10\x00\x12,\n" +
-	"(SCHEDULER_OPERATION_TYPE_LEADER_TRANSFER\x10\x01*t\n" +
+	"(SCHEDULER_OPERATION_TYPE_LEADER_TRANSFER\x10\x01\x12)\n" +
+	"%SCHEDULER_OPERATION_TYPE_SPLIT_REGION\x10\x02\x12)\n" +
+	"%SCHEDULER_OPERATION_TYPE_MERGE_REGION\x10\x03*t\n" +
 	"\x0eTransitionKind\x12\x1f\n" +
 	"\x1bTRANSITION_KIND_UNSPECIFIED\x10\x00\x12\x1f\n" +
 	"\x1bTRANSITION_KIND_PEER_CHANGE\x10\x01\x12 \n" +
@@ -3790,7 +3945,7 @@ func file_coordinator_coordinator_proto_rawDescGZIP() []byte {
 }
 
 var file_coordinator_coordinator_proto_enumTypes = make([]protoimpl.EnumInfo, 14)
-var file_coordinator_coordinator_proto_msgTypes = make([]protoimpl.MessageInfo, 43)
+var file_coordinator_coordinator_proto_msgTypes = make([]protoimpl.MessageInfo, 44)
 var file_coordinator_coordinator_proto_goTypes = []any{
 	(StoreState)(0),                        // 0: nokv.coordinator.v1.StoreState
 	(MountState)(0),                        // 1: nokv.coordinator.v1.MountState
@@ -3807,149 +3962,152 @@ var file_coordinator_coordinator_proto_goTypes = []any{
 	(ServingClass)(0),                      // 12: nokv.coordinator.v1.ServingClass
 	(SyncHealth)(0),                        // 13: nokv.coordinator.v1.SyncHealth
 	(*StoreHeartbeatRequest)(nil),          // 14: nokv.coordinator.v1.StoreHeartbeatRequest
-	(*StoreInfo)(nil),                      // 15: nokv.coordinator.v1.StoreInfo
-	(*GetStoreRequest)(nil),                // 16: nokv.coordinator.v1.GetStoreRequest
-	(*GetStoreResponse)(nil),               // 17: nokv.coordinator.v1.GetStoreResponse
-	(*ListStoresRequest)(nil),              // 18: nokv.coordinator.v1.ListStoresRequest
-	(*ListStoresResponse)(nil),             // 19: nokv.coordinator.v1.ListStoresResponse
-	(*MountInfo)(nil),                      // 20: nokv.coordinator.v1.MountInfo
-	(*GetMountRequest)(nil),                // 21: nokv.coordinator.v1.GetMountRequest
-	(*GetMountResponse)(nil),               // 22: nokv.coordinator.v1.GetMountResponse
-	(*ListMountsRequest)(nil),              // 23: nokv.coordinator.v1.ListMountsRequest
-	(*ListMountsResponse)(nil),             // 24: nokv.coordinator.v1.ListMountsResponse
-	(*SubtreeAuthorityInfo)(nil),           // 25: nokv.coordinator.v1.SubtreeAuthorityInfo
-	(*ListSubtreeAuthoritiesRequest)(nil),  // 26: nokv.coordinator.v1.ListSubtreeAuthoritiesRequest
-	(*ListSubtreeAuthoritiesResponse)(nil), // 27: nokv.coordinator.v1.ListSubtreeAuthoritiesResponse
-	(*QuotaSubject)(nil),                   // 28: nokv.coordinator.v1.QuotaSubject
-	(*QuotaFenceInfo)(nil),                 // 29: nokv.coordinator.v1.QuotaFenceInfo
-	(*GetQuotaFenceRequest)(nil),           // 30: nokv.coordinator.v1.GetQuotaFenceRequest
-	(*GetQuotaFenceResponse)(nil),          // 31: nokv.coordinator.v1.GetQuotaFenceResponse
-	(*ListQuotaFencesRequest)(nil),         // 32: nokv.coordinator.v1.ListQuotaFencesRequest
-	(*ListQuotaFencesResponse)(nil),        // 33: nokv.coordinator.v1.ListQuotaFencesResponse
-	(*WatchRootEventsRequest)(nil),         // 34: nokv.coordinator.v1.WatchRootEventsRequest
-	(*WatchRootEventsResponse)(nil),        // 35: nokv.coordinator.v1.WatchRootEventsResponse
-	(*SchedulerOperation)(nil),             // 36: nokv.coordinator.v1.SchedulerOperation
-	(*StoreHeartbeatResponse)(nil),         // 37: nokv.coordinator.v1.StoreHeartbeatResponse
-	(*RegionLivenessRequest)(nil),          // 38: nokv.coordinator.v1.RegionLivenessRequest
-	(*RegionLivenessResponse)(nil),         // 39: nokv.coordinator.v1.RegionLivenessResponse
-	(*PublishRootEventRequest)(nil),        // 40: nokv.coordinator.v1.PublishRootEventRequest
-	(*PublishRootEventResponse)(nil),       // 41: nokv.coordinator.v1.PublishRootEventResponse
-	(*TransitionEntry)(nil),                // 42: nokv.coordinator.v1.TransitionEntry
-	(*TransitionAssessment)(nil),           // 43: nokv.coordinator.v1.TransitionAssessment
-	(*ListTransitionsRequest)(nil),         // 44: nokv.coordinator.v1.ListTransitionsRequest
-	(*ListTransitionsResponse)(nil),        // 45: nokv.coordinator.v1.ListTransitionsResponse
-	(*AssessRootEventRequest)(nil),         // 46: nokv.coordinator.v1.AssessRootEventRequest
-	(*AssessRootEventResponse)(nil),        // 47: nokv.coordinator.v1.AssessRootEventResponse
-	(*RemoveRegionRequest)(nil),            // 48: nokv.coordinator.v1.RemoveRegionRequest
-	(*RemoveRegionResponse)(nil),           // 49: nokv.coordinator.v1.RemoveRegionResponse
-	(*RootToken)(nil),                      // 50: nokv.coordinator.v1.RootToken
-	(*GetRegionByKeyRequest)(nil),          // 51: nokv.coordinator.v1.GetRegionByKeyRequest
-	(*GetRegionByKeyResponse)(nil),         // 52: nokv.coordinator.v1.GetRegionByKeyResponse
-	(*AllocIDRequest)(nil),                 // 53: nokv.coordinator.v1.AllocIDRequest
-	(*AllocIDResponse)(nil),                // 54: nokv.coordinator.v1.AllocIDResponse
-	(*TsoRequest)(nil),                     // 55: nokv.coordinator.v1.TsoRequest
-	(*TsoResponse)(nil),                    // 56: nokv.coordinator.v1.TsoResponse
-	(*meta.RootCursor)(nil),                // 57: nokv.meta.v1.RootCursor
-	(*meta.RootTailToken)(nil),             // 58: nokv.meta.v1.RootTailToken
-	(*meta.RootCommittedEvent)(nil),        // 59: nokv.meta.v1.RootCommittedEvent
-	(*meta.RootEvent)(nil),                 // 60: nokv.meta.v1.RootEvent
-	(*meta.RootPendingPeerChange)(nil),     // 61: nokv.meta.v1.RootPendingPeerChange
-	(*meta.RootPendingRangeChange)(nil),    // 62: nokv.meta.v1.RootPendingRangeChange
-	(*meta.RegionDescriptor)(nil),          // 63: nokv.meta.v1.RegionDescriptor
-	(*meta.RootAuthorityEvidence)(nil),     // 64: nokv.meta.v1.RootAuthorityEvidence
+	(*RegionRuntimeStats)(nil),             // 15: nokv.coordinator.v1.RegionRuntimeStats
+	(*StoreInfo)(nil),                      // 16: nokv.coordinator.v1.StoreInfo
+	(*GetStoreRequest)(nil),                // 17: nokv.coordinator.v1.GetStoreRequest
+	(*GetStoreResponse)(nil),               // 18: nokv.coordinator.v1.GetStoreResponse
+	(*ListStoresRequest)(nil),              // 19: nokv.coordinator.v1.ListStoresRequest
+	(*ListStoresResponse)(nil),             // 20: nokv.coordinator.v1.ListStoresResponse
+	(*MountInfo)(nil),                      // 21: nokv.coordinator.v1.MountInfo
+	(*GetMountRequest)(nil),                // 22: nokv.coordinator.v1.GetMountRequest
+	(*GetMountResponse)(nil),               // 23: nokv.coordinator.v1.GetMountResponse
+	(*ListMountsRequest)(nil),              // 24: nokv.coordinator.v1.ListMountsRequest
+	(*ListMountsResponse)(nil),             // 25: nokv.coordinator.v1.ListMountsResponse
+	(*SubtreeAuthorityInfo)(nil),           // 26: nokv.coordinator.v1.SubtreeAuthorityInfo
+	(*ListSubtreeAuthoritiesRequest)(nil),  // 27: nokv.coordinator.v1.ListSubtreeAuthoritiesRequest
+	(*ListSubtreeAuthoritiesResponse)(nil), // 28: nokv.coordinator.v1.ListSubtreeAuthoritiesResponse
+	(*QuotaSubject)(nil),                   // 29: nokv.coordinator.v1.QuotaSubject
+	(*QuotaFenceInfo)(nil),                 // 30: nokv.coordinator.v1.QuotaFenceInfo
+	(*GetQuotaFenceRequest)(nil),           // 31: nokv.coordinator.v1.GetQuotaFenceRequest
+	(*GetQuotaFenceResponse)(nil),          // 32: nokv.coordinator.v1.GetQuotaFenceResponse
+	(*ListQuotaFencesRequest)(nil),         // 33: nokv.coordinator.v1.ListQuotaFencesRequest
+	(*ListQuotaFencesResponse)(nil),        // 34: nokv.coordinator.v1.ListQuotaFencesResponse
+	(*WatchRootEventsRequest)(nil),         // 35: nokv.coordinator.v1.WatchRootEventsRequest
+	(*WatchRootEventsResponse)(nil),        // 36: nokv.coordinator.v1.WatchRootEventsResponse
+	(*SchedulerOperation)(nil),             // 37: nokv.coordinator.v1.SchedulerOperation
+	(*StoreHeartbeatResponse)(nil),         // 38: nokv.coordinator.v1.StoreHeartbeatResponse
+	(*RegionLivenessRequest)(nil),          // 39: nokv.coordinator.v1.RegionLivenessRequest
+	(*RegionLivenessResponse)(nil),         // 40: nokv.coordinator.v1.RegionLivenessResponse
+	(*PublishRootEventRequest)(nil),        // 41: nokv.coordinator.v1.PublishRootEventRequest
+	(*PublishRootEventResponse)(nil),       // 42: nokv.coordinator.v1.PublishRootEventResponse
+	(*TransitionEntry)(nil),                // 43: nokv.coordinator.v1.TransitionEntry
+	(*TransitionAssessment)(nil),           // 44: nokv.coordinator.v1.TransitionAssessment
+	(*ListTransitionsRequest)(nil),         // 45: nokv.coordinator.v1.ListTransitionsRequest
+	(*ListTransitionsResponse)(nil),        // 46: nokv.coordinator.v1.ListTransitionsResponse
+	(*AssessRootEventRequest)(nil),         // 47: nokv.coordinator.v1.AssessRootEventRequest
+	(*AssessRootEventResponse)(nil),        // 48: nokv.coordinator.v1.AssessRootEventResponse
+	(*RemoveRegionRequest)(nil),            // 49: nokv.coordinator.v1.RemoveRegionRequest
+	(*RemoveRegionResponse)(nil),           // 50: nokv.coordinator.v1.RemoveRegionResponse
+	(*RootToken)(nil),                      // 51: nokv.coordinator.v1.RootToken
+	(*GetRegionByKeyRequest)(nil),          // 52: nokv.coordinator.v1.GetRegionByKeyRequest
+	(*GetRegionByKeyResponse)(nil),         // 53: nokv.coordinator.v1.GetRegionByKeyResponse
+	(*AllocIDRequest)(nil),                 // 54: nokv.coordinator.v1.AllocIDRequest
+	(*AllocIDResponse)(nil),                // 55: nokv.coordinator.v1.AllocIDResponse
+	(*TsoRequest)(nil),                     // 56: nokv.coordinator.v1.TsoRequest
+	(*TsoResponse)(nil),                    // 57: nokv.coordinator.v1.TsoResponse
+	(*meta.RootCursor)(nil),                // 58: nokv.meta.v1.RootCursor
+	(*meta.RootTailToken)(nil),             // 59: nokv.meta.v1.RootTailToken
+	(*meta.RootCommittedEvent)(nil),        // 60: nokv.meta.v1.RootCommittedEvent
+	(*meta.RegionDescriptor)(nil),          // 61: nokv.meta.v1.RegionDescriptor
+	(*meta.RootEvent)(nil),                 // 62: nokv.meta.v1.RootEvent
+	(*meta.RootPendingPeerChange)(nil),     // 63: nokv.meta.v1.RootPendingPeerChange
+	(*meta.RootPendingRangeChange)(nil),    // 64: nokv.meta.v1.RootPendingRangeChange
+	(*meta.RootAuthorityEvidence)(nil),     // 65: nokv.meta.v1.RootAuthorityEvidence
 }
 var file_coordinator_coordinator_proto_depIdxs = []int32{
-	0,  // 0: nokv.coordinator.v1.StoreInfo.state:type_name -> nokv.coordinator.v1.StoreState
-	15, // 1: nokv.coordinator.v1.GetStoreResponse.store:type_name -> nokv.coordinator.v1.StoreInfo
-	15, // 2: nokv.coordinator.v1.ListStoresResponse.stores:type_name -> nokv.coordinator.v1.StoreInfo
-	1,  // 3: nokv.coordinator.v1.MountInfo.state:type_name -> nokv.coordinator.v1.MountState
-	57, // 4: nokv.coordinator.v1.MountInfo.registered_at:type_name -> nokv.meta.v1.RootCursor
-	57, // 5: nokv.coordinator.v1.MountInfo.retired_at:type_name -> nokv.meta.v1.RootCursor
-	20, // 6: nokv.coordinator.v1.GetMountResponse.mount:type_name -> nokv.coordinator.v1.MountInfo
-	20, // 7: nokv.coordinator.v1.ListMountsResponse.mounts:type_name -> nokv.coordinator.v1.MountInfo
-	2,  // 8: nokv.coordinator.v1.SubtreeAuthorityInfo.state:type_name -> nokv.coordinator.v1.SubtreeAuthorityState
-	57, // 9: nokv.coordinator.v1.SubtreeAuthorityInfo.declared_at:type_name -> nokv.meta.v1.RootCursor
-	57, // 10: nokv.coordinator.v1.SubtreeAuthorityInfo.handoff_started_at:type_name -> nokv.meta.v1.RootCursor
-	57, // 11: nokv.coordinator.v1.SubtreeAuthorityInfo.handoff_completed_at:type_name -> nokv.meta.v1.RootCursor
-	25, // 12: nokv.coordinator.v1.ListSubtreeAuthoritiesResponse.subtrees:type_name -> nokv.coordinator.v1.SubtreeAuthorityInfo
-	28, // 13: nokv.coordinator.v1.QuotaFenceInfo.subject:type_name -> nokv.coordinator.v1.QuotaSubject
-	57, // 14: nokv.coordinator.v1.QuotaFenceInfo.updated_at:type_name -> nokv.meta.v1.RootCursor
-	28, // 15: nokv.coordinator.v1.GetQuotaFenceRequest.subject:type_name -> nokv.coordinator.v1.QuotaSubject
-	29, // 16: nokv.coordinator.v1.GetQuotaFenceResponse.fence:type_name -> nokv.coordinator.v1.QuotaFenceInfo
-	29, // 17: nokv.coordinator.v1.ListQuotaFencesResponse.fences:type_name -> nokv.coordinator.v1.QuotaFenceInfo
-	58, // 18: nokv.coordinator.v1.WatchRootEventsRequest.after:type_name -> nokv.meta.v1.RootTailToken
-	58, // 19: nokv.coordinator.v1.WatchRootEventsResponse.token:type_name -> nokv.meta.v1.RootTailToken
-	59, // 20: nokv.coordinator.v1.WatchRootEventsResponse.events:type_name -> nokv.meta.v1.RootCommittedEvent
-	3,  // 21: nokv.coordinator.v1.SchedulerOperation.type:type_name -> nokv.coordinator.v1.SchedulerOperationType
-	36, // 22: nokv.coordinator.v1.StoreHeartbeatResponse.operations:type_name -> nokv.coordinator.v1.SchedulerOperation
-	60, // 23: nokv.coordinator.v1.PublishRootEventRequest.event:type_name -> nokv.meta.v1.RootEvent
-	43, // 24: nokv.coordinator.v1.PublishRootEventResponse.assessment:type_name -> nokv.coordinator.v1.TransitionAssessment
-	4,  // 25: nokv.coordinator.v1.TransitionEntry.kind:type_name -> nokv.coordinator.v1.TransitionKind
-	5,  // 26: nokv.coordinator.v1.TransitionEntry.status:type_name -> nokv.coordinator.v1.TransitionStatus
-	6,  // 27: nokv.coordinator.v1.TransitionEntry.retry_class:type_name -> nokv.coordinator.v1.TransitionRetryClass
-	7,  // 28: nokv.coordinator.v1.TransitionEntry.reason:type_name -> nokv.coordinator.v1.TransitionReason
-	61, // 29: nokv.coordinator.v1.TransitionEntry.pending_peer_change:type_name -> nokv.meta.v1.RootPendingPeerChange
-	62, // 30: nokv.coordinator.v1.TransitionEntry.pending_range_change:type_name -> nokv.meta.v1.RootPendingRangeChange
-	4,  // 31: nokv.coordinator.v1.TransitionAssessment.kind:type_name -> nokv.coordinator.v1.TransitionKind
-	5,  // 32: nokv.coordinator.v1.TransitionAssessment.status:type_name -> nokv.coordinator.v1.TransitionStatus
-	6,  // 33: nokv.coordinator.v1.TransitionAssessment.retry_class:type_name -> nokv.coordinator.v1.TransitionRetryClass
-	7,  // 34: nokv.coordinator.v1.TransitionAssessment.reason:type_name -> nokv.coordinator.v1.TransitionReason
-	8,  // 35: nokv.coordinator.v1.TransitionAssessment.decision:type_name -> nokv.coordinator.v1.TransitionDecision
-	42, // 36: nokv.coordinator.v1.ListTransitionsResponse.entries:type_name -> nokv.coordinator.v1.TransitionEntry
-	60, // 37: nokv.coordinator.v1.AssessRootEventRequest.event:type_name -> nokv.meta.v1.RootEvent
-	43, // 38: nokv.coordinator.v1.AssessRootEventResponse.assessment:type_name -> nokv.coordinator.v1.TransitionAssessment
-	9,  // 39: nokv.coordinator.v1.GetRegionByKeyRequest.freshness:type_name -> nokv.coordinator.v1.Freshness
-	50, // 40: nokv.coordinator.v1.GetRegionByKeyRequest.required_root_token:type_name -> nokv.coordinator.v1.RootToken
-	63, // 41: nokv.coordinator.v1.GetRegionByKeyResponse.region_descriptor:type_name -> nokv.meta.v1.RegionDescriptor
-	50, // 42: nokv.coordinator.v1.GetRegionByKeyResponse.served_root_token:type_name -> nokv.coordinator.v1.RootToken
-	9,  // 43: nokv.coordinator.v1.GetRegionByKeyResponse.served_freshness:type_name -> nokv.coordinator.v1.Freshness
-	10, // 44: nokv.coordinator.v1.GetRegionByKeyResponse.degraded_mode:type_name -> nokv.coordinator.v1.DegradedMode
-	50, // 45: nokv.coordinator.v1.GetRegionByKeyResponse.current_root_token:type_name -> nokv.coordinator.v1.RootToken
-	11, // 46: nokv.coordinator.v1.GetRegionByKeyResponse.catch_up_state:type_name -> nokv.coordinator.v1.CatchUpState
-	12, // 47: nokv.coordinator.v1.GetRegionByKeyResponse.serving_class:type_name -> nokv.coordinator.v1.ServingClass
-	13, // 48: nokv.coordinator.v1.GetRegionByKeyResponse.sync_health:type_name -> nokv.coordinator.v1.SyncHealth
-	64, // 49: nokv.coordinator.v1.GetRegionByKeyResponse.authority_evidence:type_name -> nokv.meta.v1.RootAuthorityEvidence
-	64, // 50: nokv.coordinator.v1.AllocIDResponse.authority_evidence:type_name -> nokv.meta.v1.RootAuthorityEvidence
-	64, // 51: nokv.coordinator.v1.TsoResponse.authority_evidence:type_name -> nokv.meta.v1.RootAuthorityEvidence
-	14, // 52: nokv.coordinator.v1.Coordinator.StoreHeartbeat:input_type -> nokv.coordinator.v1.StoreHeartbeatRequest
-	16, // 53: nokv.coordinator.v1.Coordinator.GetStore:input_type -> nokv.coordinator.v1.GetStoreRequest
-	18, // 54: nokv.coordinator.v1.Coordinator.ListStores:input_type -> nokv.coordinator.v1.ListStoresRequest
-	21, // 55: nokv.coordinator.v1.Coordinator.GetMount:input_type -> nokv.coordinator.v1.GetMountRequest
-	23, // 56: nokv.coordinator.v1.Coordinator.ListMounts:input_type -> nokv.coordinator.v1.ListMountsRequest
-	26, // 57: nokv.coordinator.v1.Coordinator.ListSubtreeAuthorities:input_type -> nokv.coordinator.v1.ListSubtreeAuthoritiesRequest
-	30, // 58: nokv.coordinator.v1.Coordinator.GetQuotaFence:input_type -> nokv.coordinator.v1.GetQuotaFenceRequest
-	32, // 59: nokv.coordinator.v1.Coordinator.ListQuotaFences:input_type -> nokv.coordinator.v1.ListQuotaFencesRequest
-	34, // 60: nokv.coordinator.v1.Coordinator.WatchRootEvents:input_type -> nokv.coordinator.v1.WatchRootEventsRequest
-	38, // 61: nokv.coordinator.v1.Coordinator.RegionLiveness:input_type -> nokv.coordinator.v1.RegionLivenessRequest
-	40, // 62: nokv.coordinator.v1.Coordinator.PublishRootEvent:input_type -> nokv.coordinator.v1.PublishRootEventRequest
-	44, // 63: nokv.coordinator.v1.Coordinator.ListTransitions:input_type -> nokv.coordinator.v1.ListTransitionsRequest
-	46, // 64: nokv.coordinator.v1.Coordinator.AssessRootEvent:input_type -> nokv.coordinator.v1.AssessRootEventRequest
-	48, // 65: nokv.coordinator.v1.Coordinator.RemoveRegion:input_type -> nokv.coordinator.v1.RemoveRegionRequest
-	51, // 66: nokv.coordinator.v1.Coordinator.GetRegionByKey:input_type -> nokv.coordinator.v1.GetRegionByKeyRequest
-	53, // 67: nokv.coordinator.v1.Coordinator.AllocID:input_type -> nokv.coordinator.v1.AllocIDRequest
-	55, // 68: nokv.coordinator.v1.Coordinator.Tso:input_type -> nokv.coordinator.v1.TsoRequest
-	37, // 69: nokv.coordinator.v1.Coordinator.StoreHeartbeat:output_type -> nokv.coordinator.v1.StoreHeartbeatResponse
-	17, // 70: nokv.coordinator.v1.Coordinator.GetStore:output_type -> nokv.coordinator.v1.GetStoreResponse
-	19, // 71: nokv.coordinator.v1.Coordinator.ListStores:output_type -> nokv.coordinator.v1.ListStoresResponse
-	22, // 72: nokv.coordinator.v1.Coordinator.GetMount:output_type -> nokv.coordinator.v1.GetMountResponse
-	24, // 73: nokv.coordinator.v1.Coordinator.ListMounts:output_type -> nokv.coordinator.v1.ListMountsResponse
-	27, // 74: nokv.coordinator.v1.Coordinator.ListSubtreeAuthorities:output_type -> nokv.coordinator.v1.ListSubtreeAuthoritiesResponse
-	31, // 75: nokv.coordinator.v1.Coordinator.GetQuotaFence:output_type -> nokv.coordinator.v1.GetQuotaFenceResponse
-	33, // 76: nokv.coordinator.v1.Coordinator.ListQuotaFences:output_type -> nokv.coordinator.v1.ListQuotaFencesResponse
-	35, // 77: nokv.coordinator.v1.Coordinator.WatchRootEvents:output_type -> nokv.coordinator.v1.WatchRootEventsResponse
-	39, // 78: nokv.coordinator.v1.Coordinator.RegionLiveness:output_type -> nokv.coordinator.v1.RegionLivenessResponse
-	41, // 79: nokv.coordinator.v1.Coordinator.PublishRootEvent:output_type -> nokv.coordinator.v1.PublishRootEventResponse
-	45, // 80: nokv.coordinator.v1.Coordinator.ListTransitions:output_type -> nokv.coordinator.v1.ListTransitionsResponse
-	47, // 81: nokv.coordinator.v1.Coordinator.AssessRootEvent:output_type -> nokv.coordinator.v1.AssessRootEventResponse
-	49, // 82: nokv.coordinator.v1.Coordinator.RemoveRegion:output_type -> nokv.coordinator.v1.RemoveRegionResponse
-	52, // 83: nokv.coordinator.v1.Coordinator.GetRegionByKey:output_type -> nokv.coordinator.v1.GetRegionByKeyResponse
-	54, // 84: nokv.coordinator.v1.Coordinator.AllocID:output_type -> nokv.coordinator.v1.AllocIDResponse
-	56, // 85: nokv.coordinator.v1.Coordinator.Tso:output_type -> nokv.coordinator.v1.TsoResponse
-	69, // [69:86] is the sub-list for method output_type
-	52, // [52:69] is the sub-list for method input_type
-	52, // [52:52] is the sub-list for extension type_name
-	52, // [52:52] is the sub-list for extension extendee
-	0,  // [0:52] is the sub-list for field type_name
+	15, // 0: nokv.coordinator.v1.StoreHeartbeatRequest.region_stats:type_name -> nokv.coordinator.v1.RegionRuntimeStats
+	0,  // 1: nokv.coordinator.v1.StoreInfo.state:type_name -> nokv.coordinator.v1.StoreState
+	16, // 2: nokv.coordinator.v1.GetStoreResponse.store:type_name -> nokv.coordinator.v1.StoreInfo
+	16, // 3: nokv.coordinator.v1.ListStoresResponse.stores:type_name -> nokv.coordinator.v1.StoreInfo
+	1,  // 4: nokv.coordinator.v1.MountInfo.state:type_name -> nokv.coordinator.v1.MountState
+	58, // 5: nokv.coordinator.v1.MountInfo.registered_at:type_name -> nokv.meta.v1.RootCursor
+	58, // 6: nokv.coordinator.v1.MountInfo.retired_at:type_name -> nokv.meta.v1.RootCursor
+	21, // 7: nokv.coordinator.v1.GetMountResponse.mount:type_name -> nokv.coordinator.v1.MountInfo
+	21, // 8: nokv.coordinator.v1.ListMountsResponse.mounts:type_name -> nokv.coordinator.v1.MountInfo
+	2,  // 9: nokv.coordinator.v1.SubtreeAuthorityInfo.state:type_name -> nokv.coordinator.v1.SubtreeAuthorityState
+	58, // 10: nokv.coordinator.v1.SubtreeAuthorityInfo.declared_at:type_name -> nokv.meta.v1.RootCursor
+	58, // 11: nokv.coordinator.v1.SubtreeAuthorityInfo.handoff_started_at:type_name -> nokv.meta.v1.RootCursor
+	58, // 12: nokv.coordinator.v1.SubtreeAuthorityInfo.handoff_completed_at:type_name -> nokv.meta.v1.RootCursor
+	26, // 13: nokv.coordinator.v1.ListSubtreeAuthoritiesResponse.subtrees:type_name -> nokv.coordinator.v1.SubtreeAuthorityInfo
+	29, // 14: nokv.coordinator.v1.QuotaFenceInfo.subject:type_name -> nokv.coordinator.v1.QuotaSubject
+	58, // 15: nokv.coordinator.v1.QuotaFenceInfo.updated_at:type_name -> nokv.meta.v1.RootCursor
+	29, // 16: nokv.coordinator.v1.GetQuotaFenceRequest.subject:type_name -> nokv.coordinator.v1.QuotaSubject
+	30, // 17: nokv.coordinator.v1.GetQuotaFenceResponse.fence:type_name -> nokv.coordinator.v1.QuotaFenceInfo
+	30, // 18: nokv.coordinator.v1.ListQuotaFencesResponse.fences:type_name -> nokv.coordinator.v1.QuotaFenceInfo
+	59, // 19: nokv.coordinator.v1.WatchRootEventsRequest.after:type_name -> nokv.meta.v1.RootTailToken
+	59, // 20: nokv.coordinator.v1.WatchRootEventsResponse.token:type_name -> nokv.meta.v1.RootTailToken
+	60, // 21: nokv.coordinator.v1.WatchRootEventsResponse.events:type_name -> nokv.meta.v1.RootCommittedEvent
+	3,  // 22: nokv.coordinator.v1.SchedulerOperation.type:type_name -> nokv.coordinator.v1.SchedulerOperationType
+	61, // 23: nokv.coordinator.v1.SchedulerOperation.split_child:type_name -> nokv.meta.v1.RegionDescriptor
+	37, // 24: nokv.coordinator.v1.StoreHeartbeatResponse.operations:type_name -> nokv.coordinator.v1.SchedulerOperation
+	62, // 25: nokv.coordinator.v1.PublishRootEventRequest.event:type_name -> nokv.meta.v1.RootEvent
+	44, // 26: nokv.coordinator.v1.PublishRootEventResponse.assessment:type_name -> nokv.coordinator.v1.TransitionAssessment
+	4,  // 27: nokv.coordinator.v1.TransitionEntry.kind:type_name -> nokv.coordinator.v1.TransitionKind
+	5,  // 28: nokv.coordinator.v1.TransitionEntry.status:type_name -> nokv.coordinator.v1.TransitionStatus
+	6,  // 29: nokv.coordinator.v1.TransitionEntry.retry_class:type_name -> nokv.coordinator.v1.TransitionRetryClass
+	7,  // 30: nokv.coordinator.v1.TransitionEntry.reason:type_name -> nokv.coordinator.v1.TransitionReason
+	63, // 31: nokv.coordinator.v1.TransitionEntry.pending_peer_change:type_name -> nokv.meta.v1.RootPendingPeerChange
+	64, // 32: nokv.coordinator.v1.TransitionEntry.pending_range_change:type_name -> nokv.meta.v1.RootPendingRangeChange
+	4,  // 33: nokv.coordinator.v1.TransitionAssessment.kind:type_name -> nokv.coordinator.v1.TransitionKind
+	5,  // 34: nokv.coordinator.v1.TransitionAssessment.status:type_name -> nokv.coordinator.v1.TransitionStatus
+	6,  // 35: nokv.coordinator.v1.TransitionAssessment.retry_class:type_name -> nokv.coordinator.v1.TransitionRetryClass
+	7,  // 36: nokv.coordinator.v1.TransitionAssessment.reason:type_name -> nokv.coordinator.v1.TransitionReason
+	8,  // 37: nokv.coordinator.v1.TransitionAssessment.decision:type_name -> nokv.coordinator.v1.TransitionDecision
+	43, // 38: nokv.coordinator.v1.ListTransitionsResponse.entries:type_name -> nokv.coordinator.v1.TransitionEntry
+	62, // 39: nokv.coordinator.v1.AssessRootEventRequest.event:type_name -> nokv.meta.v1.RootEvent
+	44, // 40: nokv.coordinator.v1.AssessRootEventResponse.assessment:type_name -> nokv.coordinator.v1.TransitionAssessment
+	9,  // 41: nokv.coordinator.v1.GetRegionByKeyRequest.freshness:type_name -> nokv.coordinator.v1.Freshness
+	51, // 42: nokv.coordinator.v1.GetRegionByKeyRequest.required_root_token:type_name -> nokv.coordinator.v1.RootToken
+	61, // 43: nokv.coordinator.v1.GetRegionByKeyResponse.region_descriptor:type_name -> nokv.meta.v1.RegionDescriptor
+	51, // 44: nokv.coordinator.v1.GetRegionByKeyResponse.served_root_token:type_name -> nokv.coordinator.v1.RootToken
+	9,  // 45: nokv.coordinator.v1.GetRegionByKeyResponse.served_freshness:type_name -> nokv.coordinator.v1.Freshness
+	10, // 46: nokv.coordinator.v1.GetRegionByKeyResponse.degraded_mode:type_name -> nokv.coordinator.v1.DegradedMode
+	51, // 47: nokv.coordinator.v1.GetRegionByKeyResponse.current_root_token:type_name -> nokv.coordinator.v1.RootToken
+	11, // 48: nokv.coordinator.v1.GetRegionByKeyResponse.catch_up_state:type_name -> nokv.coordinator.v1.CatchUpState
+	12, // 49: nokv.coordinator.v1.GetRegionByKeyResponse.serving_class:type_name -> nokv.coordinator.v1.ServingClass
+	13, // 50: nokv.coordinator.v1.GetRegionByKeyResponse.sync_health:type_name -> nokv.coordinator.v1.SyncHealth
+	65, // 51: nokv.coordinator.v1.GetRegionByKeyResponse.authority_evidence:type_name -> nokv.meta.v1.RootAuthorityEvidence
+	65, // 52: nokv.coordinator.v1.AllocIDResponse.authority_evidence:type_name -> nokv.meta.v1.RootAuthorityEvidence
+	65, // 53: nokv.coordinator.v1.TsoResponse.authority_evidence:type_name -> nokv.meta.v1.RootAuthorityEvidence
+	14, // 54: nokv.coordinator.v1.Coordinator.StoreHeartbeat:input_type -> nokv.coordinator.v1.StoreHeartbeatRequest
+	17, // 55: nokv.coordinator.v1.Coordinator.GetStore:input_type -> nokv.coordinator.v1.GetStoreRequest
+	19, // 56: nokv.coordinator.v1.Coordinator.ListStores:input_type -> nokv.coordinator.v1.ListStoresRequest
+	22, // 57: nokv.coordinator.v1.Coordinator.GetMount:input_type -> nokv.coordinator.v1.GetMountRequest
+	24, // 58: nokv.coordinator.v1.Coordinator.ListMounts:input_type -> nokv.coordinator.v1.ListMountsRequest
+	27, // 59: nokv.coordinator.v1.Coordinator.ListSubtreeAuthorities:input_type -> nokv.coordinator.v1.ListSubtreeAuthoritiesRequest
+	31, // 60: nokv.coordinator.v1.Coordinator.GetQuotaFence:input_type -> nokv.coordinator.v1.GetQuotaFenceRequest
+	33, // 61: nokv.coordinator.v1.Coordinator.ListQuotaFences:input_type -> nokv.coordinator.v1.ListQuotaFencesRequest
+	35, // 62: nokv.coordinator.v1.Coordinator.WatchRootEvents:input_type -> nokv.coordinator.v1.WatchRootEventsRequest
+	39, // 63: nokv.coordinator.v1.Coordinator.RegionLiveness:input_type -> nokv.coordinator.v1.RegionLivenessRequest
+	41, // 64: nokv.coordinator.v1.Coordinator.PublishRootEvent:input_type -> nokv.coordinator.v1.PublishRootEventRequest
+	45, // 65: nokv.coordinator.v1.Coordinator.ListTransitions:input_type -> nokv.coordinator.v1.ListTransitionsRequest
+	47, // 66: nokv.coordinator.v1.Coordinator.AssessRootEvent:input_type -> nokv.coordinator.v1.AssessRootEventRequest
+	49, // 67: nokv.coordinator.v1.Coordinator.RemoveRegion:input_type -> nokv.coordinator.v1.RemoveRegionRequest
+	52, // 68: nokv.coordinator.v1.Coordinator.GetRegionByKey:input_type -> nokv.coordinator.v1.GetRegionByKeyRequest
+	54, // 69: nokv.coordinator.v1.Coordinator.AllocID:input_type -> nokv.coordinator.v1.AllocIDRequest
+	56, // 70: nokv.coordinator.v1.Coordinator.Tso:input_type -> nokv.coordinator.v1.TsoRequest
+	38, // 71: nokv.coordinator.v1.Coordinator.StoreHeartbeat:output_type -> nokv.coordinator.v1.StoreHeartbeatResponse
+	18, // 72: nokv.coordinator.v1.Coordinator.GetStore:output_type -> nokv.coordinator.v1.GetStoreResponse
+	20, // 73: nokv.coordinator.v1.Coordinator.ListStores:output_type -> nokv.coordinator.v1.ListStoresResponse
+	23, // 74: nokv.coordinator.v1.Coordinator.GetMount:output_type -> nokv.coordinator.v1.GetMountResponse
+	25, // 75: nokv.coordinator.v1.Coordinator.ListMounts:output_type -> nokv.coordinator.v1.ListMountsResponse
+	28, // 76: nokv.coordinator.v1.Coordinator.ListSubtreeAuthorities:output_type -> nokv.coordinator.v1.ListSubtreeAuthoritiesResponse
+	32, // 77: nokv.coordinator.v1.Coordinator.GetQuotaFence:output_type -> nokv.coordinator.v1.GetQuotaFenceResponse
+	34, // 78: nokv.coordinator.v1.Coordinator.ListQuotaFences:output_type -> nokv.coordinator.v1.ListQuotaFencesResponse
+	36, // 79: nokv.coordinator.v1.Coordinator.WatchRootEvents:output_type -> nokv.coordinator.v1.WatchRootEventsResponse
+	40, // 80: nokv.coordinator.v1.Coordinator.RegionLiveness:output_type -> nokv.coordinator.v1.RegionLivenessResponse
+	42, // 81: nokv.coordinator.v1.Coordinator.PublishRootEvent:output_type -> nokv.coordinator.v1.PublishRootEventResponse
+	46, // 82: nokv.coordinator.v1.Coordinator.ListTransitions:output_type -> nokv.coordinator.v1.ListTransitionsResponse
+	48, // 83: nokv.coordinator.v1.Coordinator.AssessRootEvent:output_type -> nokv.coordinator.v1.AssessRootEventResponse
+	50, // 84: nokv.coordinator.v1.Coordinator.RemoveRegion:output_type -> nokv.coordinator.v1.RemoveRegionResponse
+	53, // 85: nokv.coordinator.v1.Coordinator.GetRegionByKey:output_type -> nokv.coordinator.v1.GetRegionByKeyResponse
+	55, // 86: nokv.coordinator.v1.Coordinator.AllocID:output_type -> nokv.coordinator.v1.AllocIDResponse
+	57, // 87: nokv.coordinator.v1.Coordinator.Tso:output_type -> nokv.coordinator.v1.TsoResponse
+	71, // [71:88] is the sub-list for method output_type
+	54, // [54:71] is the sub-list for method input_type
+	54, // [54:54] is the sub-list for extension type_name
+	54, // [54:54] is the sub-list for extension extendee
+	0,  // [0:54] is the sub-list for field type_name
 }
 
 func init() { file_coordinator_coordinator_proto_init() }
@@ -3957,14 +4115,14 @@ func file_coordinator_coordinator_proto_init() {
 	if File_coordinator_coordinator_proto != nil {
 		return
 	}
-	file_coordinator_coordinator_proto_msgTypes[37].OneofWrappers = []any{}
+	file_coordinator_coordinator_proto_msgTypes[38].OneofWrappers = []any{}
 	type x struct{}
 	out := protoimpl.TypeBuilder{
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_coordinator_coordinator_proto_rawDesc), len(file_coordinator_coordinator_proto_rawDesc)),
 			NumEnums:      14,
-			NumMessages:   43,
+			NumMessages:   44,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/pb/coordinator/coordinator.proto
+++ b/pb/coordinator/coordinator.proto
@@ -29,6 +29,18 @@ message StoreHeartbeatRequest {
   // transport-aware scheduling. The first implementation usually matches
   // client_addr because NoKV currently shares one gRPC transport.
   string raft_addr = 9;
+  repeated RegionRuntimeStats region_stats = 10;
+}
+
+message RegionRuntimeStats {
+  uint64 region_id = 1;
+  uint64 read_qps = 2;
+  uint64 write_qps = 3;
+  uint64 write_bytes_per_sec = 4;
+  uint64 approx_region_bytes = 5;
+  uint64 atomic_mutate_qps = 6;
+  uint64 leader_store_id = 7;
+  bool pending_admin = 8;
 }
 
 enum StoreState {
@@ -171,6 +183,8 @@ message WatchRootEventsResponse {
 enum SchedulerOperationType {
   SCHEDULER_OPERATION_TYPE_NONE = 0;
   SCHEDULER_OPERATION_TYPE_LEADER_TRANSFER = 1;
+  SCHEDULER_OPERATION_TYPE_SPLIT_REGION = 2;
+  SCHEDULER_OPERATION_TYPE_MERGE_REGION = 3;
 }
 
 message SchedulerOperation {
@@ -178,6 +192,9 @@ message SchedulerOperation {
   uint64 region_id = 2;
   uint64 source_peer_id = 3;
   uint64 target_peer_id = 4;
+  bytes split_key = 5;
+  nokv.meta.v1.RegionDescriptor split_child = 6;
+  uint64 source_region_id = 7;
 }
 
 message StoreHeartbeatResponse {

--- a/pb/meta/recovery.pb.go
+++ b/pb/meta/recovery.pb.go
@@ -508,14 +508,17 @@ func (x *PendingRootEventCatalog) GetEntries() []*PendingRootEvent {
 }
 
 type PendingSchedulerOperation struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	OperationType uint32                 `protobuf:"varint,1,opt,name=operation_type,json=operationType,proto3" json:"operation_type,omitempty"`
-	RegionId      uint64                 `protobuf:"varint,2,opt,name=region_id,json=regionId,proto3" json:"region_id,omitempty"`
-	SourcePeerId  uint64                 `protobuf:"varint,3,opt,name=source_peer_id,json=sourcePeerId,proto3" json:"source_peer_id,omitempty"`
-	TargetPeerId  uint64                 `protobuf:"varint,4,opt,name=target_peer_id,json=targetPeerId,proto3" json:"target_peer_id,omitempty"`
-	Attempts      uint32                 `protobuf:"varint,5,opt,name=attempts,proto3" json:"attempts,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	state          protoimpl.MessageState `protogen:"open.v1"`
+	OperationType  uint32                 `protobuf:"varint,1,opt,name=operation_type,json=operationType,proto3" json:"operation_type,omitempty"`
+	RegionId       uint64                 `protobuf:"varint,2,opt,name=region_id,json=regionId,proto3" json:"region_id,omitempty"`
+	SourcePeerId   uint64                 `protobuf:"varint,3,opt,name=source_peer_id,json=sourcePeerId,proto3" json:"source_peer_id,omitempty"`
+	TargetPeerId   uint64                 `protobuf:"varint,4,opt,name=target_peer_id,json=targetPeerId,proto3" json:"target_peer_id,omitempty"`
+	Attempts       uint32                 `protobuf:"varint,5,opt,name=attempts,proto3" json:"attempts,omitempty"`
+	SplitKey       []byte                 `protobuf:"bytes,6,opt,name=split_key,json=splitKey,proto3" json:"split_key,omitempty"`
+	SplitChild     *RegionDescriptor      `protobuf:"bytes,7,opt,name=split_child,json=splitChild,proto3" json:"split_child,omitempty"`
+	SourceRegionId uint64                 `protobuf:"varint,8,opt,name=source_region_id,json=sourceRegionId,proto3" json:"source_region_id,omitempty"`
+	unknownFields  protoimpl.UnknownFields
+	sizeCache      protoimpl.SizeCache
 }
 
 func (x *PendingSchedulerOperation) Reset() {
@@ -579,6 +582,27 @@ func (x *PendingSchedulerOperation) GetTargetPeerId() uint64 {
 func (x *PendingSchedulerOperation) GetAttempts() uint32 {
 	if x != nil {
 		return x.Attempts
+	}
+	return 0
+}
+
+func (x *PendingSchedulerOperation) GetSplitKey() []byte {
+	if x != nil {
+		return x.SplitKey
+	}
+	return nil
+}
+
+func (x *PendingSchedulerOperation) GetSplitChild() *RegionDescriptor {
+	if x != nil {
+		return x.SplitChild
+	}
+	return nil
+}
+
+func (x *PendingSchedulerOperation) GetSourceRegionId() uint64 {
+	if x != nil {
+		return x.SourceRegionId
 	}
 	return 0
 }
@@ -782,13 +806,17 @@ const file_meta_recovery_proto_rawDesc = "" +
 	"\bsequence\x18\x01 \x01(\x04R\bsequence\x12-\n" +
 	"\x05event\x18\x02 \x01(\v2\x17.nokv.meta.v1.RootEventR\x05event\"S\n" +
 	"\x17PendingRootEventCatalog\x128\n" +
-	"\aentries\x18\x01 \x03(\v2\x1e.nokv.meta.v1.PendingRootEventR\aentries\"\xc7\x01\n" +
+	"\aentries\x18\x01 \x03(\v2\x1e.nokv.meta.v1.PendingRootEventR\aentries\"\xcf\x02\n" +
 	"\x19PendingSchedulerOperation\x12%\n" +
 	"\x0eoperation_type\x18\x01 \x01(\rR\roperationType\x12\x1b\n" +
 	"\tregion_id\x18\x02 \x01(\x04R\bregionId\x12$\n" +
 	"\x0esource_peer_id\x18\x03 \x01(\x04R\fsourcePeerId\x12$\n" +
 	"\x0etarget_peer_id\x18\x04 \x01(\x04R\ftargetPeerId\x12\x1a\n" +
-	"\battempts\x18\x05 \x01(\rR\battempts\"e\n" +
+	"\battempts\x18\x05 \x01(\rR\battempts\x12\x1b\n" +
+	"\tsplit_key\x18\x06 \x01(\fR\bsplitKey\x12?\n" +
+	"\vsplit_child\x18\a \x01(\v2\x1e.nokv.meta.v1.RegionDescriptorR\n" +
+	"splitChild\x12(\n" +
+	"\x10source_region_id\x18\b \x01(\x04R\x0esourceRegionId\"e\n" +
 	" PendingSchedulerOperationCatalog\x12A\n" +
 	"\aentries\x18\x01 \x03(\v2'.nokv.meta.v1.PendingSchedulerOperationR\aentries\"\xa1\x01\n" +
 	"\x10BlockedRootEvent\x12\x1a\n" +
@@ -841,14 +869,15 @@ var file_meta_recovery_proto_depIdxs = []int32{
 	3,  // 6: nokv.meta.v1.RaftProgressCatalog.entries:type_name -> nokv.meta.v1.RaftProgress
 	15, // 7: nokv.meta.v1.PendingRootEvent.event:type_name -> nokv.meta.v1.RootEvent
 	5,  // 8: nokv.meta.v1.PendingRootEventCatalog.entries:type_name -> nokv.meta.v1.PendingRootEvent
-	7,  // 9: nokv.meta.v1.PendingSchedulerOperationCatalog.entries:type_name -> nokv.meta.v1.PendingSchedulerOperation
-	15, // 10: nokv.meta.v1.BlockedRootEvent.event:type_name -> nokv.meta.v1.RootEvent
-	9,  // 11: nokv.meta.v1.BlockedRootEventCatalog.entries:type_name -> nokv.meta.v1.BlockedRootEvent
-	12, // [12:12] is the sub-list for method output_type
-	12, // [12:12] is the sub-list for method input_type
-	12, // [12:12] is the sub-list for extension type_name
-	12, // [12:12] is the sub-list for extension extendee
-	0,  // [0:12] is the sub-list for field type_name
+	12, // 9: nokv.meta.v1.PendingSchedulerOperation.split_child:type_name -> nokv.meta.v1.RegionDescriptor
+	7,  // 10: nokv.meta.v1.PendingSchedulerOperationCatalog.entries:type_name -> nokv.meta.v1.PendingSchedulerOperation
+	15, // 11: nokv.meta.v1.BlockedRootEvent.event:type_name -> nokv.meta.v1.RootEvent
+	9,  // 12: nokv.meta.v1.BlockedRootEventCatalog.entries:type_name -> nokv.meta.v1.BlockedRootEvent
+	13, // [13:13] is the sub-list for method output_type
+	13, // [13:13] is the sub-list for method input_type
+	13, // [13:13] is the sub-list for extension type_name
+	13, // [13:13] is the sub-list for extension extendee
+	0,  // [0:13] is the sub-list for field type_name
 }
 
 func init() { file_meta_recovery_proto_init() }

--- a/pb/meta/recovery.proto
+++ b/pb/meta/recovery.proto
@@ -65,6 +65,9 @@ message PendingSchedulerOperation {
   uint64 source_peer_id = 3;
   uint64 target_peer_id = 4;
   uint32 attempts = 5;
+  bytes split_key = 6;
+  RegionDescriptor split_child = 7;
+  uint64 source_region_id = 8;
 }
 
 message PendingSchedulerOperationCatalog {

--- a/raft_config.example.json
+++ b/raft_config.example.json
@@ -60,30 +60,11 @@
       "docker_addr": "nokv-store-3:20160"
     }
   ],
-  "regions": [
-    {
-      "id": 1,
-      "start_key": "",
-      "end_key": "m",
-      "epoch": { "version": 1, "conf_version": 1 },
-      "peers": [
-        { "store_id": 1, "peer_id": 101 },
-        { "store_id": 2, "peer_id": 201 },
-        { "store_id": 3, "peer_id": 301 }
-      ],
-      "leader_store_id": 1
-    },
-    {
-      "id": 2,
-      "start_key": "m",
-      "end_key": "",
-      "epoch": { "version": 1, "conf_version": 1 },
-      "peers": [
-        { "store_id": 1, "peer_id": 102 },
-        { "store_id": 2, "peer_id": 202 },
-        { "store_id": 3, "peer_id": 302 }
-      ],
-      "leader_store_id": 2
-    }
-  ]
+  "fsmeta_region_bootstrap": {
+    "mounts": ["default", "fsmeta-bench"],
+    "bucket_count": 16,
+    "region_id_base": 1000,
+    "peer_id_base": 100000,
+    "leader_store_ids": [1, 2, 3]
+  }
 }

--- a/raftstore/client/client.go
+++ b/raftstore/client/client.go
@@ -50,22 +50,22 @@ type RetryPolicy struct {
 
 // Client provides Region-aware helpers for StoreKV RPCs, including 2PC.
 type Client struct {
-	mu                         sync.RWMutex
-	stores                     map[uint64]*storeConn
-	regions                    map[uint64]*regionState
-	regionIndex                []regionRange
-	regionResolver             RegionResolver
-	storeResolver              StoreResolver
-	requiredDescriptorRevision uint64
-	routeLookupTimeout         time.Duration
-	storeRevalidateIn          time.Duration
-	dialTimeout                time.Duration
-	dialOpts                   []grpc.DialOption
-	retry                      RetryPolicy
-	atomicRouteSingleTotal     atomic.Uint64
-	atomicRouteMultiTotal      atomic.Uint64
-	atomicLocalFallbackTotal   atomic.Uint64
-	atomicSuccessTotal         atomic.Uint64
+	mu                       sync.RWMutex
+	stores                   map[uint64]*storeConn
+	regions                  map[uint64]*regionState
+	regionIndex              []regionRange
+	regionResolver           RegionResolver
+	storeResolver            StoreResolver
+	routeDescriptorFloors    []routeDescriptorFloor
+	routeLookupTimeout       time.Duration
+	storeRevalidateIn        time.Duration
+	dialTimeout              time.Duration
+	dialOpts                 []grpc.DialOption
+	retry                    RetryPolicy
+	atomicRouteSingleTotal   atomic.Uint64
+	atomicRouteMultiTotal    atomic.Uint64
+	atomicLocalFallbackTotal atomic.Uint64
+	atomicSuccessTotal       atomic.Uint64
 }
 
 // New constructs a Client using the provided configuration.

--- a/raftstore/client/client_route_cache.go
+++ b/raftstore/client/client_route_cache.go
@@ -30,6 +30,16 @@ type regionRange struct {
 	endKey   []byte
 }
 
+// routeDescriptorFloor is range-scoped on purpose. RootEpoch is a descriptor
+// revision for one region range, not a cluster-wide clock; a high revision in a
+// hot bucket must not force unrelated bucket lookups to reject valid older
+// descriptors.
+type routeDescriptorFloor struct {
+	startKey    []byte
+	endKey      []byte
+	minRevision uint64
+}
+
 func (c *Client) regionSnapshot(regionID uint64) (regionSnapshot, bool) {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
@@ -100,7 +110,7 @@ func (c *Client) regionForKeyFromResolver(ctx context.Context, key []byte) (regi
 	ctx, cancel := contextWithTimeout(ctx, c.routeLookupTimeout)
 	defer cancel()
 	req := &coordpb.GetRegionByKeyRequest{Key: append([]byte(nil), key...)}
-	requiredDescriptorRevision := c.requiredRouteDescriptorRevision()
+	requiredDescriptorRevision := c.requiredRouteDescriptorRevisionForKey(key)
 	if requiredDescriptorRevision != 0 {
 		req.RequiredDescriptorRevision = requiredDescriptorRevision
 	}
@@ -139,7 +149,6 @@ func (c *Client) regionForKeyFromResolver(ctx context.Context, key []byte) (regi
 		leader = old.leader
 	}
 	c.mu.Lock()
-	c.advanceRouteDescriptorRevisionLocked(desc.RootEpoch)
 	c.upsertRegionLocked(desc, leader)
 	c.mu.Unlock()
 	if !containsKey(desc, key) {
@@ -188,6 +197,9 @@ func (c *Client) handleRegionError(regionID uint64, err *errorpb.RegionError) er
 	}
 	if err.GetKeyNotInRegion() != nil || err.GetRegionNotFound() != nil {
 		c.mu.Lock()
+		if region, ok := c.regions[regionID]; ok && region != nil && region.desc.RootEpoch != 0 {
+			c.requireRouteDescriptorRevisionLocked(region.desc, nextDescriptorRevision(region.desc.RootEpoch))
+		}
 		c.removeRegionLocked(regionID)
 		c.mu.Unlock()
 		return nil
@@ -213,10 +225,16 @@ func (c *Client) handleRegionError(regionID uint64, err *errorpb.RegionError) er
 	}
 }
 
-func (c *Client) requiredRouteDescriptorRevision() uint64 {
+func (c *Client) requiredRouteDescriptorRevisionForKey(key []byte) uint64 {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
-	return c.requiredDescriptorRevision
+	var required uint64
+	for _, floor := range c.routeDescriptorFloors {
+		if routeDescriptorFloorContainsKey(floor, key) && floor.minRevision > required {
+			required = floor.minRevision
+		}
+	}
+	return required
 }
 
 func (c *Client) observeEpochMismatchLocked(regionID uint64, mismatch *errorpb.EpochNotMatch) {
@@ -224,22 +242,30 @@ func (c *Client) observeEpochMismatchLocked(regionID uint64, mismatch *errorpb.E
 		return
 	}
 	if region, ok := c.regions[regionID]; ok && region != nil && region.desc.RootEpoch != 0 {
-		c.advanceRouteDescriptorRevisionLocked(nextDescriptorRevision(region.desc.RootEpoch))
-	}
-	for _, meta := range mismatch.GetRegions() {
-		if meta == nil {
-			continue
-		}
-		desc := metawire.DescriptorFromProto(meta)
-		c.advanceRouteDescriptorRevisionLocked(desc.RootEpoch)
+		c.requireRouteDescriptorRevisionLocked(region.desc, nextDescriptorRevision(region.desc.RootEpoch))
 	}
 }
 
-func (c *Client) advanceRouteDescriptorRevisionLocked(revision uint64) {
-	if c == nil || revision == 0 || revision <= c.requiredDescriptorRevision {
+func (c *Client) requireRouteDescriptorRevisionLocked(desc topology.Descriptor, revision uint64) {
+	if c == nil || revision == 0 || desc.RegionID == 0 {
 		return
 	}
-	c.requiredDescriptorRevision = revision
+	floor := routeDescriptorFloor{
+		startKey:    append([]byte(nil), desc.StartKey...),
+		endKey:      append([]byte(nil), desc.EndKey...),
+		minRevision: revision,
+	}
+	for i := range c.routeDescriptorFloors {
+		existing := &c.routeDescriptorFloors[i]
+		if bytesCompare(existing.startKey, floor.startKey) == 0 &&
+			bytesCompare(existing.endKey, floor.endKey) == 0 {
+			if floor.minRevision > existing.minRevision {
+				existing.minRevision = floor.minRevision
+			}
+			return
+		}
+	}
+	c.routeDescriptorFloors = append(c.routeDescriptorFloors, floor)
 }
 
 func nextDescriptorRevision(revision uint64) uint64 {
@@ -391,6 +417,16 @@ func containsKey(desc topology.Descriptor, key []byte) bool {
 		return false
 	}
 	if len(end) > 0 && bytesCompare(key, end) >= 0 {
+		return false
+	}
+	return true
+}
+
+func routeDescriptorFloorContainsKey(floor routeDescriptorFloor, key []byte) bool {
+	if len(floor.startKey) > 0 && bytesCompare(key, floor.startKey) < 0 {
+		return false
+	}
+	if len(floor.endKey) > 0 && bytesCompare(key, floor.endKey) >= 0 {
 		return false
 	}
 	return true

--- a/raftstore/client/client_test.go
+++ b/raftstore/client/client_test.go
@@ -1631,6 +1631,54 @@ func TestClientEpochMismatchRaisesRouteLookupDescriptorFloor(t *testing.T) {
 	resolver.mu.Unlock()
 }
 
+func TestClientRouteDescriptorFloorIsRangeScoped(t *testing.T) {
+	resolver := &mockRegionResolver{regions: []*metapb.RegionDescriptor{
+		{
+			RegionId:  2,
+			StartKey:  []byte("a"),
+			EndKey:    []byte("m"),
+			Epoch:     &metapb.RegionEpoch{Version: 2, ConfVersion: 1},
+			RootEpoch: 8,
+			Peers:     []*metapb.RegionPeer{{StoreId: 1, PeerId: 201}},
+		},
+		{
+			RegionId:  3,
+			StartKey:  []byte("m"),
+			EndKey:    []byte("z"),
+			Epoch:     &metapb.RegionEpoch{Version: 1, ConfVersion: 1},
+			RootEpoch: 2,
+			Peers:     []*metapb.RegionPeer{{StoreId: 1, PeerId: 301}},
+		},
+	}}
+	cli, err := New(Config{
+		StoreResolver:  staticStoreResolver{{StoreID: 1, Addr: "unused"}},
+		RegionResolver: resolver,
+	})
+	require.NoError(t, err)
+	defer func() { _ = cli.Close() }()
+	cli.upsertRegionLocked(metawire.DescriptorFromProto(&metapb.RegionDescriptor{
+		RegionId:  1,
+		StartKey:  []byte("a"),
+		EndKey:    []byte("m"),
+		Epoch:     &metapb.RegionEpoch{Version: 1, ConfVersion: 1},
+		RootEpoch: 7,
+		Peers:     []*metapb.RegionPeer{{StoreId: 1, PeerId: 101}},
+	}), 1)
+
+	require.NoError(t, cli.handleRegionError(1, &errorpb.RegionError{EpochNotMatch: &errorpb.EpochNotMatch{}}))
+	_, err = cli.regionForKeyFromResolver(context.Background(), []byte("b"))
+	require.NoError(t, err)
+	resolver.mu.Lock()
+	require.Equal(t, uint64(8), resolver.lastRequiredDescriptorRevision)
+	resolver.mu.Unlock()
+
+	_, err = cli.regionForKeyFromResolver(context.Background(), []byte("q"))
+	require.NoError(t, err)
+	resolver.mu.Lock()
+	require.Zero(t, resolver.lastRequiredDescriptorRevision)
+	resolver.mu.Unlock()
+}
+
 func TestClientHandleRegionErrorDropsIndexedCacheWhenLeaderUnknown(t *testing.T) {
 	cli := &Client{
 		regions: make(map[uint64]*regionState),

--- a/raftstore/kv/apply.go
+++ b/raftstore/kv/apply.go
@@ -30,7 +30,8 @@ func Apply(db txnstore.Store, latches *latch.Manager, req *raftcmdpb.RaftCmdRequ
 		latches = latch.NewManager(defaultLatchSlots)
 	}
 	resp := &raftcmdpb.RaftCmdResponse{Header: req.Header}
-	for _, r := range req.Requests {
+	for i := 0; i < len(req.Requests); i++ {
+		r := req.Requests[i]
 		if r == nil {
 			continue
 		}
@@ -45,17 +46,49 @@ func Apply(db txnstore.Store, latches *latch.Manager, req *raftcmdpb.RaftCmdRequ
 			}
 			resp.Responses = append(resp.Responses, &raftcmdpb.Response{Cmd: &raftcmdpb.Response_Get{Get: result}})
 		case raftcmdpb.CmdType_CMD_PREWRITE:
-			result := &kvrpcpb.PrewriteResponse{Errors: percolator.Prewrite(db, latches, r.GetPrewrite())}
-			resp.Responses = append(resp.Responses, &raftcmdpb.Response{Cmd: &raftcmdpb.Response_Prewrite{Prewrite: result}})
+			end := collectCommandRun(req.Requests, i, raftcmdpb.CmdType_CMD_PREWRITE)
+			batch := []*kvrpcpb.PrewriteRequest{r.GetPrewrite()}
+			for j := i + 1; j < end; j++ {
+				batch = append(batch, req.Requests[j].GetPrewrite())
+			}
+			for _, errs := range percolator.PrewriteBatch(db, latches, batch) {
+				result := &kvrpcpb.PrewriteResponse{Errors: errs}
+				resp.Responses = append(resp.Responses, &raftcmdpb.Response{Cmd: &raftcmdpb.Response_Prewrite{Prewrite: result}})
+			}
+			i = end - 1
 		case raftcmdpb.CmdType_CMD_COMMIT:
-			err := percolator.Commit(db, latches, r.GetCommit())
-			resp.Responses = append(resp.Responses, &raftcmdpb.Response{Cmd: &raftcmdpb.Response_Commit{Commit: &kvrpcpb.CommitResponse{Error: err}}})
+			end := collectCommandRun(req.Requests, i, raftcmdpb.CmdType_CMD_COMMIT)
+			batch := []*kvrpcpb.CommitRequest{r.GetCommit()}
+			for j := i + 1; j < end; j++ {
+				batch = append(batch, req.Requests[j].GetCommit())
+			}
+			for _, err := range percolator.CommitBatch(db, latches, batch) {
+				resp.Responses = append(resp.Responses, &raftcmdpb.Response{Cmd: &raftcmdpb.Response_Commit{Commit: &kvrpcpb.CommitResponse{Error: err}}})
+			}
+			i = end - 1
 		case raftcmdpb.CmdType_CMD_BATCH_ROLLBACK:
-			err := percolator.BatchRollback(db, latches, r.GetBatchRollback())
-			resp.Responses = append(resp.Responses, &raftcmdpb.Response{Cmd: &raftcmdpb.Response_BatchRollback{BatchRollback: &kvrpcpb.BatchRollbackResponse{Error: err}}})
+			end := collectCommandRun(req.Requests, i, raftcmdpb.CmdType_CMD_BATCH_ROLLBACK)
+			batch := []*kvrpcpb.BatchRollbackRequest{r.GetBatchRollback()}
+			for j := i + 1; j < end; j++ {
+				batch = append(batch, req.Requests[j].GetBatchRollback())
+			}
+			for _, err := range percolator.BatchRollbackBatch(db, latches, batch) {
+				resp.Responses = append(resp.Responses, &raftcmdpb.Response{Cmd: &raftcmdpb.Response_BatchRollback{BatchRollback: &kvrpcpb.BatchRollbackResponse{Error: err}}})
+			}
+			i = end - 1
 		case raftcmdpb.CmdType_CMD_RESOLVE_LOCK:
-			count, err := percolator.ResolveLock(db, latches, r.GetResolveLock())
-			resp.Responses = append(resp.Responses, &raftcmdpb.Response{Cmd: &raftcmdpb.Response_ResolveLock{ResolveLock: &kvrpcpb.ResolveLockResponse{ResolvedLocks: count, Error: err}}})
+			end := collectCommandRun(req.Requests, i, raftcmdpb.CmdType_CMD_RESOLVE_LOCK)
+			batch := []*kvrpcpb.ResolveLockRequest{r.GetResolveLock()}
+			for j := i + 1; j < end; j++ {
+				batch = append(batch, req.Requests[j].GetResolveLock())
+			}
+			for _, result := range percolator.ResolveLockBatch(db, latches, batch) {
+				resp.Responses = append(resp.Responses, &raftcmdpb.Response{Cmd: &raftcmdpb.Response_ResolveLock{ResolveLock: &kvrpcpb.ResolveLockResponse{
+					ResolvedLocks: result.ResolvedLocks,
+					Error:         result.Error,
+				}}})
+			}
+			i = end - 1
 		case raftcmdpb.CmdType_CMD_CHECK_TXN_STATUS:
 			result := percolator.CheckTxnStatus(db, latches, r.GetCheckTxnStatus())
 			resp.Responses = append(resp.Responses, &raftcmdpb.Response{Cmd: &raftcmdpb.Response_CheckTxnStatus{CheckTxnStatus: result}})
@@ -63,12 +96,19 @@ func Apply(db txnstore.Store, latches *latch.Manager, req *raftcmdpb.RaftCmdRequ
 			result := percolator.TxnHeartBeat(db, latches, r.GetTxnHeartBeat())
 			resp.Responses = append(resp.Responses, &raftcmdpb.Response{Cmd: &raftcmdpb.Response_TxnHeartBeat{TxnHeartBeat: result}})
 		case raftcmdpb.CmdType_CMD_TRY_ATOMIC_MUTATE:
-			result := percolator.ApplyAtomicMutate(db, latches, r.GetTryAtomicMutate())
-			resp.Responses = append(resp.Responses, &raftcmdpb.Response{Cmd: &raftcmdpb.Response_TryAtomicMutate{TryAtomicMutate: &kvrpcpb.TryAtomicMutateResponse{
-				Error:                    result.Error,
-				AppliedKeys:              result.AppliedKeys,
-				FallbackToTwoPhaseCommit: result.Fallback,
-			}}})
+			end := collectCommandRun(req.Requests, i, raftcmdpb.CmdType_CMD_TRY_ATOMIC_MUTATE)
+			batch := []*kvrpcpb.TryAtomicMutateRequest{r.GetTryAtomicMutate()}
+			for j := i + 1; j < end; j++ {
+				batch = append(batch, req.Requests[j].GetTryAtomicMutate())
+			}
+			for _, result := range percolator.ApplyAtomicMutateBatch(db, latches, batch) {
+				resp.Responses = append(resp.Responses, &raftcmdpb.Response{Cmd: &raftcmdpb.Response_TryAtomicMutate{TryAtomicMutate: &kvrpcpb.TryAtomicMutateResponse{
+					Error:                    result.Error,
+					AppliedKeys:              result.AppliedKeys,
+					FallbackToTwoPhaseCommit: result.Fallback,
+				}}})
+			}
+			i = end - 1
 		case raftcmdpb.CmdType_CMD_MVCC_MAINTENANCE:
 			result, err := applyMVCCMaintenance(db, r.GetMvccMaintenance())
 			if err != nil {
@@ -86,6 +126,18 @@ func Apply(db txnstore.Store, latches *latch.Manager, req *raftcmdpb.RaftCmdRequ
 		}
 	}
 	return resp, nil
+}
+
+func collectCommandRun(reqs []*raftcmdpb.Request, start int, cmdType raftcmdpb.CmdType) int {
+	end := start + 1
+	for end < len(reqs) {
+		next := reqs[end]
+		if next == nil || next.GetCmdType() != cmdType {
+			break
+		}
+		end++
+	}
+	return end
 }
 
 func applyMVCCMaintenance(db txnstore.Store, req *kvrpcpb.MVCCMaintenanceRequest) (*kvrpcpb.MVCCMaintenanceResponse, error) {

--- a/raftstore/kv/apply_test.go
+++ b/raftstore/kv/apply_test.go
@@ -180,6 +180,71 @@ func TestApplyTryAtomicMutateCommandMaterializesBothKeys(t *testing.T) {
 	require.Equal(t, []byte("attrs"), inode)
 }
 
+func TestApplyTryAtomicMutateBatchFusesLocalApply(t *testing.T) {
+	opt := local.NewDefaultOptions()
+	opt.WorkDir = t.TempDir()
+	opt.LSMShardCount = 1
+	db, err := local.Open(opt)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = db.Close() })
+
+	store := &countingAtomicApplyStore{base: db}
+	resp, err := Apply(store, nil, &raftcmdpb.RaftCmdRequest{
+		Requests: []*raftcmdpb.Request{
+			{
+				CmdType: raftcmdpb.CmdType_CMD_TRY_ATOMIC_MUTATE,
+				Cmd:     &raftcmdpb.Request_TryAtomicMutate{TryAtomicMutate: atomicPutForApplyTest(40, 41, []byte("batched-a"), []byte("va"))},
+			},
+			{
+				CmdType: raftcmdpb.CmdType_CMD_TRY_ATOMIC_MUTATE,
+				Cmd:     &raftcmdpb.Request_TryAtomicMutate{TryAtomicMutate: atomicPutForApplyTest(42, 43, []byte("batched-b"), []byte("vb"))},
+			},
+		},
+	})
+	require.NoError(t, err)
+	require.Len(t, resp.GetResponses(), 2)
+	for _, raftResp := range resp.GetResponses() {
+		atomicResp := raftResp.GetTryAtomicMutate()
+		require.NotNil(t, atomicResp)
+		require.Nil(t, atomicResp.GetError())
+		require.False(t, atomicResp.GetFallbackToTwoPhaseCommit())
+		require.Equal(t, uint64(1), atomicResp.GetAppliedKeys())
+	}
+	require.Equal(t, 1, store.applyCalls)
+	require.Equal(t, []int{6}, store.appliedEntryCounts)
+}
+
+func TestApplyPrewriteBatchFusesLocalApply(t *testing.T) {
+	opt := local.NewDefaultOptions()
+	opt.WorkDir = t.TempDir()
+	db, err := local.Open(opt)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = db.Close() })
+
+	store := &countingAtomicApplyStore{base: db}
+	resp, err := Apply(store, nil, &raftcmdpb.RaftCmdRequest{
+		Requests: []*raftcmdpb.Request{
+			{
+				CmdType: raftcmdpb.CmdType_CMD_PREWRITE,
+				Cmd:     &raftcmdpb.Request_Prewrite{Prewrite: prewriteForApplyTest(50, []byte("prewrite-batched-a"), []byte("va"))},
+			},
+			{
+				CmdType: raftcmdpb.CmdType_CMD_PREWRITE,
+				Cmd:     &raftcmdpb.Request_Prewrite{Prewrite: prewriteForApplyTest(52, []byte("prewrite-batched-b"), []byte("vb"))},
+			},
+		},
+	})
+	require.NoError(t, err)
+	require.Len(t, resp.GetResponses(), 2)
+	for _, raftResp := range resp.GetResponses() {
+		prewriteResp := raftResp.GetPrewrite()
+		require.NotNil(t, prewriteResp)
+		require.Empty(t, prewriteResp.GetErrors())
+	}
+	require.Equal(t, 1, store.applyCalls)
+	require.Equal(t, []int{6}, store.appliedEntryCounts)
+}
+
 func TestApplyTryAtomicMutateCommandFallsBackForCrossShardBatch(t *testing.T) {
 	const shardCount = 4
 
@@ -223,6 +288,54 @@ func TestApplyTryAtomicMutateCommandFallsBackForCrossShardBatch(t *testing.T) {
 		_, _, err := reader.GetValue(key, commitVersion)
 		require.ErrorIs(t, err, utils.ErrKeyNotFound)
 	}
+}
+
+func atomicPutForApplyTest(startVersion, commitVersion uint64, key, value []byte) *kvrpcpb.TryAtomicMutateRequest {
+	return &kvrpcpb.TryAtomicMutateRequest{
+		StartVersion:  startVersion,
+		CommitVersion: commitVersion,
+		Predicates: []*kvrpcpb.AtomicPredicate{
+			{Key: entrykv.SafeCopy(nil, key), Kind: kvrpcpb.AtomicPredicateKind_ATOMIC_PREDICATE_KIND_NOT_EXISTS},
+		},
+		Mutations: []*kvrpcpb.Mutation{
+			{Op: kvrpcpb.Mutation_Put, Key: entrykv.SafeCopy(nil, key), Value: entrykv.SafeCopy(nil, value), AssertionNotExist: true},
+		},
+	}
+}
+
+func prewriteForApplyTest(startVersion uint64, key, value []byte) *kvrpcpb.PrewriteRequest {
+	return &kvrpcpb.PrewriteRequest{
+		Mutations: []*kvrpcpb.Mutation{
+			{Op: kvrpcpb.Mutation_Put, Key: entrykv.SafeCopy(nil, key), Value: entrykv.SafeCopy(nil, value)},
+		},
+		PrimaryLock:  entrykv.SafeCopy(nil, key),
+		StartVersion: startVersion,
+		LockTtl:      1000,
+	}
+}
+
+type countingAtomicApplyStore struct {
+	base               *local.DB
+	applyCalls         int
+	appliedEntryCounts []int
+}
+
+func (s *countingAtomicApplyStore) ApplyInternalEntries(entries []*entrykv.Entry) error {
+	s.applyCalls++
+	s.appliedEntryCounts = append(s.appliedEntryCounts, len(entries))
+	return s.base.ApplyInternalEntries(entries)
+}
+
+func (s *countingAtomicApplyStore) CanApplyInternalEntriesAtomically(entries []*entrykv.Entry) bool {
+	return s.base.CanApplyInternalEntriesAtomically(entries)
+}
+
+func (s *countingAtomicApplyStore) GetInternalEntry(cf entrykv.ColumnFamily, key []byte, version uint64) (*entrykv.Entry, error) {
+	return s.base.GetInternalEntry(cf, key, version)
+}
+
+func (s *countingAtomicApplyStore) NewInternalIterator(opt *index.Options) index.Iterator {
+	return s.base.NewInternalIterator(opt)
 }
 
 func keysWithDifferentDefaultShardsForApplyTest(t *testing.T, shardCount int, version uint64) ([]byte, []byte) {

--- a/raftstore/localmeta/store.go
+++ b/raftstore/localmeta/store.go
@@ -568,11 +568,20 @@ func loadPendingSchedulerOperationCatalog(fs vfs.FS, workdir string) (map[string
 			continue
 		}
 		op := PendingSchedulerOperation{
-			Kind:         pendingSchedulerOperationKindFromPB(item.GetOperationType()),
-			RegionID:     item.GetRegionId(),
-			SourcePeerID: item.GetSourcePeerId(),
-			TargetPeerID: item.GetTargetPeerId(),
-			Attempts:     item.GetAttempts(),
+			Kind:           pendingSchedulerOperationKindFromPB(item.GetOperationType()),
+			RegionID:       item.GetRegionId(),
+			SourcePeerID:   item.GetSourcePeerId(),
+			TargetPeerID:   item.GetTargetPeerId(),
+			Attempts:       item.GetAttempts(),
+			SplitKey:       append([]byte(nil), item.GetSplitKey()...),
+			SourceRegionID: item.GetSourceRegionId(),
+		}
+		if item.GetSplitChild() != nil {
+			child, err := FromDescriptorProto(item.GetSplitChild())
+			if err != nil {
+				return nil, err
+			}
+			op.SplitChild = child
 		}
 		if op.Kind == PendingSchedulerOperationUnknown {
 			continue
@@ -676,11 +685,14 @@ func persistPendingSchedulerOperationCatalog(fs vfs.FS, workdir string, ops map[
 	for _, key := range keys {
 		op := ops[key]
 		pbCatalog.Entries = append(pbCatalog.Entries, &metapb.PendingSchedulerOperation{
-			OperationType: pendingSchedulerOperationKindToPB(op.Kind),
-			RegionId:      op.RegionID,
-			SourcePeerId:  op.SourcePeerID,
-			TargetPeerId:  op.TargetPeerID,
-			Attempts:      op.Attempts,
+			OperationType:  pendingSchedulerOperationKindToPB(op.Kind),
+			RegionId:       op.RegionID,
+			SourcePeerId:   op.SourcePeerID,
+			TargetPeerId:   op.TargetPeerID,
+			Attempts:       op.Attempts,
+			SplitKey:       append([]byte(nil), op.SplitKey...),
+			SplitChild:     pendingSplitChildToPB(op.SplitChild),
+			SourceRegionId: op.SourceRegionID,
 		})
 	}
 	payload, err := proto.Marshal(pbCatalog)
@@ -688,6 +700,13 @@ func persistPendingSchedulerOperationCatalog(fs vfs.FS, workdir string, ops map[
 		return err
 	}
 	return persistProtoFile(fs, workdir, PendingSchedulerOperationsFileName, payload)
+}
+
+func pendingSplitChildToPB(meta RegionMeta) *metapb.RegionDescriptor {
+	if meta.ID == 0 {
+		return nil
+	}
+	return DescriptorToProto(meta)
 }
 
 func persistBlockedRootEventCatalog(fs vfs.FS, workdir string, blocked map[uint64]BlockedRootEvent) error {
@@ -865,8 +884,8 @@ func pendingSchedulerOperationKindToPB(kind PendingSchedulerOperationKind) uint3
 
 func pendingSchedulerOperationKindFromPB(kind uint32) PendingSchedulerOperationKind {
 	switch PendingSchedulerOperationKind(kind) {
-	case PendingSchedulerOperationLeaderTransfer:
-		return PendingSchedulerOperationLeaderTransfer
+	case PendingSchedulerOperationLeaderTransfer, PendingSchedulerOperationSplitRegion, PendingSchedulerOperationMergeRegion:
+		return PendingSchedulerOperationKind(kind)
 	default:
 		return PendingSchedulerOperationUnknown
 	}

--- a/raftstore/localmeta/store_test.go
+++ b/raftstore/localmeta/store_test.go
@@ -370,6 +370,49 @@ func TestLocalStorePersistsPendingSchedulerOperations(t *testing.T) {
 	require.FileExists(t, filepath.Join(dir, PendingSchedulerOperationsFileName))
 }
 
+func TestLocalStorePersistsPendingSplitAndMergeSchedulerOperations(t *testing.T) {
+	dir := t.TempDir()
+	store, err := OpenLocalStore(dir, nil)
+	require.NoError(t, err)
+
+	child := RegionMeta{
+		ID:       18,
+		StartKey: []byte("m"),
+		EndKey:   []byte("z"),
+		Peers:    []metaregion.Peer{{StoreID: 1, PeerID: 101}, {StoreID: 2, PeerID: 201}},
+		Epoch:    metaregion.Epoch{Version: 1, ConfVersion: 1},
+	}
+	require.NoError(t, store.SavePendingSchedulerOperation(PendingSchedulerOperation{
+		Kind:       PendingSchedulerOperationSplitRegion,
+		RegionID:   17,
+		SplitKey:   []byte("m"),
+		SplitChild: child,
+		Attempts:   2,
+	}))
+	require.NoError(t, store.SavePendingSchedulerOperation(PendingSchedulerOperation{
+		Kind:           PendingSchedulerOperationMergeRegion,
+		RegionID:       17,
+		SourceRegionID: 18,
+		Attempts:       4,
+	}))
+	require.NoError(t, store.Close())
+
+	reopened, err := OpenLocalStore(dir, nil)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, reopened.Close()) })
+
+	ops := reopened.PendingSchedulerOperations()
+	require.Len(t, ops, 2)
+	require.Equal(t, PendingSchedulerOperationMergeRegion, ops[0].Kind)
+	require.Equal(t, uint64(18), ops[0].SourceRegionID)
+	require.Equal(t, uint32(4), ops[0].Attempts)
+	require.Equal(t, PendingSchedulerOperationSplitRegion, ops[1].Kind)
+	require.Equal(t, []byte("m"), ops[1].SplitKey)
+	require.Equal(t, uint64(18), ops[1].SplitChild.ID)
+	require.Equal(t, []metaregion.Peer{{StoreID: 1, PeerID: 101}, {StoreID: 2, PeerID: 201}}, ops[1].SplitChild.Peers)
+	require.Equal(t, uint32(2), ops[1].Attempts)
+}
+
 func TestLocalStoreMovesPendingRootEventToBlocked(t *testing.T) {
 	dir := t.TempDir()
 	store, err := OpenLocalStore(dir, nil)

--- a/raftstore/localmeta/types.go
+++ b/raftstore/localmeta/types.go
@@ -134,6 +134,8 @@ type PendingSchedulerOperationKind uint8
 const (
 	PendingSchedulerOperationUnknown PendingSchedulerOperationKind = iota
 	PendingSchedulerOperationLeaderTransfer
+	PendingSchedulerOperationSplitRegion
+	PendingSchedulerOperationMergeRegion
 )
 
 // PendingSchedulerOperation captures one store-local scheduler decision that
@@ -143,14 +145,21 @@ const (
 // decisions that have been accepted by the store runtime but not yet consumed
 // by the local execution loop.
 type PendingSchedulerOperation struct {
-	Kind         PendingSchedulerOperationKind `json:"kind"`
-	RegionID     uint64                        `json:"region_id"`
-	SourcePeerID uint64                        `json:"source_peer_id,omitempty"`
-	TargetPeerID uint64                        `json:"target_peer_id,omitempty"`
-	Attempts     uint32                        `json:"attempts,omitempty"`
+	Kind           PendingSchedulerOperationKind `json:"kind"`
+	RegionID       uint64                        `json:"region_id"`
+	SourcePeerID   uint64                        `json:"source_peer_id,omitempty"`
+	TargetPeerID   uint64                        `json:"target_peer_id,omitempty"`
+	Attempts       uint32                        `json:"attempts,omitempty"`
+	SplitKey       []byte                        `json:"split_key,omitempty"`
+	SplitChild     RegionMeta                    `json:"split_child"`
+	SourceRegionID uint64                        `json:"source_region_id,omitempty"`
 }
 
 func ClonePendingSchedulerOperation(op PendingSchedulerOperation) PendingSchedulerOperation {
+	if op.SplitKey != nil {
+		op.SplitKey = append([]byte(nil), op.SplitKey...)
+	}
+	op.SplitChild = CloneRegionMeta(op.SplitChild)
 	return op
 }
 
@@ -177,6 +186,10 @@ func (k PendingSchedulerOperationKind) String() string {
 	switch k {
 	case PendingSchedulerOperationLeaderTransfer:
 		return "leader-transfer"
+	case PendingSchedulerOperationSplitRegion:
+		return "split-region"
+	case PendingSchedulerOperationMergeRegion:
+		return "merge-region"
 	default:
 		return "unknown"
 	}

--- a/raftstore/store/command_ops.go
+++ b/raftstore/store/command_ops.go
@@ -300,6 +300,9 @@ func (s *Store) ReadCommand(ctx context.Context, req *raftcmdpb.RaftCmdRequest) 
 	if out != nil {
 		trimScanResponse(meta, req, out)
 	}
+	if s.regionStats != nil {
+		s.regionStats.recordRead(req.Header.GetRegionId(), uint64(len(req.GetRequests())))
+	}
 	return out, nil
 }
 

--- a/raftstore/store/observer.go
+++ b/raftstore/store/observer.go
@@ -32,6 +32,7 @@ type ApplyEvent struct {
 	Source        ApplyEventSource
 	CommitVersion uint64
 	Keys          [][]byte
+	AtomicMutate  bool
 }
 
 // ApplyObserver consumes post-apply events. Store dispatch to observers is
@@ -174,10 +175,16 @@ func (s *Store) DroppedApplyObserverEvents() uint64 {
 }
 
 func (s *Store) emitApplyEvents(entry myraft.Entry, req *raftcmdpb.RaftCmdRequest, resp *raftcmdpb.RaftCmdResponse) {
-	if s == nil || s.observers == nil {
+	if s == nil {
 		return
 	}
 	for _, evt := range applyEventsFromCommand(entry, req, resp) {
+		if s.regionStats != nil {
+			s.regionStats.recordApply(evt)
+		}
+		if s.observers == nil {
+			continue
+		}
 		s.observers.emit(evt)
 	}
 }
@@ -245,6 +252,7 @@ func applyEventsFromCommand(entry myraft.Entry, req *raftcmdpb.RaftCmdRequest, r
 				Source:        ApplyEventSourceCommit,
 				CommitVersion: atomicMutate.GetCommitVersion(),
 				Keys:          cloneMutationKeys(atomicMutate.GetMutations()),
+				AtomicMutate:  true,
 			})
 		}
 	}

--- a/raftstore/store/observer_test.go
+++ b/raftstore/store/observer_test.go
@@ -106,6 +106,7 @@ func TestApplyEventsFromCommandExtractsVisibleCommitSources(t *testing.T) {
 		Source:        ApplyEventSourceCommit,
 		CommitVersion: 22,
 		Keys:          [][]byte{[]byte("dentry"), []byte("inode")},
+		AtomicMutate:  true,
 	}, events[2])
 
 	commitKeys[0][0] = 'z'

--- a/raftstore/store/region_stats.go
+++ b/raftstore/store/region_stats.go
@@ -1,0 +1,100 @@
+package store
+
+import (
+	"sync"
+	"time"
+
+	"github.com/feichai0017/NoKV/coordinator/storecontrol"
+	localmeta "github.com/feichai0017/NoKV/raftstore/localmeta"
+)
+
+type regionStatsRuntime struct {
+	mu       sync.Mutex
+	last     time.Time
+	counters map[uint64]regionTrafficCounter
+}
+
+type regionTrafficCounter struct {
+	readOps    uint64
+	writeOps   uint64
+	writeBytes uint64
+	atomicOps  uint64
+}
+
+func newRegionStatsRuntime() *regionStatsRuntime {
+	return &regionStatsRuntime{
+		last:     time.Now(),
+		counters: make(map[uint64]regionTrafficCounter),
+	}
+}
+
+func (r *regionStatsRuntime) recordRead(regionID uint64, ops uint64) {
+	if r == nil || regionID == 0 || ops == 0 {
+		return
+	}
+	r.mu.Lock()
+	counter := r.counters[regionID]
+	counter.readOps += ops
+	r.counters[regionID] = counter
+	r.mu.Unlock()
+}
+
+func (r *regionStatsRuntime) recordApply(evt ApplyEvent) {
+	if r == nil || evt.RegionID == 0 {
+		return
+	}
+	var keyBytes uint64
+	for _, key := range evt.Keys {
+		keyBytes += uint64(len(key))
+	}
+	r.mu.Lock()
+	counter := r.counters[evt.RegionID]
+	counter.writeOps++
+	counter.writeBytes += keyBytes
+	if evt.AtomicMutate {
+		counter.atomicOps++
+	}
+	r.counters[evt.RegionID] = counter
+	r.mu.Unlock()
+}
+
+func (r *regionStatsRuntime) snapshot(metas []localmeta.RegionMeta, leaderStoreID uint64, leaderRegions map[uint64]struct{}, pending map[uint64]bool) []storecontrol.RegionStats {
+	if r == nil {
+		return nil
+	}
+	now := time.Now()
+	r.mu.Lock()
+	elapsed := now.Sub(r.last)
+	if elapsed <= 0 {
+		elapsed = time.Second
+	}
+	counters := r.counters
+	r.counters = make(map[uint64]regionTrafficCounter)
+	r.last = now
+	r.mu.Unlock()
+
+	seconds := uint64(elapsed / time.Second)
+	if seconds == 0 {
+		seconds = 1
+	}
+	out := make([]storecontrol.RegionStats, 0, len(metas))
+	for _, meta := range metas {
+		if meta.ID == 0 {
+			continue
+		}
+		counter := counters[meta.ID]
+		stat := storecontrol.RegionStats{
+			RegionID:            meta.ID,
+			ReadQPS:             counter.readOps / seconds,
+			WriteQPS:            counter.writeOps / seconds,
+			WriteBytesPerSecond: counter.writeBytes / seconds,
+			AtomicMutateQPS:     counter.atomicOps / seconds,
+			PendingAdmin:        pending[meta.ID],
+		}
+		if _, ok := leaderRegions[meta.ID]; ok {
+			stat.LeaderStoreID = leaderStoreID
+		}
+		out = append(out, stat)
+	}
+	return out
+}

--- a/raftstore/store/scheduler_runtime.go
+++ b/raftstore/store/scheduler_runtime.go
@@ -150,6 +150,17 @@ func (s *Store) applyOperation(op storecontrol.Operation) bool {
 			}
 		})
 		return true
+	case storecontrol.OperationSplitRegion:
+		if op.Region == 0 || len(op.SplitKey) == 0 || op.SplitChild.RegionID == 0 {
+			return false
+		}
+		child := localmeta.FromDescriptor(op.SplitChild)
+		return s.ProposeSplit(op.Region, child, op.SplitKey) == nil
+	case storecontrol.OperationMergeRegion:
+		if op.Region == 0 || op.SourceRegion == 0 {
+			return false
+		}
+		return s.ProposeMerge(op.Region, op.SourceRegion) == nil
 	}
 	return false
 }
@@ -507,6 +518,21 @@ func localmetaSchedulerOperation(item scheduledOp) (localmeta.PendingSchedulerOp
 			TargetPeerID: item.op.Target,
 			Attempts:     item.attempts,
 		}, true
+	case storecontrol.OperationSplitRegion:
+		return localmeta.PendingSchedulerOperation{
+			Kind:       localmeta.PendingSchedulerOperationSplitRegion,
+			RegionID:   item.op.Region,
+			SplitKey:   append([]byte(nil), item.op.SplitKey...),
+			SplitChild: localmeta.FromDescriptor(item.op.SplitChild),
+			Attempts:   item.attempts,
+		}, true
+	case storecontrol.OperationMergeRegion:
+		return localmeta.PendingSchedulerOperation{
+			Kind:           localmeta.PendingSchedulerOperationMergeRegion,
+			RegionID:       item.op.Region,
+			SourceRegionID: item.op.SourceRegion,
+			Attempts:       item.attempts,
+		}, true
 	default:
 		return localmeta.PendingSchedulerOperation{}, false
 	}
@@ -520,6 +546,19 @@ func storeOperationFromLocalMeta(op localmeta.PendingSchedulerOperation) (storec
 			Region: op.RegionID,
 			Source: op.SourcePeerID,
 			Target: op.TargetPeerID,
+		}, true
+	case localmeta.PendingSchedulerOperationSplitRegion:
+		return storecontrol.Operation{
+			Type:       storecontrol.OperationSplitRegion,
+			Region:     op.RegionID,
+			SplitKey:   append([]byte(nil), op.SplitKey...),
+			SplitChild: localmeta.Descriptor(op.SplitChild, 0),
+		}, true
+	case localmeta.PendingSchedulerOperationMergeRegion:
+		return storecontrol.Operation{
+			Type:         storecontrol.OperationMergeRegion,
+			Region:       op.RegionID,
+			SourceRegion: op.SourceRegionID,
 		}, true
 	default:
 		return storecontrol.Operation{}, false
@@ -857,15 +896,20 @@ func (s *Store) storeStatsSnapshot() storecontrol.StoreStats {
 		return storecontrol.StoreStats{}
 	}
 	leaderRegions := s.leaderRegionIDs()
+	leaderSet := make(map[uint64]struct{}, len(leaderRegions))
+	for _, id := range leaderRegions {
+		leaderSet[id] = struct{}{}
+	}
 	s.addressMu.RLock()
 	clientAddr := s.clientAddr
 	raftAddr := s.raftAddr
 	s.addressMu.RUnlock()
+	metas := s.RegionMetas()
 	stats := storecontrol.StoreStats{
 		StoreID:         s.storeID,
 		ClientAddr:      clientAddr,
 		RaftAddr:        raftAddr,
-		RegionNum:       uint64(len(s.RegionMetas())),
+		RegionNum:       uint64(len(metas)),
 		LeaderNum:       uint64(len(leaderRegions)),
 		LeaderRegionIDs: leaderRegions,
 	}
@@ -878,7 +922,30 @@ func (s *Store) storeStatsSnapshot() storecontrol.StoreStats {
 		stats.Capacity = capacity
 		stats.Available = available
 	}
+	if s.regionStats != nil {
+		stats.RegionStats = s.regionStats.snapshot(metas, s.storeID, leaderSet, s.pendingAdminRegions())
+	}
 	return stats
+}
+
+func (s *Store) pendingAdminRegions() map[uint64]bool {
+	out := make(map[uint64]bool)
+	if s == nil {
+		return out
+	}
+	rm := s.regionMgr()
+	if rm == nil || rm.localMeta == nil {
+		return out
+	}
+	for _, op := range rm.localMeta.PendingSchedulerOperations() {
+		if op.RegionID != 0 {
+			out[op.RegionID] = true
+		}
+		if op.SourceRegionID != 0 {
+			out[op.SourceRegionID] = true
+		}
+	}
+	return out
 }
 
 func flattenScheduledOps(pending []scheduledOp) []storecontrol.Operation {

--- a/raftstore/store/store.go
+++ b/raftstore/store/store.go
@@ -40,6 +40,7 @@ type Store struct {
 	cmds        *commandRuntime
 	exec        *executionRuntime
 	observers   *applyObserverRuntime
+	regionStats *regionStatsRuntime
 }
 
 // NewStore constructs a Store using concrete dependencies. It keeps peer
@@ -110,8 +111,9 @@ func NewStore(cfg Config) *Store {
 			pipe:    newCommandPipeline(cfg.CommandApplier),
 			timeout: commandTimeout,
 		},
-		exec:      newExecutionRuntime(),
-		observers: newApplyObserverRuntime(),
+		exec:        newExecutionRuntime(),
+		observers:   newApplyObserverRuntime(),
+		regionStats: newRegionStatsRuntime(),
 	}
 	s.regions = &regionRuntime{
 		metrics: regionMetrics,

--- a/scripts/run_fsmeta_benchmarks.sh
+++ b/scripts/run_fsmeta_benchmarks.sh
@@ -32,6 +32,7 @@ case "$profile" in
 		default_groups=8
 		default_entries_per_group=64
 		default_artifacts_per_entry=8
+		default_workspaces=4
 		default_session_ttl=5m
 		default_stale_session_ttl=2s
 		default_timeout=25m
@@ -46,6 +47,7 @@ case "$profile" in
 		default_groups=16
 		default_entries_per_group=128
 		default_artifacts_per_entry=10
+		default_workspaces=8
 		default_session_ttl=5m
 		default_stale_session_ttl=2s
 		default_timeout=120m
@@ -65,6 +67,7 @@ reads="${NOKV_FSMETA_READS_PER_CLIENT:-$default_reads}"
 groups="${NOKV_FSMETA_GROUPS:-$default_groups}"
 entries_per_group="${NOKV_FSMETA_ENTRIES_PER_GROUP:-$default_entries_per_group}"
 artifacts_per_entry="${NOKV_FSMETA_ARTIFACTS_PER_ENTRY:-$default_artifacts_per_entry}"
+workspaces="${NOKV_FSMETA_WORKSPACES:-$default_workspaces}"
 session_ttl="${NOKV_FSMETA_SESSION_TTL:-$default_session_ttl}"
 stale_session_ttl="${NOKV_FSMETA_STALE_SESSION_TTL:-$default_stale_session_ttl}"
 timeout="${NOKV_FSMETA_TIMEOUT:-$default_timeout}"
@@ -115,6 +118,7 @@ run_bench() {
 			-fsmeta_groups "$groups" \
 			-fsmeta_entries_per_group "$entries_per_group" \
 			-fsmeta_artifacts_per_entry "$artifacts_per_entry" \
+			-fsmeta_workspaces "$workspaces" \
 			-fsmeta_session_ttl "$session_ttl" \
 			-fsmeta_stale_session_ttl "$stale_session_ttl" \
 			-fsmeta_timeout "$timeout" \
@@ -143,6 +147,7 @@ reads_per_client=$reads
 groups=$groups
 entries_per_group=$entries_per_group
 artifacts_per_entry=$artifacts_per_entry
+workspaces=$workspaces
 session_ttl=$session_ttl
 stale_session_ttl=$stale_session_ttl
 profile_seconds=$profile_seconds
@@ -224,7 +229,7 @@ print_bench_summary() {
 }
 
 run_compose_benchmarks() {
-	local workloads="${NOKV_FSMETA_WORKLOADS:-mixed,durable-snapshot,checkpoint-storm,hotspot-fanin,watch-subtree,negative-lookup}"
+	local workloads="${NOKV_FSMETA_WORKLOADS:-multi-workspace-autoscale,mixed,durable-snapshot,checkpoint-storm,hotspot-fanin,watch-subtree,negative-lookup}"
 	local output="${NOKV_FSMETA_OUTPUT:-$output_dir/fsmeta_compose_${profile}_${run_id}.csv}"
 	if [[ "${NOKV_FSMETA_COMPOSE:-1}" == "1" ]]; then
 		if [[ "${NOKV_FSMETA_COMPOSE_BUILD:-1}" == "1" ]]; then

--- a/txn/percolator/txn.go
+++ b/txn/percolator/txn.go
@@ -28,43 +28,64 @@ import (
 
 // Prewrite applies mutation prewrites for a single region transaction.
 func Prewrite(db txnstore.Store, latches *latch.Manager, req *kvrpcpb.PrewriteRequest) []*kvrpcpb.KeyError {
-	if req == nil {
+	results := PrewriteBatch(db, latches, []*kvrpcpb.PrewriteRequest{req})
+	if len(results) == 0 {
 		return nil
 	}
-	keys := make([][]byte, 0, len(req.Mutations))
-	for _, mut := range req.Mutations {
-		if mut != nil && len(mut.Key) > 0 {
-			keys = append(keys, mut.Key)
-		}
+	return results[0]
+}
+
+// PrewriteBatch applies a raft-entry batch of prewrite requests. It keeps
+// request-level errors independent while fusing local storage apply for
+// non-overlapping requests.
+func PrewriteBatch(db txnstore.Store, latches *latch.Manager, reqs []*kvrpcpb.PrewriteRequest) [][]*kvrpcpb.KeyError {
+	results := make([][]*kvrpcpb.KeyError, len(reqs))
+	keys := make([][]byte, 0)
+	for _, req := range reqs {
+		keys = append(keys, prewriteRequestKeys(req)...)
 	}
 	guard := latches.Acquire(keys)
 	defer guard.Release()
 
 	reader := NewReader(db)
-	var errs []*kvrpcpb.KeyError
-	ops := make([]versionedOp, 0, len(req.Mutations)*3)
-	for _, mut := range req.Mutations {
-		if mut == nil {
+	group := twoPCApplyGroup{}
+	for i, req := range reqs {
+		if req == nil {
 			continue
 		}
-		planned, err := planPrewriteMutation(reader, req, mut)
+		requestKeys := prewriteRequestKeys(req)
+		if group.conflicts(requestKeys) {
+			group.flush(db, func(item twoPCApplyRequest, err *kvrpcpb.KeyError) {
+				if err != nil {
+					results[item.index] = []*kvrpcpb.KeyError{err}
+				}
+			})
+		}
+		var errs []*kvrpcpb.KeyError
+		ops := make([]versionedOp, 0, len(req.Mutations)*3)
+		for _, mut := range req.Mutations {
+			if mut == nil {
+				continue
+			}
+			planned, err := planPrewriteMutation(reader, req, mut)
+			if err != nil {
+				errs = append(errs, err)
+				continue
+			}
+			ops = append(ops, planned...)
+		}
+		if len(errs) > 0 {
+			results[i] = errs
+			continue
+		}
+		group.add(i, requestKeys, ops, 0)
+	}
+	group.flush(db, func(item twoPCApplyRequest, err *kvrpcpb.KeyError) {
 		if err != nil {
-			errs = append(errs, err)
-			continue
+			results[item.index] = []*kvrpcpb.KeyError{err}
 		}
-		ops = append(ops, planned...)
-	}
-	if len(errs) > 0 {
-		return errs
-	}
-	// Prewrite is the lock admission boundary for a region request. Validation
-	// happens for every mutation before storage is touched, so semantic key
-	// errors never hide partial locks. Storage failures are retryable: replaying
-	// the same start_ts observes its own locks and finishes the missing keys.
-	if err := applyVersionedOps(db, ops...); err != nil {
-		return []*kvrpcpb.KeyError{keyErrorRetryable(err)}
-	}
-	return nil
+	})
+	return results
 }
 
 func planPrewriteMutation(reader *Reader, req *kvrpcpb.PrewriteRequest, mut *kvrpcpb.Mutation) ([]versionedOp, *kvrpcpb.KeyError) {
@@ -120,6 +141,19 @@ func planPrewriteMutation(reader *Reader, req *kvrpcpb.PrewriteRequest, mut *kvr
 	return ops, nil
 }
 
+func prewriteRequestKeys(req *kvrpcpb.PrewriteRequest) [][]byte {
+	if req == nil {
+		return nil
+	}
+	keys := make([][]byte, 0, len(req.Mutations))
+	for _, mut := range req.Mutations {
+		if mut != nil && len(mut.Key) > 0 {
+			keys = append(keys, mut.Key)
+		}
+	}
+	return keys
+}
+
 // validateCommitVersion rejects commits that would violate MVCC ordering.
 func validateCommitVersion(StartVersion uint64, CommitVersion uint64) *kvrpcpb.KeyError {
 	if CommitVersion <= StartVersion {
@@ -131,31 +165,60 @@ func validateCommitVersion(StartVersion uint64, CommitVersion uint64) *kvrpcpb.K
 // Commit finalises earlier prewrites by removing locks and writing commit
 // records. A non-nil KeyError is returned when commit should abort.
 func Commit(db txnstore.Store, latches *latch.Manager, req *kvrpcpb.CommitRequest) *kvrpcpb.KeyError {
-	if req == nil {
+	results := CommitBatch(db, latches, []*kvrpcpb.CommitRequest{req})
+	if len(results) == 0 {
 		return nil
 	}
-	if err := validateCommitVersion(req.StartVersion, req.CommitVersion); err != nil {
-		return err
+	return results[0]
+}
+
+// CommitBatch applies a raft-entry batch of commit requests. Percolator still
+// decides each transaction at its primary key; this only reduces local apply
+// fragmentation after raft has already ordered the commit requests.
+func CommitBatch(db txnstore.Store, latches *latch.Manager, reqs []*kvrpcpb.CommitRequest) []*kvrpcpb.KeyError {
+	results := make([]*kvrpcpb.KeyError, len(reqs))
+	keys := make([][]byte, 0)
+	for _, req := range reqs {
+		if req != nil {
+			keys = append(keys, req.Keys...)
+		}
 	}
-	guard := latches.Acquire(req.Keys)
+	guard := latches.Acquire(keys)
 	defer guard.Release()
 
 	reader := NewReader(db)
-	ops := make([]versionedOp, 0, len(req.Keys)*2)
-	for _, key := range req.Keys {
-		planned, err := planCommitKey(reader, key, req.StartVersion, req.CommitVersion)
-		if err != nil {
-			return err
+	group := twoPCApplyGroup{}
+	for i, req := range reqs {
+		if req == nil {
+			continue
 		}
-		ops = append(ops, planned...)
+		if err := validateCommitVersion(req.StartVersion, req.CommitVersion); err != nil {
+			results[i] = err
+			continue
+		}
+		if group.conflicts(req.Keys) {
+			group.flush(db, func(item twoPCApplyRequest, err *kvrpcpb.KeyError) {
+				results[item.index] = err
+			})
+		}
+		ops := make([]versionedOp, 0, len(req.Keys)*2)
+		for _, key := range req.Keys {
+			planned, err := planCommitKey(reader, key, req.StartVersion, req.CommitVersion)
+			if err != nil {
+				results[i] = err
+				break
+			}
+			ops = append(ops, planned...)
+		}
+		if results[i] != nil {
+			continue
+		}
+		group.add(i, req.Keys, ops, 0)
 	}
-	// Commit remains Percolator-idempotent: already committed keys produce no
-	// write op, while residual locks are cleaned with the commit records for the
-	// same key. The DB may fan multi-key requests out by LSM shard affinity.
-	if err := applyVersionedOps(db, ops...); err != nil {
-		return keyErrorRetryable(err)
-	}
-	return nil
+	group.flush(db, func(item twoPCApplyRequest, err *kvrpcpb.KeyError) {
+		results[item.index] = err
+	})
+	return results
 }
 
 // AtomicMutateResult is the local outcome for a region-local 1PC attempt.
@@ -165,20 +228,32 @@ type AtomicMutateResult struct {
 	Fallback    bool
 }
 
-type atomicMutateStatsRegistry struct {
-	applyCalledTotal   atomic.Uint64
-	localFallbackTotal atomic.Uint64
+type statsRegistry struct {
+	applyCalledTotal        atomic.Uint64
+	localFallbackTotal      atomic.Uint64
+	fusedApplyBatchesTotal  atomic.Uint64
+	fusedApplyRequestsTotal atomic.Uint64
+	fusedApplyEntriesTotal  atomic.Uint64
+	twoPCFusedBatchesTotal  atomic.Uint64
+	twoPCFusedRequestsTotal atomic.Uint64
+	twoPCFusedEntriesTotal  atomic.Uint64
 }
 
-var atomicMutateStats atomicMutateStatsRegistry
+var percolatorStats statsRegistry
 
-// AtomicMutateStats returns package-wide server-side 1PC counters. These are
-// deliberately protocol-level counters, so callers can tell whether a request
+// Stats returns package-wide server-side Percolator counters. These are
+// deliberately protocol-level counters, so callers can tell whether requests
 // reached Percolator after client-side region admission.
-func AtomicMutateStats() map[string]any {
+func Stats() map[string]any {
 	return map[string]any{
-		"atomic_apply_called_total":   atomicMutateStats.applyCalledTotal.Load(),
-		"atomic_local_fallback_total": atomicMutateStats.localFallbackTotal.Load(),
+		"atomic_apply_called_total":         percolatorStats.applyCalledTotal.Load(),
+		"atomic_local_fallback_total":       percolatorStats.localFallbackTotal.Load(),
+		"atomic_fused_apply_batches_total":  percolatorStats.fusedApplyBatchesTotal.Load(),
+		"atomic_fused_apply_requests_total": percolatorStats.fusedApplyRequestsTotal.Load(),
+		"atomic_fused_apply_entries_total":  percolatorStats.fusedApplyEntriesTotal.Load(),
+		"two_pc_fused_apply_batches_total":  percolatorStats.twoPCFusedBatchesTotal.Load(),
+		"two_pc_fused_apply_requests_total": percolatorStats.twoPCFusedRequestsTotal.Load(),
+		"two_pc_fused_apply_entries_total":  percolatorStats.twoPCFusedEntriesTotal.Load(),
 	}
 }
 
@@ -190,14 +265,98 @@ func ApplyAtomicMutate(db txnstore.Store, latches *latch.Manager, req *kvrpcpb.T
 	if req == nil {
 		return AtomicMutateResult{}
 	}
+	results := ApplyAtomicMutateBatch(db, latches, []*kvrpcpb.TryAtomicMutateRequest{req})
+	if len(results) == 0 {
+		return AtomicMutateResult{}
+	}
+	return results[0]
+}
+
+// ApplyAtomicMutateBatch applies a raft-entry batch of independent 1PC
+// attempts. It preserves per-request responses and only fuses requests when
+// their combined MVCC entries remain one local atomic apply group.
+func ApplyAtomicMutateBatch(db txnstore.Store, latches *latch.Manager, reqs []*kvrpcpb.TryAtomicMutateRequest) []AtomicMutateResult {
+	results := make([]AtomicMutateResult, len(reqs))
+	if len(reqs) == 0 {
+		return results
+	}
+	prepared := make([]atomicMutatePrepared, len(reqs))
+	var allKeys [][]byte
+	var called uint64
+	for i, req := range reqs {
+		item := prepareAtomicMutate(req)
+		prepared[i] = item
+		results[i] = item.result
+		if !item.eligible {
+			continue
+		}
+		called++
+		allKeys = append(allKeys, item.keys...)
+	}
+	if called == 0 {
+		return results
+	}
+	percolatorStats.applyCalledTotal.Add(called)
+
+	guard := latches.Acquire(allKeys)
+	defer guard.Release()
+
+	planner, hasPlanner := db.(txnstore.AtomicInternalApplyPlanner)
+	group := atomicMutateApplyGroup{}
+	for i, item := range prepared {
+		if !item.eligible {
+			continue
+		}
+		// Overlapping requests must observe raft-log order. Flush before
+		// planning the later request so its predicates see earlier writes.
+		if group.conflicts(item.keys) {
+			group.flush(db, results)
+		}
+		plan, result, ok := planAtomicMutateUnlocked(db, item.req, item.keys)
+		if !ok {
+			results[i] = result
+			continue
+		}
+		if len(plan.entries) == 0 {
+			results[i] = AtomicMutateResult{AppliedKeys: plan.appliedKeys}
+			continue
+		}
+		if !hasPlanner || !planner.CanApplyInternalEntriesAtomically(plan.entries) {
+			percolatorStats.localFallbackTotal.Add(1)
+			releaseEntries(plan.entries)
+			results[i] = AtomicMutateResult{Fallback: true}
+			continue
+		}
+		// A request can be locally atomic by itself while belonging to a
+		// different LSM shard than the current group. Split the group instead
+		// of turning a valid 1PC request into a 2PC fallback.
+		if !group.empty() && !planner.CanApplyInternalEntriesAtomically(group.entriesWith(plan.entries)) {
+			group.flush(db, results)
+		}
+		group.add(i, plan)
+	}
+	group.flush(db, results)
+	return results
+}
+
+type atomicMutatePrepared struct {
+	req      *kvrpcpb.TryAtomicMutateRequest
+	keys     [][]byte
+	eligible bool
+	result   AtomicMutateResult
+}
+
+func prepareAtomicMutate(req *kvrpcpb.TryAtomicMutateRequest) atomicMutatePrepared {
+	if req == nil {
+		return atomicMutatePrepared{}
+	}
 	if err := validateCommitVersion(req.StartVersion, req.CommitVersion); err != nil {
-		return AtomicMutateResult{Error: err}
+		return atomicMutatePrepared{result: AtomicMutateResult{Error: err}}
 	}
 	mutations := req.GetMutations()
 	if len(mutations) == 0 {
-		return AtomicMutateResult{}
+		return atomicMutatePrepared{}
 	}
-	atomicMutateStats.applyCalledTotal.Add(1)
 	keys := make([][]byte, 0, len(mutations)+len(req.GetPredicates()))
 	for _, mut := range mutations {
 		if mut != nil && len(mut.Key) > 0 {
@@ -209,21 +368,29 @@ func ApplyAtomicMutate(db txnstore.Store, latches *latch.Manager, req *kvrpcpb.T
 			keys = append(keys, pred.Key)
 		}
 	}
-	guard := latches.Acquire(keys)
-	defer guard.Release()
+	return atomicMutatePrepared{req: req, keys: keys, eligible: true}
+}
 
+type atomicMutatePlan struct {
+	entries     []*kv.Entry
+	appliedKeys uint64
+	keys        [][]byte
+}
+
+func planAtomicMutateUnlocked(db txnstore.Store, req *kvrpcpb.TryAtomicMutateRequest, keys [][]byte) (atomicMutatePlan, AtomicMutateResult, bool) {
+	mutations := req.GetMutations()
 	reader := NewReader(db)
 	if applied, err := atomicMutateAlreadyApplied(db, reader, req); err != nil {
-		return AtomicMutateResult{Error: keyErrorRetryable(err)}
+		return atomicMutatePlan{}, AtomicMutateResult{Error: keyErrorRetryable(err)}, false
 	} else if applied {
-		return AtomicMutateResult{AppliedKeys: uint64(len(mutations))}
+		return atomicMutatePlan{}, AtomicMutateResult{AppliedKeys: uint64(len(mutations))}, false
 	}
 
 	primary := mutations[0].GetKey()
 	ops := make([]versionedOp, 0, len(mutations)*3)
 	for _, pred := range req.GetPredicates() {
 		if err := validateAtomicPredicate(reader, pred, req.StartVersion); err != nil {
-			return AtomicMutateResult{Error: err}
+			return atomicMutatePlan{}, AtomicMutateResult{Error: err}, false
 		}
 	}
 	for _, mut := range mutations {
@@ -231,43 +398,102 @@ func ApplyAtomicMutate(db txnstore.Store, latches *latch.Manager, req *kvrpcpb.T
 			continue
 		}
 		if err := validateAtomicMutation(mut); err != nil {
-			return AtomicMutateResult{Error: err}
+			return atomicMutatePlan{}, AtomicMutateResult{Error: err}, false
 		}
 		key := mut.GetKey()
 		lock, err := reader.GetLock(key)
 		if err != nil {
-			return AtomicMutateResult{Error: keyErrorRetryable(err)}
+			return atomicMutatePlan{}, AtomicMutateResult{Error: keyErrorRetryable(err)}, false
 		}
 		if lock != nil {
-			return AtomicMutateResult{Error: keyErrorLocked(key, lock)}
+			return atomicMutatePlan{}, AtomicMutateResult{Error: keyErrorLocked(key, lock)}, false
 		}
 		if write, commitTs, err := reader.MostRecentWrite(key); err != nil {
-			return AtomicMutateResult{Error: keyErrorRetryable(err)}
+			return atomicMutatePlan{}, AtomicMutateResult{Error: keyErrorRetryable(err)}, false
 		} else if write != nil && commitTs >= req.StartVersion {
-			return AtomicMutateResult{Error: keyErrorWriteConflict(key, primary, commitTs, write.StartTs, req.StartVersion)}
+			return atomicMutatePlan{}, AtomicMutateResult{Error: keyErrorWriteConflict(key, primary, commitTs, write.StartTs, req.StartVersion)}, false
 		}
 		if mut.GetAssertionNotExist() {
 			exists, err := keyExistsAt(reader, key, req.StartVersion)
 			if err != nil {
-				return AtomicMutateResult{Error: keyErrorRetryable(err)}
+				return atomicMutatePlan{}, AtomicMutateResult{Error: keyErrorRetryable(err)}, false
 			}
 			if exists {
-				return AtomicMutateResult{Error: keyErrorAlreadyExists(key)}
+				return atomicMutatePlan{}, AtomicMutateResult{Error: keyErrorAlreadyExists(key)}, false
 			}
 		}
 		ops = append(ops, committedMutationOps(mut, req.StartVersion, req.CommitVersion)...)
 	}
 	entries := versionedOpsToEntries(ops...)
-	defer releaseEntries(entries)
-	planner, ok := db.(txnstore.AtomicInternalApplyPlanner)
-	if !ok || !planner.CanApplyInternalEntriesAtomically(entries) {
-		atomicMutateStats.localFallbackTotal.Add(1)
-		return AtomicMutateResult{Fallback: true}
+	return atomicMutatePlan{entries: entries, appliedKeys: uint64(len(mutations)), keys: keys}, AtomicMutateResult{}, true
+}
+
+type atomicMutateApplyGroup struct {
+	requests []atomicMutateGroupRequest
+	entries  []*kv.Entry
+	keys     map[string]struct{}
+}
+
+type atomicMutateGroupRequest struct {
+	index       int
+	appliedKeys uint64
+}
+
+func (g *atomicMutateApplyGroup) empty() bool {
+	return g == nil || len(g.requests) == 0
+}
+
+func (g *atomicMutateApplyGroup) conflicts(keys [][]byte) bool {
+	if g == nil || len(g.keys) == 0 {
+		return false
 	}
-	if err := applyVersionedEntries(db, entries); err != nil {
-		return AtomicMutateResult{Error: keyErrorRetryable(err)}
+	for _, key := range keys {
+		if _, ok := g.keys[string(key)]; ok {
+			return true
+		}
 	}
-	return AtomicMutateResult{AppliedKeys: uint64(len(mutations))}
+	return false
+}
+
+func (g *atomicMutateApplyGroup) entriesWith(entries []*kv.Entry) []*kv.Entry {
+	out := make([]*kv.Entry, 0, len(g.entries)+len(entries))
+	out = append(out, g.entries...)
+	out = append(out, entries...)
+	return out
+}
+
+func (g *atomicMutateApplyGroup) add(index int, plan atomicMutatePlan) {
+	g.requests = append(g.requests, atomicMutateGroupRequest{index: index, appliedKeys: plan.appliedKeys})
+	g.entries = append(g.entries, plan.entries...)
+	if g.keys == nil {
+		g.keys = make(map[string]struct{}, len(plan.keys))
+	}
+	for _, key := range plan.keys {
+		g.keys[string(key)] = struct{}{}
+	}
+}
+
+func (g *atomicMutateApplyGroup) flush(db txnstore.Store, results []AtomicMutateResult) {
+	if g == nil || len(g.requests) == 0 {
+		return
+	}
+	defer releaseEntries(g.entries)
+	if len(g.requests) > 1 {
+		percolatorStats.fusedApplyBatchesTotal.Add(1)
+		percolatorStats.fusedApplyRequestsTotal.Add(uint64(len(g.requests)))
+		percolatorStats.fusedApplyEntriesTotal.Add(uint64(len(g.entries)))
+	}
+	err := applyVersionedEntries(db, g.entries)
+	for _, req := range g.requests {
+		if err != nil {
+			results[req.index] = AtomicMutateResult{Error: keyErrorRetryable(err)}
+			continue
+		}
+		results[req.index] = AtomicMutateResult{AppliedKeys: req.appliedKeys}
+	}
+	g.requests = nil
+	g.entries = nil
+	g.keys = nil
 }
 
 func validateAtomicPredicate(reader *Reader, pred *kvrpcpb.AtomicPredicate, startVersion uint64) *kvrpcpb.KeyError {
@@ -386,82 +612,162 @@ func committedMutationOps(mut *kvrpcpb.Mutation, startVersion, commitVersion uin
 
 // BatchRollback rolls back the provided keys for the given start version.
 func BatchRollback(db txnstore.Store, latches *latch.Manager, req *kvrpcpb.BatchRollbackRequest) *kvrpcpb.KeyError {
-	if req == nil {
+	results := BatchRollbackBatch(db, latches, []*kvrpcpb.BatchRollbackRequest{req})
+	if len(results) == 0 {
 		return nil
 	}
-	guard := latches.Acquire(req.Keys)
-	defer guard.Release()
-	reader := NewReader(db)
-	ops := make([]versionedOp, 0, len(req.Keys)*3)
-	for _, key := range req.Keys {
-		planned, err := planRollbackKey(reader, key, req.StartVersion)
-		if err != nil {
-			return err
+	return results[0]
+}
+
+// BatchRollbackBatch applies a raft-entry batch of rollback requests. Rollback
+// remains idempotent per start_ts; this only shares local storage apply for
+// independent rollback records already ordered by raft.
+func BatchRollbackBatch(db txnstore.Store, latches *latch.Manager, reqs []*kvrpcpb.BatchRollbackRequest) []*kvrpcpb.KeyError {
+	results := make([]*kvrpcpb.KeyError, len(reqs))
+	keys := make([][]byte, 0)
+	for _, req := range reqs {
+		if req != nil {
+			keys = append(keys, req.Keys...)
 		}
-		ops = append(ops, planned...)
 	}
-	// Rollback markers and lock tombstones for one key must be planned together;
-	// the DB preserves per-key shard affinity when it persists the internal
-	// entries, and retries keep rollback idempotent.
-	if err := applyVersionedOps(db, ops...); err != nil {
-		return keyErrorRetryable(err)
+	guard := latches.Acquire(keys)
+	defer guard.Release()
+
+	reader := NewReader(db)
+	group := twoPCApplyGroup{}
+	for i, req := range reqs {
+		if req == nil {
+			continue
+		}
+		if group.conflicts(req.Keys) {
+			group.flush(db, func(item twoPCApplyRequest, err *kvrpcpb.KeyError) {
+				results[item.index] = err
+			})
+		}
+		ops := make([]versionedOp, 0, len(req.Keys)*3)
+		for _, key := range req.Keys {
+			planned, err := planRollbackKey(reader, key, req.StartVersion)
+			if err != nil {
+				results[i] = err
+				break
+			}
+			ops = append(ops, planned...)
+		}
+		if results[i] != nil {
+			continue
+		}
+		group.add(i, req.Keys, ops, 0)
 	}
-	return nil
+	group.flush(db, func(item twoPCApplyRequest, err *kvrpcpb.KeyError) {
+		results[item.index] = err
+	})
+	return results
+}
+
+type ResolveLockResult struct {
+	ResolvedLocks uint64
+	Error         *kvrpcpb.KeyError
 }
 
 // ResolveLock resolves locks for the given transaction. commitVersion == 0
 // performs a rollback; otherwise the keys are committed.
 func ResolveLock(db txnstore.Store, latches *latch.Manager, req *kvrpcpb.ResolveLockRequest) (uint64, *kvrpcpb.KeyError) {
-	if req == nil {
+	results := ResolveLockBatch(db, latches, []*kvrpcpb.ResolveLockRequest{req})
+	if len(results) == 0 {
 		return 0, nil
 	}
-	if req.CommitVersion != 0 {
-		if err := validateCommitVersion(req.StartVersion, req.CommitVersion); err != nil {
-			return 0, err
+	return results[0].ResolvedLocks, results[0].Error
+}
+
+// ResolveLockBatch applies a raft-entry batch of lock resolution requests. It
+// preserves resolved-count semantics for every logical request while sharing the
+// local apply when the resolved key sets do not overlap.
+func ResolveLockBatch(db txnstore.Store, latches *latch.Manager, reqs []*kvrpcpb.ResolveLockRequest) []ResolveLockResult {
+	results := make([]ResolveLockResult, len(reqs))
+	keys := make([][]byte, 0)
+	for _, req := range reqs {
+		if req != nil {
+			keys = append(keys, req.Keys...)
 		}
 	}
-	guard := latches.Acquire(req.Keys)
+	guard := latches.Acquire(keys)
 	defer guard.Release()
 
 	reader := NewReader(db)
-	var resolved uint64
-	ops := make([]versionedOp, 0, len(req.Keys)*3)
-	seen := make(map[string]struct{}, len(req.Keys))
-	for _, key := range req.Keys {
-		if len(key) == 0 {
+	group := twoPCApplyGroup{}
+	for i, req := range reqs {
+		if req == nil {
 			continue
 		}
-		keyID := string(key)
-		if _, ok := seen[keyID]; ok {
+		if req.CommitVersion != 0 {
+			if err := validateCommitVersion(req.StartVersion, req.CommitVersion); err != nil {
+				results[i].Error = err
+				continue
+			}
+		}
+		if group.conflicts(req.Keys) {
+			group.flush(db, func(item twoPCApplyRequest, err *kvrpcpb.KeyError) {
+				if err != nil {
+					results[item.index].Error = err
+					return
+				}
+				results[item.index].ResolvedLocks = item.resolvedLocks
+			})
+		}
+		var resolved uint64
+		ops := make([]versionedOp, 0, len(req.Keys)*3)
+		seen := make(map[string]struct{}, len(req.Keys))
+		for _, key := range req.Keys {
+			if len(key) == 0 {
+				continue
+			}
+			keyID := string(key)
+			if _, ok := seen[keyID]; ok {
+				continue
+			}
+			seen[keyID] = struct{}{}
+			lock, err := reader.GetLock(key)
+			if err != nil {
+				results[i].Error = keyErrorRetryable(err)
+				break
+			}
+			if lock == nil || lock.Ts != req.StartVersion {
+				continue
+			}
+			if req.CommitVersion == 0 {
+				planned, err := planRollbackKey(reader, key, req.StartVersion)
+				if err != nil {
+					results[i].Error = err
+					break
+				}
+				ops = append(ops, planned...)
+			} else {
+				planned, err := planCommitKeyWithLock(reader, key, lock, req.CommitVersion)
+				if err != nil {
+					results[i].Error = err
+					break
+				}
+				ops = append(ops, planned...)
+			}
+			resolved++
+		}
+		if results[i].Error != nil {
 			continue
 		}
-		seen[keyID] = struct{}{}
-		lock, err := reader.GetLock(key)
+		if len(ops) == 0 {
+			results[i].ResolvedLocks = resolved
+			continue
+		}
+		group.add(i, req.Keys, ops, resolved)
+	}
+	group.flush(db, func(item twoPCApplyRequest, err *kvrpcpb.KeyError) {
 		if err != nil {
-			return resolved, keyErrorRetryable(err)
+			results[item.index].Error = err
+			return
 		}
-		if lock == nil || lock.Ts != req.StartVersion {
-			continue
-		}
-		if req.CommitVersion == 0 {
-			planned, err := planRollbackKey(reader, key, req.StartVersion)
-			if err != nil {
-				return resolved, err
-			}
-			ops = append(ops, planned...)
-		} else {
-			planned, err := planCommitKeyWithLock(reader, key, lock, req.CommitVersion)
-			if err != nil {
-				return resolved, err
-			}
-			ops = append(ops, planned...)
-		}
-		resolved++
-	}
-	if err := applyVersionedOps(db, ops...); err != nil {
-		return 0, keyErrorRetryable(err)
-	}
-	return resolved, nil
+		results[item.index].ResolvedLocks = item.resolvedLocks
+	})
+	return results
 }
 
 // CheckTxnStatus inspects the primary lock state and optionally rolls back
@@ -752,6 +1058,65 @@ type versionedOp struct {
 	value   []byte
 	meta    byte
 	expires uint64
+}
+
+type twoPCApplyGroup struct {
+	requests []twoPCApplyRequest
+	entries  []*kv.Entry
+	keys     map[string]struct{}
+}
+
+type twoPCApplyRequest struct {
+	index         int
+	resolvedLocks uint64
+}
+
+func (g *twoPCApplyGroup) conflicts(keys [][]byte) bool {
+	if g == nil || len(g.keys) == 0 {
+		return false
+	}
+	for _, key := range keys {
+		if _, ok := g.keys[string(key)]; ok {
+			return true
+		}
+	}
+	return false
+}
+
+func (g *twoPCApplyGroup) add(index int, keys [][]byte, ops []versionedOp, resolvedLocks uint64) {
+	if len(ops) == 0 {
+		return
+	}
+	g.requests = append(g.requests, twoPCApplyRequest{index: index, resolvedLocks: resolvedLocks})
+	g.entries = append(g.entries, versionedOpsToEntries(ops...)...)
+	if g.keys == nil {
+		g.keys = make(map[string]struct{}, len(keys))
+	}
+	for _, key := range keys {
+		g.keys[string(key)] = struct{}{}
+	}
+}
+
+func (g *twoPCApplyGroup) flush(db txnstore.Store, setResult func(twoPCApplyRequest, *kvrpcpb.KeyError)) {
+	if g == nil || len(g.requests) == 0 {
+		return
+	}
+	defer releaseEntries(g.entries)
+	if len(g.requests) > 1 {
+		percolatorStats.twoPCFusedBatchesTotal.Add(1)
+		percolatorStats.twoPCFusedRequestsTotal.Add(uint64(len(g.requests)))
+		percolatorStats.twoPCFusedEntriesTotal.Add(uint64(len(g.entries)))
+	}
+	var keyErr *kvrpcpb.KeyError
+	if err := applyVersionedEntries(db, g.entries); err != nil {
+		keyErr = keyErrorRetryable(err)
+	}
+	for _, req := range g.requests {
+		setResult(req, keyErr)
+	}
+	g.requests = nil
+	g.entries = nil
+	g.keys = nil
 }
 
 func applyVersionedOps(db txnstore.Store, ops ...versionedOp) error {

--- a/txn/percolator/txn_test.go
+++ b/txn/percolator/txn_test.go
@@ -57,6 +57,19 @@ func atomicPutIfAbsentRequest(startVersion, commitVersion uint64, firstKey, firs
 	}
 }
 
+func atomicPutRequest(startVersion, commitVersion uint64, key, value []byte) *kvrpcpb.TryAtomicMutateRequest {
+	return &kvrpcpb.TryAtomicMutateRequest{
+		StartVersion:  startVersion,
+		CommitVersion: commitVersion,
+		Predicates: []*kvrpcpb.AtomicPredicate{
+			{Key: kv.SafeCopy(nil, key), Kind: kvrpcpb.AtomicPredicateKind_ATOMIC_PREDICATE_KIND_NOT_EXISTS},
+		},
+		Mutations: []*kvrpcpb.Mutation{
+			{Op: kvrpcpb.Mutation_Put, Key: kv.SafeCopy(nil, key), Value: kv.SafeCopy(nil, value), AssertionNotExist: true},
+		},
+	}
+}
+
 func atomicMutateStat(t *testing.T, stats map[string]any, key string) uint64 {
 	t.Helper()
 	raw, ok := stats[key]
@@ -159,6 +172,18 @@ func (s *countingStore) NewInternalIterator(opt *index.Options) index.Iterator {
 func (s *countingStore) failNextApply(err error) {
 	s.failApplyErr = err
 	s.failApplyRemaining = 1
+}
+
+type countingAtomicStore struct {
+	*countingStore
+}
+
+func newCountingAtomicStore(base *local.DB) *countingAtomicStore {
+	return &countingAtomicStore{countingStore: newCountingStore(base)}
+}
+
+func (s *countingAtomicStore) CanApplyInternalEntriesAtomically(entries []*kv.Entry) bool {
+	return s.base.CanApplyInternalEntriesAtomically(entries)
 }
 
 type testIterator struct {
@@ -274,16 +299,135 @@ func TestApplyAtomicMutateStatsRecordLocalFallback(t *testing.T) {
 	db := openTestDB(t)
 	store := newCountingStore(db)
 	latches := latch.NewManager(16)
-	before := AtomicMutateStats()
+	before := Stats()
 
 	result := ApplyAtomicMutate(store, latches, atomicPutIfAbsentRequest(20, 21, []byte("dentry"), []byte("ino=42"), []byte("inode"), []byte("attrs")))
 	require.Nil(t, result.Error)
 	require.True(t, result.Fallback)
 	require.Zero(t, store.applyCalls)
 
-	after := AtomicMutateStats()
+	after := Stats()
 	require.Equal(t, atomicMutateStat(t, before, "atomic_apply_called_total")+1, atomicMutateStat(t, after, "atomic_apply_called_total"))
 	require.Equal(t, atomicMutateStat(t, before, "atomic_local_fallback_total")+1, atomicMutateStat(t, after, "atomic_local_fallback_total"))
+}
+
+func TestApplyAtomicMutateBatchFusesIndependentRequests(t *testing.T) {
+	opt := testOptionsForDir(t.TempDir())
+	opt.LSMShardCount = 1
+	db, err := local.Open(opt)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = db.Close() })
+
+	store := newCountingAtomicStore(db)
+	latches := latch.NewManager(16)
+	before := Stats()
+	results := ApplyAtomicMutateBatch(store, latches, []*kvrpcpb.TryAtomicMutateRequest{
+		atomicPutRequest(40, 41, []byte("atomic-batch-a"), []byte("va")),
+		atomicPutRequest(42, 43, []byte("atomic-batch-b"), []byte("vb")),
+	})
+	require.Len(t, results, 2)
+	for _, result := range results {
+		require.Nil(t, result.Error)
+		require.False(t, result.Fallback)
+		require.Equal(t, uint64(1), result.AppliedKeys)
+	}
+	require.Equal(t, 1, store.applyCalls)
+	require.Equal(t, []int{6}, store.appliedEntryCounts)
+
+	reader := NewReader(db)
+	value, _, err := reader.GetValue([]byte("atomic-batch-a"), 50)
+	require.NoError(t, err)
+	require.Equal(t, []byte("va"), value)
+	value, _, err = reader.GetValue([]byte("atomic-batch-b"), 50)
+	require.NoError(t, err)
+	require.Equal(t, []byte("vb"), value)
+
+	after := Stats()
+	require.Equal(t, atomicMutateStat(t, before, "atomic_fused_apply_batches_total")+1, atomicMutateStat(t, after, "atomic_fused_apply_batches_total"))
+	require.Equal(t, atomicMutateStat(t, before, "atomic_fused_apply_requests_total")+2, atomicMutateStat(t, after, "atomic_fused_apply_requests_total"))
+	require.Equal(t, atomicMutateStat(t, before, "atomic_fused_apply_entries_total")+6, atomicMutateStat(t, after, "atomic_fused_apply_entries_total"))
+}
+
+func TestApplyAtomicMutateBatchSplitsDifferentLocalApplyGroups(t *testing.T) {
+	const shardCount = 4
+
+	opt := testOptionsForDir(t.TempDir())
+	opt.LSMShardCount = shardCount
+	db, err := local.Open(opt)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = db.Close() })
+
+	first, second := keysWithAscendingCommitShards(t, shardCount)
+	firstShard := lsm.ShardForInternalKey(kv.InternalKey(kv.CFDefault, first, 50), shardCount)
+	secondShard := lsm.ShardForInternalKey(kv.InternalKey(kv.CFDefault, second, 52), shardCount)
+	require.NotEqual(t, firstShard, secondShard)
+
+	store := newCountingAtomicStore(db)
+	results := ApplyAtomicMutateBatch(store, latch.NewManager(16), []*kvrpcpb.TryAtomicMutateRequest{
+		atomicPutRequest(50, 51, first, []byte("first")),
+		atomicPutRequest(52, 53, second, []byte("second")),
+	})
+	require.Len(t, results, 2)
+	for _, result := range results {
+		require.Nil(t, result.Error)
+		require.False(t, result.Fallback)
+		require.Equal(t, uint64(1), result.AppliedKeys)
+	}
+	require.Equal(t, 2, store.applyCalls)
+	require.Equal(t, []int{3, 3}, store.appliedEntryCounts)
+}
+
+func TestApplyAtomicMutateBatchPreservesOverlappingRequestOrder(t *testing.T) {
+	opt := testOptionsForDir(t.TempDir())
+	opt.LSMShardCount = 1
+	db, err := local.Open(opt)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = db.Close() })
+
+	store := newCountingAtomicStore(db)
+	key := []byte("atomic-overlap")
+	results := ApplyAtomicMutateBatch(store, latch.NewManager(16), []*kvrpcpb.TryAtomicMutateRequest{
+		atomicPutRequest(60, 61, key, []byte("first")),
+		atomicPutRequest(62, 63, key, []byte("second")),
+	})
+	require.Len(t, results, 2)
+	require.Nil(t, results[0].Error)
+	require.Equal(t, uint64(1), results[0].AppliedKeys)
+	require.NotNil(t, results[1].Error)
+	require.NotNil(t, results[1].Error.GetAlreadyExists())
+	require.Equal(t, 1, store.applyCalls)
+
+	value, _, err := NewReader(db).GetValue(key, 70)
+	require.NoError(t, err)
+	require.Equal(t, []byte("first"), value)
+}
+
+func TestApplyAtomicMutateBatchApplyFailureMarksWholeFusedGroup(t *testing.T) {
+	opt := testOptionsForDir(t.TempDir())
+	opt.LSMShardCount = 1
+	db, err := local.Open(opt)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = db.Close() })
+
+	injected := errors.New("fused atomic apply failed")
+	store := newCountingAtomicStore(db)
+	store.failNextApply(injected)
+	results := ApplyAtomicMutateBatch(store, latch.NewManager(16), []*kvrpcpb.TryAtomicMutateRequest{
+		atomicPutRequest(70, 71, []byte("atomic-fail-a"), []byte("va")),
+		atomicPutRequest(72, 73, []byte("atomic-fail-b"), []byte("vb")),
+	})
+	require.Len(t, results, 2)
+	for _, result := range results {
+		require.NotNil(t, result.Error)
+		require.Contains(t, result.Error.GetRetryable(), injected.Error())
+	}
+	require.Equal(t, 1, store.applyCalls)
+
+	reader := NewReader(db)
+	_, _, err = reader.GetValue([]byte("atomic-fail-a"), 80)
+	require.ErrorIs(t, err, utils.ErrKeyNotFound)
+	_, _, err = reader.GetValue([]byte("atomic-fail-b"), 80)
+	require.ErrorIs(t, err, utils.ErrKeyNotFound)
 }
 
 func TestApplyAtomicMutateRejectsExistingDentry(t *testing.T) {
@@ -643,6 +787,186 @@ func TestPrewriteBatchAppliesAllMutationsOnce(t *testing.T) {
 		require.NotNil(t, lock, "key=%s", key)
 		require.Equal(t, uint64(8), lock.Ts)
 	}
+}
+
+func TestPrewriteRequestBatchFusesIndependentRequests(t *testing.T) {
+	db := openTestDB(t)
+	store := newCountingStore(db)
+	latches := latch.NewManager(32)
+	before := Stats()
+
+	results := PrewriteBatch(store, latches, []*kvrpcpb.PrewriteRequest{
+		{
+			Mutations:    []*kvrpcpb.Mutation{{Op: kvrpcpb.Mutation_Put, Key: []byte("prewrite-fused-a"), Value: []byte("va")}},
+			PrimaryLock:  []byte("prewrite-fused-a"),
+			StartVersion: 20,
+			LockTtl:      1000,
+		},
+		{
+			Mutations:    []*kvrpcpb.Mutation{{Op: kvrpcpb.Mutation_Put, Key: []byte("prewrite-fused-b"), Value: []byte("vb")}},
+			PrimaryLock:  []byte("prewrite-fused-b"),
+			StartVersion: 22,
+			LockTtl:      1000,
+		},
+	})
+	require.Len(t, results, 2)
+	require.Empty(t, results[0])
+	require.Empty(t, results[1])
+	require.Equal(t, 1, store.applyCalls)
+	require.Equal(t, []int{6}, store.appliedEntryCounts)
+
+	after := Stats()
+	require.Equal(t, atomicMutateStat(t, before, "two_pc_fused_apply_batches_total")+1, atomicMutateStat(t, after, "two_pc_fused_apply_batches_total"))
+	require.Equal(t, atomicMutateStat(t, before, "two_pc_fused_apply_requests_total")+2, atomicMutateStat(t, after, "two_pc_fused_apply_requests_total"))
+	require.Equal(t, atomicMutateStat(t, before, "two_pc_fused_apply_entries_total")+6, atomicMutateStat(t, after, "two_pc_fused_apply_entries_total"))
+}
+
+func TestPrewriteRequestBatchPreservesOverlappingOrder(t *testing.T) {
+	db := openTestDB(t)
+	store := newCountingStore(db)
+	latches := latch.NewManager(32)
+	key := []byte("prewrite-overlap")
+
+	results := PrewriteBatch(store, latches, []*kvrpcpb.PrewriteRequest{
+		{
+			Mutations:    []*kvrpcpb.Mutation{{Op: kvrpcpb.Mutation_Put, Key: key, Value: []byte("first")}},
+			PrimaryLock:  key,
+			StartVersion: 30,
+			LockTtl:      1000,
+		},
+		{
+			Mutations:    []*kvrpcpb.Mutation{{Op: kvrpcpb.Mutation_Put, Key: key, Value: []byte("second")}},
+			PrimaryLock:  key,
+			StartVersion: 32,
+			LockTtl:      1000,
+		},
+	})
+	require.Len(t, results, 2)
+	require.Empty(t, results[0])
+	require.Len(t, results[1], 1)
+	require.NotNil(t, results[1][0].GetLocked())
+	require.Equal(t, 1, store.applyCalls)
+
+	lock, err := NewReader(db).GetLock(key)
+	require.NoError(t, err)
+	require.NotNil(t, lock)
+	require.Equal(t, uint64(30), lock.Ts)
+}
+
+func TestPrewriteRequestBatchApplyFailureMarksFusedRequests(t *testing.T) {
+	db := openTestDB(t)
+	store := newCountingStore(db)
+	injected := errors.New("fused prewrite apply failed")
+	store.failNextApply(injected)
+	latches := latch.NewManager(32)
+
+	results := PrewriteBatch(store, latches, []*kvrpcpb.PrewriteRequest{
+		{
+			Mutations:    []*kvrpcpb.Mutation{{Op: kvrpcpb.Mutation_Put, Key: []byte("prewrite-fail-a"), Value: []byte("va")}},
+			PrimaryLock:  []byte("prewrite-fail-a"),
+			StartVersion: 40,
+			LockTtl:      1000,
+		},
+		{
+			Mutations:    []*kvrpcpb.Mutation{{Op: kvrpcpb.Mutation_Put, Key: []byte("prewrite-fail-b"), Value: []byte("vb")}},
+			PrimaryLock:  []byte("prewrite-fail-b"),
+			StartVersion: 42,
+			LockTtl:      1000,
+		},
+	})
+	require.Len(t, results, 2)
+	for _, errs := range results {
+		require.Len(t, errs, 1)
+		require.Contains(t, errs[0].GetRetryable(), injected.Error())
+	}
+	require.Equal(t, 1, store.applyCalls)
+
+	reader := NewReader(db)
+	for _, key := range [][]byte{[]byte("prewrite-fail-a"), []byte("prewrite-fail-b")} {
+		lock, err := reader.GetLock(key)
+		require.NoError(t, err)
+		require.Nil(t, lock)
+	}
+}
+
+func TestCommitRequestBatchFusesIndependentRequests(t *testing.T) {
+	db := openTestDB(t)
+	latches := latch.NewManager(32)
+	keys := [][]byte{[]byte("commit-fused-a"), []byte("commit-fused-b")}
+	require.Empty(t, Prewrite(db, latches, &kvrpcpb.PrewriteRequest{
+		Mutations: []*kvrpcpb.Mutation{
+			{Op: kvrpcpb.Mutation_Put, Key: keys[0], Value: []byte("va")},
+			{Op: kvrpcpb.Mutation_Put, Key: keys[1], Value: []byte("vb")},
+		},
+		PrimaryLock:  keys[0],
+		StartVersion: 50,
+		LockTtl:      1000,
+	}))
+
+	store := newCountingStore(db)
+	results := CommitBatch(store, latches, []*kvrpcpb.CommitRequest{
+		{Keys: [][]byte{keys[0]}, StartVersion: 50, CommitVersion: 60},
+		{Keys: [][]byte{keys[1]}, StartVersion: 50, CommitVersion: 60},
+	})
+	require.Len(t, results, 2)
+	require.Nil(t, results[0])
+	require.Nil(t, results[1])
+	require.Equal(t, 1, store.applyCalls)
+	require.Equal(t, []int{4}, store.appliedEntryCounts)
+}
+
+func TestBatchRollbackRequestBatchFusesIndependentRequests(t *testing.T) {
+	db := openTestDB(t)
+	latches := latch.NewManager(32)
+	keys := [][]byte{[]byte("rollback-fused-a"), []byte("rollback-fused-b")}
+	require.Empty(t, Prewrite(db, latches, &kvrpcpb.PrewriteRequest{
+		Mutations: []*kvrpcpb.Mutation{
+			{Op: kvrpcpb.Mutation_Put, Key: keys[0], Value: []byte("va")},
+			{Op: kvrpcpb.Mutation_Put, Key: keys[1], Value: []byte("vb")},
+		},
+		PrimaryLock:  keys[0],
+		StartVersion: 70,
+		LockTtl:      1000,
+	}))
+
+	store := newCountingStore(db)
+	results := BatchRollbackBatch(store, latches, []*kvrpcpb.BatchRollbackRequest{
+		{Keys: [][]byte{keys[0]}, StartVersion: 70},
+		{Keys: [][]byte{keys[1]}, StartVersion: 70},
+	})
+	require.Len(t, results, 2)
+	require.Nil(t, results[0])
+	require.Nil(t, results[1])
+	require.Equal(t, 1, store.applyCalls)
+	require.Equal(t, []int{6}, store.appliedEntryCounts)
+}
+
+func TestResolveLockRequestBatchFusesIndependentRequests(t *testing.T) {
+	db := openTestDB(t)
+	latches := latch.NewManager(32)
+	keys := [][]byte{[]byte("resolve-fused-a"), []byte("resolve-fused-b")}
+	require.Empty(t, Prewrite(db, latches, &kvrpcpb.PrewriteRequest{
+		Mutations: []*kvrpcpb.Mutation{
+			{Op: kvrpcpb.Mutation_Put, Key: keys[0], Value: []byte("va")},
+			{Op: kvrpcpb.Mutation_Put, Key: keys[1], Value: []byte("vb")},
+		},
+		PrimaryLock:  keys[0],
+		StartVersion: 80,
+		LockTtl:      1000,
+	}))
+
+	store := newCountingStore(db)
+	results := ResolveLockBatch(store, latches, []*kvrpcpb.ResolveLockRequest{
+		{Keys: [][]byte{keys[0]}, StartVersion: 80, CommitVersion: 90},
+		{Keys: [][]byte{keys[1]}, StartVersion: 80, CommitVersion: 90},
+	})
+	require.Len(t, results, 2)
+	for _, result := range results {
+		require.Nil(t, result.Error)
+		require.Equal(t, uint64(1), result.ResolvedLocks)
+	}
+	require.Equal(t, 1, store.applyCalls)
+	require.Equal(t, []int{4}, store.appliedEntryCounts)
 }
 
 func TestCommitMissingLock(t *testing.T) {


### PR DESCRIPTION
## Summary
- add fsmeta affinity-bucket key placement and bootstrap planning for multi-workspace locality
- add dynamic region scheduling inputs and store-control split/merge wiring
- replace local shard/prefix hooks with a generic UserKeyShapeExtractor so fsmeta supplies shape while local remains schema-neutral
- fix fsmeta benchmark workload fake watch streams so multi-workspace tests terminate cleanly

## Validation
- make fmt
- make lint
- go test ./...
- cd benchmark && go test ./fsmeta ./fsmeta/workload
- NOKV_FSMETA_PROFILE=median NOKV_FSMETA_OUTPUT_DIR=benchmark/data/fsmeta/results ./scripts/run_fsmeta_benchmarks.sh

## Benchmark Evidence
- fsmeta median CSV: benchmark/data/fsmeta/results/fsmeta_compose_median_20260509T081135Z.csv
- mixed aggregate: 175.583 ops/s, 0 errors
- multi-workspace aggregate: 439.903 ops/s, 0 errors
- fsmeta counters after run: atomic_local_fallback_total=0, atomic_route_multi_total=24, inode_alloc_affinity_miss_total=0

## Notes
- This PR intentionally does not implement compact fsmeta values, Percolator short-value, or numeric mount ids.
- .claude/ remains untracked and is not included.