### PR TITLE
Fix YCSB benchmark key shape option

### DIFF
--- a/benchmark/ycsb/ycsb_engine_test.go
+++ b/benchmark/ycsb/ycsb_engine_test.go
@@ -93,6 +93,7 @@ func TestBuildNoKVBenchmarkOptions(t *testing.T) {
 	require.Zero(t, opts.WriteBatchWait)
 	require.Zero(t, opts.WriteHotKeyLimit)
 	require.False(t, opts.EnableWALWatchdog)
+	require.Nil(t, opts.UserKeyShapeExtractor)
 	require.Equal(t, ycsbNoKVWriteBatchMaxCount, opts.WriteBatchMaxCount)
 	require.Equal(t, int64(ycsbNoKVWriteBatchMaxCount), opts.MaxBatchCount)
 	require.Equal(t, int64(384)<<20, opts.BlockCacheBytes)

--- a/benchmark/ycsb/ycsb_profiles.go
+++ b/benchmark/ycsb/ycsb_profiles.go
@@ -121,11 +121,10 @@ func buildNoKVBenchmarkOptions(dir string, opts ycsbEngineOptions, memtable loca
 	cfg.ManifestSync = false
 
 	// Maximum-throughput profile: skip the production defaults that trade
-	// CPU for IO/bloom benefits — the benchmark stresses the write path
-	// on a fast local disk where snappy compression and the prefix bloom
-	// filter cost more than they save. Production keeps both on.
+	// CPU for IO benefits. YCSB uses generic keys, so it deliberately does
+	// not provide a semantic key shape for local shard or prefix-bloom hints.
 	cfg.BlockCompression = nokvlsm.BlockCompressionNone
-	cfg.PrefixExtractor = nil
+	cfg.UserKeyShapeExtractor = nil
 
 	return cfg
 }


### PR DESCRIPTION
## Summary
- update YCSB NoKV benchmark options after the local key-shape API cleanup
- keep YCSB on generic keys by explicitly leaving UserKeyShapeExtractor nil
- add a focused option test so the benchmark does not regress to old PrefixExtractor usage

## Test Plan
- cd benchmark && go test ./ycsb
- cd benchmark && go test ./ycsb ./fsmeta ./fsmeta/workload
- make fmt
- make lint
- go test ./...