### PR TITLE
Optimize fsmeta read path and atomic RMW safety

### DIFF
--- a/benchmark/fsmeta/fsmeta_bench_test.go
+++ b/benchmark/fsmeta/fsmeta_bench_test.go
@@ -44,6 +44,8 @@ var (
 	fsmetaWorkspaces      = flag.Int("fsmeta_workspaces", 4, "multi-workspace-autoscale workspace count")
 	fsmetaSessionTTL      = flag.Duration("fsmeta_session_ttl", 5*time.Minute, "mixed writer session TTL")
 	fsmetaStaleSessionTTL = flag.Duration("fsmeta_stale_session_ttl", 2*time.Second, "mixed stale-session cleanup TTL")
+	fsmetaLookupCache     = flag.Int("fsmeta_lookup_cache_entries", 4096, "client-side positive Lookup cache entries; 0 disables")
+	fsmetaLookupCacheTTL  = flag.Duration("fsmeta_lookup_cache_ttl", time.Second, "client-side positive Lookup cache TTL")
 	fsmetaTimeout         = flag.Duration("fsmeta_timeout", 5*time.Minute, "overall benchmark timeout")
 	fsmetaOutput          = flag.String("fsmeta_output", "", "summary CSV output path")
 )
@@ -138,6 +140,17 @@ func openBenchmarkClient(t *testing.T, ctx context.Context) (workload.Client, fu
 	cli, err := fsmetaclient.NewGRPCClient(ctx, *fsmetaAddr)
 	if err != nil {
 		t.Fatalf("dial fsmeta: %v", err)
+	}
+	if *fsmetaLookupCache > 0 {
+		cached, err := fsmetaclient.NewCachedClient(cli, fsmetaclient.LookupCacheConfig{
+			MaxEntries: *fsmetaLookupCache,
+			TTL:        *fsmetaLookupCacheTTL,
+		})
+		if err != nil {
+			_ = cli.Close()
+			t.Fatalf("open fsmeta lookup cache: %v", err)
+		}
+		return cached, func() { _ = cached.Close() }
 	}
 	return cli, func() { _ = cli.Close() }
 }

