### PR TITLE
Fix fsmeta benchmark mount initialization

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -292,10 +292,12 @@ services:
     entrypoint: ["/bin/sh", "-c"]
     command:
       - |
-        until /usr/local/bin/nokv mount register \
-          --coordinator-addr nokv-coordinator-1:2379,nokv-coordinator-2:2379,nokv-coordinator-3:2379 \
-          --mount default --root-inode 1 --schema-version 1; do
-          sleep 1
+        for mount in $(printf '%s' "${NOKV_MOUNT_IDS:-default}" | tr ',' ' '); do
+          until /usr/local/bin/nokv mount register \
+            --coordinator-addr nokv-coordinator-1:2379,nokv-coordinator-2:2379,nokv-coordinator-3:2379 \
+            --mount "$$mount" --root-inode 1 --schema-version 1; do
+            sleep 1
+          done
         done
     depends_on:
       coordinator-1: { condition: service_started }

--- a/scripts/run_fsmeta_benchmarks.sh
+++ b/scripts/run_fsmeta_benchmarks.sh
@@ -232,6 +232,10 @@ run_compose_benchmarks() {
 	local workloads="${NOKV_FSMETA_WORKLOADS:-multi-workspace-autoscale,mixed,durable-snapshot,checkpoint-storm,hotspot-fanin,watch-subtree,negative-lookup}"
 	local output="${NOKV_FSMETA_OUTPUT:-$output_dir/fsmeta_compose_${profile}_${run_id}.csv}"
 	if [[ "${NOKV_FSMETA_COMPOSE:-1}" == "1" ]]; then
+		# The benchmark mount must exist before the fsmeta gateway starts.
+		# Otherwise the run depends on asynchronous root watch catch-up during
+		# the benchmark bootstrap window, which makes long/profiled CI runs flaky.
+		export NOKV_MOUNT_IDS="${NOKV_MOUNT_IDS:-default,$mount}"
 		if [[ "${NOKV_FSMETA_COMPOSE_BUILD:-1}" == "1" ]]; then
 			echo "starting Docker Compose NoKV cluster with local build"
 			docker compose up -d --build


### PR DESCRIPTION
## Summary
- register the benchmark mount before the fsmeta gateway starts in Docker Compose benchmark runs
- let mount-init register a comma-separated mount list while keeping the shared Eunomia key environment
- keep runtime benchmark mount bootstrap as a fallback for non-Compose or external clusters

## Root Cause
main's Benchmark / fsmeta long failed because the Compose bootstrap registered only the default mount, while the benchmark uses fsmeta-bench. The benchmark then published fsmeta-bench after the fsmeta gateway had already started, making the run depend on asynchronous root watch catch-up during the profiled long benchmark startup window.

## Test Plan
- bash -n scripts/run_fsmeta_benchmarks.sh
- NOKV_MOUNT_IDS=default,fsmeta-bench docker compose config --quiet
- NOKV_FSMETA_PROFILE=long NOKV_FSMETA_CAPTURE_PROFILES=1 NOKV_FSMETA_PROFILE_SECONDS=5 NOKV_FSMETA_WORKLOADS=negative-lookup NOKV_FSMETA_CLIENTS=2 NOKV_FSMETA_FILES=64 NOKV_FSMETA_READS_PER_CLIENT=16 NOKV_FSMETA_OUTPUT_DIR=benchmark/data/fsmeta/results NOKV_FSMETA_COMPOSE_DOWN=1 ./scripts/run_fsmeta_benchmarks.sh
- cd benchmark && go test ./fsmeta
- make fmt
- make lint
- go test ./...

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Mount registration now supports multiple mounts instead of a single mount.

* **Chores**
  * Updated benchmark scripts to support multiple mount configurations.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/feichai0017/NoKV/pull/257)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->