### PR TITLE
Inline small MVCC values in write records

### DIFF
--- a/raftstore/integration/coordinator_degraded_test.go
+++ b/raftstore/integration/coordinator_degraded_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/feichai0017/NoKV/raftstore/client"
 	"github.com/feichai0017/NoKV/raftstore/migrate"
 	"github.com/feichai0017/NoKV/raftstore/testcluster"
+	"github.com/feichai0017/NoKV/txn/percolator"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
@@ -85,8 +86,8 @@ func TestClusterSurvivesCoordinatorUnavailableAfterStartup(t *testing.T) {
 	updated := []byte("coordinator-outage-updated")
 	require.NoError(t, cli.Put(ctx, key, updated, 20, 21, 3000))
 	require.Eventually(t, func() bool {
-		entry, err := target.DB.Get(key)
-		return err == nil && string(entry.Value) == string(updated)
+		got, _, err := percolator.NewReader(target.DB).GetValue(key, 30)
+		return err == nil && string(got) == string(updated)
 	}, 5*time.Second, 20*time.Millisecond)
 
 	getResp, err = cli.Get(ctx, key, 30)

--- a/raftstore/integration/transport_chaos_test.go
+++ b/raftstore/integration/transport_chaos_test.go
@@ -2,14 +2,15 @@ package integration
 
 import (
 	"context"
-	metapb "github.com/feichai0017/NoKV/pb/meta"
 	"testing"
 	"time"
 
 	workdirmode "github.com/feichai0017/NoKV/local/workdir"
+	metapb "github.com/feichai0017/NoKV/pb/meta"
 	"github.com/feichai0017/NoKV/raftstore/client"
 	"github.com/feichai0017/NoKV/raftstore/migrate"
 	"github.com/feichai0017/NoKV/raftstore/testcluster"
+	"github.com/feichai0017/NoKV/txn/percolator"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
@@ -84,7 +85,7 @@ func TestPartitionedFollowerCatchesUpAfterRecovery(t *testing.T) {
 	value := []byte("partitioned-follower-value")
 	require.NoError(t, cli.Put(ctx, key, value, 10, 11, 3000))
 
-	_, err = target3.DB.Get(key)
+	_, _, err = percolator.NewReader(target3.DB).GetValue(key, 12)
 	require.Error(t, err)
 
 	target3.Restart(t, nil, true)
@@ -102,8 +103,8 @@ func TestPartitionedFollowerCatchesUpAfterRecovery(t *testing.T) {
 	target2.UnblockPeer(301)
 
 	require.Eventually(t, func() bool {
-		entry, err := target3.DB.Get(key)
-		return err == nil && string(entry.Value) == string(value)
+		got, _, err := percolator.NewReader(target3.DB).GetValue(key, 12)
+		return err == nil && string(got) == string(value)
 	}, 5*time.Second, 50*time.Millisecond)
 }
 

--- a/raftstore/kv/apply_test.go
+++ b/raftstore/kv/apply_test.go
@@ -211,7 +211,7 @@ func TestApplyTryAtomicMutateBatchFusesLocalApply(t *testing.T) {
 		require.Equal(t, uint64(1), atomicResp.GetAppliedKeys())
 	}
 	require.Equal(t, 1, store.applyCalls)
-	require.Equal(t, []int{6}, store.appliedEntryCounts)
+	require.Equal(t, []int{2}, store.appliedEntryCounts)
 }
 
 func TestApplyPrewriteBatchFusesLocalApply(t *testing.T) {
@@ -242,7 +242,7 @@ func TestApplyPrewriteBatchFusesLocalApply(t *testing.T) {
 		require.Empty(t, prewriteResp.GetErrors())
 	}
 	require.Equal(t, 1, store.applyCalls)
-	require.Equal(t, []int{6}, store.appliedEntryCounts)
+	require.Equal(t, []int{2}, store.appliedEntryCounts)
 }
 
 func TestApplyTryAtomicMutateCommandFallsBackForCrossShardBatch(t *testing.T) {

--- a/txn/mvcc/codec.go
+++ b/txn/mvcc/codec.go
@@ -22,6 +22,12 @@ const (
 //	ttl_ms uvarint
 //	mutation_kind byte
 //	min_commit_ts uvarint
+//	has_short_value byte
+//	if has_short_value == 1:
+//	  short_value_len uvarint
+//	  short_value bytes
+//	if short value or expires_at is present:
+//	  expires_at uvarint
 //
 // TTL is measured from start_time_unix_ms. start_ts remains the MVCC logical
 // timestamp and must not be used as a physical clock.
@@ -38,12 +44,14 @@ type Lock struct {
 	TTL         uint64
 	Kind        kvrpcpb.Mutation_Op
 	MinCommitTs uint64
+	ShortValue  []byte
+	ExpiresAt   uint64
 }
 
 // EncodeLock serialises a lock entry.
 func EncodeLock(lock Lock) []byte {
 	primaryLen := len(lock.Primary)
-	buf := make([]byte, 0, 1+binary.MaxVarintLen64*5+primaryLen)
+	buf := make([]byte, 0, 1+binary.MaxVarintLen64*7+primaryLen+len(lock.ShortValue))
 	buf = append(buf, lockCodecVersion)
 	buf = binary.AppendUvarint(buf, uint64(primaryLen))
 	buf = append(buf, lock.Primary...)
@@ -52,6 +60,16 @@ func EncodeLock(lock Lock) []byte {
 	buf = binary.AppendUvarint(buf, lock.TTL)
 	buf = append(buf, byte(lock.Kind))
 	buf = binary.AppendUvarint(buf, lock.MinCommitTs)
+	if len(lock.ShortValue) > 0 {
+		buf = append(buf, 1)
+		buf = binary.AppendUvarint(buf, uint64(len(lock.ShortValue)))
+		buf = append(buf, lock.ShortValue...)
+	} else {
+		buf = append(buf, 0)
+	}
+	if len(lock.ShortValue) > 0 || lock.ExpiresAt > 0 {
+		buf = binary.AppendUvarint(buf, lock.ExpiresAt)
+	}
 	return buf
 }
 
@@ -76,7 +94,7 @@ func DecodeLock(data []byte) (Lock, error) {
 	if err != nil {
 		return Lock{}, err
 	}
-	if pos+int(primaryLen) > len(data) {
+	if primaryLen > uint64(len(data)-pos) {
 		return Lock{}, fmt.Errorf("mvcc: lock primary truncated")
 	}
 	lock := Lock{
@@ -105,6 +123,30 @@ func DecodeLock(data []byte) (Lock, error) {
 			return Lock{}, err
 		}
 	}
+	if pos < len(data) {
+		hasShort := data[pos]
+		pos++
+		switch hasShort {
+		case 0:
+		case 1:
+			sz, err := readUvarint()
+			if err != nil {
+				return Lock{}, err
+			}
+			if sz > uint64(len(data)-pos) {
+				return Lock{}, fmt.Errorf("mvcc: lock short value truncated")
+			}
+			lock.ShortValue = append([]byte(nil), data[pos:pos+int(sz)]...)
+			pos += int(sz)
+		default:
+			return Lock{}, fmt.Errorf("mvcc: invalid lock short value marker %d", hasShort)
+		}
+	}
+	if pos < len(data) {
+		if lock.ExpiresAt, err = readUvarint(); err != nil {
+			return Lock{}, err
+		}
+	}
 	return lock, nil
 }
 
@@ -115,6 +157,16 @@ type Write struct {
 	StartTs    uint64
 	ShortValue []byte
 	ExpiresAt  uint64
+}
+
+const DefaultShortValueMaxBytes = 128
+
+// CanInlineShortValue reports whether a Put value can be carried by the MVCC
+// lock/write records instead of the default CF. Empty values stay on the
+// default CF because ShortValue's nil/empty representation is reserved for
+// "not inlined".
+func CanInlineShortValue(kind kvrpcpb.Mutation_Op, value []byte) bool {
+	return kind == kvrpcpb.Mutation_Put && len(value) > 0 && len(value) <= DefaultShortValueMaxBytes
 }
 
 // Write encoding layout:

--- a/txn/mvcc/codec_test.go
+++ b/txn/mvcc/codec_test.go
@@ -16,6 +16,8 @@ func TestEncodeDecodeLockRoundTrip(t *testing.T) {
 		TTL:         20,
 		Kind:        kvrpcpb.Mutation_Put,
 		MinCommitTs: 30,
+		ShortValue:  []byte("short-lock"),
+		ExpiresAt:   12345,
 	}
 	encoded := EncodeLock(lock)
 	got, err := DecodeLock(encoded)
@@ -26,6 +28,8 @@ func TestEncodeDecodeLockRoundTrip(t *testing.T) {
 	require.Equal(t, lock.TTL, got.TTL)
 	require.Equal(t, lock.Kind, got.Kind)
 	require.Equal(t, lock.MinCommitTs, got.MinCommitTs)
+	require.Equal(t, lock.ShortValue, got.ShortValue)
+	require.Equal(t, lock.ExpiresAt, got.ExpiresAt)
 }
 
 func TestDecodeLockErrors(t *testing.T) {
@@ -65,6 +69,13 @@ func TestEncodeDecodeWriteRoundTrip(t *testing.T) {
 	require.Equal(t, write.StartTs, got.StartTs)
 	require.Equal(t, write.ShortValue, got.ShortValue)
 	require.Equal(t, write.ExpiresAt, got.ExpiresAt)
+}
+
+func TestCanInlineShortValue(t *testing.T) {
+	require.True(t, CanInlineShortValue(kvrpcpb.Mutation_Put, []byte("small")))
+	require.False(t, CanInlineShortValue(kvrpcpb.Mutation_Put, nil))
+	require.False(t, CanInlineShortValue(kvrpcpb.Mutation_Put, make([]byte, DefaultShortValueMaxBytes+1)))
+	require.False(t, CanInlineShortValue(kvrpcpb.Mutation_Delete, []byte("small")))
 }
 
 func TestDecodeWriteDefaultsMissingExpiresAtToZero(t *testing.T) {

--- a/txn/percolator/txn.go
+++ b/txn/percolator/txn.go
@@ -117,12 +117,23 @@ func planPrewriteMutation(reader *Reader, req *kvrpcpb.PrewriteRequest, mut *kvr
 		}
 	}
 	ops := make([]versionedOp, 0, 3)
+	var shortValue []byte
+	var shortValueExpiresAt uint64
 	switch mut.Op {
 	case kvrpcpb.Mutation_Put:
-		ops = append(ops,
-			versionedOp{cf: kv.CFDefault, key: key, version: req.StartVersion, meta: kv.BitDelete},
-			versionedOp{cf: kv.CFDefault, key: key, version: req.StartVersion, value: mut.Value, expires: mut.GetExpiresAt()},
-		)
+		if mvcc.CanInlineShortValue(mut.GetOp(), mut.GetValue()) {
+			// Commit sees only the lock, not the original mutation request.
+			// Keep small values in the lock so commit can materialize the
+			// committed write without writing a default-CF record.
+			shortValue = kv.SafeCopy(nil, mut.GetValue())
+			shortValueExpiresAt = mut.GetExpiresAt()
+			percolatorStats.shortValuePrewriteTotal.Add(1)
+		} else {
+			ops = append(ops,
+				versionedOp{cf: kv.CFDefault, key: key, version: req.StartVersion, meta: kv.BitDelete},
+				versionedOp{cf: kv.CFDefault, key: key, version: req.StartVersion, value: mut.Value, expires: mut.GetExpiresAt()},
+			)
+		}
 	case kvrpcpb.Mutation_Delete, kvrpcpb.Mutation_Lock:
 		ops = append(ops,
 			versionedOp{cf: kv.CFDefault, key: key, version: req.StartVersion, meta: kv.BitDelete},
@@ -137,6 +148,8 @@ func planPrewriteMutation(reader *Reader, req *kvrpcpb.PrewriteRequest, mut *kvr
 		TTL:         req.LockTtl,
 		Kind:        mut.Op,
 		MinCommitTs: req.MinCommitTs,
+		ShortValue:  shortValue,
+		ExpiresAt:   shortValueExpiresAt,
 	}
 	encoded := mvcc.EncodeLock(newLock)
 	ops = append(ops, versionedOp{cf: kv.CFLock, key: key, version: lockColumnTs, value: encoded})
@@ -239,6 +252,9 @@ type statsRegistry struct {
 	twoPCFusedBatchesTotal  atomic.Uint64
 	twoPCFusedRequestsTotal atomic.Uint64
 	twoPCFusedEntriesTotal  atomic.Uint64
+	shortValuePrewriteTotal atomic.Uint64
+	shortValueCommitTotal   atomic.Uint64
+	shortValueAtomicTotal   atomic.Uint64
 }
 
 var percolatorStats statsRegistry
@@ -256,6 +272,9 @@ func Stats() map[string]any {
 		"two_pc_fused_apply_batches_total":  percolatorStats.twoPCFusedBatchesTotal.Load(),
 		"two_pc_fused_apply_requests_total": percolatorStats.twoPCFusedRequestsTotal.Load(),
 		"two_pc_fused_apply_entries_total":  percolatorStats.twoPCFusedEntriesTotal.Load(),
+		"short_value_prewrite_total":        percolatorStats.shortValuePrewriteTotal.Load(),
+		"short_value_commit_total":          percolatorStats.shortValueCommitTotal.Load(),
+		"short_value_atomic_total":          percolatorStats.shortValueAtomicTotal.Load(),
 	}
 }
 
@@ -583,13 +602,20 @@ func atomicMutateAlreadyApplied(db txnstore.Store, reader *Reader, req *kvrpcpb.
 			return false, nil
 		}
 		if mut.GetOp() == kvrpcpb.Mutation_Put {
-			matches, err := defaultRecordMatches(db, mut, req.StartVersion)
+			matches, err := committedPutMatches(db, write, mut, req.StartVersion)
 			if err != nil || !matches {
 				return false, err
 			}
 		}
 	}
 	return anyPresent && allPresent, nil
+}
+
+func committedPutMatches(db txnstore.Store, write *mvcc.Write, mut *kvrpcpb.Mutation, startVersion uint64) (bool, error) {
+	if len(write.ShortValue) > 0 {
+		return bytes.Equal(write.ShortValue, mut.GetValue()) && write.ExpiresAt == mut.GetExpiresAt(), nil
+	}
+	return defaultRecordMatches(db, mut, startVersion)
 }
 
 func defaultRecordMatches(db txnstore.Store, mut *kvrpcpb.Mutation, startVersion uint64) (bool, error) {
@@ -605,15 +631,22 @@ func defaultRecordMatches(db txnstore.Store, mut *kvrpcpb.Mutation, startVersion
 }
 
 func committedMutationOps(mut *kvrpcpb.Mutation, startVersion, commitVersion uint64) []versionedOp {
-	write := mvcc.EncodeWrite(mvcc.Write{Kind: mut.GetOp(), StartTs: startVersion})
 	switch mut.GetOp() {
 	case kvrpcpb.Mutation_Put:
+		write := committedWriteForMutation(mut, startVersion)
+		if len(write.ShortValue) > 0 {
+			percolatorStats.shortValueAtomicTotal.Add(1)
+			return []versionedOp{
+				{cf: kv.CFWrite, key: mut.GetKey(), version: commitVersion, value: mvcc.EncodeWrite(write)},
+			}
+		}
 		return []versionedOp{
 			{cf: kv.CFDefault, key: mut.GetKey(), version: startVersion, meta: kv.BitDelete},
 			{cf: kv.CFDefault, key: mut.GetKey(), version: startVersion, value: mut.GetValue(), expires: mut.GetExpiresAt()},
-			{cf: kv.CFWrite, key: mut.GetKey(), version: commitVersion, value: write},
+			{cf: kv.CFWrite, key: mut.GetKey(), version: commitVersion, value: mvcc.EncodeWrite(write)},
 		}
 	case kvrpcpb.Mutation_Delete:
+		write := mvcc.EncodeWrite(mvcc.Write{Kind: mut.GetOp(), StartTs: startVersion})
 		return []versionedOp{
 			{cf: kv.CFDefault, key: mut.GetKey(), version: startVersion, meta: kv.BitDelete},
 			{cf: kv.CFWrite, key: mut.GetKey(), version: commitVersion, value: write},
@@ -621,6 +654,15 @@ func committedMutationOps(mut *kvrpcpb.Mutation, startVersion, commitVersion uin
 	default:
 		return nil
 	}
+}
+
+func committedWriteForMutation(mut *kvrpcpb.Mutation, startVersion uint64) mvcc.Write {
+	write := mvcc.Write{Kind: mut.GetOp(), StartTs: startVersion}
+	if mvcc.CanInlineShortValue(mut.GetOp(), mut.GetValue()) {
+		write.ShortValue = kv.SafeCopy(nil, mut.GetValue())
+		write.ExpiresAt = mut.GetExpiresAt()
+	}
+	return write
 }
 
 // BatchRollback rolls back the provided keys for the given start version.
@@ -987,12 +1029,12 @@ func planCommitKey(reader *Reader, key []byte, startVersion, commitVersion uint6
 }
 
 func planCommitKeyWithLock(reader *Reader, key []byte, lock *mvcc.Lock, commitVersion uint64) ([]versionedOp, *kvrpcpb.KeyError) {
-	write, _, err := reader.GetWriteByStartTs(key, lock.Ts)
+	committed, _, err := reader.GetWriteByStartTs(key, lock.Ts)
 	if err != nil {
 		return nil, keyErrorRetryable(err)
 	}
-	if write != nil {
-		if write.Kind == kvrpcpb.Mutation_Rollback {
+	if committed != nil {
+		if committed.Kind == kvrpcpb.Mutation_Rollback {
 			return nil, keyErrorTxnAlreadyRolledBack()
 		}
 		return []versionedOp{{
@@ -1007,7 +1049,13 @@ func planCommitKeyWithLock(reader *Reader, key []byte, lock *mvcc.Lock, commitVe
 		return nil, keyErrorCommitTsExpired(key, commitVersion, lock.MinCommitTs)
 	}
 
-	entry := mvcc.EncodeWrite(mvcc.Write{Kind: lock.Kind, StartTs: lock.Ts})
+	write := mvcc.Write{Kind: lock.Kind, StartTs: lock.Ts}
+	if len(lock.ShortValue) > 0 {
+		write.ShortValue = kv.SafeCopy(nil, lock.ShortValue)
+		write.ExpiresAt = lock.ExpiresAt
+		percolatorStats.shortValueCommitTotal.Add(1)
+	}
+	entry := mvcc.EncodeWrite(write)
 	return []versionedOp{
 		{cf: kv.CFWrite, key: key, version: commitVersion, value: entry},
 		{cf: kv.CFLock, key: key, version: lockColumnTs, meta: kv.BitDelete},
@@ -1054,10 +1102,13 @@ func planRollbackKey(reader *Reader, key []byte, startTs uint64) ([]versionedOp,
 	}
 
 	rollback := mvcc.EncodeWrite(mvcc.Write{Kind: kvrpcpb.Mutation_Rollback, StartTs: startTs})
-	ops := []versionedOp{
-		{cf: kv.CFDefault, key: key, version: startTs, meta: kv.BitDelete},
-		{cf: kv.CFWrite, key: key, version: startTs, value: rollback},
+	ops := make([]versionedOp, 0, 3)
+	// A short-value prewrite never created a default-CF record, so rollback
+	// only needs the rollback marker and lock tombstone for that case.
+	if lock == nil || lock.Ts != startTs || len(lock.ShortValue) == 0 {
+		ops = append(ops, versionedOp{cf: kv.CFDefault, key: key, version: startTs, meta: kv.BitDelete})
 	}
+	ops = append(ops, versionedOp{cf: kv.CFWrite, key: key, version: startTs, value: rollback})
 	if lock != nil && lock.Ts == startTs {
 		ops = append(ops, versionedOp{cf: kv.CFLock, key: key, version: lockColumnTs, meta: kv.BitDelete})
 	}

--- a/txn/percolator/txn_test.go
+++ b/txn/percolator/txn_test.go
@@ -1,6 +1,7 @@
 package percolator
 
 import (
+	"bytes"
 	"errors"
 	"fmt"
 	kvrpcpb "github.com/feichai0017/NoKV/pb/kv"
@@ -332,7 +333,7 @@ func TestApplyAtomicMutateBatchFusesIndependentRequests(t *testing.T) {
 		require.Equal(t, uint64(1), result.AppliedKeys)
 	}
 	require.Equal(t, 1, store.applyCalls)
-	require.Equal(t, []int{6}, store.appliedEntryCounts)
+	require.Equal(t, []int{2}, store.appliedEntryCounts)
 
 	reader := NewReader(db)
 	value, _, err := reader.GetValue([]byte("atomic-batch-a"), 50)
@@ -345,7 +346,7 @@ func TestApplyAtomicMutateBatchFusesIndependentRequests(t *testing.T) {
 	after := Stats()
 	require.Equal(t, atomicMutateStat(t, before, "atomic_fused_apply_batches_total")+1, atomicMutateStat(t, after, "atomic_fused_apply_batches_total"))
 	require.Equal(t, atomicMutateStat(t, before, "atomic_fused_apply_requests_total")+2, atomicMutateStat(t, after, "atomic_fused_apply_requests_total"))
-	require.Equal(t, atomicMutateStat(t, before, "atomic_fused_apply_entries_total")+6, atomicMutateStat(t, after, "atomic_fused_apply_entries_total"))
+	require.Equal(t, atomicMutateStat(t, before, "atomic_fused_apply_entries_total")+2, atomicMutateStat(t, after, "atomic_fused_apply_entries_total"))
 }
 
 func TestApplyAtomicMutateBatchSplitsDifferentLocalApplyGroups(t *testing.T) {
@@ -374,7 +375,7 @@ func TestApplyAtomicMutateBatchSplitsDifferentLocalApplyGroups(t *testing.T) {
 		require.Equal(t, uint64(1), result.AppliedKeys)
 	}
 	require.Equal(t, 2, store.applyCalls)
-	require.Equal(t, []int{3, 3}, store.appliedEntryCounts)
+	require.Equal(t, []int{1, 1}, store.appliedEntryCounts)
 }
 
 func TestApplyAtomicMutateBatchPreservesOverlappingRequestOrder(t *testing.T) {
@@ -837,7 +838,7 @@ func TestPrewriteBatchAppliesAllMutationsOnce(t *testing.T) {
 		LockTtl:      1000,
 	}))
 	require.Equal(t, 1, store.applyCalls)
-	require.Equal(t, []int{9}, store.appliedEntryCounts)
+	require.Equal(t, []int{3}, store.appliedEntryCounts)
 
 	reader := NewReader(db)
 	for _, key := range keys {
@@ -872,12 +873,12 @@ func TestPrewriteRequestBatchFusesIndependentRequests(t *testing.T) {
 	require.Empty(t, results[0])
 	require.Empty(t, results[1])
 	require.Equal(t, 1, store.applyCalls)
-	require.Equal(t, []int{6}, store.appliedEntryCounts)
+	require.Equal(t, []int{2}, store.appliedEntryCounts)
 
 	after := Stats()
 	require.Equal(t, atomicMutateStat(t, before, "two_pc_fused_apply_batches_total")+1, atomicMutateStat(t, after, "two_pc_fused_apply_batches_total"))
 	require.Equal(t, atomicMutateStat(t, before, "two_pc_fused_apply_requests_total")+2, atomicMutateStat(t, after, "two_pc_fused_apply_requests_total"))
-	require.Equal(t, atomicMutateStat(t, before, "two_pc_fused_apply_entries_total")+6, atomicMutateStat(t, after, "two_pc_fused_apply_entries_total"))
+	require.Equal(t, atomicMutateStat(t, before, "two_pc_fused_apply_entries_total")+2, atomicMutateStat(t, after, "two_pc_fused_apply_entries_total"))
 }
 
 func TestPrewriteRequestBatchPreservesOverlappingOrder(t *testing.T) {
@@ -997,7 +998,7 @@ func TestBatchRollbackRequestBatchFusesIndependentRequests(t *testing.T) {
 	require.Nil(t, results[0])
 	require.Nil(t, results[1])
 	require.Equal(t, 1, store.applyCalls)
-	require.Equal(t, []int{6}, store.appliedEntryCounts)
+	require.Equal(t, []int{4}, store.appliedEntryCounts)
 }
 
 func TestResolveLockRequestBatchFusesIndependentRequests(t *testing.T) {
@@ -1476,7 +1477,7 @@ func TestBatchRollbackAppliesAllKeysOnce(t *testing.T) {
 		StartVersion: 18,
 	}))
 	require.Equal(t, 1, store.applyCalls)
-	require.Equal(t, []int{9}, store.appliedEntryCounts)
+	require.Equal(t, []int{7}, store.appliedEntryCounts)
 }
 
 func TestBatchRollbackDoesNotDeleteOtherTransactionLock(t *testing.T) {
@@ -1956,15 +1957,14 @@ func TestCommitRecoveryDropsCorruptedCommitBatch(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, lock)
 	require.Equal(t, startTs, lock.Ts)
+	require.Equal(t, []byte("value"), lock.ShortValue)
 
 	write, _, err := reader.GetWriteByStartTs(key, startTs)
 	require.NoError(t, err)
 	require.Nil(t, write)
 
-	entry, err := db2.GetInternalEntry(kv.CFDefault, key, startTs)
-	require.NoError(t, err)
-	require.Equal(t, []byte("value"), entry.Value)
-	entry.DecrRef()
+	_, err = db2.GetInternalEntry(kv.CFDefault, key, startTs)
+	require.ErrorIs(t, err, utils.ErrKeyNotFound)
 }
 
 func TestCheckTxnStatusTTLExpire(t *testing.T) {
@@ -2349,6 +2349,147 @@ func TestReaderGetValueFromExpiredShortValue(t *testing.T) {
 
 	_, _, err := reader.GetValue(key, 30)
 	require.ErrorIs(t, err, utils.ErrKeyNotFound)
+}
+
+func TestPrewriteCommitShortValueSkipsDefaultCF(t *testing.T) {
+	db := openTestDB(t)
+	latches := latch.NewManager(16)
+	key := []byte("short-prewrite")
+	value := []byte("inline")
+	expiresAt := uint64(^uint64(0))
+
+	require.Empty(t, Prewrite(db, latches, &kvrpcpb.PrewriteRequest{
+		Mutations: []*kvrpcpb.Mutation{{
+			Op:        kvrpcpb.Mutation_Put,
+			Key:       key,
+			Value:     value,
+			ExpiresAt: expiresAt,
+		}},
+		PrimaryLock:  key,
+		StartVersion: 10,
+		LockTtl:      1000,
+	}))
+
+	_, err := db.GetInternalEntry(kv.CFDefault, key, 10)
+	require.ErrorIs(t, err, utils.ErrKeyNotFound)
+
+	reader := NewReader(db)
+	lock, err := reader.GetLock(key)
+	require.NoError(t, err)
+	require.NotNil(t, lock)
+	require.Equal(t, value, lock.ShortValue)
+	require.Equal(t, expiresAt, lock.ExpiresAt)
+
+	require.Nil(t, Commit(db, latches, &kvrpcpb.CommitRequest{
+		Keys:          [][]byte{key},
+		StartVersion:  10,
+		CommitVersion: 20,
+	}))
+
+	write, commitTs, err := reader.GetWriteByStartTs(key, 10)
+	require.NoError(t, err)
+	require.NotNil(t, write)
+	require.Equal(t, uint64(20), commitTs)
+	require.Equal(t, value, write.ShortValue)
+	require.Equal(t, expiresAt, write.ExpiresAt)
+
+	got, gotExpiresAt, err := reader.GetValue(key, 30)
+	require.NoError(t, err)
+	require.Equal(t, value, got)
+	require.Equal(t, expiresAt, gotExpiresAt)
+}
+
+func TestPrewriteLargeValueKeepsDefaultCF(t *testing.T) {
+	db := openTestDB(t)
+	latches := latch.NewManager(16)
+	key := []byte("large-prewrite")
+	value := bytes.Repeat([]byte("x"), mvcc.DefaultShortValueMaxBytes+1)
+
+	require.Empty(t, Prewrite(db, latches, &kvrpcpb.PrewriteRequest{
+		Mutations: []*kvrpcpb.Mutation{{
+			Op:    kvrpcpb.Mutation_Put,
+			Key:   key,
+			Value: value,
+		}},
+		PrimaryLock:  key,
+		StartVersion: 11,
+		LockTtl:      1000,
+	}))
+
+	entry, err := db.GetInternalEntry(kv.CFDefault, key, 11)
+	require.NoError(t, err)
+	require.Equal(t, value, entry.Value)
+	entry.DecrRef()
+
+	require.Nil(t, Commit(db, latches, &kvrpcpb.CommitRequest{
+		Keys:          [][]byte{key},
+		StartVersion:  11,
+		CommitVersion: 21,
+	}))
+
+	write, _, err := NewReader(db).GetWriteByStartTs(key, 11)
+	require.NoError(t, err)
+	require.NotNil(t, write)
+	require.Empty(t, write.ShortValue)
+}
+
+func TestAtomicMutateShortValueSkipsDefaultCF(t *testing.T) {
+	opt := testOptionsForDir(filepath.Join(t.TempDir(), "db"))
+	opt.LSMShardCount = 1
+	db, err := local.Open(opt)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = db.Close() })
+
+	key := []byte("atomic-short")
+	value := []byte("inline")
+	req := atomicPutRequest(30, 31, key, value)
+	result := ApplyAtomicMutate(db, latch.NewManager(16), req)
+	require.Nil(t, result.Error)
+	require.False(t, result.Fallback)
+	require.Equal(t, uint64(1), result.AppliedKeys)
+
+	_, err = db.GetInternalEntry(kv.CFDefault, key, 30)
+	require.ErrorIs(t, err, utils.ErrKeyNotFound)
+
+	reader := NewReader(db)
+	write, commitTs, err := reader.GetWriteByStartTs(key, 30)
+	require.NoError(t, err)
+	require.NotNil(t, write)
+	require.Equal(t, uint64(31), commitTs)
+	require.Equal(t, value, write.ShortValue)
+
+	got, _, err := reader.GetValue(key, 40)
+	require.NoError(t, err)
+	require.Equal(t, value, got)
+}
+
+func TestBatchRollbackShortValueLockDoesNotWriteDefaultTombstone(t *testing.T) {
+	db := openTestDB(t)
+	latches := latch.NewManager(16)
+	key := []byte("short-rollback")
+
+	require.Empty(t, Prewrite(db, latches, &kvrpcpb.PrewriteRequest{
+		Mutations: []*kvrpcpb.Mutation{{
+			Op:    kvrpcpb.Mutation_Put,
+			Key:   key,
+			Value: []byte("inline"),
+		}},
+		PrimaryLock:  key,
+		StartVersion: 40,
+		LockTtl:      1000,
+	}))
+	require.Nil(t, BatchRollback(db, latches, &kvrpcpb.BatchRollbackRequest{
+		Keys:         [][]byte{key},
+		StartVersion: 40,
+	}))
+
+	_, err := db.GetInternalEntry(kv.CFDefault, key, 40)
+	require.ErrorIs(t, err, utils.ErrKeyNotFound)
+	write, commitTs, err := NewReader(db).GetWriteByStartTs(key, 40)
+	require.NoError(t, err)
+	require.NotNil(t, write)
+	require.Equal(t, kvrpcpb.Mutation_Rollback, write.Kind)
+	require.Equal(t, uint64(40), commitTs)
 }
 
 func TestKeyErrorHelpers(t *testing.T) {


### PR DESCRIPTION
## Summary

- inline small MVCC Put values (<=128B) into Percolator lock/write records instead of writing CFDefault
- teach 2PC commit, rollback, and AtomicMutate idempotency to handle short-value writes correctly
- update raftstore integration tests to validate committed MVCC values instead of depending on the old raw Default CF layout

## Correctness notes

- large values still use CFDefault
- empty values stay on CFDefault because empty/nil `ShortValue` means "not inlined"
- rollback of a short-value lock writes the rollback marker and lock tombstone without inventing a default tombstone
- AtomicMutate still uses the existing region/local atomic safety gate; this only changes the physical entries for small values

## Validation

- `make fmt`
- `make lint`
- `go test ./...`
- `cd benchmark && go test ./fsmeta ./fsmeta/workload`
- `NOKV_FSMETA_PROFILE=median NOKV_FSMETA_CAPTURE_PROFILES=0 ./scripts/run_fsmeta_benchmarks.sh`

Median fsmeta result after a clean `docker compose down -v`:

- `mixed`: 188.4 aggregate ops/s, 0 errors
- `multi-workspace-autoscale`: 446.6 aggregate ops/s, 0 errors
- `checkpoint-storm`: 468.8 aggregate ops/s, 0 errors
- `watch-subtree`: 461.5 aggregate ops/s, 0 errors
- `negative-lookup`: 5965.0 aggregate ops/s, 0 errors

Store expvar confirmed short-value path was exercised:

- `short_value_atomic_total`: 57978
- `short_value_prewrite_total`: 40
- `short_value_commit_total`: 40
- `atomic_local_fallback_total`: 0