--- a/cmd/nokv-fsmeta-history/main.go
+++ b/cmd/nokv-fsmeta-history/main.go
@@ -51,9 +51,12 @@ func main() {
 		scopeName := fmt.Sprintf("%s-%06d-%d", *scope, seed, unique)
 		scopeInode := fsmeta.InodeID(9_000_000_000 + seed*1_000_000 + unique%1_000_000)
 		scopeOp := scopeCreateOperation(mountID, scopeName, scopeInode)
-		if err := createScopeWithRetry(ctx, cli, scopeOp); err != nil {
+		scopeResult, err := createScopeWithRetry(ctx, cli, scopeOp)
+		if err != nil {
 			log.Fatalf("create history scope seed=%d: %v", seed, err)
 		}
+		scopeOp.Inode = scopeResult.Inode.Inode
+		scopeInode = scopeResult.Inode.Inode
 		if got := model.Apply(scopeOp); got.Err != nil {
 			log.Fatalf("apply history scope seed=%d: %v", seed, got.Err)
 		}
@@ -61,8 +64,12 @@ func main() {
 		if len(ops) == 0 {
 			log.Fatalf("seed %d generated no external-safe operations", seed)
 		}
+		historyExec, err := fsmetacontract.NewInodeMappingExecutor(cli)
+		if err != nil {
+			log.Fatalf("open history inode mapper: %v", err)
+		}
 		opts := fsmetacontract.HistoryOptions{AllowIndeterminateErrors: *allowIndeterminate}
-		if err := fsmetacontract.RunConcurrentBatches(ctx, cli, model, ops, *batch, opts); err != nil {
+		if err := fsmetacontract.RunConcurrentBatches(ctx, historyExec, model, ops, *batch, opts); err != nil {
 			fmt.Fprintf(os.Stderr, "fsmeta history failed seed=%d steps=%d filtered_ops=%d\n", seed, *steps, len(ops))
 			log.Fatal(err)
 		}
@@ -82,10 +89,10 @@ func scopeCreateOperation(mount fsmeta.MountID, scopeName string, scopeInode fsm
 	}
 }
 
-func createScopeWithRetry(ctx context.Context, cli fsmetaclient.Client, op fsmetacontract.Operation) error {
+func createScopeWithRetry(ctx context.Context, cli fsmetaclient.Client, op fsmetacontract.Operation) (fsmeta.CreateResult, error) {
 	delay := 100 * time.Millisecond
 	for {
-		_, err := cli.Create(ctx, fsmeta.CreateRequest{
+		req := fsmeta.CreateRequest{
 			Mount:  op.Mount,
 			Parent: op.Parent,
 			Name:   op.Name,
@@ -93,22 +100,29 @@ func createScopeWithRetry(ctx context.Context, cli fsmetaclient.Client, op fsmet
 				Type: op.Type,
 				Mode: op.Mode,
 			},
-		})
+		}
+		result, err := cli.Create(ctx, req)
 		if err == nil || errors.Is(err, fsmeta.ErrExists) {
-			return nil
+			if err == nil {
+				return result, nil
+			}
+			dentry, lookupErr := cli.Lookup(ctx, fsmeta.LookupRequest{Mount: op.Mount, Parent: op.Parent, Name: op.Name})
+			if lookupErr == nil {
+				return fsmeta.CreateResult{Dentry: dentry, Inode: req.Attrs.InodeRecord(dentry.Inode)}, nil
+			}
 		}
 		// Compose startup can return NotFound until the fsmeta gateway observes
 		// rooted mount/root admission. The scope create is an admission barrier,
 		// so retrying here keeps startup synchronization out of the generated
 		// correctness history.
 		if !nokverrors.Retryable(err) && !nokverrors.IsKind(err, nokverrors.KindNotFound) {
-			return err
+			return fsmeta.CreateResult{}, err
 		}
 		timer := time.NewTimer(delay)
 		select {
 		case <-ctx.Done():
 			timer.Stop()
-			return ctx.Err()
+			return fsmeta.CreateResult{}, ctx.Err()
 		case <-timer.C:
 		}
 		if delay < time.Second {

--- a/cmd/nokv-fsmeta-soak/main.go
+++ b/cmd/nokv-fsmeta-soak/main.go
@@ -8,10 +8,13 @@ import (
 	"log"
 	"time"
 
+	nokverrors "github.com/feichai0017/NoKV/errors"
 	"github.com/feichai0017/NoKV/fsmeta"
 	fsmetaclient "github.com/feichai0017/NoKV/fsmeta/client"
 	fsmetacontract "github.com/feichai0017/NoKV/fsmeta/contract"
 )
+
+const minSoakRoundBudget = 15 * time.Second
 
 func main() {
 	var (
@@ -32,12 +35,16 @@ func main() {
 
 	mountID := fsmeta.MountID(*mount)
 	deadline := time.Now().Add(*duration)
-	for seed := *seedStart; time.Now().Before(deadline); seed++ {
+	for seed := *seedStart; shouldRunSoakRound(time.Now(), deadline, minSoakRoundBudget); seed++ {
 		if err := runRound(ctx, *addr, mountID, seed, *steps, *batch); err != nil {
 			log.Fatalf("soak round failed seed=%d: %v", seed, err)
 		}
 		log.Printf("soak round passed seed=%d remaining=%s", seed, time.Until(deadline).Round(time.Second))
 	}
+}
+
+func shouldRunSoakRound(now, deadline time.Time, minBudget time.Duration) bool {
+	return deadline.Sub(now) >= minBudget
 }
 
 func runRound(ctx context.Context, addr string, mount fsmeta.MountID, seed int64, steps, batch int) error {
@@ -53,12 +60,40 @@ func runRound(ctx context.Context, addr string, mount fsmeta.MountID, seed int64
 	model := fsmetacontract.NewModel(mount)
 	unique := time.Now().UnixNano()
 	scopeName := fmt.Sprintf("soak-history-%06d-%d", seed, unique)
-	scopeInode := fsmeta.InodeID(8_000_000_000 + seed*1_000_000 + unique%1_000_000)
-	ops := soakHistoryOps(fsmetacontract.GenerateScript(seed, steps), mount, scopeName, scopeInode)
+	scopeResult, err := createScopeWithRetry(roundCtx, cli, fsmeta.CreateRequest{
+		Mount:  mount,
+		Parent: fsmeta.RootInode,
+		Name:   scopeName,
+		Attrs: fsmeta.CreateAttrs{
+			Type: fsmeta.InodeTypeDirectory,
+			Mode: 0o755,
+		},
+	})
+	if err != nil {
+		return fmt.Errorf("create history scope: %w", err)
+	}
+	scopeInode := scopeResult.Inode.Inode
+	scopeOp := fsmetacontract.Operation{
+		Kind:   fsmetacontract.OpCreate,
+		Mount:  mount,
+		Parent: fsmeta.RootInode,
+		Name:   scopeName,
+		Inode:  scopeInode,
+		Type:   fsmeta.InodeTypeDirectory,
+		Mode:   0o755,
+	}
+	if got := model.Apply(scopeOp); got.Err != nil {
+		return fmt.Errorf("seed model scope: %w", got.Err)
+	}
+	historyExec, err := fsmetacontract.NewInodeMappingExecutor(cli)
+	if err != nil {
+		return err
+	}
+	ops := soakHistoryOps(fsmetacontract.GenerateScript(seed, steps), mount, scopeInode)
 	if len(ops) == 0 {
 		return fmt.Errorf("generated no namespace operations")
 	}
-	if err := fsmetacontract.RunConcurrentBatches(roundCtx, cli, model, ops, batch, fsmetacontract.HistoryOptions{}); err != nil {
+	if err := fsmetacontract.RunConcurrentBatches(roundCtx, historyExec, model, ops, batch, fsmetacontract.HistoryOptions{AllowIndeterminateErrors: true}); err != nil {
 		return fmt.Errorf("namespace history: %w", err)
 	}
 	if err := runSessionProbe(roundCtx, cli, mount, seed); err != nil {
@@ -73,17 +108,8 @@ func runRound(ctx context.Context, addr string, mount fsmeta.MountID, seed int64
 	return nil
 }
 
-func soakHistoryOps(in []fsmetacontract.Operation, mount fsmeta.MountID, scopeName string, scopeInode fsmeta.InodeID) []fsmetacontract.Operation {
-	out := make([]fsmetacontract.Operation, 0, len(in)+1)
-	out = append(out, fsmetacontract.Operation{
-		Kind:   fsmetacontract.OpCreate,
-		Mount:  mount,
-		Parent: fsmeta.RootInode,
-		Name:   scopeName,
-		Inode:  scopeInode,
-		Type:   fsmeta.InodeTypeDirectory,
-		Mode:   0o755,
-	})
+func soakHistoryOps(in []fsmetacontract.Operation, mount fsmeta.MountID, scopeInode fsmeta.InodeID) []fsmetacontract.Operation {
+	out := make([]fsmetacontract.Operation, 0, len(in))
 	for _, op := range in {
 		switch op.Kind {
 		case fsmetacontract.OpOpenWriteSession,
@@ -94,19 +120,72 @@ func soakHistoryOps(in []fsmetacontract.Operation, mount fsmeta.MountID, scopeNa
 			continue
 		default:
 			op.Mount = mount
+			op.Inode = scopedGeneratedInode(scopeInode, op.Inode)
 			if op.Parent == fsmeta.RootInode {
 				op.Parent = scopeInode
+			} else {
+				op.Parent = scopedGeneratedInode(scopeInode, op.Parent)
 			}
 			if op.FromParent == fsmeta.RootInode {
 				op.FromParent = scopeInode
+			} else {
+				op.FromParent = scopedGeneratedInode(scopeInode, op.FromParent)
 			}
 			if op.ToParent == fsmeta.RootInode {
 				op.ToParent = scopeInode
+			} else {
+				op.ToParent = scopedGeneratedInode(scopeInode, op.ToParent)
 			}
 			out = append(out, op)
 		}
 	}
 	return out
+}
+
+func createScopeWithRetry(ctx context.Context, cli fsmetaclient.Client, req fsmeta.CreateRequest) (fsmeta.CreateResult, error) {
+	delay := 100 * time.Millisecond
+	for {
+		result, err := cli.Create(ctx, req)
+		if err == nil {
+			return result, nil
+		}
+		if errors.Is(err, fsmeta.ErrExists) {
+			dentry, lookupErr := cli.Lookup(ctx, fsmeta.LookupRequest{Mount: req.Mount, Parent: req.Parent, Name: req.Name})
+			if lookupErr == nil {
+				return fsmeta.CreateResult{Dentry: dentry, Inode: req.Attrs.InodeRecord(dentry.Inode)}, nil
+			}
+		}
+		if !retryScopeCreateError(err) {
+			return fsmeta.CreateResult{}, err
+		}
+		timer := time.NewTimer(delay)
+		select {
+		case <-ctx.Done():
+			timer.Stop()
+			return fsmeta.CreateResult{}, ctx.Err()
+		case <-timer.C:
+		}
+		if delay < time.Second {
+			delay *= 2
+		}
+	}
+}
+
+func retryScopeCreateError(err error) bool {
+	if err == nil {
+		return false
+	}
+	if errors.Is(err, fsmeta.ErrMountNotRegistered) {
+		return true
+	}
+	return nokverrors.Retryable(err) || nokverrors.IsKind(err, nokverrors.KindNotFound)
+}
+
+func scopedGeneratedInode(base, inode fsmeta.InodeID) fsmeta.InodeID {
+	if inode == 0 {
+		return 0
+	}
+	return base + inode
 }
 
 func runSessionProbe(ctx context.Context, cli *fsmetaclient.GRPCClient, mount fsmeta.MountID, seed int64) error {

--- a/cmd/nokv-fsmeta-soak/main_test.go
+++ b/cmd/nokv-fsmeta-soak/main_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"testing"
+	"time"
 
 	"github.com/feichai0017/NoKV/fsmeta"
 	fsmetacontract "github.com/feichai0017/NoKV/fsmeta/contract"
@@ -10,7 +11,6 @@ import (
 func TestSoakHistoryOpsScopesExternalNamespaceOperations(t *testing.T) {
 	const (
 		mount      = fsmeta.MountID("prod")
-		scopeName  = "soak-scope"
 		scopeInode = fsmeta.InodeID(8001)
 	)
 	ops := soakHistoryOps([]fsmetacontract.Operation{
@@ -19,20 +19,30 @@ func TestSoakHistoryOpsScopesExternalNamespaceOperations(t *testing.T) {
 		{Kind: fsmetacontract.OpReadDirPlus, Mount: "vol", Parent: fsmeta.RootInode, StartAfter: "a", Limit: 10},
 		{Kind: fsmetacontract.OpUnlink, Mount: "vol", Parent: fsmeta.RootInode, Name: "alpha"},
 		{Kind: fsmetacontract.OpExpireSessions, Mount: "vol", Limit: 1},
-	}, mount, scopeName, scopeInode)
+	}, mount, scopeInode)
 
-	if len(ops) != 4 {
-		t.Fatalf("filtered op count=%d, want 4: %#v", len(ops), ops)
+	if len(ops) != 3 {
+		t.Fatalf("filtered op count=%d, want 3: %#v", len(ops), ops)
 	}
-	if ops[0].Kind != fsmetacontract.OpCreate || ops[0].Mount != mount || ops[0].Parent != fsmeta.RootInode || ops[0].Name != scopeName || ops[0].Inode != scopeInode {
-		t.Fatalf("scope create mismatch: %#v", ops[0])
-	}
-	for _, op := range ops[1:] {
+	for _, op := range ops {
 		if op.Mount != mount || op.Parent != scopeInode {
 			t.Fatalf("op was not scoped into generated root: %#v", op)
 		}
 	}
-	if ops[2].StartAfter != "a" || ops[2].Limit != 10 {
-		t.Fatalf("ReadDirPlus pagination fields changed: %#v", ops[2])
+	if ops[1].StartAfter != "a" || ops[1].Limit != 10 {
+		t.Fatalf("ReadDirPlus pagination fields changed: %#v", ops[1])
+	}
+	if ops[2].Inode != 0 {
+		t.Fatalf("zero inode remapped to %d", ops[2].Inode)
+	}
+}
+
+func TestShouldRunSoakRoundKeepsFinalDeadlineForCleanup(t *testing.T) {
+	now := time.Unix(100, 0)
+	if !shouldRunSoakRound(now, now.Add(minSoakRoundBudget), minSoakRoundBudget) {
+		t.Fatal("expected exact minimum budget to allow one more round")
+	}
+	if shouldRunSoakRound(now, now.Add(minSoakRoundBudget-time.Nanosecond), minSoakRoundBudget) {
+		t.Fatal("expected short remaining budget to stop before probes inherit an expiring context")
 	}
 }

--- a/cmd/nokv/cmd_serve.go
+++ b/cmd/nokv/cmd_serve.go
@@ -507,14 +507,14 @@ func startStorePeers(server *serverpkg.Node, storage serverpkg.Storage, localMet
 			return result.Meta.Region, nil
 		}
 		cfg := &peer.Config{
-			RaftConfig: myraft.Config{
+			RaftConfig: peer.EnableLeaseRead(myraft.Config{
 				ID:              peerID,
 				ElectionTick:    electionTick,
 				HeartbeatTick:   heartbeatTick,
 				MaxSizePerMsg:   uint64(maxMsgBytes),
 				MaxInflightMsgs: maxInflight,
 				PreVote:         true,
-			},
+			}),
 			Transport:      transport,
 			Apply:          kv.NewEntryApplier(storage.MVCC),
 			SnapshotExport: storage.Snapshot.ExportSnapshot,

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -34,7 +34,7 @@ x-nokv-image: &nokv-image
   # and only keeps all local containers on one Eunomia grant key; production
   # deployments must provide their own signing and verification keys.
   environment:
-    NOKV_EUNOMIA_GRANT_SIGNING_PRIVATE_KEY: "rM0DUr4noWKwu7NlAoX2A6FXpdUyLESmwvqNYOkeNIc="
+    NOKV_EUNOMIA_GRANT_SIGNING_PRIVATE_KEY: "${NOKV_EUNOMIA_GRANT_SIGNING_PRIVATE_KEY:-rM0DUr4noWKwu7NlAoX2A6FXpdUyLESmwvqNYOkeNIc=}"
 
 x-common: &common
   image: ${NOKV_IMAGE:-ghcr.io/feichai0017/nokv:${NOKV_IMAGE_TAG:-latest}}
@@ -45,7 +45,7 @@ x-common: &common
   # and only keeps all local containers on one Eunomia grant key; production
   # deployments must provide their own signing and verification keys.
   environment:
-    NOKV_EUNOMIA_GRANT_SIGNING_PRIVATE_KEY: "rM0DUr4noWKwu7NlAoX2A6FXpdUyLESmwvqNYOkeNIc="
+    NOKV_EUNOMIA_GRANT_SIGNING_PRIVATE_KEY: "${NOKV_EUNOMIA_GRANT_SIGNING_PRIVATE_KEY:-rM0DUr4noWKwu7NlAoX2A6FXpdUyLESmwvqNYOkeNIc=}"
 
 services:
   # ---------- bootstrap (seed stores once, then exit) ----------

--- a/engine/slab/negativecache/cache_test.go
+++ b/engine/slab/negativecache/cache_test.go
@@ -161,3 +161,25 @@ func TestPersistenceMissingFileIsClean(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, 0, n)
 }
+
+func TestSnapshotCodecRejectsBadChecksum(t *testing.T) {
+	body, written := encodeSnapshotKeys([][]byte{[]byte("alpha"), []byte("beta")}, 1<<20)
+	require.Equal(t, 2, written)
+	body[len(body)-1] ^= 0xff
+
+	keys, ok := decodeSnapshotKeys(body)
+	require.False(t, ok)
+	require.Nil(t, keys)
+}
+
+func TestSnapshotCodecRestoresValidPrefixFromTruncatedTail(t *testing.T) {
+	body, written := encodeSnapshotKeys([][]byte{[]byte("alpha"), []byte("beta")}, 1<<20)
+	require.Equal(t, 2, written)
+	body = body[:len(body)-2]
+
+	keys, ok := decodeSnapshotKeys(body)
+	require.True(t, ok)
+	require.Len(t, keys, 2)
+	require.Equal(t, []byte("alpha"), keys[0])
+	require.Equal(t, []byte("beta"), keys[1])
+}

--- a/engine/slab/negativecache/codec.go
+++ b/engine/slab/negativecache/codec.go
@@ -1,0 +1,103 @@
+package negativecache
+
+import (
+	"encoding/binary"
+	"hash/crc32"
+)
+
+// Wire format for the slab snapshot.
+//
+//	magic      uint32 ("NCSL", little-endian)
+//	version    uint16
+//	entries    repeated of:
+//	    len      uvarint   (length of full key in bytes)
+//	    key      [len]byte
+//	terminator zero-length record (uvarint 0)
+//	crc32      uint32 little-endian over entries + terminator
+//
+// Reload tolerates missing, truncated, or bad snapshots by restoring no more
+// than the valid prefix. Negative cache entries are derived hints, so the safe
+// failure mode is a cold cache and an authoritative re-probe.
+const (
+	snapshotMagic   uint32 = 0x4e43534c // "NCSL"
+	snapshotVersion uint16 = 1
+	snapshotHeader         = 4 + 2 // magic + version
+	snapshotTrailer        = 1 + 4 // zero terminator + crc32
+	snapshotFile           = "negative.slab"
+)
+
+func encodeSnapshotKeys(keys [][]byte, maxSize int64) ([]byte, int) {
+	minSize := int64(snapshotHeader + snapshotTrailer)
+	if maxSize < minSize {
+		maxSize = minSize
+	}
+	buf := make([]byte, snapshotHeader, min(int(maxSize), snapshotHeader+len(keys)*32))
+	binary.LittleEndian.PutUint32(buf[0:4], snapshotMagic)
+	binary.LittleEndian.PutUint16(buf[4:6], snapshotVersion)
+
+	hasher := crc32.NewIEEE()
+	written := 0
+	var lenBuf [binary.MaxVarintLen64]byte
+	for _, key := range keys {
+		n := binary.PutUvarint(lenBuf[:], uint64(len(key)))
+		if int64(len(buf))+int64(n)+int64(len(key))+int64(snapshotTrailer) > maxSize {
+			break
+		}
+		buf = append(buf, lenBuf[:n]...)
+		hasher.Write(lenBuf[:n])
+		buf = append(buf, key...)
+		hasher.Write(key)
+		written++
+	}
+
+	buf = append(buf, 0)
+	hasher.Write([]byte{0})
+	var crcBuf [4]byte
+	binary.LittleEndian.PutUint32(crcBuf[:], hasher.Sum32())
+	buf = append(buf, crcBuf[:]...)
+	return buf, written
+}
+
+func decodeSnapshotKeys(body []byte) ([][]byte, bool) {
+	if len(body) < snapshotHeader {
+		return nil, false
+	}
+	if magic := binary.LittleEndian.Uint32(body[0:4]); magic != snapshotMagic {
+		return nil, false
+	}
+	if ver := binary.LittleEndian.Uint16(body[4:6]); ver != snapshotVersion {
+		return nil, false
+	}
+
+	hasher := crc32.NewIEEE()
+	cursor := snapshotHeader
+	var keys [][]byte
+	for cursor < len(body) {
+		klen, n := binary.Uvarint(body[cursor:])
+		if n <= 0 {
+			return keys, true
+		}
+		hasher.Write(body[cursor : cursor+n])
+		cursor += n
+		if klen == 0 {
+			if cursor+4 > len(body) {
+				return keys, true
+			}
+			want := binary.LittleEndian.Uint32(body[cursor : cursor+4])
+			if want != hasher.Sum32() {
+				return nil, false
+			}
+			return keys, true
+		}
+		if klen > uint64(len(body)-cursor) {
+			return keys, true
+		}
+		end := cursor + int(klen)
+		key := make([]byte, int(klen))
+		copy(key, body[cursor:end])
+		hasher.Write(body[cursor:end])
+		keys = append(keys, key)
+		cursor = end
+	}
+	return keys, true
+}

--- a/engine/slab/negativecache/errors.go
+++ b/engine/slab/negativecache/errors.go
@@ -1,0 +1,5 @@
+package negativecache
+
+import "errors"
+
+var errPersistenceDirRequired = errors.New("negativecache persistence: dir required")

--- a/engine/slab/negativecache/persist.go
+++ b/engine/slab/negativecache/persist.go
@@ -1,37 +1,13 @@
 package negativecache
 
 import (
-	"encoding/binary"
 	"errors"
 	"fmt"
-	"hash/crc32"
 	"os"
 	"path/filepath"
 
 	"github.com/feichai0017/NoKV/engine/file"
 	"github.com/feichai0017/NoKV/engine/slab"
-)
-
-// Wire format for the slab snapshot. See snapshot-substrate note §6.1
-// (Negative Slab) for the rationale.
-//
-//	magic     uint32 ("NCSL", little-endian)
-//	version   uint16
-//	entries   repeated of:
-//	    len     uvarint   (length of full key in bytes)
-//	    key     [len]byte
-//	terminator: zero-length record (uvarint 0) followed by a uint32 LE
-//	            CRC32 of the framed body (header + every {len,key} pair
-//	            up to and including the zero-length terminator's len byte).
-//
-// Reload tolerates partial trailing records and CRC mismatches by
-// returning zero restored entries and forcing a clean re-warm — Derived
-// consistency means we'd rather start cold than serve a corrupt cache.
-const (
-	snapshotMagic   uint32 = 0x4e43534c // "NCSL"
-	snapshotVersion uint16 = 1
-	snapshotHeader         = 4 + 2 // magic + version
-	snapshotFile           = "negative.slab"
 )
 
 // PersistConfig opens a Persistence sidecar for a Cache. Persistence is
@@ -63,7 +39,7 @@ type Persistence struct {
 // first Has call.
 func OpenWithPersistence(cacheCfg Config, persistCfg PersistConfig) (*Cache, *Persistence, error) {
 	if persistCfg.Dir == "" {
-		return nil, nil, errors.New("negativecache persistence: dir required")
+		return nil, nil, errPersistenceDirRequired
 	}
 	if persistCfg.MaxSize <= 0 {
 		persistCfg.MaxSize = 64 << 20
@@ -88,6 +64,7 @@ func (p *Persistence) Snapshot() (int, error) {
 		return 0, nil
 	}
 	keys := p.cache.SnapshotKeys()
+	body, written := encodeSnapshotKeys(keys, p.maxSize)
 	if err := os.MkdirAll(p.dir, 0o755); err != nil {
 		return 0, fmt.Errorf("negativecache snapshot dir: %w", err)
 	}
@@ -107,50 +84,10 @@ func (p *Persistence) Snapshot() (int, error) {
 	}
 	defer func() { _ = seg.Close() }()
 
-	if err := seg.Truncate(int64(snapshotHeader)); err != nil {
-		return 0, fmt.Errorf("negativecache snapshot truncate: %w", err)
+	if err := seg.Write(0, body); err != nil {
+		return 0, fmt.Errorf("negativecache snapshot write: %w", err)
 	}
-	header := make([]byte, snapshotHeader)
-	binary.LittleEndian.PutUint32(header[0:4], snapshotMagic)
-	binary.LittleEndian.PutUint16(header[4:6], snapshotVersion)
-	if err := seg.Write(0, header); err != nil {
-		return 0, fmt.Errorf("negativecache snapshot header: %w", err)
-	}
-
-	offset := uint32(snapshotHeader)
-	hasher := crc32.NewIEEE()
-	written := 0
-	var lenBuf [binary.MaxVarintLen64]byte
-	for _, key := range keys {
-		if int64(offset)+int64(len(key))+binary.MaxVarintLen64+5 >= p.maxSize {
-			break
-		}
-		n := binary.PutUvarint(lenBuf[:], uint64(len(key)))
-		if err := seg.Write(offset, lenBuf[:n]); err != nil {
-			return written, fmt.Errorf("negativecache snapshot len: %w", err)
-		}
-		hasher.Write(lenBuf[:n])
-		offset += uint32(n)
-		if err := seg.Write(offset, key); err != nil {
-			return written, fmt.Errorf("negativecache snapshot key: %w", err)
-		}
-		hasher.Write(key)
-		offset += uint32(len(key))
-		written++
-	}
-	zero := []byte{0}
-	if err := seg.Write(offset, zero); err != nil {
-		return written, fmt.Errorf("negativecache snapshot terminator: %w", err)
-	}
-	hasher.Write(zero)
-	offset++
-	var crcBuf [4]byte
-	binary.LittleEndian.PutUint32(crcBuf[:], hasher.Sum32())
-	if err := seg.Write(offset, crcBuf[:]); err != nil {
-		return written, fmt.Errorf("negativecache snapshot crc: %w", err)
-	}
-	offset += 4
-	if err := seg.DoneWriting(offset); err != nil {
+	if err := seg.DoneWriting(uint32(len(body))); err != nil {
 		return written, fmt.Errorf("negativecache snapshot seal: %w", err)
 	}
 	return written, nil
@@ -172,45 +109,12 @@ func (p *Persistence) Reload() (int, error) {
 		}
 		return 0, err
 	}
-	if len(body) < snapshotHeader {
+	keys, ok := decodeSnapshotKeys(body)
+	if !ok {
 		return 0, nil
 	}
-	if magic := binary.LittleEndian.Uint32(body[0:4]); magic != snapshotMagic {
-		return 0, nil
-	}
-	if ver := binary.LittleEndian.Uint16(body[4:6]); ver != snapshotVersion {
-		return 0, nil
-	}
-
-	hasher := crc32.NewIEEE()
-	cursor := snapshotHeader
-	restored := 0
-	for cursor < len(body) {
-		klen, n := binary.Uvarint(body[cursor:])
-		if n <= 0 {
-			return restored, nil
-		}
-		hasher.Write(body[cursor : cursor+n])
-		cursor += n
-		if klen == 0 {
-			if cursor+4 <= len(body) {
-				want := binary.LittleEndian.Uint32(body[cursor : cursor+4])
-				if want != hasher.Sum32() {
-					return 0, nil
-				}
-			}
-			return restored, nil
-		}
-		end := cursor + int(klen)
-		if end > len(body) {
-			return restored, nil
-		}
-		key := make([]byte, klen)
-		copy(key, body[cursor:end])
-		hasher.Write(body[cursor:end])
+	for _, key := range keys {
 		p.cache.Remember(key)
-		restored++
-		cursor = end
 	}
-	return restored, nil
+	return len(keys), nil
 }

--- a/fsmeta/client/cache.go
+++ b/fsmeta/client/cache.go
@@ -1,0 +1,374 @@
+package client
+
+import (
+	"container/list"
+	"context"
+	"sync"
+	"time"
+
+	"github.com/feichai0017/NoKV/fsmeta"
+)
+
+const (
+	defaultLookupCacheEntries = 4096
+	defaultLookupCacheTTL     = time.Second
+)
+
+// LookupCacheConfig controls the optional client-side positive dentry cache.
+//
+// The cache is deliberately bounded and TTL-based. It is an optimization for
+// hot path resolution, not an authority source: callers that need externally
+// synchronized freshness should disable it or pair it with watch-based
+// invalidation at a higher layer.
+type LookupCacheConfig struct {
+	MaxEntries int
+	TTL        time.Duration
+}
+
+// LookupCacheStats is a low-cardinality snapshot of client cache behavior.
+type LookupCacheStats struct {
+	Hits          uint64
+	Misses        uint64
+	Inserts       uint64
+	Invalidations uint64
+	Evictions     uint64
+	Expired       uint64
+}
+
+// CachedClient wraps a typed fsmeta Client with an optional positive Lookup
+// cache. Mutations issued through this wrapper update or invalidate exact
+// parent/name entries so the local caller does not see its own stale results.
+type CachedClient struct {
+	base   Client
+	lookup *lookupCache
+}
+
+var _ Client = (*CachedClient)(nil)
+
+// NewCachedClient wraps base with a bounded Lookup cache. A zero config uses
+// conservative defaults; negative capacity or TTL values are rejected.
+func NewCachedClient(base Client, cfg LookupCacheConfig) (*CachedClient, error) {
+	if base == nil {
+		return nil, errCachedClientRequired
+	}
+	normalized, err := normalizeLookupCacheConfig(cfg)
+	if err != nil {
+		return nil, err
+	}
+	return &CachedClient{
+		base:   base,
+		lookup: newLookupCache(normalized),
+	}, nil
+}
+
+func normalizeLookupCacheConfig(cfg LookupCacheConfig) (LookupCacheConfig, error) {
+	if cfg.MaxEntries < 0 || cfg.TTL < 0 {
+		return LookupCacheConfig{}, errLookupCacheInvalidConfig
+	}
+	if cfg.MaxEntries == 0 {
+		cfg.MaxEntries = defaultLookupCacheEntries
+	}
+	if cfg.TTL == 0 {
+		cfg.TTL = defaultLookupCacheTTL
+	}
+	return cfg, nil
+}
+
+// LookupCacheStats returns a point-in-time copy of cache counters.
+func (c *CachedClient) LookupCacheStats() LookupCacheStats {
+	if c == nil || c.lookup == nil {
+		return LookupCacheStats{}
+	}
+	return c.lookup.Stats()
+}
+
+func (c *CachedClient) Create(ctx context.Context, req fsmeta.CreateRequest) (fsmeta.CreateResult, error) {
+	result, err := c.base.Create(ctx, req)
+	if err == nil {
+		c.lookup.Put(req.Mount, result.Dentry)
+	}
+	return result, err
+}
+
+func (c *CachedClient) UpdateInode(ctx context.Context, req fsmeta.UpdateInodeRequest) (fsmeta.InodeRecord, error) {
+	return c.base.UpdateInode(ctx, req)
+}
+
+func (c *CachedClient) Lookup(ctx context.Context, req fsmeta.LookupRequest) (fsmeta.DentryRecord, error) {
+	key := lookupCacheKey{mount: req.Mount, parent: req.Parent, name: req.Name}
+	if record, ok := c.lookup.Get(key); ok {
+		return record, nil
+	}
+	record, err := c.base.Lookup(ctx, req)
+	if err == nil {
+		c.lookup.Put(req.Mount, record)
+	}
+	return record, err
+}
+
+func (c *CachedClient) ReadDir(ctx context.Context, req fsmeta.ReadDirRequest) ([]fsmeta.DentryRecord, error) {
+	records, err := c.base.ReadDir(ctx, req)
+	if err == nil && req.SnapshotVersion == 0 {
+		c.lookup.PutMany(req.Mount, records)
+	}
+	return records, err
+}
+
+func (c *CachedClient) ReadDirPlus(ctx context.Context, req fsmeta.ReadDirRequest) ([]fsmeta.DentryAttrPair, error) {
+	pairs, err := c.base.ReadDirPlus(ctx, req)
+	if err == nil && req.SnapshotVersion == 0 {
+		for _, pair := range pairs {
+			c.lookup.Put(req.Mount, pair.Dentry)
+		}
+	}
+	return pairs, err
+}
+
+func (c *CachedClient) WatchSubtree(ctx context.Context, req fsmeta.WatchRequest) (WatchSubscription, error) {
+	return c.base.WatchSubtree(ctx, req)
+}
+
+func (c *CachedClient) GetReadVersion(ctx context.Context, req fsmeta.ReadVersionRequest) (uint64, error) {
+	return c.base.GetReadVersion(ctx, req)
+}
+
+func (c *CachedClient) SnapshotSubtree(ctx context.Context, req fsmeta.SnapshotSubtreeRequest) (fsmeta.SnapshotSubtreeToken, error) {
+	return c.base.SnapshotSubtree(ctx, req)
+}
+
+func (c *CachedClient) RetireSnapshotSubtree(ctx context.Context, token fsmeta.SnapshotSubtreeToken) error {
+	return c.base.RetireSnapshotSubtree(ctx, token)
+}
+
+func (c *CachedClient) GetQuotaUsage(ctx context.Context, req fsmeta.QuotaUsageRequest) (fsmeta.UsageRecord, error) {
+	return c.base.GetQuotaUsage(ctx, req)
+}
+
+func (c *CachedClient) Rename(ctx context.Context, req fsmeta.RenameRequest) error {
+	from := lookupCacheKey{mount: req.Mount, parent: req.FromParent, name: req.FromName}
+	to := lookupCacheKey{mount: req.Mount, parent: req.ToParent, name: req.ToName}
+	record, hadSource := c.lookup.Peek(from)
+	if err := c.base.Rename(ctx, req); err != nil {
+		return err
+	}
+	c.lookup.Invalidate(from)
+	c.lookup.Invalidate(to)
+	if hadSource {
+		record.Parent = req.ToParent
+		record.Name = req.ToName
+		c.lookup.Put(req.Mount, record)
+	}
+	return nil
+}
+
+func (c *CachedClient) RenameSubtree(ctx context.Context, req fsmeta.RenameSubtreeRequest) error {
+	from := lookupCacheKey{mount: req.Mount, parent: req.FromParent, name: req.FromName}
+	to := lookupCacheKey{mount: req.Mount, parent: req.ToParent, name: req.ToName}
+	record, hadSource := c.lookup.Peek(from)
+	if err := c.base.RenameSubtree(ctx, req); err != nil {
+		return err
+	}
+	c.lookup.Invalidate(from)
+	c.lookup.Invalidate(to)
+	if hadSource {
+		record.Parent = req.ToParent
+		record.Name = req.ToName
+		c.lookup.Put(req.Mount, record)
+	}
+	return nil
+}
+
+func (c *CachedClient) Link(ctx context.Context, req fsmeta.LinkRequest) error {
+	if err := c.base.Link(ctx, req); err != nil {
+		return err
+	}
+	c.lookup.Invalidate(lookupCacheKey{mount: req.Mount, parent: req.ToParent, name: req.ToName})
+	return nil
+}
+
+func (c *CachedClient) Unlink(ctx context.Context, req fsmeta.UnlinkRequest) error {
+	if err := c.base.Unlink(ctx, req); err != nil {
+		return err
+	}
+	c.lookup.Invalidate(lookupCacheKey{mount: req.Mount, parent: req.Parent, name: req.Name})
+	return nil
+}
+
+func (c *CachedClient) OpenWriteSession(ctx context.Context, req fsmeta.OpenWriteSessionRequest) (fsmeta.SessionRecord, error) {
+	return c.base.OpenWriteSession(ctx, req)
+}
+
+func (c *CachedClient) HeartbeatWriteSession(ctx context.Context, req fsmeta.HeartbeatWriteSessionRequest) (fsmeta.SessionRecord, error) {
+	return c.base.HeartbeatWriteSession(ctx, req)
+}
+
+func (c *CachedClient) CloseWriteSession(ctx context.Context, req fsmeta.CloseWriteSessionRequest) error {
+	return c.base.CloseWriteSession(ctx, req)
+}
+
+func (c *CachedClient) ExpireWriteSessions(ctx context.Context, req fsmeta.ExpireWriteSessionsRequest) (fsmeta.ExpireWriteSessionsResult, error) {
+	return c.base.ExpireWriteSessions(ctx, req)
+}
+
+func (c *CachedClient) Close() error {
+	if c != nil && c.lookup != nil {
+		c.lookup.Clear()
+	}
+	if c == nil || c.base == nil {
+		return nil
+	}
+	return c.base.Close()
+}
+
+type lookupCacheKey struct {
+	mount  fsmeta.MountID
+	parent fsmeta.InodeID
+	name   string
+}
+
+type lookupCacheEntry struct {
+	key       lookupCacheKey
+	record    fsmeta.DentryRecord
+	expiresAt time.Time
+}
+
+type lookupCache struct {
+	mu         sync.Mutex
+	maxEntries int
+	ttl        time.Duration
+	now        func() time.Time
+	items      map[lookupCacheKey]*list.Element
+	lru        *list.List
+	stats      LookupCacheStats
+}
+
+func newLookupCache(cfg LookupCacheConfig) *lookupCache {
+	return &lookupCache{
+		maxEntries: cfg.MaxEntries,
+		ttl:        cfg.TTL,
+		now:        time.Now,
+		items:      make(map[lookupCacheKey]*list.Element, cfg.MaxEntries),
+		lru:        list.New(),
+	}
+}
+
+func (c *lookupCache) Stats() LookupCacheStats {
+	if c == nil {
+		return LookupCacheStats{}
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.stats
+}
+
+func (c *lookupCache) Get(key lookupCacheKey) (fsmeta.DentryRecord, bool) {
+	if c == nil {
+		return fsmeta.DentryRecord{}, false
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	elem := c.items[key]
+	if elem == nil {
+		c.stats.Misses++
+		return fsmeta.DentryRecord{}, false
+	}
+	entry := elem.Value.(*lookupCacheEntry)
+	if !entry.expiresAt.After(c.now()) {
+		c.removeElement(elem)
+		c.stats.Expired++
+		c.stats.Misses++
+		return fsmeta.DentryRecord{}, false
+	}
+	c.lru.MoveToFront(elem)
+	c.stats.Hits++
+	return entry.record, true
+}
+
+func (c *lookupCache) Peek(key lookupCacheKey) (fsmeta.DentryRecord, bool) {
+	if c == nil {
+		return fsmeta.DentryRecord{}, false
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	elem := c.items[key]
+	if elem == nil {
+		return fsmeta.DentryRecord{}, false
+	}
+	entry := elem.Value.(*lookupCacheEntry)
+	if !entry.expiresAt.After(c.now()) {
+		c.removeElement(elem)
+		c.stats.Expired++
+		return fsmeta.DentryRecord{}, false
+	}
+	return entry.record, true
+}
+
+func (c *lookupCache) Put(mount fsmeta.MountID, record fsmeta.DentryRecord) {
+	if c == nil || c.maxEntries == 0 {
+		return
+	}
+	key := lookupCacheKey{mount: mount, parent: record.Parent, name: record.Name}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.putLocked(key, record)
+}
+
+func (c *lookupCache) PutMany(mount fsmeta.MountID, records []fsmeta.DentryRecord) {
+	for _, record := range records {
+		c.Put(mount, record)
+	}
+}
+
+func (c *lookupCache) Invalidate(key lookupCacheKey) {
+	if c == nil {
+		return
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if elem := c.items[key]; elem != nil {
+		c.removeElement(elem)
+		c.stats.Invalidations++
+	}
+}
+
+func (c *lookupCache) Clear() {
+	if c == nil {
+		return
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.items = make(map[lookupCacheKey]*list.Element, c.maxEntries)
+	c.lru.Init()
+}
+
+func (c *lookupCache) putLocked(key lookupCacheKey, record fsmeta.DentryRecord) {
+	if elem := c.items[key]; elem != nil {
+		entry := elem.Value.(*lookupCacheEntry)
+		entry.record = record
+		entry.expiresAt = c.now().Add(c.ttl)
+		c.lru.MoveToFront(elem)
+		c.stats.Inserts++
+		return
+	}
+	entry := &lookupCacheEntry{
+		key:       key,
+		record:    record,
+		expiresAt: c.now().Add(c.ttl),
+	}
+	c.items[key] = c.lru.PushFront(entry)
+	c.stats.Inserts++
+	for len(c.items) > c.maxEntries {
+		back := c.lru.Back()
+		if back == nil {
+			break
+		}
+		c.removeElement(back)
+		c.stats.Evictions++
+	}
+}
+
+func (c *lookupCache) removeElement(elem *list.Element) {
+	c.lru.Remove(elem)
+	entry := elem.Value.(*lookupCacheEntry)
+	delete(c.items, entry.key)
+}

--- a/fsmeta/client/cache_test.go
+++ b/fsmeta/client/cache_test.go
@@ -1,0 +1,206 @@
+package client
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/feichai0017/NoKV/fsmeta"
+	"github.com/stretchr/testify/require"
+)
+
+type lookupCacheBase struct {
+	lookupCount      int
+	readDirPlusCount int
+	entries          map[lookupCacheKey]fsmeta.DentryRecord
+}
+
+func newLookupCacheBase(entries ...fsmeta.DentryRecord) *lookupCacheBase {
+	base := &lookupCacheBase{entries: make(map[lookupCacheKey]fsmeta.DentryRecord)}
+	for _, entry := range entries {
+		base.entries[lookupCacheKey{mount: "vol", parent: entry.Parent, name: entry.Name}] = entry
+	}
+	return base
+}
+
+func (b *lookupCacheBase) Create(_ context.Context, req fsmeta.CreateRequest) (fsmeta.CreateResult, error) {
+	dentry := fsmeta.DentryRecord{Parent: req.Parent, Name: req.Name, Inode: 99, Type: req.Attrs.Type}
+	b.entries[lookupCacheKey{mount: req.Mount, parent: req.Parent, name: req.Name}] = dentry
+	return fsmeta.CreateResult{Dentry: dentry, Inode: req.Attrs.InodeRecord(99)}, nil
+}
+
+func (b *lookupCacheBase) UpdateInode(context.Context, fsmeta.UpdateInodeRequest) (fsmeta.InodeRecord, error) {
+	return fsmeta.InodeRecord{}, nil
+}
+
+func (b *lookupCacheBase) Lookup(_ context.Context, req fsmeta.LookupRequest) (fsmeta.DentryRecord, error) {
+	b.lookupCount++
+	record, ok := b.entries[lookupCacheKey{mount: req.Mount, parent: req.Parent, name: req.Name}]
+	if !ok {
+		return fsmeta.DentryRecord{}, fsmeta.ErrNotFound
+	}
+	return record, nil
+}
+
+func (b *lookupCacheBase) ReadDir(context.Context, fsmeta.ReadDirRequest) ([]fsmeta.DentryRecord, error) {
+	return nil, nil
+}
+
+func (b *lookupCacheBase) ReadDirPlus(_ context.Context, req fsmeta.ReadDirRequest) ([]fsmeta.DentryAttrPair, error) {
+	b.readDirPlusCount++
+	var out []fsmeta.DentryAttrPair
+	for key, entry := range b.entries {
+		if key.mount == req.Mount && key.parent == req.Parent {
+			out = append(out, fsmeta.DentryAttrPair{Dentry: entry, Inode: fsmeta.InodeRecord{Inode: entry.Inode, Type: entry.Type}})
+		}
+	}
+	return out, nil
+}
+
+func (b *lookupCacheBase) WatchSubtree(context.Context, fsmeta.WatchRequest) (WatchSubscription, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (b *lookupCacheBase) GetReadVersion(context.Context, fsmeta.ReadVersionRequest) (uint64, error) {
+	return 0, nil
+}
+
+func (b *lookupCacheBase) SnapshotSubtree(context.Context, fsmeta.SnapshotSubtreeRequest) (fsmeta.SnapshotSubtreeToken, error) {
+	return fsmeta.SnapshotSubtreeToken{}, nil
+}
+
+func (b *lookupCacheBase) RetireSnapshotSubtree(context.Context, fsmeta.SnapshotSubtreeToken) error {
+	return nil
+}
+
+func (b *lookupCacheBase) GetQuotaUsage(context.Context, fsmeta.QuotaUsageRequest) (fsmeta.UsageRecord, error) {
+	return fsmeta.UsageRecord{}, nil
+}
+
+func (b *lookupCacheBase) Rename(_ context.Context, req fsmeta.RenameRequest) error {
+	from := lookupCacheKey{mount: req.Mount, parent: req.FromParent, name: req.FromName}
+	entry, ok := b.entries[from]
+	if !ok {
+		return fsmeta.ErrNotFound
+	}
+	delete(b.entries, from)
+	entry.Parent = req.ToParent
+	entry.Name = req.ToName
+	b.entries[lookupCacheKey{mount: req.Mount, parent: req.ToParent, name: req.ToName}] = entry
+	return nil
+}
+
+func (b *lookupCacheBase) RenameSubtree(ctx context.Context, req fsmeta.RenameSubtreeRequest) error {
+	return b.Rename(ctx, fsmeta.RenameRequest(req))
+}
+
+func (b *lookupCacheBase) Link(context.Context, fsmeta.LinkRequest) error { return nil }
+
+func (b *lookupCacheBase) Unlink(_ context.Context, req fsmeta.UnlinkRequest) error {
+	delete(b.entries, lookupCacheKey{mount: req.Mount, parent: req.Parent, name: req.Name})
+	return nil
+}
+
+func (b *lookupCacheBase) OpenWriteSession(context.Context, fsmeta.OpenWriteSessionRequest) (fsmeta.SessionRecord, error) {
+	return fsmeta.SessionRecord{}, nil
+}
+
+func (b *lookupCacheBase) HeartbeatWriteSession(context.Context, fsmeta.HeartbeatWriteSessionRequest) (fsmeta.SessionRecord, error) {
+	return fsmeta.SessionRecord{}, nil
+}
+
+func (b *lookupCacheBase) CloseWriteSession(context.Context, fsmeta.CloseWriteSessionRequest) error {
+	return nil
+}
+
+func (b *lookupCacheBase) ExpireWriteSessions(context.Context, fsmeta.ExpireWriteSessionsRequest) (fsmeta.ExpireWriteSessionsResult, error) {
+	return fsmeta.ExpireWriteSessionsResult{}, nil
+}
+
+func (b *lookupCacheBase) Close() error { return nil }
+
+func TestCachedClientLookupHit(t *testing.T) {
+	base := newLookupCacheBase(fsmeta.DentryRecord{Parent: 7, Name: "run", Inode: 42, Type: fsmeta.InodeTypeDirectory})
+	cli, err := NewCachedClient(base, LookupCacheConfig{MaxEntries: 8, TTL: time.Minute})
+	require.NoError(t, err)
+
+	req := fsmeta.LookupRequest{Mount: "vol", Parent: 7, Name: "run"}
+	first, err := cli.Lookup(context.Background(), req)
+	require.NoError(t, err)
+	second, err := cli.Lookup(context.Background(), req)
+	require.NoError(t, err)
+
+	require.Equal(t, first, second)
+	require.Equal(t, 1, base.lookupCount)
+	require.Equal(t, LookupCacheStats{Hits: 1, Misses: 1, Inserts: 1}, cli.LookupCacheStats())
+}
+
+func TestCachedClientExpiresLookup(t *testing.T) {
+	base := newLookupCacheBase(fsmeta.DentryRecord{Parent: 7, Name: "run", Inode: 42, Type: fsmeta.InodeTypeDirectory})
+	cli, err := NewCachedClient(base, LookupCacheConfig{MaxEntries: 8, TTL: time.Nanosecond})
+	require.NoError(t, err)
+
+	req := fsmeta.LookupRequest{Mount: "vol", Parent: 7, Name: "run"}
+	_, err = cli.Lookup(context.Background(), req)
+	require.NoError(t, err)
+	time.Sleep(time.Millisecond)
+	_, err = cli.Lookup(context.Background(), req)
+	require.NoError(t, err)
+
+	require.Equal(t, 2, base.lookupCount)
+	require.Equal(t, uint64(1), cli.LookupCacheStats().Expired)
+}
+
+func TestCachedClientPopulatesFromReadDirPlus(t *testing.T) {
+	base := newLookupCacheBase(fsmeta.DentryRecord{Parent: 7, Name: "run", Inode: 42, Type: fsmeta.InodeTypeDirectory})
+	cli, err := NewCachedClient(base, LookupCacheConfig{MaxEntries: 8, TTL: time.Minute})
+	require.NoError(t, err)
+
+	_, err = cli.ReadDirPlus(context.Background(), fsmeta.ReadDirRequest{Mount: "vol", Parent: 7})
+	require.NoError(t, err)
+	record, err := cli.Lookup(context.Background(), fsmeta.LookupRequest{Mount: "vol", Parent: 7, Name: "run"})
+	require.NoError(t, err)
+
+	require.Equal(t, fsmeta.InodeID(42), record.Inode)
+	require.Equal(t, 0, base.lookupCount)
+	require.Equal(t, 1, base.readDirPlusCount)
+	require.Equal(t, uint64(1), cli.LookupCacheStats().Hits)
+}
+
+func TestCachedClientInvalidatesAfterMutation(t *testing.T) {
+	base := newLookupCacheBase(fsmeta.DentryRecord{Parent: 7, Name: "run", Inode: 42, Type: fsmeta.InodeTypeDirectory})
+	cli, err := NewCachedClient(base, LookupCacheConfig{MaxEntries: 8, TTL: time.Minute})
+	require.NoError(t, err)
+
+	req := fsmeta.LookupRequest{Mount: "vol", Parent: 7, Name: "run"}
+	_, err = cli.Lookup(context.Background(), req)
+	require.NoError(t, err)
+	require.NoError(t, cli.Unlink(context.Background(), fsmeta.UnlinkRequest{Mount: "vol", Parent: 7, Name: "run"}))
+	_, err = cli.Lookup(context.Background(), req)
+	require.ErrorIs(t, err, fsmeta.ErrNotFound)
+
+	require.Equal(t, 2, base.lookupCount)
+	require.Equal(t, uint64(1), cli.LookupCacheStats().Invalidations)
+}
+
+func TestCachedClientMovesRenameHit(t *testing.T) {
+	base := newLookupCacheBase(fsmeta.DentryRecord{Parent: 7, Name: "run.tmp", Inode: 42, Type: fsmeta.InodeTypeDirectory})
+	cli, err := NewCachedClient(base, LookupCacheConfig{MaxEntries: 8, TTL: time.Minute})
+	require.NoError(t, err)
+
+	_, err = cli.Lookup(context.Background(), fsmeta.LookupRequest{Mount: "vol", Parent: 7, Name: "run.tmp"})
+	require.NoError(t, err)
+	require.NoError(t, cli.Rename(context.Background(), fsmeta.RenameRequest{
+		Mount:      "vol",
+		FromParent: 7,
+		FromName:   "run.tmp",
+		ToParent:   8,
+		ToName:     "run",
+	}))
+	record, err := cli.Lookup(context.Background(), fsmeta.LookupRequest{Mount: "vol", Parent: 8, Name: "run"})
+	require.NoError(t, err)
+
+	require.Equal(t, fsmeta.InodeID(42), record.Inode)
+	require.Equal(t, 1, base.lookupCount)
+}

--- a/fsmeta/client/errors.go
+++ b/fsmeta/client/errors.go
@@ -7,6 +7,8 @@ var (
 	errDirectoryReaderRequired     = nokverrors.New(nokverrors.KindInvalidArgument, "fsmeta/client: directory reader is required")
 	errWatchClientRequired         = nokverrors.New(nokverrors.KindInvalidArgument, "fsmeta/client: watch client is required")
 	errStagedPublishClientRequired = nokverrors.New(nokverrors.KindInvalidArgument, "fsmeta/client: staged publish client is required")
+	errCachedClientRequired        = nokverrors.New(nokverrors.KindInvalidArgument, "fsmeta/client: cached client requires an inner client")
+	errLookupCacheInvalidConfig    = nokverrors.New(nokverrors.KindInvalidArgument, "fsmeta/client: invalid lookup cache config")
 	errWatchStreamNotConfigured    = nokverrors.New(nokverrors.KindInvalidArgument, "fsmeta/client: watch stream is not configured")
 	errWatchSessionNotConfigured   = nokverrors.New(nokverrors.KindInvalidArgument, "fsmeta/client: watch session is not configured")
 	errRPCClientNotConfigured      = nokverrors.New(nokverrors.KindInvalidArgument, "fsmeta/client: rpc client is not configured")

--- a/fsmeta/contract/errors.go
+++ b/fsmeta/contract/errors.go
@@ -5,4 +5,5 @@ import nokverrors "github.com/feichai0017/NoKV/errors"
 var (
 	errExecutorRequired = nokverrors.New(nokverrors.KindInvalidArgument, "fsmeta/contract: executor is required")
 	errModelRequired    = nokverrors.New(nokverrors.KindInvalidArgument, "fsmeta/contract: model is required")
+	errMappingRequired  = nokverrors.New(nokverrors.KindInvalidArgument, "fsmeta/contract: inode mapping executor requires a base executor")
 )

--- a/fsmeta/contract/mapping.go
+++ b/fsmeta/contract/mapping.go
@@ -1,0 +1,233 @@
+package contract
+
+import (
+	"context"
+	"sync"
+
+	nokverrors "github.com/feichai0017/NoKV/errors"
+	"github.com/feichai0017/NoKV/fsmeta"
+)
+
+// NewInodeMappingExecutor adapts an external fsmeta service to the contract
+// harness. Generated histories use deterministic inode ids so later operations
+// can refer to objects before the real service allocates storage ids; the
+// adapter translates those planned ids to server-assigned ids at the API
+// boundary and translates returned records back before the model checker sees
+// them.
+func NewInodeMappingExecutor(base Executor) (Executor, error) {
+	if base == nil {
+		return nil, errMappingRequired
+	}
+	m := &inodeMappingExecutor{
+		base:            base,
+		plannedToActual: make(map[fsmeta.InodeID]fsmeta.InodeID),
+		actualToPlanned: make(map[fsmeta.InodeID]fsmeta.InodeID),
+	}
+	m.rememberLocked(fsmeta.RootInode, fsmeta.RootInode)
+	return m, nil
+}
+
+type inodeMappingExecutor struct {
+	base Executor
+
+	mu              sync.RWMutex
+	plannedToActual map[fsmeta.InodeID]fsmeta.InodeID
+	actualToPlanned map[fsmeta.InodeID]fsmeta.InodeID
+}
+
+func (m *inodeMappingExecutor) Create(ctx context.Context, req fsmeta.CreateRequest) (fsmeta.CreateResult, error) {
+	planned, hasPlanned := plannedCreateInode(ctx)
+	req.Parent = m.actualInode(req.Parent)
+	result, err := m.base.Create(ctx, req)
+	if err != nil {
+		if hasPlanned && createOutcomeAmbiguous(err) {
+			if recovered, ok := m.recoverCreate(ctx, req, planned); ok {
+				return recovered, nil
+			}
+		}
+		return fsmeta.CreateResult{}, err
+	}
+	if !hasPlanned {
+		planned = result.Inode.Inode
+	}
+	m.remember(planned, result.Inode.Inode)
+	return m.translateCreateResult(result), nil
+}
+
+func createOutcomeAmbiguous(err error) bool {
+	return nokverrors.Retryable(err)
+}
+
+func (m *inodeMappingExecutor) UpdateInode(ctx context.Context, req fsmeta.UpdateInodeRequest) (fsmeta.InodeRecord, error) {
+	req.Parent = m.actualInode(req.Parent)
+	req.Inode = m.actualInode(req.Inode)
+	record, err := m.base.UpdateInode(ctx, req)
+	if err != nil {
+		return fsmeta.InodeRecord{}, err
+	}
+	return m.translateInodeRecord(record), nil
+}
+
+func (m *inodeMappingExecutor) Lookup(ctx context.Context, req fsmeta.LookupRequest) (fsmeta.DentryRecord, error) {
+	req.Parent = m.actualInode(req.Parent)
+	record, err := m.base.Lookup(ctx, req)
+	if err != nil {
+		return fsmeta.DentryRecord{}, err
+	}
+	return m.translateDentryRecord(record), nil
+}
+
+func (m *inodeMappingExecutor) ReadDirPlus(ctx context.Context, req fsmeta.ReadDirRequest) ([]fsmeta.DentryAttrPair, error) {
+	req.Parent = m.actualInode(req.Parent)
+	pairs, err := m.base.ReadDirPlus(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]fsmeta.DentryAttrPair, len(pairs))
+	for i, pair := range pairs {
+		out[i] = fsmeta.DentryAttrPair{
+			Dentry: m.translateDentryRecord(pair.Dentry),
+			Inode:  m.translateInodeRecord(pair.Inode),
+		}
+	}
+	return out, nil
+}
+
+func (m *inodeMappingExecutor) SnapshotSubtree(ctx context.Context, req fsmeta.SnapshotSubtreeRequest) (fsmeta.SnapshotSubtreeToken, error) {
+	req.RootInode = m.actualInode(req.RootInode)
+	token, err := m.base.SnapshotSubtree(ctx, req)
+	if err != nil {
+		return fsmeta.SnapshotSubtreeToken{}, err
+	}
+	token.RootInode = m.plannedInode(token.RootInode)
+	return token, nil
+}
+
+func (m *inodeMappingExecutor) Rename(ctx context.Context, req fsmeta.RenameRequest) error {
+	req.FromParent = m.actualInode(req.FromParent)
+	req.ToParent = m.actualInode(req.ToParent)
+	return m.base.Rename(ctx, req)
+}
+
+func (m *inodeMappingExecutor) RenameSubtree(ctx context.Context, req fsmeta.RenameSubtreeRequest) error {
+	req.FromParent = m.actualInode(req.FromParent)
+	req.ToParent = m.actualInode(req.ToParent)
+	return m.base.RenameSubtree(ctx, req)
+}
+
+func (m *inodeMappingExecutor) Link(ctx context.Context, req fsmeta.LinkRequest) error {
+	req.FromParent = m.actualInode(req.FromParent)
+	req.ToParent = m.actualInode(req.ToParent)
+	return m.base.Link(ctx, req)
+}
+
+func (m *inodeMappingExecutor) Unlink(ctx context.Context, req fsmeta.UnlinkRequest) error {
+	req.Parent = m.actualInode(req.Parent)
+	return m.base.Unlink(ctx, req)
+}
+
+func (m *inodeMappingExecutor) OpenWriteSession(ctx context.Context, req fsmeta.OpenWriteSessionRequest) (fsmeta.SessionRecord, error) {
+	req.Inode = m.actualInode(req.Inode)
+	record, err := m.base.OpenWriteSession(ctx, req)
+	if err != nil {
+		return fsmeta.SessionRecord{}, err
+	}
+	return m.translateSessionRecord(record), nil
+}
+
+func (m *inodeMappingExecutor) HeartbeatWriteSession(ctx context.Context, req fsmeta.HeartbeatWriteSessionRequest) (fsmeta.SessionRecord, error) {
+	req.Inode = m.actualInode(req.Inode)
+	record, err := m.base.HeartbeatWriteSession(ctx, req)
+	if err != nil {
+		return fsmeta.SessionRecord{}, err
+	}
+	return m.translateSessionRecord(record), nil
+}
+
+func (m *inodeMappingExecutor) CloseWriteSession(ctx context.Context, req fsmeta.CloseWriteSessionRequest) error {
+	req.Inode = m.actualInode(req.Inode)
+	return m.base.CloseWriteSession(ctx, req)
+}
+
+func (m *inodeMappingExecutor) ExpireWriteSessions(ctx context.Context, req fsmeta.ExpireWriteSessionsRequest) (fsmeta.ExpireWriteSessionsResult, error) {
+	return m.base.ExpireWriteSessions(ctx, req)
+}
+
+func (m *inodeMappingExecutor) recoverCreate(ctx context.Context, req fsmeta.CreateRequest, planned fsmeta.InodeID) (fsmeta.CreateResult, bool) {
+	dentry, err := m.base.Lookup(ctx, fsmeta.LookupRequest{
+		Mount:  req.Mount,
+		Parent: req.Parent,
+		Name:   req.Name,
+	})
+	if err != nil {
+		return fsmeta.CreateResult{}, false
+	}
+	m.remember(planned, dentry.Inode)
+	return m.translateCreateResult(fsmeta.CreateResult{
+		Dentry: dentry,
+		Inode:  req.Attrs.InodeRecord(dentry.Inode),
+	}), true
+}
+
+func (m *inodeMappingExecutor) translateCreateResult(result fsmeta.CreateResult) fsmeta.CreateResult {
+	return fsmeta.CreateResult{
+		Dentry: m.translateDentryRecord(result.Dentry),
+		Inode:  m.translateInodeRecord(result.Inode),
+	}
+}
+
+func (m *inodeMappingExecutor) translateDentryRecord(record fsmeta.DentryRecord) fsmeta.DentryRecord {
+	record.Parent = m.plannedInode(record.Parent)
+	record.Inode = m.plannedInode(record.Inode)
+	return record
+}
+
+func (m *inodeMappingExecutor) translateInodeRecord(record fsmeta.InodeRecord) fsmeta.InodeRecord {
+	record.Inode = m.plannedInode(record.Inode)
+	return record
+}
+
+func (m *inodeMappingExecutor) translateSessionRecord(record fsmeta.SessionRecord) fsmeta.SessionRecord {
+	record.Inode = m.plannedInode(record.Inode)
+	return record
+}
+
+func (m *inodeMappingExecutor) actualInode(planned fsmeta.InodeID) fsmeta.InodeID {
+	if planned == 0 {
+		return 0
+	}
+	m.mu.RLock()
+	actual, ok := m.plannedToActual[planned]
+	m.mu.RUnlock()
+	if ok {
+		return actual
+	}
+	return planned
+}
+
+func (m *inodeMappingExecutor) plannedInode(actual fsmeta.InodeID) fsmeta.InodeID {
+	if actual == 0 {
+		return 0
+	}
+	m.mu.RLock()
+	planned, ok := m.actualToPlanned[actual]
+	m.mu.RUnlock()
+	if ok {
+		return planned
+	}
+	return actual
+}
+
+func (m *inodeMappingExecutor) remember(planned, actual fsmeta.InodeID) {
+	if planned == 0 || actual == 0 {
+		return
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.rememberLocked(planned, actual)
+}
+
+func (m *inodeMappingExecutor) rememberLocked(planned, actual fsmeta.InodeID) {
+	m.plannedToActual[planned] = actual
+	m.actualToPlanned[actual] = planned
+}

--- a/fsmeta/contract/mapping_test.go
+++ b/fsmeta/contract/mapping_test.go
@@ -1,0 +1,178 @@
+package contract
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/feichai0017/NoKV/fsmeta"
+)
+
+func TestInodeMappingExecutorTranslatesGeneratedHistoryIDs(t *testing.T) {
+	base := newFakeExternalExecutor()
+	exec, err := NewInodeMappingExecutor(base)
+	if err != nil {
+		t.Fatalf("NewInodeMappingExecutor: %v", err)
+	}
+	model := NewModel("vol")
+	ops := []Operation{
+		{Kind: OpCreate, Mount: "vol", Parent: fsmeta.RootInode, Name: "alpha", Inode: 10, Type: fsmeta.InodeTypeFile, Mode: 0o644},
+		{Kind: OpUpdateInode, Mount: "vol", Parent: fsmeta.RootInode, Name: "alpha", Inode: 10, Size: 42, Mode: 0o600},
+		{Kind: OpReadDirPlus, Mount: "vol", Parent: fsmeta.RootInode, Limit: 16},
+	}
+	if err := Run(context.Background(), exec, model, ops); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if base.lastUpdated != 1000 {
+		t.Fatalf("base update used inode %d, want real inode 1000", base.lastUpdated)
+	}
+}
+
+func TestInodeMappingExecutorRecoversCommittedCreate(t *testing.T) {
+	base := newFakeExternalExecutor()
+	base.createErrAfterCommit = context.DeadlineExceeded
+	exec, err := NewInodeMappingExecutor(base)
+	if err != nil {
+		t.Fatalf("NewInodeMappingExecutor: %v", err)
+	}
+	result, err := exec.Create(withPlannedCreateInode(context.Background(), 10), fsmeta.CreateRequest{
+		Mount:  "vol",
+		Parent: fsmeta.RootInode,
+		Name:   "alpha",
+		Attrs:  fsmeta.CreateAttrs{Type: fsmeta.InodeTypeFile, Mode: 0o644},
+	})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if result.Dentry.Inode != 10 || result.Inode.Inode != 10 {
+		t.Fatalf("result was not translated to planned inode: %+v", result)
+	}
+}
+
+func TestInodeMappingExecutorDoesNotRecoverSemanticCreateError(t *testing.T) {
+	base := newFakeExternalExecutor()
+	_, err := base.Create(context.Background(), fsmeta.CreateRequest{
+		Mount:  "vol",
+		Parent: fsmeta.RootInode,
+		Name:   "alpha",
+		Attrs:  fsmeta.CreateAttrs{Type: fsmeta.InodeTypeDirectory, Mode: 0o755},
+	})
+	if err != nil {
+		t.Fatalf("seed Create: %v", err)
+	}
+	exec, err := NewInodeMappingExecutor(base)
+	if err != nil {
+		t.Fatalf("NewInodeMappingExecutor: %v", err)
+	}
+	_, err = exec.Create(withPlannedCreateInode(context.Background(), 10), fsmeta.CreateRequest{
+		Mount:  "vol",
+		Parent: fsmeta.RootInode,
+		Name:   "alpha",
+		Attrs:  fsmeta.CreateAttrs{Type: fsmeta.InodeTypeFile, Mode: 0o644},
+	})
+	if !errors.Is(err, fsmeta.ErrExists) {
+		t.Fatalf("Create error = %v, want ErrExists", err)
+	}
+}
+
+type fakeExternalExecutor struct {
+	next                 fsmeta.InodeID
+	dentries             map[[2]any]fsmeta.DentryRecord
+	inodes               map[fsmeta.InodeID]fsmeta.InodeRecord
+	lastUpdated          fsmeta.InodeID
+	createErrAfterCommit error
+}
+
+func newFakeExternalExecutor() *fakeExternalExecutor {
+	f := &fakeExternalExecutor{
+		next:     1000,
+		dentries: make(map[[2]any]fsmeta.DentryRecord),
+		inodes:   map[fsmeta.InodeID]fsmeta.InodeRecord{fsmeta.RootInode: {Inode: fsmeta.RootInode, Type: fsmeta.InodeTypeDirectory, LinkCount: 1}},
+	}
+	return f
+}
+
+func (f *fakeExternalExecutor) Create(_ context.Context, req fsmeta.CreateRequest) (fsmeta.CreateResult, error) {
+	key := [2]any{req.Parent, req.Name}
+	if _, ok := f.dentries[key]; ok {
+		return fsmeta.CreateResult{}, fsmeta.ErrExists
+	}
+	inodeID := f.next
+	f.next++
+	inode := req.Attrs.InodeRecord(inodeID)
+	dentry := fsmeta.DentryRecord{Parent: req.Parent, Name: req.Name, Inode: inodeID, Type: req.Attrs.Type}
+	f.dentries[key] = dentry
+	f.inodes[inodeID] = inode
+	if f.createErrAfterCommit != nil {
+		return fsmeta.CreateResult{}, f.createErrAfterCommit
+	}
+	return fsmeta.CreateResult{Dentry: dentry, Inode: inode}, nil
+}
+
+func (f *fakeExternalExecutor) UpdateInode(_ context.Context, req fsmeta.UpdateInodeRequest) (fsmeta.InodeRecord, error) {
+	dentry, ok := f.dentries[[2]any{req.Parent, req.Name}]
+	if !ok || dentry.Inode != req.Inode {
+		return fsmeta.InodeRecord{}, fsmeta.ErrNotFound
+	}
+	inode := f.inodes[req.Inode]
+	inode.Size = req.Size
+	inode.Mode = req.Mode
+	f.inodes[req.Inode] = inode
+	f.lastUpdated = req.Inode
+	return inode, nil
+}
+
+func (f *fakeExternalExecutor) Lookup(_ context.Context, req fsmeta.LookupRequest) (fsmeta.DentryRecord, error) {
+	dentry, ok := f.dentries[[2]any{req.Parent, req.Name}]
+	if !ok {
+		return fsmeta.DentryRecord{}, fsmeta.ErrNotFound
+	}
+	return dentry, nil
+}
+
+func (f *fakeExternalExecutor) ReadDirPlus(_ context.Context, req fsmeta.ReadDirRequest) ([]fsmeta.DentryAttrPair, error) {
+	var out []fsmeta.DentryAttrPair
+	for key, dentry := range f.dentries {
+		if key[0] != req.Parent {
+			continue
+		}
+		out = append(out, fsmeta.DentryAttrPair{Dentry: dentry, Inode: f.inodes[dentry.Inode]})
+	}
+	return out, nil
+}
+
+func (f *fakeExternalExecutor) SnapshotSubtree(_ context.Context, req fsmeta.SnapshotSubtreeRequest) (fsmeta.SnapshotSubtreeToken, error) {
+	return fsmeta.SnapshotSubtreeToken{Mount: req.Mount, RootInode: req.RootInode, ReadVersion: 1}, nil
+}
+
+func (f *fakeExternalExecutor) Rename(context.Context, fsmeta.RenameRequest) error {
+	return nil
+}
+
+func (f *fakeExternalExecutor) RenameSubtree(context.Context, fsmeta.RenameSubtreeRequest) error {
+	return nil
+}
+
+func (f *fakeExternalExecutor) Link(context.Context, fsmeta.LinkRequest) error {
+	return nil
+}
+
+func (f *fakeExternalExecutor) Unlink(context.Context, fsmeta.UnlinkRequest) error {
+	return nil
+}
+
+func (f *fakeExternalExecutor) OpenWriteSession(context.Context, fsmeta.OpenWriteSessionRequest) (fsmeta.SessionRecord, error) {
+	return fsmeta.SessionRecord{}, errors.New("not implemented")
+}
+
+func (f *fakeExternalExecutor) HeartbeatWriteSession(context.Context, fsmeta.HeartbeatWriteSessionRequest) (fsmeta.SessionRecord, error) {
+	return fsmeta.SessionRecord{}, errors.New("not implemented")
+}
+
+func (f *fakeExternalExecutor) CloseWriteSession(context.Context, fsmeta.CloseWriteSessionRequest) error {
+	return errors.New("not implemented")
+}
+
+func (f *fakeExternalExecutor) ExpireWriteSessions(context.Context, fsmeta.ExpireWriteSessionsRequest) (fsmeta.ExpireWriteSessionsResult, error) {
+	return fsmeta.ExpireWriteSessionsResult{}, nil
+}

--- a/fsmeta/exec/runner.go
+++ b/fsmeta/exec/runner.go
@@ -567,6 +567,14 @@ func atomicNotExists(key []byte) *kvrpcpb.AtomicPredicate {
 	return &kvrpcpb.AtomicPredicate{Key: cloneBytes(key), Kind: kvrpcpb.AtomicPredicateKind_ATOMIC_PREDICATE_KIND_NOT_EXISTS}
 }
 
+func atomicValueEquals(key, value []byte) *kvrpcpb.AtomicPredicate {
+	return &kvrpcpb.AtomicPredicate{
+		Key:           cloneBytes(key),
+		Kind:          kvrpcpb.AtomicPredicateKind_ATOMIC_PREDICATE_KIND_VALUE_EQUALS,
+		ExpectedValue: cloneBytes(value),
+	}
+}
+
 // UpdateInode updates mutable inode attributes and applies the size quota delta
 // in the same transaction. The parent field is required because quota and
 // DirPage invalidation are directory-scoped by parent inode and page token.
@@ -589,6 +597,10 @@ func (e *Executor) UpdateInode(ctx context.Context, req fsmeta.UpdateInodeReques
 		if err != nil {
 			return err
 		}
+		dentryValue, err := fsmeta.EncodeDentryValue(dentry)
+		if err != nil {
+			return err
+		}
 		if dentry.Inode != req.Inode {
 			return fsmeta.ErrInvalidRequest
 		}
@@ -607,6 +619,10 @@ func (e *Executor) UpdateInode(ctx context.Context, req fsmeta.UpdateInodeReques
 		// parent, so reject it rather than silently corrupting accounting.
 		if inode.LinkCount != 1 {
 			return fsmeta.ErrInvalidRequest
+		}
+		oldInodeValue, err := fsmeta.EncodeInodeValue(inode)
+		if err != nil {
+			return err
 		}
 		sizeDelta := int64(0)
 		if req.SetSize {
@@ -644,13 +660,15 @@ func (e *Executor) UpdateInode(ctx context.Context, req fsmeta.UpdateInodeReques
 			mutations = append(mutations, quotaMutations...)
 		}
 		if sizeDelta == 0 || len(mutations) == 1 {
-			if err := e.mutateWithAtomicFastPath(ctx, plan.Kind, plan.PrimaryKey, []*kvrpcpb.AtomicPredicate{atomicExists(plan.MutateKeys[0])}, mutations, startVersion, commitVersion); err != nil {
+			predicates := []*kvrpcpb.AtomicPredicate{
+				atomicValueEquals(plan.ReadKeys[0], dentryValue),
+				atomicValueEquals(plan.MutateKeys[0], oldInodeValue),
+			}
+			if err := e.mutateWithAtomicFastPath(ctx, plan.Kind, plan.PrimaryKey, predicates, mutations, startVersion, commitVersion); err != nil {
 				return err
 			}
-		} else {
-			if err := e.mutateWithoutAtomicFastPath(ctx, plan.Kind, plan.PrimaryKey, mutations, startVersion, commitVersion); err != nil {
-				return err
-			}
+		} else if err := e.mutateWithoutAtomicFastPath(ctx, plan.Kind, plan.PrimaryKey, mutations, startVersion, commitVersion); err != nil {
+			return err
 		}
 		updated = inode
 		return nil
@@ -1024,6 +1042,10 @@ func (e *Executor) Link(ctx context.Context, req fsmeta.LinkRequest) error {
 		if err != nil {
 			return err
 		}
+		sourceDentryValue, err := fsmeta.EncodeDentryValue(record)
+		if err != nil {
+			return err
+		}
 		if record.Type == fsmeta.InodeTypeDirectory {
 			return fsmeta.ErrInvalidRequest
 		}
@@ -1047,6 +1069,10 @@ func (e *Executor) Link(ctx context.Context, req fsmeta.LinkRequest) error {
 		}
 		if inode.LinkCount == 0 {
 			inode.LinkCount = 1
+		}
+		oldInodeValue, err := fsmeta.EncodeInodeValue(inode)
+		if err != nil {
+			return err
 		}
 		inode.LinkCount++
 
@@ -1092,7 +1118,15 @@ func (e *Executor) Link(ctx context.Context, req fsmeta.LinkRequest) error {
 		}
 		mutations = append(mutations, quotaMutations...)
 		if len(quotaMutations) == 0 {
-			predicates := []*kvrpcpb.AtomicPredicate{atomicNotExists(plan.ReadKeys[1]), atomicExists(inodeKey)}
+			// Link is safe on 1PC only when the source dentry and inode still
+			// equal the records read by this attempt. These value predicates are
+			// the correctness boundary that prevents overwriting a concurrent
+			// UpdateInode with an older inode body.
+			predicates := []*kvrpcpb.AtomicPredicate{
+				atomicValueEquals(plan.ReadKeys[0], sourceDentryValue),
+				atomicNotExists(plan.ReadKeys[1]),
+				atomicValueEquals(inodeKey, oldInodeValue),
+			}
 			return e.mutateWithAtomicFastPath(ctx, plan.Kind, plan.PrimaryKey, predicates, mutations, startVersion, commitVersion)
 		}
 		return e.mutateWithoutAtomicFastPath(ctx, plan.Kind, plan.PrimaryKey, mutations, startVersion, commitVersion)
@@ -1124,11 +1158,15 @@ func (e *Executor) Unlink(ctx context.Context, req fsmeta.UnlinkRequest) error {
 		if err != nil {
 			return err
 		}
+		dentryValue, err := fsmeta.EncodeDentryValue(record)
+		if err != nil {
+			return err
+		}
 		mutations := []*kvrpcpb.Mutation{{
 			Op:  kvrpcpb.Mutation_Delete,
 			Key: cloneBytes(plan.MutateKeys[0]),
 		}}
-		predicates := []*kvrpcpb.AtomicPredicate{atomicExists(plan.PrimaryKey)}
+		predicates := []*kvrpcpb.AtomicPredicate{atomicValueEquals(plan.PrimaryKey, dentryValue)}
 		if inode, ok, err := e.readInode(ctx, mount, record.Inode, startVersion); err != nil {
 			return err
 		} else if ok {
@@ -1136,7 +1174,11 @@ func (e *Executor) Unlink(ctx context.Context, req fsmeta.UnlinkRequest) error {
 			if err != nil {
 				return err
 			}
-			predicates = append(predicates, atomicExists(inodeKey))
+			oldInodeValue, err := fsmeta.EncodeInodeValue(inode)
+			if err != nil {
+				return err
+			}
+			predicates = append(predicates, atomicValueEquals(inodeKey, oldInodeValue))
 			if inode.LinkCount <= 1 {
 				mutations = append(mutations, &kvrpcpb.Mutation{Op: kvrpcpb.Mutation_Delete, Key: inodeKey})
 			} else {
@@ -1204,6 +1246,14 @@ func (e *Executor) OpenWriteSession(ctx context.Context, req fsmeta.OpenWriteSes
 		if inode.Type != fsmeta.InodeTypeFile {
 			return fsmeta.ErrInvalidRequest
 		}
+		inodeKey, err := fsmeta.EncodeInodeKey(mount, inode.Inode)
+		if err != nil {
+			return err
+		}
+		inodeValue, err := fsmeta.EncodeInodeValue(inode)
+		if err != nil {
+			return err
+		}
 		nowTime := e.clock()
 		expiresUnixNs, ok := sessionExpiryUnixNs(nowTime, req.TTL)
 		if !ok {
@@ -1211,13 +1261,17 @@ func (e *Executor) OpenWriteSession(ctx context.Context, req fsmeta.OpenWriteSes
 		}
 		candidate := fsmeta.SessionRecord{Session: req.Session, Inode: req.Inode, ExpiresUnixNs: expiresUnixNs}
 		now := nowTime.UnixNano()
-		predicates := make([]*kvrpcpb.AtomicPredicate, 0, 2)
+		predicates := make([]*kvrpcpb.AtomicPredicate, 0, 4)
 		if existing, ok, err := e.readSessionByKey(ctx, plan.ReadKeys[1], startVersion); err != nil {
 			return err
 		} else if ok && sessionLive(existing, now) {
 			return fsmeta.ErrExists
 		} else if ok {
-			predicates = append(predicates, atomicExists(plan.ReadKeys[1]))
+			existingValue, err := fsmeta.EncodeSessionValue(existing)
+			if err != nil {
+				return err
+			}
+			predicates = append(predicates, atomicValueEquals(plan.ReadKeys[1], existingValue))
 		} else {
 			predicates = append(predicates, atomicNotExists(plan.ReadKeys[1]))
 		}
@@ -1228,19 +1282,20 @@ func (e *Executor) OpenWriteSession(ctx context.Context, req fsmeta.OpenWriteSes
 			if sessionLive(owner, now) {
 				return fsmeta.ErrExists
 			}
-			predicates = append(predicates, atomicExists(plan.ReadKeys[2]))
+			ownerValue, err := fsmeta.EncodeSessionValue(owner)
+			if err != nil {
+				return err
+			}
+			predicates = append(predicates, atomicValueEquals(plan.ReadKeys[2], ownerValue))
 			staleSessionKey, err := fsmeta.EncodeSessionKey(mount, owner.Inode, owner.Session)
 			if err != nil {
 				return err
 			}
 			if string(staleSessionKey) != string(plan.ReadKeys[1]) {
-				ownerValue, err := fsmeta.EncodeSessionValue(owner)
-				if err != nil {
-					return err
-				}
 				if value, ok, err := e.runner.Get(ctx, staleSessionKey, startVersion); err != nil {
 					return err
 				} else if ok && bytes.Equal(value, ownerValue) {
+					predicates = append(predicates, atomicValueEquals(staleSessionKey, ownerValue))
 					mutations = append(mutations, &kvrpcpb.Mutation{Op: kvrpcpb.Mutation_Delete, Key: staleSessionKey})
 				}
 			}
@@ -1255,13 +1310,12 @@ func (e *Executor) OpenWriteSession(ctx context.Context, req fsmeta.OpenWriteSes
 			&kvrpcpb.Mutation{Op: kvrpcpb.Mutation_Put, Key: cloneBytes(plan.MutateKeys[0]), Value: value},
 			&kvrpcpb.Mutation{Op: kvrpcpb.Mutation_Put, Key: cloneBytes(plan.MutateKeys[1]), Value: value},
 		)
-		// Deleting an arbitrary stale session needs value-compare semantics that
-		// AtomicMutate does not expose; keep that rare cleanup case on 2PC.
-		if len(mutations) == 2 {
-			if err := e.mutateWithAtomicFastPath(ctx, plan.Kind, plan.PrimaryKey, predicates, mutations, startVersion, commitVersion); err != nil {
-				return err
-			}
-		} else if err := e.mutateWithoutAtomicFastPath(ctx, plan.Kind, plan.PrimaryKey, mutations, startVersion, commitVersion); err != nil {
+		predicates = append(predicates, atomicValueEquals(inodeKey, inodeValue))
+		// Open is a value-sensitive admission path: the session-id key, owner
+		// key, inode key, and any stale cleanup key must still match the values
+		// read above. Value predicates make the 1PC attempt a real CAS instead
+		// of an existence-only overwrite.
+		if err := e.mutateWithAtomicFastPath(ctx, plan.Kind, plan.PrimaryKey, predicates, mutations, startVersion, commitVersion); err != nil {
 			return err
 		}
 		record = candidate
@@ -1303,12 +1357,20 @@ func (e *Executor) HeartbeatWriteSession(ctx context.Context, req fsmeta.Heartbe
 		if !ok || !sessionLive(session, now) || session.Inode != req.Inode {
 			return fsmeta.ErrNotFound
 		}
+		sessionValue, err := fsmeta.EncodeSessionValue(session)
+		if err != nil {
+			return err
+		}
 		owner, ok, err := e.readSessionByKey(ctx, plan.ReadKeys[1], startVersion)
 		if err != nil {
 			return err
 		}
 		if !ok || !sessionLive(owner, now) || owner.Session != req.Session || owner.Inode != req.Inode {
 			return fsmeta.ErrNotFound
+		}
+		ownerValue, err := fsmeta.EncodeSessionValue(owner)
+		if err != nil {
+			return err
 		}
 		value, err := fsmeta.EncodeSessionValue(candidate)
 		if err != nil {
@@ -1318,7 +1380,10 @@ func (e *Executor) HeartbeatWriteSession(ctx context.Context, req fsmeta.Heartbe
 			{Op: kvrpcpb.Mutation_Put, Key: cloneBytes(plan.MutateKeys[0]), Value: value},
 			{Op: kvrpcpb.Mutation_Put, Key: cloneBytes(plan.MutateKeys[1]), Value: value},
 		}
-		predicates := []*kvrpcpb.AtomicPredicate{atomicExists(plan.ReadKeys[0]), atomicExists(plan.ReadKeys[1])}
+		predicates := []*kvrpcpb.AtomicPredicate{
+			atomicValueEquals(plan.ReadKeys[0], sessionValue),
+			atomicValueEquals(plan.ReadKeys[1], ownerValue),
+		}
 		if err := e.mutateWithAtomicFastPath(ctx, plan.Kind, plan.PrimaryKey, predicates, mutations, startVersion, commitVersion); err != nil {
 			return err
 		}
@@ -1353,7 +1418,12 @@ func (e *Executor) CloseWriteSession(ctx context.Context, req fsmeta.CloseWriteS
 		if session.Inode != req.Inode {
 			return fsmeta.ErrNotFound
 		}
+		sessionValue, err := fsmeta.EncodeSessionValue(session)
+		if err != nil {
+			return err
+		}
 		mutations := []*kvrpcpb.Mutation{{Op: kvrpcpb.Mutation_Delete, Key: cloneBytes(plan.MutateKeys[0])}}
+		predicates := []*kvrpcpb.AtomicPredicate{atomicValueEquals(plan.ReadKeys[0], sessionValue)}
 		ownerKey, err := fsmeta.EncodeInodeSessionKey(mount, session.Inode)
 		if err != nil {
 			return err
@@ -1361,11 +1431,12 @@ func (e *Executor) CloseWriteSession(ctx context.Context, req fsmeta.CloseWriteS
 		if owner, ok, err := e.readSessionByKey(ctx, ownerKey, startVersion); err != nil {
 			return err
 		} else if ok && owner.Session == req.Session && owner.Inode == session.Inode {
+			ownerValue, err := fsmeta.EncodeSessionValue(owner)
+			if err != nil {
+				return err
+			}
+			predicates = append(predicates, atomicValueEquals(ownerKey, ownerValue))
 			mutations = append(mutations, &kvrpcpb.Mutation{Op: kvrpcpb.Mutation_Delete, Key: ownerKey})
-		}
-		predicates := []*kvrpcpb.AtomicPredicate{atomicExists(plan.ReadKeys[0])}
-		if len(mutations) > 1 {
-			predicates = append(predicates, atomicExists(ownerKey))
 		}
 		return e.mutateWithAtomicFastPath(ctx, plan.Kind, plan.PrimaryKey, predicates, mutations, startVersion, commitVersion)
 	}); err != nil {
@@ -1963,9 +2034,10 @@ func cloneAtomicPredicates(in []*kvrpcpb.AtomicPredicate) []*kvrpcpb.AtomicPredi
 			continue
 		}
 		out = append(out, &kvrpcpb.AtomicPredicate{
-			Key:         cloneBytes(pred.GetKey()),
-			Kind:        pred.GetKind(),
-			ReadVersion: pred.GetReadVersion(),
+			Key:           cloneBytes(pred.GetKey()),
+			Kind:          pred.GetKind(),
+			ReadVersion:   pred.GetReadVersion(),
+			ExpectedValue: cloneBytes(pred.GetExpectedValue()),
 		})
 	}
 	return out

--- a/fsmeta/exec/runner_test.go
+++ b/fsmeta/exec/runner_test.go
@@ -456,6 +456,10 @@ func (r *fakeAtomicRunner) TryAtomicMutate(_ context.Context, primary []byte, pr
 			if !exists {
 				return true, fsmeta.ErrNotFound
 			}
+		case kvrpcpb.AtomicPredicateKind_ATOMIC_PREDICATE_KIND_VALUE_EQUALS:
+			if !exists || !bytes.Equal(r.data[string(pred.GetKey())], pred.GetExpectedValue()) {
+				return true, fsmeta.ErrInvalidValue
+			}
 		default:
 			return true, fsmeta.ErrInvalidRequest
 		}
@@ -687,7 +691,7 @@ func TestExecutorCreateSkipsAtomicMutateWhenQuotaMutates(t *testing.T) {
 	require.Equal(t, quotaKey, base.mutations[0][2].GetKey())
 }
 
-func TestExecutorUpdateInodeUsesAtomicMutateWhenQuotaDoesNotMutate(t *testing.T) {
+func TestExecutorUpdateInodeUsesAtomicMutateWithValuePredicates(t *testing.T) {
 	base := newFakeRunner()
 	runner := &fakeAtomicRunner{fakeRunner: base, handled: true}
 	seedDentry(t, runner.fakeRunner, "vol", 7, "file", 22)
@@ -708,6 +712,8 @@ func TestExecutorUpdateInodeUsesAtomicMutateWhenQuotaDoesNotMutate(t *testing.T)
 	require.Len(t, runner.atomicCalls, 1)
 	require.Empty(t, base.mutations)
 	requireAtomicStatUint(t, executor.Stats(), fsmeta.OperationUpdateInode, "success_total", 1)
+	require.Equal(t, kvrpcpb.AtomicPredicateKind_ATOMIC_PREDICATE_KIND_VALUE_EQUALS, runner.atomicCalls[0].predicates[0].GetKind())
+	require.Equal(t, kvrpcpb.AtomicPredicateKind_ATOMIC_PREDICATE_KIND_VALUE_EQUALS, runner.atomicCalls[0].predicates[1].GetKind())
 
 	stored, ok, err := executor.readInode(context.Background(), testMountIdentity, 22, 99)
 	require.NoError(t, err)
@@ -985,7 +991,7 @@ func TestExecutorWriteSessionLifecycle(t *testing.T) {
 	require.NotContains(t, runner.data, string(ownerKey))
 }
 
-func TestExecutorWriteSessionLifecycleUsesAtomicMutate(t *testing.T) {
+func TestExecutorWriteSessionLifecycleUsesAtomicMutateWithValuePredicates(t *testing.T) {
 	base := newFakeRunner()
 	runner := &fakeAtomicRunner{fakeRunner: base, handled: true}
 	seedInode(t, runner.fakeRunner, "vol", fsmeta.InodeRecord{Inode: 22, Type: fsmeta.InodeTypeFile, LinkCount: 1})
@@ -1016,9 +1022,11 @@ func TestExecutorWriteSessionLifecycleUsesAtomicMutate(t *testing.T) {
 	requireAtomicStatUint(t, stats, fsmeta.OperationOpenWriteSession, "success_total", 1)
 	requireAtomicStatUint(t, stats, fsmeta.OperationHeartbeatSession, "success_total", 1)
 	requireAtomicStatUint(t, stats, fsmeta.OperationCloseSession, "success_total", 1)
+	require.Equal(t, kvrpcpb.AtomicPredicateKind_ATOMIC_PREDICATE_KIND_VALUE_EQUALS, runner.atomicCalls[1].predicates[0].GetKind())
+	require.Equal(t, kvrpcpb.AtomicPredicateKind_ATOMIC_PREDICATE_KIND_VALUE_EQUALS, runner.atomicCalls[2].predicates[0].GetKind())
 }
 
-func TestExecutorOpenWriteSessionSkipsAtomicMutateForStaleSessionCleanup(t *testing.T) {
+func TestExecutorOpenWriteSessionUsesAtomicMutateForStaleSessionCleanup(t *testing.T) {
 	base := newFakeRunner()
 	runner := &fakeAtomicRunner{fakeRunner: base, handled: true}
 	seedInode(t, runner.fakeRunner, "vol", fsmeta.InodeRecord{Inode: 22, Type: fsmeta.InodeTypeFile, LinkCount: 1})
@@ -1042,10 +1050,11 @@ func TestExecutorOpenWriteSessionSkipsAtomicMutateForStaleSessionCleanup(t *test
 	})
 	require.NoError(t, err)
 
-	require.Empty(t, runner.atomicCalls)
-	require.Len(t, base.mutations, 1)
+	require.Len(t, runner.atomicCalls, 1)
+	require.Empty(t, base.mutations)
 	require.NotContains(t, runner.data, string(oldSessionKey))
-	requireAtomicStatUint(t, executor.Stats(), fsmeta.OperationOpenWriteSession, "skip_total", 1)
+	requireAtomicStatUint(t, executor.Stats(), fsmeta.OperationOpenWriteSession, "success_total", 1)
+	require.Equal(t, kvrpcpb.AtomicPredicateKind_ATOMIC_PREDICATE_KIND_VALUE_EQUALS, runner.atomicCalls[0].predicates[2].GetKind())
 }
 
 func TestExecutorWriteSessionRejectsNonPositiveTTL(t *testing.T) {
@@ -1300,7 +1309,7 @@ func TestExecutorLinkCreatesDentryAndIncrementsLinkCount(t *testing.T) {
 	require.Equal(t, [][]QuotaChange{{{Mount: "vol", MountKeyID: 1, Scope: 8, Bytes: 4096, Inodes: 1}}}, quota.changes)
 }
 
-func TestExecutorLinkUsesAtomicMutateWhenQuotaDoesNotMutate(t *testing.T) {
+func TestExecutorLinkUsesAtomicMutateWithValuePredicates(t *testing.T) {
 	base := newFakeRunner()
 	runner := &fakeAtomicRunner{fakeRunner: base, handled: true}
 	seedDentry(t, runner.fakeRunner, "vol", 7, "file", 22)
@@ -1320,6 +1329,9 @@ func TestExecutorLinkUsesAtomicMutateWhenQuotaDoesNotMutate(t *testing.T) {
 	require.Len(t, runner.atomicCalls, 1)
 	require.Empty(t, base.mutations)
 	requireAtomicStatUint(t, executor.Stats(), fsmeta.OperationLink, "success_total", 1)
+	require.Equal(t, kvrpcpb.AtomicPredicateKind_ATOMIC_PREDICATE_KIND_VALUE_EQUALS, runner.atomicCalls[0].predicates[0].GetKind())
+	require.Equal(t, kvrpcpb.AtomicPredicateKind_ATOMIC_PREDICATE_KIND_NOT_EXISTS, runner.atomicCalls[0].predicates[1].GetKind())
+	require.Equal(t, kvrpcpb.AtomicPredicateKind_ATOMIC_PREDICATE_KIND_VALUE_EQUALS, runner.atomicCalls[0].predicates[2].GetKind())
 	inode, ok, err := executor.readInode(context.Background(), testMountIdentity, 22, 99)
 	require.NoError(t, err)
 	require.True(t, ok)
@@ -1771,7 +1783,7 @@ func TestExecutorUnlinkRemovesDentry(t *testing.T) {
 	require.False(t, ok)
 }
 
-func TestExecutorUnlinkUsesAtomicMutateWhenQuotaDoesNotMutate(t *testing.T) {
+func TestExecutorUnlinkUsesAtomicMutateWithValuePredicates(t *testing.T) {
 	base := newFakeRunner()
 	runner := &fakeAtomicRunner{fakeRunner: base, handled: true}
 	seedDentry(t, runner.fakeRunner, "vol", 7, "file", 22)
@@ -1785,6 +1797,8 @@ func TestExecutorUnlinkUsesAtomicMutateWhenQuotaDoesNotMutate(t *testing.T) {
 	require.Len(t, runner.atomicCalls, 1)
 	require.Empty(t, base.mutations)
 	requireAtomicStatUint(t, executor.Stats(), fsmeta.OperationUnlink, "success_total", 1)
+	require.Equal(t, kvrpcpb.AtomicPredicateKind_ATOMIC_PREDICATE_KIND_VALUE_EQUALS, runner.atomicCalls[0].predicates[0].GetKind())
+	require.Equal(t, kvrpcpb.AtomicPredicateKind_ATOMIC_PREDICATE_KIND_VALUE_EQUALS, runner.atomicCalls[0].predicates[1].GetKind())
 	_, ok, err := executor.readInode(context.Background(), testMountIdentity, 22, 99)
 	require.NoError(t, err)
 	require.False(t, ok)

--- a/pb/kv/kv.pb.go
+++ b/pb/kv/kv.pb.go
@@ -225,8 +225,9 @@ func (TxnHeartBeatAction) EnumDescriptor() ([]byte, []int) {
 type AtomicPredicateKind int32
 
 const (
-	AtomicPredicateKind_ATOMIC_PREDICATE_KIND_NOT_EXISTS AtomicPredicateKind = 0
-	AtomicPredicateKind_ATOMIC_PREDICATE_KIND_EXISTS     AtomicPredicateKind = 1
+	AtomicPredicateKind_ATOMIC_PREDICATE_KIND_NOT_EXISTS   AtomicPredicateKind = 0
+	AtomicPredicateKind_ATOMIC_PREDICATE_KIND_EXISTS       AtomicPredicateKind = 1
+	AtomicPredicateKind_ATOMIC_PREDICATE_KIND_VALUE_EQUALS AtomicPredicateKind = 2
 )
 
 // Enum value maps for AtomicPredicateKind.
@@ -234,10 +235,12 @@ var (
 	AtomicPredicateKind_name = map[int32]string{
 		0: "ATOMIC_PREDICATE_KIND_NOT_EXISTS",
 		1: "ATOMIC_PREDICATE_KIND_EXISTS",
+		2: "ATOMIC_PREDICATE_KIND_VALUE_EQUALS",
 	}
 	AtomicPredicateKind_value = map[string]int32{
-		"ATOMIC_PREDICATE_KIND_NOT_EXISTS": 0,
-		"ATOMIC_PREDICATE_KIND_EXISTS":     1,
+		"ATOMIC_PREDICATE_KIND_NOT_EXISTS":   0,
+		"ATOMIC_PREDICATE_KIND_EXISTS":       1,
+		"ATOMIC_PREDICATE_KIND_VALUE_EQUALS": 2,
 	}
 )
 
@@ -1864,6 +1867,7 @@ type AtomicPredicate struct {
 	Key           []byte                 `protobuf:"bytes,1,opt,name=key,proto3" json:"key,omitempty"`
 	Kind          AtomicPredicateKind    `protobuf:"varint,2,opt,name=kind,proto3,enum=nokv.kv.v1.AtomicPredicateKind" json:"kind,omitempty"`
 	ReadVersion   uint64                 `protobuf:"varint,3,opt,name=read_version,json=readVersion,proto3" json:"read_version,omitempty"`
+	ExpectedValue []byte                 `protobuf:"bytes,4,opt,name=expected_value,json=expectedValue,proto3" json:"expected_value,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -1917,6 +1921,13 @@ func (x *AtomicPredicate) GetReadVersion() uint64 {
 		return x.ReadVersion
 	}
 	return 0
+}
+
+func (x *AtomicPredicate) GetExpectedValue() []byte {
+	if x != nil {
+		return x.ExpectedValue
+	}
+	return nil
 }
 
 type TryAtomicMutateRequest struct {
@@ -3835,11 +3846,12 @@ const file_kv_kv_proto_rawDesc = "" +
 	"tombstones\"n\n" +
 	"\x17MVCCMaintenanceResponse\x12*\n" +
 	"\x05error\x18\x01 \x01(\v2\x14.nokv.kv.v1.KeyErrorR\x05error\x12'\n" +
-	"\x0fapplied_entries\x18\x02 \x01(\x04R\x0eappliedEntries\"{\n" +
+	"\x0fapplied_entries\x18\x02 \x01(\x04R\x0eappliedEntries\"\xa2\x01\n" +
 	"\x0fAtomicPredicate\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\fR\x03key\x123\n" +
 	"\x04kind\x18\x02 \x01(\x0e2\x1f.nokv.kv.v1.AtomicPredicateKindR\x04kind\x12!\n" +
-	"\fread_version\x18\x03 \x01(\x04R\vreadVersion\"\xd5\x01\n" +
+	"\fread_version\x18\x03 \x01(\x04R\vreadVersion\x12%\n" +
+	"\x0eexpected_value\x18\x04 \x01(\fR\rexpectedValue\"\xd5\x01\n" +
 	"\x16TryAtomicMutateRequest\x12;\n" +
 	"\n" +
 	"predicates\x18\x01 \x03(\v2\x1b.nokv.kv.v1.AtomicPredicateR\n" +
@@ -3975,10 +3987,11 @@ const file_kv_kv_proto_rawDesc = "" +
 	"\x14TxnHeartBeatNoAction\x10\x00\x12\x1b\n" +
 	"\x17TxnHeartBeatTTLExtended\x10\x01\x12!\n" +
 	"\x1dTxnHeartBeatTTLExpireRollback\x10\x02\x12$\n" +
-	" TxnHeartBeatLockNotExistRollback\x10\x03*]\n" +
+	" TxnHeartBeatLockNotExistRollback\x10\x03*\x85\x01\n" +
 	"\x13AtomicPredicateKind\x12$\n" +
 	" ATOMIC_PREDICATE_KIND_NOT_EXISTS\x10\x00\x12 \n" +
-	"\x1cATOMIC_PREDICATE_KIND_EXISTS\x10\x01*\x91\x01\n" +
+	"\x1cATOMIC_PREDICATE_KIND_EXISTS\x10\x01\x12&\n" +
+	"\"ATOMIC_PREDICATE_KIND_VALUE_EQUALS\x10\x02*\x91\x01\n" +
 	"\x15ApplyWatchEventSource\x12(\n" +
 	"$APPLY_WATCH_EVENT_SOURCE_UNSPECIFIED\x10\x00\x12#\n" +
 	"\x1fAPPLY_WATCH_EVENT_SOURCE_COMMIT\x10\x01\x12)\n" +

--- a/pb/kv/kv.proto
+++ b/pb/kv/kv.proto
@@ -199,12 +199,14 @@ message MVCCMaintenanceResponse {
 enum AtomicPredicateKind {
   ATOMIC_PREDICATE_KIND_NOT_EXISTS = 0;
   ATOMIC_PREDICATE_KIND_EXISTS = 1;
+  ATOMIC_PREDICATE_KIND_VALUE_EQUALS = 2;
 }
 
 message AtomicPredicate {
   bytes key = 1;
   AtomicPredicateKind kind = 2;
   uint64 read_version = 3;
+  bytes expected_value = 4;
 }
 
 message TryAtomicMutateRequest {

--- a/raft/raft.go
+++ b/raft/raft.go
@@ -9,6 +9,7 @@ type (
 	// Aliases to etcd/raft exposed types so callers don't import the dependency directly.
 	StateType        = etcdraft.StateType
 	Config           = etcdraft.Config
+	ReadOnlyOption   = etcdraft.ReadOnlyOption
 	RawNode          = etcdraft.RawNode
 	Ready            = etcdraft.Ready
 	SoftState        = etcdraft.SoftState
@@ -34,6 +35,11 @@ const (
 	StateCandidate    = etcdraft.StateCandidate
 	StateLeader       = etcdraft.StateLeader
 	StatePreCandidate = etcdraft.StatePreCandidate
+)
+
+const (
+	ReadOnlySafe       = etcdraft.ReadOnlySafe
+	ReadOnlyLeaseBased = etcdraft.ReadOnlyLeaseBased
 )
 
 const (

--- a/raftstore/integration/context_propagation_test.go
+++ b/raftstore/integration/context_propagation_test.go
@@ -143,9 +143,13 @@ func TestClientReadWriteHonorContextUnderQuorumLoss(t *testing.T) {
 	_, err := migrate.Init(migrate.InitConfig{WorkDir: seedDir, StoreID: 1, RegionID: 1, PeerID: 101})
 	require.NoError(t, err)
 
-	seed := testcluster.StartNode(t, 1, seedDir, []workdirmode.Mode{workdirmode.ModeSeeded, workdirmode.ModeCluster}, true)
-	target2 := testcluster.StartNode(t, 2, t.TempDir(), nil, false)
-	target3 := testcluster.StartNode(t, 3, t.TempDir(), nil, false)
+	seed := testcluster.StartNodeWithConfig(t, 1, seedDir, testcluster.NodeConfig{
+		AllowedModes:    []workdirmode.Mode{workdirmode.ModeSeeded, workdirmode.ModeCluster},
+		StartPeers:      true,
+		EnableLeaseRead: true,
+	})
+	target2 := testcluster.StartNodeWithConfig(t, 2, t.TempDir(), testcluster.NodeConfig{EnableLeaseRead: true})
+	target3 := testcluster.StartNodeWithConfig(t, 3, t.TempDir(), testcluster.NodeConfig{EnableLeaseRead: true})
 	defer seed.Close(t)
 	defer target2.Close(t)
 	defer target3.Close(t)
@@ -211,16 +215,24 @@ func TestClientReadWriteHonorContextUnderQuorumLoss(t *testing.T) {
 	}()
 
 	readCtx, readCancel := context.WithTimeout(context.Background(), 300*time.Millisecond)
-	defer readCancel()
-	_, err = cli.Get(readCtx, key, 3)
-	require.Error(t, err)
-	require.Equal(t, codes.DeadlineExceeded, status.Code(err))
+	readResp, err := cli.Get(readCtx, key, 3)
+	readCancel()
+	if err == nil {
+		require.Equal(t, value, readResp.GetValue())
+	}
 
 	writeCtx, writeCancel := context.WithTimeout(context.Background(), 300*time.Millisecond)
 	defer writeCancel()
 	err = cli.Put(writeCtx, []byte("ctx-write-key"), []byte("ctx-write-value"), 10, 11, 3000)
 	require.Error(t, err)
 	require.Equal(t, codes.DeadlineExceeded, status.Code(err))
+
+	require.Eventually(t, func() bool {
+		readCtx, readCancel := context.WithTimeout(context.Background(), 300*time.Millisecond)
+		defer readCancel()
+		_, err := cli.Get(readCtx, key, 3)
+		return err != nil
+	}, 3*time.Second, 50*time.Millisecond, "partitioned leader must stop serving lease reads after check-quorum expires")
 
 	seed.UnblockPeer(201)
 	seed.UnblockPeer(301)

--- a/raftstore/peer/config.go
+++ b/raftstore/peer/config.go
@@ -42,6 +42,18 @@ type Config struct {
 	BatchMaxWait time.Duration
 }
 
+// EnableLeaseRead configures etcd/raft's lease-based ReadIndex path. Reads
+// still flow through RawNode.ReadIndex and wait for the returned committed
+// index to be applied, but the leader can answer from its local lease instead
+// of broadcasting every read to a quorum. CheckQuorum is required by
+// etcd/raft for this mode: it is the fence that makes a partitioned old leader
+// step down once its quorum lease is no longer defensible.
+func EnableLeaseRead(cfg myraft.Config) myraft.Config {
+	cfg.CheckQuorum = true
+	cfg.ReadOnlyOption = myraft.ReadOnlyLeaseBased
+	return cfg
+}
+
 // ResolveStorage chooses the backing log engine (in-memory, on-disk, or WAL).
 func ResolveStorage(cfg *Config) (raftlog.PeerStorage, error) {
 	if cfg == nil {

--- a/raftstore/peer/peer.go
+++ b/raftstore/peer/peer.go
@@ -747,9 +747,11 @@ func (p *Peer) finishApply(entries []myraft.Entry) {
 	p.applyMark.DoneMany(indices)
 }
 
-// LinearizableRead performs a raft ReadIndex round-trip to ensure the peer
-// still holds leadership and returns the corresponding log index. Callers
-// should subsequently wait for that index to be applied before reading state.
+// LinearizableRead asks raft for a read index and returns the committed index
+// that must be applied before serving local state. With EnableLeaseRead the
+// underlying RawNode uses etcd/raft's lease-based ReadIndex path, so the leader
+// can answer from its quorum lease without broadcasting every read; without it,
+// ReadIndex falls back to the quorum-confirmed safe path.
 func (p *Peer) LinearizableRead(ctx context.Context) (uint64, error) {
 	if p == nil {
 		return 0, errNilPeer

--- a/raftstore/peer/peer_test.go
+++ b/raftstore/peer/peer_test.go
@@ -62,6 +62,13 @@ func newTestPeer(t *testing.T, storage raftlog.PeerStorage, apply ApplyFunc) *Pe
 	return p
 }
 
+func TestEnableLeaseReadConfig(t *testing.T) {
+	cfg := EnableLeaseRead(myraft.Config{ID: 7, ElectionTick: 5, HeartbeatTick: 1})
+	require.True(t, cfg.CheckQuorum)
+	require.Equal(t, myraft.ReadOnlyLeaseBased, cfg.ReadOnlyOption)
+	require.Equal(t, uint64(7), cfg.ID)
+}
+
 func TestSnapshotExportsPayloadAndRefreshesMetadata(t *testing.T) {
 	storage := newPayloadTestStorage()
 	require.NoError(t, storage.ApplySnapshot(myraft.Snapshot{

--- a/raftstore/server/peer_builder.go
+++ b/raftstore/server/peer_builder.go
@@ -64,5 +64,5 @@ func defaultRaftConfig(base myraft.Config, peerID uint64) myraft.Config {
 	if base.MaxInflightMsgs == 0 {
 		base.MaxInflightMsgs = 256
 	}
-	return base
+	return peer.EnableLeaseRead(base)
 }

--- a/raftstore/server/peer_builder_test.go
+++ b/raftstore/server/peer_builder_test.go
@@ -38,6 +38,8 @@ func TestDefaultRaftConfigAppliesDefaults(t *testing.T) {
 	require.Equal(t, 2, cfg.HeartbeatTick)
 	require.Equal(t, uint64(1<<20), cfg.MaxSizePerMsg)
 	require.Equal(t, 256, cfg.MaxInflightMsgs)
+	require.True(t, cfg.CheckQuorum)
+	require.Equal(t, myraft.ReadOnlyLeaseBased, cfg.ReadOnlyOption)
 }
 
 func TestDefaultRaftConfigPreservesExplicitValues(t *testing.T) {
@@ -52,6 +54,8 @@ func TestDefaultRaftConfigPreservesExplicitValues(t *testing.T) {
 	require.Equal(t, 4, cfg.HeartbeatTick)
 	require.Equal(t, uint64(4096), cfg.MaxSizePerMsg)
 	require.Equal(t, 32, cfg.MaxInflightMsgs)
+	require.True(t, cfg.CheckQuorum)
+	require.Equal(t, myraft.ReadOnlyLeaseBased, cfg.ReadOnlyOption)
 }
 
 func TestDefaultPeerBuilderRequiresLocalPeer(t *testing.T) {

--- a/raftstore/testcluster/cluster.go
+++ b/raftstore/testcluster/cluster.go
@@ -42,11 +42,12 @@ import (
 )
 
 type Node struct {
-	StoreID   uint64
-	WorkDir   string
-	DB        *local.DB
-	LocalMeta *localmeta.Store
-	Server    *serverpkg.Node
+	StoreID         uint64
+	WorkDir         string
+	EnableLeaseRead bool
+	DB              *local.DB
+	LocalMeta       *localmeta.Store
+	Server          *serverpkg.Node
 }
 
 type NodeConfig struct {
@@ -54,6 +55,7 @@ type NodeConfig struct {
 	StartPeers        bool
 	Scheduler         storecontrol.Client
 	HeartbeatInterval time.Duration
+	EnableLeaseRead   bool
 }
 
 type Coordinator struct {
@@ -114,13 +116,7 @@ func StartNodeWithConfig(tb testing.TB, storeID uint64, dir string, cfg NodeConf
 			Scheduler:         cfg.Scheduler,
 			HeartbeatInterval: cfg.HeartbeatInterval,
 		},
-		Raft: myraft.Config{
-			ElectionTick:    5,
-			HeartbeatTick:   1,
-			MaxSizePerMsg:   1 << 20,
-			MaxInflightMsgs: 256,
-			PreVote:         true,
-		},
+		Raft:          raftConfig(0, cfg.EnableLeaseRead),
 		TransportAddr: "127.0.0.1:0",
 	})
 	if err != nil {
@@ -128,7 +124,7 @@ func StartNodeWithConfig(tb testing.TB, storeID uint64, dir string, cfg NodeConf
 		_ = localMeta.Close()
 		tb.Fatalf("new server: %v", err)
 	}
-	node := &Node{StoreID: storeID, WorkDir: dir, DB: db, LocalMeta: localMeta, Server: srv}
+	node := &Node{StoreID: storeID, WorkDir: dir, EnableLeaseRead: cfg.EnableLeaseRead, DB: db, LocalMeta: localMeta, Server: srv}
 	if cfg.StartPeers {
 		StartPeers(tb, node)
 	}
@@ -495,8 +491,13 @@ func (n *Node) Restart(tb testing.TB, allowedModes []workdirmode.Mode, startPeer
 	tb.Helper()
 	workDir := n.WorkDir
 	storeID := n.StoreID
+	enableLeaseRead := n.EnableLeaseRead
 	n.Close(tb)
-	restarted := StartNode(tb, storeID, workDir, allowedModes, startPeers)
+	restarted := StartNodeWithConfig(tb, storeID, workDir, NodeConfig{
+		AllowedModes:    allowedModes,
+		StartPeers:      startPeers,
+		EnableLeaseRead: enableLeaseRead,
+	})
 	*n = *restarted
 }
 
@@ -692,14 +693,7 @@ func peerConfig(node *Node, meta localmeta.RegionMeta, peerID uint64, storage ra
 		return result.Meta.Region, nil
 	}
 	return &peer.Config{
-		RaftConfig: myraft.Config{
-			ID:              peerID,
-			ElectionTick:    5,
-			HeartbeatTick:   1,
-			MaxSizePerMsg:   1 << 20,
-			MaxInflightMsgs: 256,
-			PreVote:         true,
-		},
+		RaftConfig:     raftConfig(peerID, node.EnableLeaseRead),
 		Transport:      node.Server.Transport(),
 		Apply:          raftkv.NewEntryApplier(node.DB),
 		SnapshotExport: snapshotStore.ExportSnapshot,
@@ -708,6 +702,21 @@ func peerConfig(node *Node, meta localmeta.RegionMeta, peerID uint64, storage ra
 		GroupID:        meta.ID,
 		Region:         localmeta.CloneRegionMetaPtr(&meta),
 	}
+}
+
+func raftConfig(peerID uint64, enableLeaseRead bool) myraft.Config {
+	cfg := myraft.Config{
+		ID:              peerID,
+		ElectionTick:    5,
+		HeartbeatTick:   1,
+		MaxSizePerMsg:   1 << 20,
+		MaxInflightMsgs: 256,
+		PreVote:         true,
+	}
+	if enableLeaseRead {
+		return peer.EnableLeaseRead(cfg)
+	}
+	return cfg
 }
 
 func EnsureRegionPeer(tb testing.TB, node *Node, regionID, peerID uint64) {

--- a/scripts/run_fsmeta_benchmarks.sh
+++ b/scripts/run_fsmeta_benchmarks.sh
@@ -4,6 +4,11 @@ set -euo pipefail
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$ROOT"
 
+# Host-side benchmark code validates Eunomia grant evidence returned by the
+# Compose coordinators. Keep the host test process and local Compose containers
+# on the same dev/test key material; production deployments override this env.
+export NOKV_EUNOMIA_GRANT_SIGNING_PRIVATE_KEY="${NOKV_EUNOMIA_GRANT_SIGNING_PRIVATE_KEY:-rM0DUr4noWKwu7NlAoX2A6FXpdUyLESmwvqNYOkeNIc=}"
+
 mode="${NOKV_FSMETA_BENCH_MODE:-compose}"
 profile="${NOKV_FSMETA_PROFILE:-median}"
 run_id="$(date -u +%Y%m%dT%H%M%SZ)"
@@ -70,6 +75,8 @@ artifacts_per_entry="${NOKV_FSMETA_ARTIFACTS_PER_ENTRY:-$default_artifacts_per_e
 workspaces="${NOKV_FSMETA_WORKSPACES:-$default_workspaces}"
 session_ttl="${NOKV_FSMETA_SESSION_TTL:-$default_session_ttl}"
 stale_session_ttl="${NOKV_FSMETA_STALE_SESSION_TTL:-$default_stale_session_ttl}"
+lookup_cache_entries="${NOKV_FSMETA_LOOKUP_CACHE_ENTRIES:-4096}"
+lookup_cache_ttl="${NOKV_FSMETA_LOOKUP_CACHE_TTL:-1s}"
 timeout="${NOKV_FSMETA_TIMEOUT:-$default_timeout}"
 stabilize_seconds="${NOKV_FSMETA_STABILIZE_SECONDS:-$default_stabilize_seconds}"
 
@@ -121,6 +128,8 @@ run_bench() {
 			-fsmeta_workspaces "$workspaces" \
 			-fsmeta_session_ttl "$session_ttl" \
 			-fsmeta_stale_session_ttl "$stale_session_ttl" \
+			-fsmeta_lookup_cache_entries "$lookup_cache_entries" \
+			-fsmeta_lookup_cache_ttl "$lookup_cache_ttl" \
 			-fsmeta_timeout "$timeout" \
 			-fsmeta_output "$output"
 	)
@@ -150,6 +159,8 @@ artifacts_per_entry=$artifacts_per_entry
 workspaces=$workspaces
 session_ttl=$session_ttl
 stale_session_ttl=$stale_session_ttl
+lookup_cache_entries=$lookup_cache_entries
+lookup_cache_ttl=$lookup_cache_ttl
 profile_seconds=$profile_seconds
 targets=$profile_targets
 EOF

--- a/txn/percolator/errors.go
+++ b/txn/percolator/errors.go
@@ -15,6 +15,7 @@ var (
 	errEmptyRollbackKey            = errors.New("percolator: empty key in rollback")
 	errUnsupportedMutationOp       = errors.New("percolator: unsupported mutation op")
 	errInvalidAtomicMutate         = errors.New("percolator: invalid atomic mutate")
+	errAtomicPredicateMismatch     = errors.New("percolator: atomic predicate mismatch")
 	errCommitVersionNotAfterStart  = errors.New("percolator: commit version must be greater than start version")
 	errTxnAlreadyRolledBack        = errors.New("percolator: transaction already rolled back")
 	errLockNotFound                = errors.New("percolator: lock not found")

--- a/txn/percolator/txn.go
+++ b/txn/percolator/txn.go
@@ -15,6 +15,7 @@ package percolator
 
 import (
 	"bytes"
+	"errors"
 	"sync/atomic"
 	"time"
 
@@ -24,6 +25,7 @@ import (
 	"github.com/feichai0017/NoKV/txn/latch"
 	"github.com/feichai0017/NoKV/txn/mvcc"
 	txnstore "github.com/feichai0017/NoKV/txn/storage"
+	"github.com/feichai0017/NoKV/utils"
 )
 
 // Prewrite applies mutation prewrites for a single region transaction.
@@ -531,6 +533,17 @@ func validateAtomicPredicate(reader *Reader, pred *kvrpcpb.AtomicPredicate, star
 	case kvrpcpb.AtomicPredicateKind_ATOMIC_PREDICATE_KIND_EXISTS:
 		if !exists {
 			return keyErrorAbort(errInvalidAtomicMutate)
+		}
+	case kvrpcpb.AtomicPredicateKind_ATOMIC_PREDICATE_KIND_VALUE_EQUALS:
+		value, _, err := reader.GetValue(key, readVersion)
+		if err != nil {
+			if errors.Is(err, utils.ErrKeyNotFound) {
+				return keyErrorRetryable(errAtomicPredicateMismatch)
+			}
+			return keyErrorRetryable(err)
+		}
+		if !bytes.Equal(value, pred.GetExpectedValue()) {
+			return keyErrorRetryable(errAtomicPredicateMismatch)
 		}
 	default:
 		return keyErrorAbort(errInvalidAtomicMutate)

--- a/txn/percolator/txn_test.go
+++ b/txn/percolator/txn_test.go
@@ -454,6 +454,65 @@ func TestApplyAtomicMutateRejectsExistingDentry(t *testing.T) {
 	require.Equal(t, []byte("dentry"), keyErr.GetAlreadyExists().GetKey())
 }
 
+func TestApplyAtomicMutateValueEqualsPredicate(t *testing.T) {
+	db := openTestDB(t)
+	latches := latch.NewManager(16)
+	key := []byte("rmw-key")
+	require.Empty(t, Prewrite(db, latches, &kvrpcpb.PrewriteRequest{
+		StartVersion: 1,
+		PrimaryLock:  key,
+		Mutations: []*kvrpcpb.Mutation{{
+			Op:    kvrpcpb.Mutation_Put,
+			Key:   key,
+			Value: []byte("old"),
+		}},
+	}))
+	require.Nil(t, Commit(db, latches, &kvrpcpb.CommitRequest{
+		Keys:          [][]byte{key},
+		StartVersion:  1,
+		CommitVersion: 5,
+	}))
+
+	result := ApplyAtomicMutate(db, latches, &kvrpcpb.TryAtomicMutateRequest{
+		StartVersion:  6,
+		CommitVersion: 7,
+		Predicates: []*kvrpcpb.AtomicPredicate{{
+			Key:           kv.SafeCopy(nil, key),
+			Kind:          kvrpcpb.AtomicPredicateKind_ATOMIC_PREDICATE_KIND_VALUE_EQUALS,
+			ExpectedValue: []byte("old"),
+		}},
+		Mutations: []*kvrpcpb.Mutation{{
+			Op:    kvrpcpb.Mutation_Put,
+			Key:   kv.SafeCopy(nil, key),
+			Value: []byte("new"),
+		}},
+	})
+	require.Nil(t, result.Error)
+	value, _, err := NewReader(db).GetValue(key, 7)
+	require.NoError(t, err)
+	require.Equal(t, []byte("new"), value)
+
+	result = ApplyAtomicMutate(db, latches, &kvrpcpb.TryAtomicMutateRequest{
+		StartVersion:  8,
+		CommitVersion: 9,
+		Predicates: []*kvrpcpb.AtomicPredicate{{
+			Key:           kv.SafeCopy(nil, key),
+			Kind:          kvrpcpb.AtomicPredicateKind_ATOMIC_PREDICATE_KIND_VALUE_EQUALS,
+			ExpectedValue: []byte("old"),
+		}},
+		Mutations: []*kvrpcpb.Mutation{{
+			Op:    kvrpcpb.Mutation_Put,
+			Key:   kv.SafeCopy(nil, key),
+			Value: []byte("bad"),
+		}},
+	})
+	require.NotNil(t, result.Error)
+	require.Contains(t, result.Error.GetRetryable(), errAtomicPredicateMismatch.Error())
+	value, _, err = NewReader(db).GetValue(key, 9)
+	require.NoError(t, err)
+	require.Equal(t, []byte("new"), value)
+}
+
 func TestApplyAtomicMutateRejectsLockedPredicate(t *testing.T) {
 	opt := testOptionsForDir(filepath.Join(t.TempDir(), "db"))
 	opt.LSMShardCount = 1


### PR DESCRIPTION
## Summary
- add fsmeta client positive lookup cache and benchmark flags
- refactor negative cache slab persistence codec/error handling
- enable raft lease-based read configuration path
- add AtomicMutate value-equals predicates so fsmeta RMW operations can stay on 1PC with CAS safety
- fix fsmeta soak/history harness for server-side inode allocation and bounded final-round execution

## Validation
- make fmt
- make lint
- go test ./...
- cd benchmark && go test ./fsmeta ./fsmeta/workload
- NOKV_SOAK_DOWN=1 NOKV_SOAK_DURATION=2m NOKV_SOAK_ROLLING_RESTARTS=0 NOKV_SOAK_STEPS=8 NOKV_SOAK_BATCH=2 NOKV_SOAK_READY_TIMEOUT=180 ./scripts/soak/fsmeta_soak.sh

Short soak finished with scrub: directories=237 dentries=922 inodes=881 issues=0.