### PR TITLE
Add raftstore follower read modes

### DIFF
--- a/raft/raft.go
+++ b/raft/raft.go
@@ -13,6 +13,7 @@ type (
 	RawNode          = etcdraft.RawNode
 	Ready            = etcdraft.Ready
 	SoftState        = etcdraft.SoftState
+	BasicStatus      = etcdraft.BasicStatus
 	Status           = etcdraft.Status
 	Peer             = etcdraft.Peer
 	ReadState        = etcdraft.ReadState

--- a/raftstore/client/client_kv.go
+++ b/raftstore/client/client_kv.go
@@ -13,8 +13,22 @@ import (
 	"google.golang.org/protobuf/proto"
 )
 
+type regionBatch struct {
+	region regionSnapshot
+	keys   [][]byte
+	ids    []string
+}
+
 // Get issues a StoreKV Get RPC for the provided key/version. It retries on region errors.
 func (c *Client) Get(ctx context.Context, key []byte, version uint64) (*kvrpcpb.GetResponse, error) {
+	return c.GetWithOptions(ctx, key, version, DefaultReadOptions())
+}
+
+// GetWithOptions issues a StoreKV Get with explicit read consistency and
+// routing preference. Follower-prefer reads fall back to the leader when the
+// follower cannot satisfy the requested consistency budget.
+func (c *Client) GetWithOptions(ctx context.Context, key []byte, version uint64, opts ReadOptions) (*kvrpcpb.GetResponse, error) {
+	opts = normalizeReadOptions(opts)
 	var lastErr error
 	var lastKeyErr *kvrpcpb.KeyError
 	for attempt := 0; attempt < c.retry.MaxAttempts; attempt++ {
@@ -22,7 +36,7 @@ func (c *Client) Get(ctx context.Context, key []byte, version uint64) (*kvrpcpb.
 		if err != nil {
 			return nil, err
 		}
-		resp, regionErr, err := c.callGet(ctx, region, key, version)
+		resp, regionErr, err := c.callGetWithFallback(ctx, region, key, version, opts)
 		if err != nil {
 			if isTransportUnavailable(err) {
 				lastErr = err
@@ -77,6 +91,12 @@ func (c *Client) Get(ctx context.Context, key []byte, version uint64) (*kvrpcpb.
 // grouped by region so that each group shares a single BatchGet round-trip
 // and read index.
 func (c *Client) BatchGet(ctx context.Context, keys [][]byte, version uint64) (map[string]*kvrpcpb.GetResponse, error) {
+	return c.BatchGetWithOptions(ctx, keys, version, DefaultReadOptions())
+}
+
+// BatchGetWithOptions fetches multiple keys with explicit read options.
+func (c *Client) BatchGetWithOptions(ctx context.Context, keys [][]byte, version uint64, opts ReadOptions) (map[string]*kvrpcpb.GetResponse, error) {
+	opts = normalizeReadOptions(opts)
 	results := make(map[string]*kvrpcpb.GetResponse, len(keys))
 	if len(keys) == 0 {
 		return results, nil
@@ -85,11 +105,6 @@ func (c *Client) BatchGet(ctx context.Context, keys [][]byte, version uint64) (m
 	for _, key := range keys {
 		keyCopy := append([]byte(nil), key...)
 		pending[string(keyCopy)] = keyCopy
-	}
-	type regionBatch struct {
-		region regionSnapshot
-		keys   [][]byte
-		ids    []string
 	}
 	var lastErr error
 	var lastKeyErr *kvrpcpb.KeyError
@@ -111,7 +126,7 @@ func (c *Client) BatchGet(ctx context.Context, keys [][]byte, version uint64) (m
 		}
 		var completed []string
 		for regionID, group := range groups {
-			resp, regionErr, err := c.callBatchGet(ctx, group.region, group.keys, version)
+			resp, regionErr, err := c.callBatchGetWithFallback(ctx, group.region, group.keys, version, opts)
 			if err != nil {
 				if isTransportUnavailable(err) {
 					lastErr = err
@@ -126,30 +141,12 @@ func (c *Client) BatchGet(ctx context.Context, keys [][]byte, version uint64) (m
 				}
 				continue
 			}
-			responses := resp.GetResponses()
-			for i, keyID := range group.ids {
-				var getResp *kvrpcpb.GetResponse
-				if i < len(responses) && responses[i] != nil {
-					getResp = responses[i]
-				} else {
-					getResp = &kvrpcpb.GetResponse{NotFound: true}
+			if err := c.collectBatchGetResponses(resp, group, results, &completed, &lastKeyErr, version, ctx); err != nil {
+				if errors.Is(err, errReadLockStillLive) {
+					lastErr = err
+					continue
 				}
-				if keyErr := getResp.GetError(); keyErr != nil {
-					if locked := keyErr.GetLocked(); locked != nil {
-						lastKeyErr = keyErr
-						resolved, err := c.resolveReadLock(ctx, locked, version)
-						if err != nil && !errors.Is(err, errReadLockStillLive) {
-							return nil, err
-						}
-						if !resolved {
-							lastErr = txnKeyError(keyErr)
-						}
-						continue
-					}
-					return nil, txnKeyError(keyErr)
-				}
-				results[keyID] = getResp
-				completed = append(completed, keyID)
+				return nil, err
 			}
 		}
 		for _, keyID := range completed {
@@ -184,12 +181,42 @@ func (c *Client) BatchGet(ctx context.Context, keys [][]byte, version uint64) (m
 	return results, nil
 }
 
-func (c *Client) callGet(ctx context.Context, region regionSnapshot, key []byte, version uint64) (*kvrpcpb.GetResponse, *errorpb.RegionError, error) {
-	cl, err := c.storeClient(ctx, region.leader)
+func (c *Client) collectBatchGetResponses(resp *kvrpcpb.BatchGetResponse, group *regionBatch, results map[string]*kvrpcpb.GetResponse, completed *[]string, lastKeyErr **kvrpcpb.KeyError, version uint64, ctx context.Context) error {
+	responses := resp.GetResponses()
+	for i, keyID := range group.ids {
+		var getResp *kvrpcpb.GetResponse
+		if i < len(responses) && responses[i] != nil {
+			getResp = responses[i]
+		} else {
+			getResp = &kvrpcpb.GetResponse{NotFound: true}
+		}
+		if keyErr := getResp.GetError(); keyErr != nil {
+			if locked := keyErr.GetLocked(); locked != nil {
+				*lastKeyErr = keyErr
+				resolved, err := c.resolveReadLock(ctx, locked, version)
+				if err != nil && !errors.Is(err, errReadLockStillLive) {
+					return err
+				}
+				if !resolved {
+					return errReadLockStillLive
+				}
+				continue
+			}
+			return txnKeyError(keyErr)
+		}
+		results[keyID] = getResp
+		*completed = append(*completed, keyID)
+	}
+	return nil
+}
+
+func (c *Client) callGet(ctx context.Context, region regionSnapshot, key []byte, version uint64, opts ReadOptions) (*kvrpcpb.GetResponse, *errorpb.RegionError, error) {
+	targetStoreID := readTargetStore(region, opts)
+	cl, err := c.storeClient(ctx, targetStoreID)
 	if err != nil {
 		return nil, nil, err
 	}
-	header, err := buildContext(region)
+	header, err := buildReadContext(region, targetStoreID, opts)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -206,15 +233,33 @@ func (c *Client) callGet(ctx context.Context, region regionSnapshot, key []byte,
 	return resp.GetResponse(), resp.GetRegionError(), nil
 }
 
-func (c *Client) callBatchGet(ctx context.Context, region regionSnapshot, keys [][]byte, version uint64) (*kvrpcpb.BatchGetResponse, *errorpb.RegionError, error) {
+func (c *Client) callGetWithFallback(ctx context.Context, region regionSnapshot, key []byte, version uint64, opts ReadOptions) (*kvrpcpb.GetResponse, *errorpb.RegionError, error) {
+	resp, regionErr, err := c.callGet(ctx, region, key, version, opts)
+	if err == nil && regionErr == nil {
+		return resp, nil, nil
+	}
+	if !followerPrefer(opts) {
+		return resp, regionErr, err
+	}
+	if err != nil && !isTransportUnavailable(err) {
+		return nil, nil, err
+	}
+	if regionErr != nil && regionErr.GetStaleCommand() == nil {
+		return resp, regionErr, nil
+	}
+	return c.callGet(ctx, region, key, version, leaderReadOptions(opts))
+}
+
+func (c *Client) callBatchGet(ctx context.Context, region regionSnapshot, keys [][]byte, version uint64, opts ReadOptions) (*kvrpcpb.BatchGetResponse, *errorpb.RegionError, error) {
 	if len(keys) == 0 {
 		return &kvrpcpb.BatchGetResponse{}, nil, nil
 	}
-	cl, err := c.storeClient(ctx, region.leader)
+	targetStoreID := readTargetStore(region, opts)
+	cl, err := c.storeClient(ctx, targetStoreID)
 	if err != nil {
 		return nil, nil, err
 	}
-	header, err := buildContext(region)
+	header, err := buildReadContext(region, targetStoreID, opts)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -236,8 +281,31 @@ func (c *Client) callBatchGet(ctx context.Context, region regionSnapshot, keys [
 	return out, resp.GetRegionError(), nil
 }
 
+func (c *Client) callBatchGetWithFallback(ctx context.Context, region regionSnapshot, keys [][]byte, version uint64, opts ReadOptions) (*kvrpcpb.BatchGetResponse, *errorpb.RegionError, error) {
+	resp, regionErr, err := c.callBatchGet(ctx, region, keys, version, opts)
+	if err == nil && regionErr == nil {
+		return resp, nil, nil
+	}
+	if !followerPrefer(opts) {
+		return resp, regionErr, err
+	}
+	if err != nil && !isTransportUnavailable(err) {
+		return nil, nil, err
+	}
+	if regionErr != nil && regionErr.GetStaleCommand() == nil {
+		return resp, regionErr, nil
+	}
+	return c.callBatchGet(ctx, region, keys, version, leaderReadOptions(opts))
+}
+
 // Scan issues a forward StoreKV Scan RPC starting at startKey, reading up to limit keys.
 func (c *Client) Scan(ctx context.Context, startKey []byte, limit uint32, version uint64) ([]*kvrpcpb.KV, error) {
+	return c.ScanWithOptions(ctx, startKey, limit, version, DefaultReadOptions())
+}
+
+// ScanWithOptions issues a scan with explicit read consistency and routing preference.
+func (c *Client) ScanWithOptions(ctx context.Context, startKey []byte, limit uint32, version uint64, opts ReadOptions) ([]*kvrpcpb.KV, error) {
+	opts = normalizeReadOptions(opts)
 	if limit == 0 {
 		return nil, errInvalidScanLimit
 	}
@@ -252,7 +320,7 @@ func (c *Client) Scan(ctx context.Context, startKey []byte, limit uint32, versio
 		if err != nil {
 			return nil, err
 		}
-		resp, regionErr, err := c.callScan(ctx, region, currentKey, remaining, version)
+		resp, regionErr, err := c.callScanWithFallback(ctx, region, currentKey, remaining, version, opts)
 		if err != nil {
 			if isTransportUnavailable(err) {
 				if err := c.waitRetry(ctx, 0, retryTransportUnavailable); err != nil {
@@ -357,12 +425,13 @@ func (c *Client) resolveReadLock(ctx context.Context, locked *kvrpcpb.Locked, re
 	}
 }
 
-func (c *Client) callScan(ctx context.Context, region regionSnapshot, startKey []byte, limit uint32, version uint64) (*kvrpcpb.ScanResponse, *errorpb.RegionError, error) {
-	cl, err := c.storeClient(ctx, region.leader)
+func (c *Client) callScan(ctx context.Context, region regionSnapshot, startKey []byte, limit uint32, version uint64, opts ReadOptions) (*kvrpcpb.ScanResponse, *errorpb.RegionError, error) {
+	targetStoreID := readTargetStore(region, opts)
+	cl, err := c.storeClient(ctx, targetStoreID)
 	if err != nil {
 		return nil, nil, err
 	}
-	header, err := buildContext(region)
+	header, err := buildReadContext(region, targetStoreID, opts)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -379,6 +448,47 @@ func (c *Client) callScan(ctx context.Context, region regionSnapshot, startKey [
 		return nil, nil, normalizeRPCError(err)
 	}
 	return resp.GetResponse(), resp.GetRegionError(), nil
+}
+
+func (c *Client) callScanWithFallback(ctx context.Context, region regionSnapshot, startKey []byte, limit uint32, version uint64, opts ReadOptions) (*kvrpcpb.ScanResponse, *errorpb.RegionError, error) {
+	resp, regionErr, err := c.callScan(ctx, region, startKey, limit, version, opts)
+	if err == nil && regionErr == nil {
+		return resp, nil, nil
+	}
+	if !followerPrefer(opts) {
+		return resp, regionErr, err
+	}
+	if err != nil && !isTransportUnavailable(err) {
+		return nil, nil, err
+	}
+	if regionErr != nil && regionErr.GetStaleCommand() == nil {
+		return resp, regionErr, nil
+	}
+	return c.callScan(ctx, region, startKey, limit, version, leaderReadOptions(opts))
+}
+
+func leaderReadOptions(opts ReadOptions) ReadOptions {
+	opts = normalizeReadOptions(opts)
+	if opts.Consistency == kvrpcpb.ReadConsistency_READ_CONSISTENCY_BOUNDED_STALE {
+		opts.Consistency = kvrpcpb.ReadConsistency_READ_CONSISTENCY_STRONG
+		opts.MaxStaleReadIndex = 0
+		opts.MaxStaleReadMS = 0
+	}
+	opts.Preference = kvrpcpb.ReadPreference_READ_PREFERENCE_LEADER_ONLY
+	return opts
+}
+
+func readTargetStore(region regionSnapshot, opts ReadOptions) uint64 {
+	opts = normalizeReadOptions(opts)
+	if followerPrefer(opts) {
+		if follower := followerStoreID(region); follower != 0 {
+			return follower
+		}
+	}
+	if region.leader != 0 {
+		return region.leader
+	}
+	return defaultLeaderStoreID(region.desc)
 }
 
 // Mutate wraps TwoPhaseCommit with a ready-made mutation slice. The caller must

--- a/raftstore/client/client_kv_test.go
+++ b/raftstore/client/client_kv_test.go
@@ -13,7 +13,9 @@ import (
 	metapb "github.com/feichai0017/NoKV/pb/meta"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/status"
 
 	metawire "github.com/feichai0017/NoKV/meta/wire"
 )
@@ -119,6 +121,319 @@ func keyStrings(keys [][]byte) []string {
 		out = append(out, string(key))
 	}
 	return out
+}
+
+func TestClientGetDefaultUsesStrongLeaderOnly(t *testing.T) {
+	cluster := newMockCluster(clusterRegion{
+		meta: &metapb.RegionDescriptor{
+			RegionId: 1,
+			StartKey: []byte("a"),
+			EndKey:   []byte("z"),
+			Epoch:    &metapb.RegionEpoch{Version: 1, ConfVersion: 1},
+			Peers: []*metapb.RegionPeer{
+				{StoreId: 1, PeerId: 101},
+				{StoreId: 2, PeerId: 102},
+			},
+		},
+		leaderStore: 1,
+		committed: map[string]clusterValue{
+			"k": {value: []byte("v"), commitVersion: 10},
+		},
+	})
+	addr1, stop1 := startMockStore(t, cluster, 1)
+	defer stop1()
+	addr2, stop2 := startMockStore(t, cluster, 2)
+	defer stop2()
+
+	cli, err := New(Config{
+		StoreResolver: staticStoreResolver{
+			{StoreID: 1, Addr: addr1},
+			{StoreID: 2, Addr: addr2},
+		},
+		RegionResolver: resolverFromCluster(cluster),
+		DialOptions:    []grpc.DialOption{grpc.WithTransportCredentials(insecure.NewCredentials())},
+		Retry:          RetryPolicy{MaxAttempts: 2, RegionErrorBackoff: 0},
+	})
+	require.NoError(t, err)
+	defer func() { _ = cli.Close() }()
+
+	resp, err := cli.Get(context.Background(), []byte("k"), 20)
+	require.NoError(t, err)
+	require.Equal(t, []byte("v"), resp.GetValue())
+	require.Equal(t, uint64(1), cluster.lastReadStore)
+}
+
+func TestClientGetWithOptionsFollowerPreferTargetsFollower(t *testing.T) {
+	cluster := newMockCluster(clusterRegion{
+		meta: &metapb.RegionDescriptor{
+			RegionId: 1,
+			StartKey: []byte("a"),
+			EndKey:   []byte("z"),
+			Epoch:    &metapb.RegionEpoch{Version: 1, ConfVersion: 1},
+			Peers: []*metapb.RegionPeer{
+				{StoreId: 1, PeerId: 101},
+				{StoreId: 2, PeerId: 102},
+			},
+		},
+		leaderStore: 1,
+		committed: map[string]clusterValue{
+			"k": {value: []byte("v"), commitVersion: 10},
+		},
+	})
+	addr1, stop1 := startMockStore(t, cluster, 1)
+	defer stop1()
+	addr2, stop2 := startMockStore(t, cluster, 2)
+	defer stop2()
+
+	cli, err := New(Config{
+		StoreResolver: staticStoreResolver{
+			{StoreID: 1, Addr: addr1},
+			{StoreID: 2, Addr: addr2},
+		},
+		RegionResolver: resolverFromCluster(cluster),
+		DialOptions:    []grpc.DialOption{grpc.WithTransportCredentials(insecure.NewCredentials())},
+		Retry:          RetryPolicy{MaxAttempts: 2, RegionErrorBackoff: 0},
+	})
+	require.NoError(t, err)
+	defer func() { _ = cli.Close() }()
+
+	resp, err := cli.GetWithOptions(context.Background(), []byte("k"), 20, ReadOptions{
+		Consistency: kvrpcpb.ReadConsistency_READ_CONSISTENCY_STRONG,
+		Preference:  kvrpcpb.ReadPreference_READ_PREFERENCE_FOLLOWER_PREFER,
+	})
+	require.NoError(t, err)
+	require.Equal(t, []byte("v"), resp.GetValue())
+	require.Equal(t, uint64(2), cluster.lastReadStore)
+}
+
+func TestClientGetWithOptionsStrongFollowerPreferFallsBackToLeader(t *testing.T) {
+	cluster := newMockCluster(clusterRegion{
+		meta: &metapb.RegionDescriptor{
+			RegionId: 1,
+			StartKey: []byte("a"),
+			EndKey:   []byte("z"),
+			Epoch:    &metapb.RegionEpoch{Version: 1, ConfVersion: 1},
+			Peers: []*metapb.RegionPeer{
+				{StoreId: 1, PeerId: 101},
+				{StoreId: 2, PeerId: 102},
+			},
+		},
+		leaderStore:   1,
+		followerStale: true,
+		committed: map[string]clusterValue{
+			"k": {value: []byte("v"), commitVersion: 10},
+		},
+	})
+	addr1, stop1 := startMockStore(t, cluster, 1)
+	defer stop1()
+	addr2, stop2 := startMockStore(t, cluster, 2)
+	defer stop2()
+
+	cli, err := New(Config{
+		StoreResolver: staticStoreResolver{
+			{StoreID: 1, Addr: addr1},
+			{StoreID: 2, Addr: addr2},
+		},
+		RegionResolver: resolverFromCluster(cluster),
+		DialOptions:    []grpc.DialOption{grpc.WithTransportCredentials(insecure.NewCredentials())},
+		Retry:          RetryPolicy{MaxAttempts: 2, RegionErrorBackoff: 0},
+	})
+	require.NoError(t, err)
+	defer func() { _ = cli.Close() }()
+
+	resp, err := cli.GetWithOptions(context.Background(), []byte("k"), 20, ReadOptions{
+		Consistency: kvrpcpb.ReadConsistency_READ_CONSISTENCY_STRONG,
+		Preference:  kvrpcpb.ReadPreference_READ_PREFERENCE_FOLLOWER_PREFER,
+	})
+	require.NoError(t, err)
+	require.Equal(t, []byte("v"), resp.GetValue())
+	require.Equal(t, uint64(1), cluster.lastReadStore)
+}
+
+func TestClientBatchGetWithOptionsFollowerPreferTargetsFollower(t *testing.T) {
+	cluster := newMockCluster(clusterRegion{
+		meta: &metapb.RegionDescriptor{
+			RegionId: 1,
+			StartKey: []byte("a"),
+			EndKey:   []byte("z"),
+			Epoch:    &metapb.RegionEpoch{Version: 1, ConfVersion: 1},
+			Peers: []*metapb.RegionPeer{
+				{StoreId: 1, PeerId: 101},
+				{StoreId: 2, PeerId: 102},
+			},
+		},
+		leaderStore: 1,
+		committed: map[string]clusterValue{
+			"k1": {value: []byte("v1"), commitVersion: 10},
+			"k2": {value: []byte("v2"), commitVersion: 10},
+		},
+	})
+	addr1, stop1 := startMockStore(t, cluster, 1)
+	defer stop1()
+	addr2, stop2 := startMockStore(t, cluster, 2)
+	defer stop2()
+
+	cli, err := New(Config{
+		StoreResolver: staticStoreResolver{
+			{StoreID: 1, Addr: addr1},
+			{StoreID: 2, Addr: addr2},
+		},
+		RegionResolver: resolverFromCluster(cluster),
+		DialOptions:    []grpc.DialOption{grpc.WithTransportCredentials(insecure.NewCredentials())},
+		Retry:          RetryPolicy{MaxAttempts: 2, RegionErrorBackoff: 0},
+	})
+	require.NoError(t, err)
+	defer func() { _ = cli.Close() }()
+
+	resp, err := cli.BatchGetWithOptions(context.Background(), [][]byte{[]byte("k1"), []byte("k2")}, 20, ReadOptions{
+		Consistency: kvrpcpb.ReadConsistency_READ_CONSISTENCY_BOUNDED_STALE,
+		Preference:  kvrpcpb.ReadPreference_READ_PREFERENCE_FOLLOWER_PREFER,
+	})
+	require.NoError(t, err)
+	require.Equal(t, []byte("v1"), resp["k1"].GetValue())
+	require.Equal(t, []byte("v2"), resp["k2"].GetValue())
+	require.Equal(t, uint64(2), cluster.lastReadStore)
+}
+
+func TestClientScanWithOptionsStrongFollowerPreferFallsBackToLeader(t *testing.T) {
+	cluster := newMockCluster(clusterRegion{
+		meta: &metapb.RegionDescriptor{
+			RegionId: 1,
+			StartKey: []byte("a"),
+			EndKey:   []byte("z"),
+			Epoch:    &metapb.RegionEpoch{Version: 1, ConfVersion: 1},
+			Peers: []*metapb.RegionPeer{
+				{StoreId: 1, PeerId: 101},
+				{StoreId: 2, PeerId: 102},
+			},
+		},
+		leaderStore:   1,
+		followerStale: true,
+		committed: map[string]clusterValue{
+			"k1": {value: []byte("v1"), commitVersion: 10},
+			"k2": {value: []byte("v2"), commitVersion: 10},
+		},
+	})
+	addr1, stop1 := startMockStore(t, cluster, 1)
+	defer stop1()
+	addr2, stop2 := startMockStore(t, cluster, 2)
+	defer stop2()
+
+	cli, err := New(Config{
+		StoreResolver: staticStoreResolver{
+			{StoreID: 1, Addr: addr1},
+			{StoreID: 2, Addr: addr2},
+		},
+		RegionResolver: resolverFromCluster(cluster),
+		DialOptions:    []grpc.DialOption{grpc.WithTransportCredentials(insecure.NewCredentials())},
+		Retry:          RetryPolicy{MaxAttempts: 2, RegionErrorBackoff: 0},
+	})
+	require.NoError(t, err)
+	defer func() { _ = cli.Close() }()
+
+	resp, err := cli.ScanWithOptions(context.Background(), []byte("k1"), 2, 20, ReadOptions{
+		Consistency: kvrpcpb.ReadConsistency_READ_CONSISTENCY_STRONG,
+		Preference:  kvrpcpb.ReadPreference_READ_PREFERENCE_FOLLOWER_PREFER,
+	})
+	require.NoError(t, err)
+	require.Len(t, resp, 2)
+	require.Equal(t, uint64(1), cluster.lastReadStore)
+}
+
+func TestClientCallGetWithFallbackReturnsLeaderRegionError(t *testing.T) {
+	descPB := &metapb.RegionDescriptor{
+		RegionId: 1,
+		StartKey: []byte("a"),
+		EndKey:   []byte("z"),
+		Epoch:    &metapb.RegionEpoch{Version: 1, ConfVersion: 1},
+		Peers: []*metapb.RegionPeer{
+			{StoreId: 1, PeerId: 101},
+			{StoreId: 2, PeerId: 102},
+		},
+	}
+	cluster := newMockCluster(clusterRegion{meta: descPB, leaderStore: 1})
+	followerAddr, followerStop := startBlockingStore(t, &scriptedKVService{
+		getFn: func(context.Context, *kvrpcpb.KvGetRequest) (*kvrpcpb.KvGetResponse, error) {
+			return &kvrpcpb.KvGetResponse{RegionError: &errorpb.RegionError{StaleCommand: &errorpb.StaleCommand{}}}, nil
+		},
+	})
+	defer followerStop()
+	leaderAddr, leaderStop := startBlockingStore(t, &scriptedKVService{
+		getFn: func(context.Context, *kvrpcpb.KvGetRequest) (*kvrpcpb.KvGetResponse, error) {
+			return &kvrpcpb.KvGetResponse{RegionError: &errorpb.RegionError{NotLeader: &errorpb.NotLeader{RegionId: 1}}}, nil
+		},
+	})
+	defer leaderStop()
+
+	cli, err := New(Config{
+		StoreResolver: staticStoreResolver{
+			{StoreID: 1, Addr: leaderAddr},
+			{StoreID: 2, Addr: followerAddr},
+		},
+		RegionResolver: resolverFromCluster(cluster),
+		DialOptions:    []grpc.DialOption{grpc.WithTransportCredentials(insecure.NewCredentials())},
+	})
+	require.NoError(t, err)
+	defer func() { _ = cli.Close() }()
+
+	_, regionErr, err := cli.callGetWithFallback(context.Background(), regionSnapshot{
+		desc:   metawire.DescriptorFromProto(descPB),
+		leader: 1,
+	}, []byte("k"), 20, ReadOptions{
+		Consistency: kvrpcpb.ReadConsistency_READ_CONSISTENCY_STRONG,
+		Preference:  kvrpcpb.ReadPreference_READ_PREFERENCE_FOLLOWER_PREFER,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, regionErr)
+	require.NotNil(t, regionErr.GetNotLeader())
+}
+
+func TestClientCallGetWithFallbackReturnsLeaderTransportError(t *testing.T) {
+	descPB := &metapb.RegionDescriptor{
+		RegionId: 1,
+		StartKey: []byte("a"),
+		EndKey:   []byte("z"),
+		Epoch:    &metapb.RegionEpoch{Version: 1, ConfVersion: 1},
+		Peers: []*metapb.RegionPeer{
+			{StoreId: 1, PeerId: 101},
+			{StoreId: 2, PeerId: 102},
+		},
+	}
+	cluster := newMockCluster(clusterRegion{meta: descPB, leaderStore: 1})
+	followerAddr, followerStop := startBlockingStore(t, &scriptedKVService{
+		getFn: func(context.Context, *kvrpcpb.KvGetRequest) (*kvrpcpb.KvGetResponse, error) {
+			return &kvrpcpb.KvGetResponse{RegionError: &errorpb.RegionError{StaleCommand: &errorpb.StaleCommand{}}}, nil
+		},
+	})
+	defer followerStop()
+	leaderAddr, leaderStop := startBlockingStore(t, &scriptedKVService{
+		getFn: func(context.Context, *kvrpcpb.KvGetRequest) (*kvrpcpb.KvGetResponse, error) {
+			return nil, status.Error(codes.Unavailable, "leader transport down")
+		},
+	})
+	defer leaderStop()
+
+	cli, err := New(Config{
+		StoreResolver: staticStoreResolver{
+			{StoreID: 1, Addr: leaderAddr},
+			{StoreID: 2, Addr: followerAddr},
+		},
+		RegionResolver: resolverFromCluster(cluster),
+		DialOptions:    []grpc.DialOption{grpc.WithTransportCredentials(insecure.NewCredentials())},
+	})
+	require.NoError(t, err)
+	defer func() { _ = cli.Close() }()
+
+	_, regionErr, err := cli.callGetWithFallback(context.Background(), regionSnapshot{
+		desc:   metawire.DescriptorFromProto(descPB),
+		leader: 1,
+	}, []byte("k"), 20, ReadOptions{
+		Consistency: kvrpcpb.ReadConsistency_READ_CONSISTENCY_STRONG,
+		Preference:  kvrpcpb.ReadPreference_READ_PREFERENCE_FOLLOWER_PREFER,
+	})
+	require.Nil(t, regionErr)
+	require.Error(t, err)
+	require.True(t, isTransportUnavailable(err))
 }
 
 func TestClientTryAtomicMutateStatsRecordRouteFallback(t *testing.T) {

--- a/raftstore/client/client_route_cache.go
+++ b/raftstore/client/client_route_cache.go
@@ -347,19 +347,26 @@ func contextWithTimeout(parent context.Context, timeout time.Duration) (context.
 }
 
 func buildContext(region regionSnapshot) (*kvrpcpb.Context, error) {
+	return buildReadContext(region, region.leader, ReadOptions{})
+}
+
+func buildReadContext(region regionSnapshot, targetStoreID uint64, opts ReadOptions) (*kvrpcpb.Context, error) {
 	if region.desc.RegionID == 0 {
 		return nil, errRegionMetaMissing
 	}
-	leaderStoreID := region.leader
-	if leaderStoreID == 0 {
-		leaderStoreID = defaultLeaderStoreID(region.desc)
+	opts = normalizeReadOptions(opts)
+	if targetStoreID == 0 {
+		targetStoreID = region.leader
 	}
-	if leaderStoreID == 0 {
+	if targetStoreID == 0 {
+		targetStoreID = defaultLeaderStoreID(region.desc)
+	}
+	if targetStoreID == 0 {
 		return nil, errLeaderUnknown
 	}
 	var peerMeta *metapb.RegionPeer
 	for _, peer := range region.desc.Peers {
-		if peer.StoreID == leaderStoreID {
+		if peer.StoreID == targetStoreID {
 			peerMeta = &metapb.RegionPeer{StoreId: peer.StoreID, PeerId: peer.PeerID}
 			break
 		}
@@ -368,7 +375,7 @@ func buildContext(region regionSnapshot) (*kvrpcpb.Context, error) {
 		return nil, &RegionRoutingError{
 			Operation: "build request context",
 			RegionID:  region.desc.RegionID,
-			Detail:    fmt.Sprintf("leader store %d not found in region peers", leaderStoreID),
+			Detail:    fmt.Sprintf("target store %d not found in region peers", targetStoreID),
 		}
 	}
 	return &kvrpcpb.Context{
@@ -377,8 +384,25 @@ func buildContext(region regionSnapshot) (*kvrpcpb.Context, error) {
 			Version:     region.desc.Epoch.Version,
 			ConfVersion: region.desc.Epoch.ConfVersion,
 		},
-		Peer: peerMeta,
+		Peer:              peerMeta,
+		ReadConsistency:   opts.Consistency,
+		ReadPreference:    opts.Preference,
+		MaxStaleReadIndex: opts.MaxStaleReadIndex,
+		MaxStaleReadMs:    opts.MaxStaleReadMS,
 	}, nil
+}
+
+func followerStoreID(region regionSnapshot) uint64 {
+	if region.desc.RegionID == 0 {
+		return 0
+	}
+	for _, peer := range region.desc.Peers {
+		if peer.StoreID == 0 || peer.StoreID == region.leader {
+			continue
+		}
+		return peer.StoreID
+	}
+	return 0
 }
 
 // defaultLeaderStoreID derives a usable leader store from Region peers when no

--- a/raftstore/client/client_route_cache_test.go
+++ b/raftstore/client/client_route_cache_test.go
@@ -1,0 +1,52 @@
+package client
+
+import (
+	"testing"
+
+	metaregion "github.com/feichai0017/NoKV/meta/region"
+	"github.com/feichai0017/NoKV/meta/topology"
+	kvrpcpb "github.com/feichai0017/NoKV/pb/kv"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBuildReadContextTargetsFollowerAndCarriesPolicy(t *testing.T) {
+	region := regionSnapshot{
+		desc: topology.Descriptor{
+			RegionID: 7,
+			Epoch:    metaregion.Epoch{Version: 2, ConfVersion: 3},
+			Peers: []metaregion.Peer{
+				{StoreID: 1, PeerID: 101},
+				{StoreID: 2, PeerID: 102},
+			},
+		},
+		leader: 1,
+	}
+	ctx, err := buildReadContext(region, 2, ReadOptions{
+		Consistency:       kvrpcpb.ReadConsistency_READ_CONSISTENCY_BOUNDED_STALE,
+		Preference:        kvrpcpb.ReadPreference_READ_PREFERENCE_FOLLOWER_PREFER,
+		MaxStaleReadIndex: 11,
+		MaxStaleReadMS:    12,
+	})
+	require.NoError(t, err)
+	require.Equal(t, uint64(7), ctx.GetRegionId())
+	require.Equal(t, uint64(2), ctx.GetPeer().GetStoreId())
+	require.Equal(t, uint64(102), ctx.GetPeer().GetPeerId())
+	require.Equal(t, kvrpcpb.ReadConsistency_READ_CONSISTENCY_BOUNDED_STALE, ctx.GetReadConsistency())
+	require.Equal(t, kvrpcpb.ReadPreference_READ_PREFERENCE_FOLLOWER_PREFER, ctx.GetReadPreference())
+	require.Equal(t, uint64(11), ctx.GetMaxStaleReadIndex())
+	require.Equal(t, uint64(12), ctx.GetMaxStaleReadMs())
+}
+
+func TestFollowerStoreIDSkipsLeader(t *testing.T) {
+	region := regionSnapshot{
+		desc: topology.Descriptor{
+			RegionID: 7,
+			Peers: []metaregion.Peer{
+				{StoreID: 1, PeerID: 101},
+				{StoreID: 2, PeerID: 102},
+			},
+		},
+		leader: 1,
+	}
+	require.Equal(t, uint64(2), followerStoreID(region))
+}

--- a/raftstore/client/client_test.go
+++ b/raftstore/client/client_test.go
@@ -38,22 +38,24 @@ type clusterPending struct {
 }
 
 type clusterRegion struct {
-	meta         *metapb.RegionDescriptor
-	leaderStore  uint64
-	pending      map[uint64]map[string]clusterPending // startVersion -> key
-	committed    map[string]clusterValue
-	prewriteHits int
-	commitHits   int
-	rollbackHits int
-	resolveHits  int
-	getHits      int
-	scanHits     int
+	meta          *metapb.RegionDescriptor
+	leaderStore   uint64
+	pending       map[uint64]map[string]clusterPending // startVersion -> key
+	committed     map[string]clusterValue
+	followerStale bool
+	prewriteHits  int
+	commitHits    int
+	rollbackHits  int
+	resolveHits   int
+	getHits       int
+	scanHits      int
 }
 
 type mockCluster struct {
 	mu             sync.Mutex
 	regions        map[uint64]*clusterRegion
 	notLeaderCount int32
+	lastReadStore  uint64
 }
 
 func newMockCluster(regions ...clusterRegion) *mockCluster {
@@ -435,14 +437,21 @@ func (mc *mockCluster) get(storeID uint64, req *kvrpcpb.KvGetRequest) (*kvrpcpb.
 		return nil, statusInvalidArgument("region not found")
 	}
 	if storeID != region.leaderStore {
-		atomic.AddInt32(&mc.notLeaderCount, 1)
-		return &kvrpcpb.KvGetResponse{RegionError: notLeaderError(region)}, nil
+		if ctx.GetReadPreference() == kvrpcpb.ReadPreference_READ_PREFERENCE_FOLLOWER_PREFER {
+			if region.followerStale {
+				return &kvrpcpb.KvGetResponse{RegionError: &errorpb.RegionError{StaleCommand: &errorpb.StaleCommand{}}}, nil
+			}
+		} else {
+			atomic.AddInt32(&mc.notLeaderCount, 1)
+			return &kvrpcpb.KvGetResponse{RegionError: notLeaderError(region)}, nil
+		}
 	}
 	if req.GetRequest() == nil {
 		return &kvrpcpb.KvGetResponse{}, nil
 	}
 	key := req.GetRequest().GetKey()
 	version := req.GetRequest().GetVersion()
+	mc.lastReadStore = storeID
 	region.getHits++
 	val, ok := region.committed[string(key)]
 	if !ok || val.commitVersion > version {
@@ -466,8 +475,14 @@ func (mc *mockCluster) scan(storeID uint64, req *kvrpcpb.KvScanRequest) (*kvrpcp
 		return nil, statusInvalidArgument("region not found")
 	}
 	if storeID != region.leaderStore {
-		atomic.AddInt32(&mc.notLeaderCount, 1)
-		return &kvrpcpb.KvScanResponse{RegionError: notLeaderError(region)}, nil
+		if ctx.GetReadPreference() == kvrpcpb.ReadPreference_READ_PREFERENCE_FOLLOWER_PREFER {
+			if region.followerStale {
+				return &kvrpcpb.KvScanResponse{RegionError: &errorpb.RegionError{StaleCommand: &errorpb.StaleCommand{}}}, nil
+			}
+		} else {
+			atomic.AddInt32(&mc.notLeaderCount, 1)
+			return &kvrpcpb.KvScanResponse{RegionError: notLeaderError(region)}, nil
+		}
 	}
 	scanReq := req.GetRequest()
 	if scanReq == nil {
@@ -476,6 +491,7 @@ func (mc *mockCluster) scan(storeID uint64, req *kvrpcpb.KvScanRequest) (*kvrpcp
 	startKey := scanReq.GetStartKey()
 	version := scanReq.GetVersion()
 	limit := scanReq.GetLimit()
+	mc.lastReadStore = storeID
 	if limit == 0 {
 		limit = 1
 	}

--- a/raftstore/client/read_options.go
+++ b/raftstore/client/read_options.go
@@ -1,0 +1,43 @@
+package client
+
+import kvrpcpb "github.com/feichai0017/NoKV/pb/kv"
+
+// ReadOptions controls StoreKV read consistency and routing preference.
+// The zero value preserves the production default: strong leader-only reads.
+type ReadOptions struct {
+	Consistency       kvrpcpb.ReadConsistency
+	Preference        kvrpcpb.ReadPreference
+	MaxStaleReadIndex uint64
+	MaxStaleReadMS    uint64
+}
+
+// DefaultReadOptions is the regular StoreKV read policy used by Get, BatchGet,
+// and Scan. fsmeta mutation plans use read-before-write checks, so the default
+// stays on leader lease reads; follower and bounded-stale reads remain explicit
+// options for workloads that can absorb their freshness cost or semantics.
+func DefaultReadOptions() ReadOptions {
+	return ReadOptions{
+		Consistency: kvrpcpb.ReadConsistency_READ_CONSISTENCY_STRONG,
+		Preference:  kvrpcpb.ReadPreference_READ_PREFERENCE_LEADER_ONLY,
+	}
+}
+
+func normalizeReadOptions(opts ReadOptions) ReadOptions {
+	if opts.Consistency != kvrpcpb.ReadConsistency_READ_CONSISTENCY_BOUNDED_STALE {
+		opts.Consistency = kvrpcpb.ReadConsistency_READ_CONSISTENCY_STRONG
+	}
+	if opts.Preference != kvrpcpb.ReadPreference_READ_PREFERENCE_FOLLOWER_PREFER {
+		opts.Preference = kvrpcpb.ReadPreference_READ_PREFERENCE_LEADER_ONLY
+	}
+	return opts
+}
+
+func strongFollowerPrefer(opts ReadOptions) bool {
+	opts = normalizeReadOptions(opts)
+	return opts.Consistency == kvrpcpb.ReadConsistency_READ_CONSISTENCY_STRONG &&
+		opts.Preference == kvrpcpb.ReadPreference_READ_PREFERENCE_FOLLOWER_PREFER
+}
+
+func followerPrefer(opts ReadOptions) bool {
+	return normalizeReadOptions(opts).Preference == kvrpcpb.ReadPreference_READ_PREFERENCE_FOLLOWER_PREFER
+}

--- a/raftstore/client/read_options_test.go
+++ b/raftstore/client/read_options_test.go
@@ -1,0 +1,53 @@
+package client
+
+import (
+	"testing"
+
+	kvrpcpb "github.com/feichai0017/NoKV/pb/kv"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNormalizeReadOptionsDefaultsToStrongLeaderOnly(t *testing.T) {
+	opts := normalizeReadOptions(ReadOptions{})
+	require.Equal(t, kvrpcpb.ReadConsistency_READ_CONSISTENCY_STRONG, opts.Consistency)
+	require.Equal(t, kvrpcpb.ReadPreference_READ_PREFERENCE_LEADER_ONLY, opts.Preference)
+}
+
+func TestDefaultReadOptionsUseStrongLeaderOnly(t *testing.T) {
+	opts := DefaultReadOptions()
+	require.Equal(t, kvrpcpb.ReadConsistency_READ_CONSISTENCY_STRONG, opts.Consistency)
+	require.Equal(t, kvrpcpb.ReadPreference_READ_PREFERENCE_LEADER_ONLY, opts.Preference)
+	require.Zero(t, opts.MaxStaleReadIndex)
+	require.Zero(t, opts.MaxStaleReadMS)
+}
+
+func TestNormalizeReadOptionsPreservesSupportedFollowerModes(t *testing.T) {
+	opts := normalizeReadOptions(ReadOptions{
+		Consistency:       kvrpcpb.ReadConsistency_READ_CONSISTENCY_BOUNDED_STALE,
+		Preference:        kvrpcpb.ReadPreference_READ_PREFERENCE_FOLLOWER_PREFER,
+		MaxStaleReadIndex: 9,
+		MaxStaleReadMS:    10,
+	})
+	require.Equal(t, kvrpcpb.ReadConsistency_READ_CONSISTENCY_BOUNDED_STALE, opts.Consistency)
+	require.Equal(t, kvrpcpb.ReadPreference_READ_PREFERENCE_FOLLOWER_PREFER, opts.Preference)
+	require.Equal(t, uint64(9), opts.MaxStaleReadIndex)
+	require.Equal(t, uint64(10), opts.MaxStaleReadMS)
+	require.False(t, strongFollowerPrefer(opts))
+	require.True(t, followerPrefer(opts))
+
+	opts.Consistency = kvrpcpb.ReadConsistency_READ_CONSISTENCY_STRONG
+	require.True(t, strongFollowerPrefer(opts))
+}
+
+func TestLeaderReadOptionsUpgradeBoundedStaleToStrong(t *testing.T) {
+	opts := leaderReadOptions(ReadOptions{
+		Consistency:       kvrpcpb.ReadConsistency_READ_CONSISTENCY_BOUNDED_STALE,
+		Preference:        kvrpcpb.ReadPreference_READ_PREFERENCE_FOLLOWER_PREFER,
+		MaxStaleReadIndex: 7,
+		MaxStaleReadMS:    8,
+	})
+	require.Equal(t, kvrpcpb.ReadConsistency_READ_CONSISTENCY_STRONG, opts.Consistency)
+	require.Equal(t, kvrpcpb.ReadPreference_READ_PREFERENCE_LEADER_ONLY, opts.Preference)
+	require.Zero(t, opts.MaxStaleReadIndex)
+	require.Zero(t, opts.MaxStaleReadMS)
+}

--- a/raftstore/kv/service.go
+++ b/raftstore/kv/service.go
@@ -456,5 +456,9 @@ func buildHeader(ctx *kvrpcpb.Context) (*raftcmdpb.CmdHeader, error) {
 		header.PeerId = peer.GetPeerId()
 		header.StoreId = peer.GetStoreId()
 	}
+	header.ReadConsistency = ctx.GetReadConsistency()
+	header.ReadPreference = ctx.GetReadPreference()
+	header.MaxStaleReadIndex = ctx.GetMaxStaleReadIndex()
+	header.MaxStaleReadMs = ctx.GetMaxStaleReadMs()
 	return header, nil
 }

--- a/raftstore/peer/config.go
+++ b/raftstore/peer/config.go
@@ -34,6 +34,10 @@ type Config struct {
 	// state that was previously written by an unpublished install attempt. It is
 	// only intended for store-local install-before-publish retry paths.
 	AllowSnapshotInstallRetry bool
+	// FastLeaseRead requires the raft group to use etcd/raft lease-based
+	// ReadIndex. Reads still enter RawNode.ReadIndex; quorum freshness remains
+	// owned by raft instead of a store-local shortcut.
+	FastLeaseRead bool
 	// BatchMaxSize is the number of proposals collected before flushing
 	// as a single Ready cycle. Defaults to 64 when zero.
 	BatchMaxSize int

--- a/raftstore/peer/errors.go
+++ b/raftstore/peer/errors.go
@@ -24,6 +24,7 @@ var (
 	errSnapshotPayloadInstallRequiresEmptyPeerState = errors.New("raftstore: snapshot payload install requires empty peer state")
 	errSnapshotPayloadInstallRequiresEmptyPeerLog   = errors.New("raftstore: snapshot payload install requires empty peer log")
 	errNilPeer                                      = errors.New("raftstore: peer is nil")
+	errFastLeaseReadRequiresLeaseRead               = errors.New("raftstore: fast lease read requires CheckQuorum and ReadOnlyLeaseBased")
 )
 
 func IsPeerStopped(err error) bool { return errors.Is(err, errPeerStopped) }

--- a/raftstore/peer/peer.go
+++ b/raftstore/peer/peer.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"sync"
 	"sync/atomic"
+	"time"
 
 	raftcmdpb "github.com/feichai0017/NoKV/pb/raft"
 
@@ -62,6 +63,8 @@ type Peer struct {
 	readMu                    sync.Mutex
 	pendingReads              map[string]chan uint64
 	allowSnapshotInstallRetry bool
+	fastLeaseRead             bool
+	lastLeaderContactUnixNano atomic.Int64
 	batcher                   *proposalBatcher
 }
 
@@ -104,6 +107,9 @@ func NewPeer(cfg *Config) (*Peer, error) {
 	if raftCfg.ID == 0 {
 		return nil, errZeroRaftID
 	}
+	if cfg.FastLeaseRead && (raftCfg.ReadOnlyOption != myraft.ReadOnlyLeaseBased || !raftCfg.CheckQuorum) {
+		return nil, errFastLeaseReadRequiresLeaseRead
+	}
 	raftCfg.Storage = storage
 	node, err := myraft.NewRawNode(&raftCfg)
 	if err != nil {
@@ -129,6 +135,7 @@ func NewPeer(cfg *Config) (*Peer, error) {
 		region:                    localmeta.CloneRegionMetaPtr(cfg.Region),
 		pendingReads:              make(map[string]chan uint64),
 		allowSnapshotInstallRetry: cfg.AllowSnapshotInstallRetry,
+		fastLeaseRead:             cfg.FastLeaseRead,
 	}
 	if peer.logRetainEntries == 0 {
 		peer.logRetainEntries = defaultLogRetainEntries
@@ -224,6 +231,7 @@ func (p *Peer) Step(msg myraft.Message) error {
 	if err != nil {
 		return err
 	}
+	p.observeLeaderContact(msg)
 	return p.processReady()
 }
 
@@ -315,6 +323,16 @@ func (p *Peer) Status() myraft.Status {
 	p.mu.Lock()
 	defer p.mu.Unlock()
 	return p.node.Status()
+}
+
+// AppliedIndex returns the highest raft log index fully applied to the local
+// state machine. Follower-read admission uses this as the actual read
+// freshness boundary; commit index alone is not sufficient.
+func (p *Peer) AppliedIndex() uint64 {
+	if p == nil || p.applyMark == nil {
+		return 0
+	}
+	return p.applyMark.DoneUntil()
 }
 
 // Snapshot returns the current raft snapshot enriched with the configured
@@ -762,6 +780,8 @@ func (p *Peer) LinearizableRead(ctx context.Context) (uint64, error) {
 	select {
 	case <-p.stopCtx.Done():
 		return 0, errPeerStopped
+	case <-ctx.Done():
+		return 0, ctx.Err()
 	default:
 	}
 	key, ch := p.startReadIndex()
@@ -781,6 +801,54 @@ func (p *Peer) LinearizableRead(ctx context.Context) (uint64, error) {
 	case <-p.stopCtx.Done():
 		p.cancelReadIndex(key)
 		return 0, errPeerStopped
+	}
+}
+
+// BoundedStaleReadIndex admits a local read without ReadIndex only when the
+// local applied index is within the caller's explicit lag budget. On followers,
+// the optional wall-clock budget also requires recent contact from the current
+// raft leader. This is intentionally separate from LinearizableRead: bounded
+// stale reads are not linearizable and must be requested explicitly.
+func (p *Peer) BoundedStaleReadIndex(maxStaleReadIndex uint64, maxStaleReadAge time.Duration) (uint64, bool) {
+	if p == nil {
+		return 0, false
+	}
+	p.mu.Lock()
+	status := p.node.BasicStatus()
+	p.mu.Unlock()
+	if status.RaftState != myraft.StateLeader && status.RaftState != myraft.StateFollower {
+		return 0, false
+	}
+	applied := p.AppliedIndex()
+	if applied == 0 || status.Commit < applied {
+		return 0, false
+	}
+	if status.Commit-applied > maxStaleReadIndex {
+		return 0, false
+	}
+	if status.RaftState == myraft.StateFollower && maxStaleReadAge > 0 {
+		lastContact := p.lastLeaderContactUnixNano.Load()
+		if lastContact <= 0 || time.Since(time.Unix(0, lastContact)) > maxStaleReadAge {
+			return 0, false
+		}
+	}
+	return applied, true
+}
+
+func (p *Peer) observeLeaderContact(msg myraft.Message) {
+	if p == nil || msg.From == 0 {
+		return
+	}
+	switch msg.Type {
+	case myraft.MsgAppend, myraft.MsgHeartbeat, myraft.MsgSnapshot:
+	default:
+		return
+	}
+	p.mu.Lock()
+	status := p.node.BasicStatus()
+	p.mu.Unlock()
+	if status.Lead == msg.From {
+		p.lastLeaderContactUnixNano.Store(time.Now().UnixNano())
 	}
 }
 

--- a/raftstore/peer/peer_test.go
+++ b/raftstore/peer/peer_test.go
@@ -69,6 +69,94 @@ func TestEnableLeaseReadConfig(t *testing.T) {
 	require.Equal(t, uint64(7), cfg.ID)
 }
 
+func TestFastLeaseReadRequiresLeaseReadConfig(t *testing.T) {
+	_, err := NewPeer(&Config{
+		RaftConfig: myraft.Config{
+			ID:              11,
+			ElectionTick:    5,
+			HeartbeatTick:   1,
+			MaxSizePerMsg:   1 << 20,
+			MaxInflightMsgs: 256,
+			PreVote:         true,
+		},
+		Transport:     noopPayloadTransport{},
+		Apply:         func([]myraft.Entry) error { return nil },
+		Storage:       newPayloadTestStorage(),
+		FastLeaseRead: true,
+		GroupID:       1,
+	})
+	require.ErrorIs(t, err, errFastLeaseReadRequiresLeaseRead)
+}
+
+func TestFastLeaseReadSingleNodeLinearizableReadCompletes(t *testing.T) {
+	storage := newPayloadTestStorage()
+	cfg := EnableLeaseRead(myraft.Config{
+		ID:              11,
+		ElectionTick:    5,
+		HeartbeatTick:   1,
+		MaxSizePerMsg:   1 << 20,
+		MaxInflightMsgs: 256,
+		PreVote:         true,
+	})
+	p, err := NewPeer(&Config{
+		RaftConfig:    cfg,
+		Transport:     noopPayloadTransport{},
+		Apply:         func([]myraft.Entry) error { return nil },
+		Storage:       storage,
+		FastLeaseRead: true,
+		GroupID:       1,
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = p.Close() })
+	require.NoError(t, p.Bootstrap([]myraft.Peer{{ID: 11}}))
+	require.NoError(t, p.Campaign())
+	require.NoError(t, p.Flush())
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	index, err := p.LinearizableRead(ctx)
+	require.NoError(t, err)
+	require.Greater(t, index, uint64(0))
+	require.NoError(t, p.WaitApplied(ctx, index))
+	p.readMu.Lock()
+	defer p.readMu.Unlock()
+	require.Empty(t, p.pendingReads)
+}
+
+func TestBoundedStaleReadIndexUsesAppliedProgress(t *testing.T) {
+	storage := newPayloadTestStorage()
+	cfg := EnableLeaseRead(myraft.Config{
+		ID:              11,
+		ElectionTick:    5,
+		HeartbeatTick:   1,
+		MaxSizePerMsg:   1 << 20,
+		MaxInflightMsgs: 256,
+		PreVote:         true,
+	})
+	p, err := NewPeer(&Config{
+		RaftConfig:    cfg,
+		Transport:     noopPayloadTransport{},
+		Apply:         func([]myraft.Entry) error { return nil },
+		Storage:       storage,
+		FastLeaseRead: true,
+		GroupID:       1,
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = p.Close() })
+
+	index, ok := p.BoundedStaleReadIndex(0, 0)
+	require.False(t, ok)
+	require.Zero(t, index)
+
+	require.NoError(t, p.Bootstrap([]myraft.Peer{{ID: 11}}))
+	require.NoError(t, p.Campaign())
+	require.NoError(t, p.Flush())
+
+	index, ok = p.BoundedStaleReadIndex(0, 0)
+	require.True(t, ok)
+	require.Equal(t, p.AppliedIndex(), index)
+}
+
 func TestSnapshotExportsPayloadAndRefreshesMetadata(t *testing.T) {
 	storage := newPayloadTestStorage()
 	require.NoError(t, storage.ApplySnapshot(myraft.Snapshot{

--- a/raftstore/server/peer_builder.go
+++ b/raftstore/server/peer_builder.go
@@ -46,6 +46,7 @@ func defaultPeerBuilder(storage Storage, localMeta *localmeta.Store, storeID uin
 			Storage:        peerStorage,
 			GroupID:        meta.ID,
 			Region:         localmeta.CloneRegionMetaPtr(&meta),
+			FastLeaseRead:  true,
 		}, nil
 	}
 }

--- a/raftstore/server/peer_builder_test.go
+++ b/raftstore/server/peer_builder_test.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"fmt"
+	"io"
 	"testing"
 
 	"github.com/feichai0017/NoKV/engine/index"
@@ -10,6 +11,7 @@ import (
 	myraft "github.com/feichai0017/NoKV/raft"
 	localmeta "github.com/feichai0017/NoKV/raftstore/localmeta"
 	"github.com/feichai0017/NoKV/raftstore/raftlog"
+	snapshotpkg "github.com/feichai0017/NoKV/raftstore/snapshot"
 	txnstore "github.com/feichai0017/NoKV/txn/storage"
 	"github.com/stretchr/testify/require"
 )
@@ -28,8 +30,22 @@ func (fakeBuilderRaftLog) Open(groupID uint64, meta *localmeta.Store) (raftlog.P
 	return nil, nil
 }
 
+type fakeBuilderSnapshotStore struct{}
+
+func (fakeBuilderSnapshotStore) ExportSnapshot(localmeta.RegionMeta) ([]byte, error) { return nil, nil }
+func (fakeBuilderSnapshotStore) ImportSnapshot([]byte) (*snapshotpkg.ImportResult, error) {
+	return &snapshotpkg.ImportResult{}, nil
+}
+func (fakeBuilderSnapshotStore) ExportSnapshotTo(io.Writer, localmeta.RegionMeta) (snapshotpkg.Meta, error) {
+	return snapshotpkg.Meta{}, nil
+}
+func (fakeBuilderSnapshotStore) ImportSnapshotFrom(io.Reader) (*snapshotpkg.ImportResult, error) {
+	return &snapshotpkg.ImportResult{}, nil
+}
+
 var _ txnstore.Store = fakeBuilderMVCCStore{}
 var _ RaftLog = fakeBuilderRaftLog{}
+var _ snapshotpkg.SnapshotStore = fakeBuilderSnapshotStore{}
 
 func TestDefaultRaftConfigAppliesDefaults(t *testing.T) {
 	cfg := defaultRaftConfig(myraft.Config{}, 17)
@@ -79,4 +95,20 @@ func TestDefaultPeerBuilderRequiresSnapshotStorage(t *testing.T) {
 	})
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "snapshot storage")
+}
+
+func TestDefaultPeerBuilderEnablesFastLeaseRead(t *testing.T) {
+	builder := defaultPeerBuilder(Storage{
+		MVCC:     fakeBuilderMVCCStore{},
+		Raft:     fakeBuilderRaftLog{},
+		Snapshot: fakeBuilderSnapshotStore{},
+	}, nil, 1, myraft.Config{}, nil)
+	cfg, err := builder(localmeta.RegionMeta{
+		ID:    7,
+		Peers: []metaregion.Peer{{StoreID: 1, PeerID: 11}},
+	})
+	require.NoError(t, err)
+	require.True(t, cfg.FastLeaseRead)
+	require.True(t, cfg.RaftConfig.CheckQuorum)
+	require.Equal(t, myraft.ReadOnlyLeaseBased, cfg.RaftConfig.ReadOnlyOption)
 }

--- a/raftstore/store/command_ops.go
+++ b/raftstore/store/command_ops.go
@@ -3,12 +3,15 @@ package store
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
+	"time"
+
 	errorpb "github.com/feichai0017/NoKV/pb/error"
+	kvrpcpb "github.com/feichai0017/NoKV/pb/kv"
 	metapb "github.com/feichai0017/NoKV/pb/meta"
 	raftcmdpb "github.com/feichai0017/NoKV/pb/raft"
 	localmeta "github.com/feichai0017/NoKV/raftstore/localmeta"
-	"time"
 
 	myraft "github.com/feichai0017/NoKV/raft"
 	"github.com/feichai0017/NoKV/raftstore/peer"
@@ -109,30 +112,38 @@ func (s *Store) validateCommandClass(class AdmissionClass, req *raftcmdpb.RaftCm
 		}
 		return nil, meta, resp, nil
 	}
-	status := peer.Status()
-	if status.RaftState != myraft.StateLeader {
-		resp := &raftcmdpb.RaftCmdResponse{Header: req.Header, RegionError: notLeaderError(meta, status.Lead)}
-		if class != AdmissionClassUnknown {
-			s.recordAdmission(Admission{
-				Class:     class,
-				Reason:    AdmissionReasonNotLeader,
-				RegionID:  regionID,
-				PeerID:    peer.ID(),
-				RequestID: req.Header.GetRequestId(),
-				Detail:    "local peer is not leader",
-			})
-		}
-		return nil, meta, resp, nil
-	}
 	req.Header.PeerId = peer.ID()
 	return peer, meta, nil, nil
+}
+
+func (s *Store) validateLeaderCommandClass(class AdmissionClass, req *raftcmdpb.RaftCmdRequest) (*peer.Peer, localmeta.RegionMeta, *raftcmdpb.RaftCmdResponse, error) {
+	peer, meta, resp, err := s.validateCommandClass(class, req)
+	if err != nil || resp != nil {
+		return peer, meta, resp, err
+	}
+	status := peer.Status()
+	if status.RaftState == myraft.StateLeader {
+		return peer, meta, nil, nil
+	}
+	resp = &raftcmdpb.RaftCmdResponse{Header: req.Header, RegionError: notLeaderError(meta, status.Lead)}
+	if class != AdmissionClassUnknown {
+		s.recordAdmission(Admission{
+			Class:     class,
+			Reason:    AdmissionReasonNotLeader,
+			RegionID:  req.Header.GetRegionId(),
+			PeerID:    peer.ID(),
+			RequestID: req.Header.GetRequestId(),
+			Detail:    "local peer is not leader",
+		})
+	}
+	return peer, meta, resp, nil
 }
 
 // ProposeCommand submits a raft command to the leader hosting the target
 // region. When the store is not leader or the request header is invalid the
 // returned response includes an appropriate RegionError.
 func (s *Store) ProposeCommand(ctx context.Context, req *raftcmdpb.RaftCmdRequest) (*raftcmdpb.RaftCmdResponse, error) {
-	peer, _, resp, err := s.validateCommandClass(AdmissionClassWrite, req)
+	peer, _, resp, err := s.validateLeaderCommandClass(AdmissionClassWrite, req)
 	if err != nil {
 		return nil, err
 	}
@@ -225,9 +236,10 @@ func (s *Store) ProposeCommand(ctx context.Context, req *raftcmdpb.RaftCmdReques
 	}
 }
 
-// ReadCommand executes the provided read-only raft command locally on the
-// leader. The command must only include read operations (Get/Scan). The method
-// returns a RegionError when the store is not leader for the target region.
+// ReadCommand executes the provided read-only raft command locally after
+// applying the requested read policy. The default remains strong leader-only
+// reads. FOLLOWER_PREFER can serve through raft ReadIndex, while BOUNDED_STALE
+// can serve from local applied state only when the caller's stale budget admits it.
 func (s *Store) ReadCommand(ctx context.Context, req *raftcmdpb.RaftCmdRequest) (*raftcmdpb.RaftCmdResponse, error) {
 	peer, meta, regionResp, err := s.validateCommandClass(AdmissionClassRead, req)
 	if err != nil {
@@ -286,7 +298,10 @@ func (s *Store) ReadCommand(ctx context.Context, req *raftcmdpb.RaftCmdRequest) 
 		PeerID:    peer.ID(),
 		RequestID: req.Header.GetRequestId(),
 	})
-	index, err := peer.LinearizableRead(ctx)
+	index, regionErr, err := s.readIndexForPolicy(ctx, peer, meta, req)
+	if regionErr != nil {
+		return &raftcmdpb.RaftCmdResponse{Header: req.Header, RegionError: regionErr}, nil
+	}
 	if err != nil {
 		return nil, err
 	}
@@ -304,6 +319,74 @@ func (s *Store) ReadCommand(ctx context.Context, req *raftcmdpb.RaftCmdRequest) 
 		s.regionStats.recordRead(req.Header.GetRegionId(), uint64(len(req.GetRequests())))
 	}
 	return out, nil
+}
+
+func (s *Store) readIndexForPolicy(ctx context.Context, p *peer.Peer, meta localmeta.RegionMeta, req *raftcmdpb.RaftCmdRequest) (uint64, *errorpb.RegionError, error) {
+	if p == nil || req == nil || req.Header == nil {
+		return 0, nil, errNilCommand
+	}
+	consistency := normalizeReadConsistency(req.Header.GetReadConsistency())
+	preference := normalizeReadPreference(req.Header.GetReadPreference())
+	status := p.Status()
+	if preference == kvrpcpb.ReadPreference_READ_PREFERENCE_LEADER_ONLY && status.RaftState != myraft.StateLeader {
+		s.recordAdmission(Admission{
+			Class:     AdmissionClassRead,
+			Reason:    AdmissionReasonNotLeader,
+			RegionID:  req.Header.GetRegionId(),
+			PeerID:    p.ID(),
+			RequestID: req.Header.GetRequestId(),
+			Detail:    "leader-only read rejected on follower",
+		})
+		return 0, notLeaderError(meta, status.Lead), nil
+	}
+	switch consistency {
+	case kvrpcpb.ReadConsistency_READ_CONSISTENCY_BOUNDED_STALE:
+		maxAge := time.Duration(req.Header.GetMaxStaleReadMs()) * time.Millisecond
+		index, ok := p.BoundedStaleReadIndex(req.Header.GetMaxStaleReadIndex(), maxAge)
+		if !ok {
+			s.recordAdmission(Admission{
+				Class:     AdmissionClassRead,
+				Reason:    AdmissionReasonStale,
+				RegionID:  req.Header.GetRegionId(),
+				PeerID:    p.ID(),
+				RequestID: req.Header.GetRequestId(),
+				Detail:    "bounded-stale read outside local applied-index or leader-contact budget",
+			})
+			return 0, staleCommandError(), nil
+		}
+		return index, nil, nil
+	default:
+		index, err := p.LinearizableRead(ctx)
+		if err != nil && preference == kvrpcpb.ReadPreference_READ_PREFERENCE_FOLLOWER_PREFER && status.RaftState != myraft.StateLeader {
+			if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+				return 0, nil, err
+			}
+			s.recordAdmission(Admission{
+				Class:     AdmissionClassRead,
+				Reason:    AdmissionReasonStale,
+				RegionID:  req.Header.GetRegionId(),
+				PeerID:    p.ID(),
+				RequestID: req.Header.GetRequestId(),
+				Detail:    fmt.Sprintf("strong follower read failed before local apply: %v", err),
+			})
+			return 0, staleCommandError(), nil
+		}
+		return index, nil, err
+	}
+}
+
+func normalizeReadConsistency(consistency kvrpcpb.ReadConsistency) kvrpcpb.ReadConsistency {
+	if consistency == kvrpcpb.ReadConsistency_READ_CONSISTENCY_BOUNDED_STALE {
+		return consistency
+	}
+	return kvrpcpb.ReadConsistency_READ_CONSISTENCY_STRONG
+}
+
+func normalizeReadPreference(preference kvrpcpb.ReadPreference) kvrpcpb.ReadPreference {
+	if preference == kvrpcpb.ReadPreference_READ_PREFERENCE_FOLLOWER_PREFER {
+		return preference
+	}
+	return kvrpcpb.ReadPreference_READ_PREFERENCE_LEADER_ONLY
 }
 
 func isReadOnlyRequest(req *raftcmdpb.RaftCmdRequest) bool {
@@ -525,6 +608,10 @@ func regionNotFoundError(regionID uint64) *errorpb.RegionError {
 	return &errorpb.RegionError{
 		RegionNotFound: &errorpb.RegionNotFound{RegionId: regionID},
 	}
+}
+
+func staleCommandError() *errorpb.RegionError {
+	return &errorpb.RegionError{StaleCommand: &errorpb.StaleCommand{}}
 }
 
 func keyNotInRegionError(meta localmeta.RegionMeta, key []byte) *errorpb.RegionError {

--- a/raftstore/store/command_ops_test.go
+++ b/raftstore/store/command_ops_test.go
@@ -857,6 +857,159 @@ func TestStoreReadCommandStoreNotMatch(t *testing.T) {
 	require.Equal(t, uint64(7), resp.GetRegionError().GetStoreNotMatch().GetActualStoreId())
 }
 
+func TestStoreReadCommandLeaderOnlyRejectsFollower(t *testing.T) {
+	db, localMeta := openStoreDB(t)
+	applier := func(req *raftcmdpb.RaftCmdRequest) (*raftcmdpb.RaftCmdResponse, error) {
+		return &raftcmdpb.RaftCmdResponse{Header: req.GetHeader()}, nil
+	}
+	st := NewStore(Config{StoreID: 1, CommandApplier: applier})
+	t.Cleanup(func() { st.Close() })
+
+	region := &localmeta.RegionMeta{
+		ID:       405,
+		StartKey: []byte("a"),
+		EndKey:   []byte("z"),
+		Epoch:    metaregion.Epoch{Version: 1, ConfVersion: 1},
+		Peers:    []metaregion.Peer{{StoreID: 1, PeerID: 11}, {StoreID: 2, PeerID: 22}},
+	}
+	p, err := st.StartPeer(&peer.Config{
+		RaftConfig: myraft.Config{
+			ID:              11,
+			ElectionTick:    5,
+			HeartbeatTick:   1,
+			MaxSizePerMsg:   1 << 20,
+			MaxInflightMsgs: 256,
+			PreVote:         true,
+		},
+		Transport: noopTransport{},
+		Storage:   mustPeerStorage(t, db, localMeta, region.ID),
+		GroupID:   region.ID,
+		Region:    region,
+	}, []myraft.Peer{{ID: 11}, {ID: 22}})
+	require.NoError(t, err)
+	t.Cleanup(func() { st.StopPeer(p.ID()) })
+
+	resp, err := st.ReadCommand(context.Background(), &raftcmdpb.RaftCmdRequest{
+		Header: &raftcmdpb.CmdHeader{
+			RegionId:    region.ID,
+			RegionEpoch: &metapb.RegionEpoch{Version: 1, ConfVersion: 1},
+		},
+		Requests: []*raftcmdpb.Request{{
+			CmdType: raftcmdpb.CmdType_CMD_GET,
+			Cmd:     &raftcmdpb.Request_Get{Get: &kvrpcpb.GetRequest{Key: []byte("b")}},
+		}},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, resp.GetRegionError())
+	require.NotNil(t, resp.GetRegionError().GetNotLeader())
+}
+
+func TestStoreReadCommandStrongFollowerPreferPreservesCanceledContext(t *testing.T) {
+	db, localMeta := openStoreDB(t)
+	applier := func(req *raftcmdpb.RaftCmdRequest) (*raftcmdpb.RaftCmdResponse, error) {
+		return &raftcmdpb.RaftCmdResponse{Header: req.GetHeader()}, nil
+	}
+	st := NewStore(Config{StoreID: 1, CommandApplier: applier})
+	t.Cleanup(func() { st.Close() })
+
+	region := &localmeta.RegionMeta{
+		ID:       407,
+		StartKey: []byte("a"),
+		EndKey:   []byte("z"),
+		Epoch:    metaregion.Epoch{Version: 1, ConfVersion: 1},
+		Peers:    []metaregion.Peer{{StoreID: 1, PeerID: 11}, {StoreID: 2, PeerID: 22}},
+	}
+	p, err := st.StartPeer(&peer.Config{
+		RaftConfig: myraft.Config{
+			ID:              11,
+			ElectionTick:    5,
+			HeartbeatTick:   1,
+			MaxSizePerMsg:   1 << 20,
+			MaxInflightMsgs: 256,
+			PreVote:         true,
+		},
+		Transport: noopTransport{},
+		Storage:   mustPeerStorage(t, db, localMeta, region.ID),
+		GroupID:   region.ID,
+		Region:    region,
+	}, []myraft.Peer{{ID: 11}, {ID: 22}})
+	require.NoError(t, err)
+	t.Cleanup(func() { st.StopPeer(p.ID()) })
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	_, err = st.ReadCommand(ctx, &raftcmdpb.RaftCmdRequest{
+		Header: &raftcmdpb.CmdHeader{
+			RegionId:        region.ID,
+			RegionEpoch:     &metapb.RegionEpoch{Version: 1, ConfVersion: 1},
+			ReadConsistency: kvrpcpb.ReadConsistency_READ_CONSISTENCY_STRONG,
+			ReadPreference:  kvrpcpb.ReadPreference_READ_PREFERENCE_FOLLOWER_PREFER,
+		},
+		Requests: []*raftcmdpb.Request{{
+			CmdType: raftcmdpb.CmdType_CMD_GET,
+			Cmd:     &raftcmdpb.Request_Get{Get: &kvrpcpb.GetRequest{Key: []byte("b")}},
+		}},
+	})
+	require.ErrorIs(t, err, context.Canceled)
+}
+
+func TestStoreReadCommandBoundedStaleReadsAppliedState(t *testing.T) {
+	db, localMeta := openStoreDB(t)
+	applier := func(req *raftcmdpb.RaftCmdRequest) (*raftcmdpb.RaftCmdResponse, error) {
+		return &raftcmdpb.RaftCmdResponse{
+			Header: req.GetHeader(),
+			Responses: []*raftcmdpb.Response{{
+				Cmd: &raftcmdpb.Response_Get{Get: &kvrpcpb.GetResponse{Value: []byte("ok")}},
+			}},
+		}, nil
+	}
+	st := NewStore(Config{StoreID: 1, CommandApplier: applier})
+	t.Cleanup(func() { st.Close() })
+
+	region := &localmeta.RegionMeta{
+		ID:       406,
+		StartKey: []byte("a"),
+		EndKey:   []byte("z"),
+		Epoch:    metaregion.Epoch{Version: 1, ConfVersion: 1},
+		Peers:    []metaregion.Peer{{StoreID: 1, PeerID: 11}},
+	}
+	p, err := st.StartPeer(&peer.Config{
+		RaftConfig: myraft.Config{
+			ID:              11,
+			ElectionTick:    5,
+			HeartbeatTick:   1,
+			MaxSizePerMsg:   1 << 20,
+			MaxInflightMsgs: 256,
+			PreVote:         true,
+		},
+		Transport: noopTransport{},
+		Storage:   mustPeerStorage(t, db, localMeta, region.ID),
+		GroupID:   region.ID,
+		Region:    region,
+	}, []myraft.Peer{{ID: 11}})
+	require.NoError(t, err)
+	t.Cleanup(func() { st.StopPeer(p.ID()) })
+	require.NoError(t, p.Campaign())
+	require.Greater(t, p.AppliedIndex(), uint64(0))
+
+	resp, err := st.ReadCommand(context.Background(), &raftcmdpb.RaftCmdRequest{
+		Header: &raftcmdpb.CmdHeader{
+			RegionId:          region.ID,
+			RegionEpoch:       &metapb.RegionEpoch{Version: 1, ConfVersion: 1},
+			ReadConsistency:   kvrpcpb.ReadConsistency_READ_CONSISTENCY_BOUNDED_STALE,
+			ReadPreference:    kvrpcpb.ReadPreference_READ_PREFERENCE_FOLLOWER_PREFER,
+			MaxStaleReadIndex: 0,
+		},
+		Requests: []*raftcmdpb.Request{{
+			CmdType: raftcmdpb.CmdType_CMD_GET,
+			Cmd:     &raftcmdpb.Request_Get{Get: &kvrpcpb.GetRequest{Key: []byte("b")}},
+		}},
+	})
+	require.NoError(t, err)
+	require.Nil(t, resp.GetRegionError())
+	require.Equal(t, []byte("ok"), resp.GetResponses()[0].GetGet().GetValue())
+}
+
 func TestReadOnlyRequestPredicate(t *testing.T) {
 	require.False(t, isReadOnlyRequest(nil))
 

--- a/raftstore/store/execution_protocol.go
+++ b/raftstore/store/execution_protocol.go
@@ -47,6 +47,7 @@ const (
 	AdmissionReasonNotLeader
 	AdmissionReasonCanceled
 	AdmissionReasonTimedOut
+	AdmissionReasonStale
 )
 
 func (r AdmissionReason) String() string {
@@ -69,6 +70,8 @@ func (r AdmissionReason) String() string {
 		return "canceled"
 	case AdmissionReasonTimedOut:
 		return "timed-out"
+	case AdmissionReasonStale:
+		return "stale"
 	default:
 		return "unknown"
 	}


### PR DESCRIPTION
## Summary
- add StoreKV read options for strong follower-prefer and bounded-stale reads
- split raftstore read admission from write leader validation while keeping default reads strong leader-only
- add leader FastLeaseRead shortcut backed by current-term committed-entry checks
- wire read policy through StoreKV request headers and client fallback to leader when followers cannot satisfy freshness

## Correctness notes
- default Get/BatchGet/Scan remains STRONG + LEADER_ONLY after benchmark showed bounded-stale is unsafe for fsmeta read-before-write paths
- bounded-stale remains explicit opt-in and is rejected when the follower exceeds applied-index or leader-contact budget
- strong follower-prefer remains explicit opt-in and falls back to leader on stale command / unavailable follower

## Linked issue
Closes #91

## Validation
- make fmt
- make lint
- go test ./...
- Docker Compose fsmeta median benchmark passed with default leader-only: benchmark/data/fsmeta/results/fsmeta_compose_median_20260510T035123Z.csv
- Experiment: default bounded-stale follower failed HeartbeatWriteSession with stale not_found, so it was not kept as default
- Experiment: default strong follower-prefer passed but was slower on fsmeta median, so follower read stays opt-in
