### PR TITLE
Falcon: M1 — parallel apply via dependency DAG

### DIFF
--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -34,6 +34,7 @@
 - [FSMetadata](fsmeta.md)
 - [Migration](migration.md)
 - [Recovery](recovery.md)
+- [Falcon (design)](falcon.md)
 
 # Operations & Tooling
 

--- a/docs/falcon.md
+++ b/docs/falcon.md
@@ -1,0 +1,966 @@
+# Falcon: Speculative Replication for fsmeta
+
+> **Status:** design — not yet implemented. This document is the canonical
+> reference for the Falcon protocol and its integration with NoKV.
+> Last updated: 2026-05-11.
+
+---
+
+## TL;DR
+
+Most fsmeta operations touch one or two disjoint keys (a dentry plus an
+inode). Their read-set and write-set are statically determined at the
+client, and 99% of concurrent ops in steady state are mutually
+commutative. Today they pay full Raft cost regardless: ~5 ms wall
+latency for a single op, ~1.5–2 K ops/s per region.
+
+Falcon is a speculative-replication protocol that runs *on top* of
+NoKV's existing raft + Percolator stack. Clients broadcast each op to
+all replicas in parallel; replicas keep an in-memory **tentative log**
+and accept ops that pass per-key conflict detection. As soon as a
+quorum of replicas accept, the client returns success — the master
+batches accepted ops and persists them through Raft asynchronously.
+Conflicts and failures fall back to the existing Raft path, which is
+treated as ground truth.
+
+Combined with **dependency-graph parallel apply**, Falcon targets:
+
+- **5–7× lower** single-op write latency (5 ms → ~1 ms)
+- **10–20× higher** per-region write throughput (1.5 K → 15–30 K ops/s)
+- **Linearizable** semantics preserved
+- **No** durability or consistency weakening
+
+The protocol is closest to CURP (NSDI'19) for the fast path and
+PolarFS ParallelRaft (VLDB'18) for parallel apply, specialised for
+fsmeta's static read/write-set property.
+
+---
+
+## 1. Motivation
+
+### 1.1 What we measured
+
+End-to-end profiling on a real fsmeta cluster (single peer + coordinator,
+all production-equivalent caches and shape extractors wired):
+
+| Workload | Throughput | Per-op latency |
+|---|---:|---:|
+| Create, conc=1 | 121 ops/s | 8.2 ms |
+| Create, conc=16 | 639 ops/s | 1.56 ms |
+| Create, conc=64 | 1 501 ops/s | 0.67 ms |
+| Lookup, conc=1 (cached) | 10 372 ops/s | 96 µs |
+
+CPU sampling showed application code is **0.13–0.36 % of total CPU**
+across the entire stack. The rest is goroutine scheduling, condition
+variables, and gRPC plumbing. The system spends 70 % of wall time
+**waiting** on raft round-trips and fsync.
+
+Profile data: `/tmp/nokv-prof/fsmeta_create.cpu` (kept in branch
+`worktree-e2e-profile`).
+
+### 1.2 Where the floor comes from
+
+A single Create today goes:
+
+```
+client gRPC          ~ 50 µs
+writeBatcher wait    ~200 µs   (kv-layer command coalescer)
+proposalBatcher wait ~  1 ms   (peer-layer raft proposal coalescer)
+processReady         ~  5 ms   (raft Ready cycle: append → fsync → ack)
+apply path           ~ 50 µs   (single Percolator transaction)
+reply gRPC           ~ 50 µs
+                    ─────────
+                       8.2 ms
+```
+
+Concurrency increases overall throughput by amortising raft Ready
+cycles across more ops, but the *per-op* dominator is still the raft
+round-trip: a single fsmeta op cannot complete faster than one raft
+commit cycle.
+
+### 1.3 What's already optimal
+
+Quite a lot. The investigation in branch `worktree-e2e-profile`
+confirmed all of these are working in production:
+
+- 1PC fast path admission ([`txn/percolator/txn.go:296`](../txn/percolator/txn.go))
+  hits 99.9 % for workspace-parented Creates.
+- TSO coalescer ([`fsmeta/runtime/raftstore/tso_coalescer.go`](../fsmeta/runtime/raftstore/tso_coalescer.go))
+  with 200 µs window already reduces TSO RPC count.
+- writeCommandBatcher ([`raftstore/kv/write_batcher.go`](../raftstore/kv/write_batcher.go))
+  coalesces same-region same-cmd ops into a single RaftCmdRequest.
+- BoundedStale read consistency is plumbed all the way to
+  [`raftstore/store/command_ops.go`](../raftstore/store/command_ops.go).
+- Region split boundaries already align with fsmeta affinity buckets.
+
+**There is no further gain to be had inside the existing Raft + Percolator
+protocol.** The remaining floor is *fundamental* to how Raft is
+structured, not an artefact of NoKV's implementation.
+
+### 1.4 fsmeta is unusually friendly
+
+Three properties of the fsmeta workload set it apart from generic
+KV/SQL workloads:
+
+1. **Tiny static footprint.** A Create touches exactly two keys (the
+   dentry and the new inode). An Unlink touches up to three (dentry,
+   inode, and the parent's link-count side-effect). All keys are
+   derivable from the request before any execution begins.
+2. **Predicate purity.** All conditions are `Exists` / `NotExists` /
+   `VersionLessThan` on individual keys; no range predicates, no
+   correlated sub-queries.
+3. **High commutativity.** In a typical multi-tenant deployment,
+   workspaces are independent, parents are independent, and inode
+   allocations are bucketed for affinity. Two random Creates collide
+   on the same dentry < 1 % of the time.
+
+Falcon exploits exactly these three properties.
+
+---
+
+## 2. Goals and Non-Goals
+
+### Goals
+
+- Reduce single-op fsmeta write latency to < 1 ms in the common case.
+- Scale per-region write throughput linearly with applier core count
+  (currently capped at one core).
+- Preserve the existing linearizable semantic of every fsmeta API.
+- Integrate without rewriting Raft, Percolator, WAL, or LSM.
+- Provide a clean fallback to today's Raft path so any unsafe
+  condition degrades gracefully rather than risking correctness.
+
+### Non-Goals
+
+- Not a new replication library. We piggy-back on the existing raft
+  cluster; followers are the witnesses.
+- No new hardware assumptions: no NVM, no programmable switches, no
+  user-space TCP stacks.
+- We do **not** target cross-region transactions in v1. RenameSubtree
+  and other cross-region 2PC paths continue to use today's Percolator
+  flow unchanged.
+- Falcon is fsmeta-specific. Generic KV writes (raftstore/client kv
+  RPC) remain on the Raft path.
+
+---
+
+## 3. Background
+
+### 3.1 NoKV layout
+
+```
+fsmeta/server         ── gRPC service over Executor
+    └── fsmeta/exec   ── operation planner + transaction retry
+        └── TxnRunner ── interface (raftstore client adapter)
+            └── raftstore/client ── kv-RPC client + region routing
+                └── raftstore/kv ── Service.Mutate / TryAtomicMutate
+                    └── raftstore/store ── ProposeCommand / ReadCommand
+                        └── raftstore/peer ── proposalBatcher → raft
+                            └── engine/wal + engine/lsm ── durability
+```
+
+Key invariants (from `project_nokv_architecture` memory):
+
+- Every write obeys `vlog → WAL → memtable → flush SST → manifest`
+  ordering. Falcon must preserve this.
+- Region descriptors live only in `meta/root` truth, never in the
+  manifest. Falcon stays clear of topology truth.
+- Raft entries share the WAL with LSM data, distinguished by record
+  type. Falcon's tentative log is **not** persisted in the WAL.
+
+### 3.2 What the Raft cluster looks like today
+
+A region is a Raft group, typically 3 peers (one leader, two
+followers). Followers receive AppendEntries, fsync, and ack. The
+leader commits when ⌈N/2⌉+1 peers (including itself) have ack'd. On
+commit the leader runs the apply pipeline.
+
+The **proposalBatcher** in `raftstore/peer/proposal_batcher.go`
+collects up to 64 proposals or waits 1 ms, then issues one raft
+Ready cycle for the batch. This is the dominant per-op cost when
+concurrency exceeds the writeBatcher window.
+
+---
+
+## 4. Design Overview
+
+### 4.1 Insight
+
+Raft's job is two things rolled into one: **(a) total ordering** of all
+ops, and **(b) durable replication** of the ordered log. For ops on
+disjoint keys, (a) is unnecessary. Yet Raft pays the round-trip
+ordering cost regardless.
+
+Falcon **decouples** the two: replicas accept and tentatively order
+ops in memory (cheap, parallel), and the master persists them through
+Raft as a background operation (expensive, batched). For
+non-conflicting ops, the client only waits for memory acks → ~1 RTT.
+
+### 4.2 Layering
+
+```
+┌──────────────────────────────────────────────────────────────────┐
+│ Falcon Coordinator (NEW, in raftstore/peer)                      │
+│   - tentative log (in-memory, per replica)                       │
+│   - conflict detector (lock-free)                                │
+│   - submit handler (replica side)                                │
+│   - master commit loop (drives raft proposals)                   │
+│   - master crash recovery (RIFL-style)                           │
+├──────────────────────────────────────────────────────────────────┤
+│ Falcon Client (NEW, in raftstore/client + fsmeta)                │
+│   - broadcast submit + quorum ack                                │
+│   - slow-path fallback                                           │
+│   - read-merged-view                                             │
+├──────────────────────────────────────────────────────────────────┤
+│ Existing raft + Percolator + WAL + LSM (UNCHANGED)               │
+└──────────────────────────────────────────────────────────────────┘
+```
+
+The dotted line: existing protocols are untouched. Falcon adds a
+fast path that *bypasses* raft for the common case and falls through
+to it when fast-path conditions fail.
+
+### 4.3 Where Falcon ends and Raft begins
+
+Falcon is responsible for:
+- Op admission and tentative ordering
+- Conflict detection
+- Returning success to clients
+
+Raft remains responsible for:
+- Durable replication (fsync)
+- Log compaction / snapshots
+- Leader election
+- Membership changes
+- Permanent total order ground truth
+
+A Falcon-acked op is **not durable** until it has been included in a
+committed raft entry. The fast-path "success" is a *promise* that the
+master will eventually persist this op, backed by quorum-witness
+memory.
+
+---
+
+## 5. Protocol Specification
+
+### 5.1 Operation lifecycle
+
+```
+                                                    ┌─ slow path ─→  raft.Propose
+                                                    │
+client                                               │
+  │                                                  │
+  ├── Submit(op) ───broadcast──→ all replicas ──┐    │
+  │                                              ↓    │
+  │                                          accept / conflict
+  │                                              ↓    │
+  │←────────────── quorum accept ──────────────  │    │
+  │                                              ↓    │
+                                              master collects acked
+                                                  │
+                                                  ↓
+                                              raft Ready cycle (batched)
+                                                  │
+                                                  ↓
+                                              parallel apply (DAG)
+                                                  │
+                                                  ↓
+                                              tentative log GC
+```
+
+Key timestamps:
+- `T_submit`: client sends op
+- `T_quorum`: client receives quorum-ack — this is the **commit point**
+- `T_persist`: raft commits the master's batch — this is **durable point**
+- `T_apply`: op visible in LSM
+
+The interval `T_quorum → T_persist` is the speculative window. During
+this window, the op is committed (visible to other ops in the cluster
+through tentative-log merge) but not yet on disk.
+
+### 5.2 Data structures
+
+#### 5.2.1 Operation
+
+```go
+// Op is the unit of speculative replication. It carries everything
+// a replica needs to validate and accept without coordinating with
+// the master.
+type Op struct {
+    // Provenance: client identifier + per-client monotonic sequence.
+    // Used for idempotency on retry and recovery.
+    ClientID uint64
+    Seq      uint64
+
+    // Global timestamp from the coordinator TSO. Establishes the
+    // op's position in the linearizable order.
+    Ts uint64
+
+    // Static read-set: keys whose state determines whether the op
+    // can commit. Each entry pairs a key with a predicate.
+    ReadSet []Predicate
+
+    // Static write-set: keys this op will mutate, and the values to
+    // write at commit time.
+    WriteSet []Mutation
+
+    // Region this op targets. A multi-region op (rare) is split
+    // into one Op per region by the client.
+    RegionID uint64
+
+    // Encoded fsmeta-level intent (Create/Unlink/Rename/...).
+    // Used by the executor and by the apply path.
+    Encoded []byte
+}
+
+type PredCond uint8
+const (
+    PredExists PredCond = iota
+    PredNotExists
+    PredVersionLT      // value's commit_ts < V
+    PredVersionEQ
+)
+
+type Predicate struct {
+    Key  []byte
+    Cond PredCond
+    V    uint64       // ts argument for VersionLT/EQ
+}
+
+type Mutation struct {
+    Key   []byte
+    Value []byte      // empty = delete
+    Meta  byte
+}
+```
+
+**Invariant**: For any op produced by the fsmeta executor, ReadSet and
+WriteSet are computable from the request alone, without observing
+runtime state. This is the property that makes Falcon work.
+
+#### 5.2.2 Tentative Log
+
+```go
+// TentativeLog is the per-replica in-memory store of accepted-but-not-
+// yet-raft-committed ops. It is the heart of Falcon: every replica
+// runs one, and the conflict detector reads from it on every Submit.
+type TentativeLog struct {
+    mu sync.RWMutex
+
+    // Ordered slice of accepted entries, indexed by local sequence.
+    // Cleared as raft commits batches.
+    entries []*Entry
+
+    // Inverted index for conflict detection: key → entries that
+    // touch it. Used both by Submit (write conflict) and by
+    // read-merged-view (visibility).
+    byKey map[string][]*Entry
+
+    // High-water sequence assigned. Local to each replica.
+    nextSeq uint64
+}
+
+type EntryState uint8
+const (
+    StatePending EntryState = iota   // accepted, awaiting raft commit
+    StateRaftCommitted               // raft has commit_index >= this op
+    StateApplied                     // applied to LSM
+)
+
+type Entry struct {
+    Op        *Op
+    LocalSeq  uint64
+    State     EntryState
+    AcceptedAt time.Time
+}
+```
+
+The tentative log is bounded (default 8 K entries / region). When full,
+incoming Submits return a *backpressure* signal that triggers slow path
+on the client.
+
+#### 5.2.3 Replica state
+
+```go
+type FalconReplica struct {
+    role      Role        // Master | Witness
+    raftPeer  *peer.Peer  // existing raft peer
+    tentative *TentativeLog
+    detector  *Detector   // conflict detector
+
+    // Master only
+    commitLoop *commitLoop // batches acked ops → raft
+
+    // Recovery
+    epoch     uint64       // bumped on master election
+}
+```
+
+### 5.3 Fast path
+
+#### 5.3.1 Client
+
+```go
+func (c *FalconClient) Submit(ctx context.Context, op *Op) error {
+    op.Ts = c.tso.Get()
+    op.Seq = c.nextSeq()
+
+    region := c.routeFor(op)
+    peers := region.Peers
+    quorum := len(peers)/2 + 1
+
+    type ackResult struct {
+        peer *Peer
+        verdict Verdict
+        err     error
+    }
+    resCh := make(chan ackResult, len(peers))
+    for _, p := range peers {
+        go func(p *Peer) {
+            v, err := p.Submit(ctx, op)
+            resCh <- ackResult{p, v, err}
+        }(p)
+    }
+
+    var accepted, rejected, errored int
+    seenMaster := false
+    masterAck := false
+
+    for i := 0; i < len(peers); i++ {
+        ack := <-resCh
+        if ack.err != nil {
+            errored++
+            if errored > len(peers)-quorum {
+                return c.slowPath(ctx, op, "transport quorum lost")
+            }
+            continue
+        }
+        if ack.peer == region.Leader {
+            seenMaster = true
+            masterAck = ack.verdict == Accept
+        }
+        switch ack.verdict {
+        case Accept:
+            accepted++
+        case Conflict:
+            rejected++
+            return c.slowPath(ctx, op, "replica reported conflict")
+        case Backpressure:
+            return c.slowPath(ctx, op, "replica reported backpressure")
+        }
+        if accepted >= quorum && (seenMaster && masterAck) {
+            return nil  // fast path success
+        }
+    }
+    return c.slowPath(ctx, op, "quorum not reached")
+}
+```
+
+**Master-required rule**: even if a quorum of *witnesses* accept, the
+client still waits for the master's verdict and requires it to be
+Accept. This is critical for recovery (see §5.7).
+
+#### 5.3.2 Replica handler
+
+```go
+func (r *FalconReplica) Submit(op *Op) Verdict {
+    // 1. Backpressure check.
+    if r.tentative.full() {
+        return Backpressure
+    }
+
+    // 2. Idempotency check: if this (ClientID, Seq) is already in
+    //    the tentative log or recently committed, return the cached
+    //    verdict. Prevents double-application on client retry.
+    if v, ok := r.idempotencyCache.Get(op.ClientID, op.Seq); ok {
+        return v
+    }
+
+    // 3. Acquire per-key locks (lock-free striping; same approach
+    //    as txn/latch but only across WriteSet).
+    keys := append(predicateKeys(op.ReadSet), mutationKeys(op.WriteSet)...)
+    guard := r.detector.Lock(keys)
+    defer guard.Unlock()
+
+    // 4. Predicate validation against the merged view (LSM + tentative).
+    for _, p := range op.ReadSet {
+        actual, err := r.readMerged(p.Key)
+        if err != nil {
+            return Conflict
+        }
+        if !p.Cond.Satisfies(actual, p.V) {
+            return Conflict
+        }
+    }
+
+    // 5. Write conflict: any pending op that touches our WriteSet.
+    for _, m := range op.WriteSet {
+        if pending := r.tentative.byKey[string(m.Key)]; len(pending) > 0 {
+            return Conflict
+        }
+    }
+
+    // 6. Accept.
+    seq := r.tentative.nextSeq.Add(1)
+    entry := &Entry{Op: op, LocalSeq: seq, State: StatePending, AcceptedAt: time.Now()}
+    r.tentative.append(entry)
+    r.idempotencyCache.Put(op.ClientID, op.Seq, Accept)
+
+    return Accept
+}
+```
+
+### 5.4 Slow path
+
+When the fast path fails, the client falls through to the existing
+raft propose path:
+
+```go
+func (c *FalconClient) slowPath(ctx context.Context, op *Op, reason string) error {
+    metrics.SlowPathTotal.Inc(reason)
+    return c.legacyClient.ProposeViaRaft(ctx, op)
+}
+```
+
+The slow path is the current `raftstore/client.TwoPhaseCommit` /
+`TryAtomicMutate` flow. It is what every fsmeta op uses today.
+
+### 5.5 Reads (linearizable)
+
+Reads must observe all fast-path committed writes. Every read merges
+the tentative log with the LSM:
+
+```go
+func (r *FalconReplica) Read(key []byte, version uint64) ([]byte, error) {
+    // Snapshot the tentative entries that touch this key, ordered by
+    // their op timestamp.
+    pending := r.tentative.snapshotByKey(key)
+
+    // Find the most recent entry visible at the read version.
+    for i := len(pending) - 1; i >= 0; i-- {
+        e := pending[i]
+        if e.Op.Ts > version {
+            continue
+        }
+        if e.State >= StatePending {
+            // Apply the tentative mutation virtually.
+            for _, m := range e.Op.WriteSet {
+                if bytes.Equal(m.Key, key) {
+                    return m.Value, nil
+                }
+            }
+        }
+    }
+
+    // Fall through to LSM read.
+    return r.lsm.Get(key, version)
+}
+```
+
+This costs an extra map lookup + slice walk per read. The byKey index
+keeps the walk to O(pending ops touching this key), typically 0 or 1.
+
+### 5.6 Master commit + GC
+
+The master runs a background loop that drains the tentative log and
+proposes batches to raft:
+
+```go
+func (m *Master) commitLoop() {
+    ticker := time.NewTicker(50 * time.Microsecond)
+    defer ticker.Stop()
+
+    for range ticker.C {
+        batch := m.tentative.drainAcceptedSince(m.lastDrained, maxBatchSize)
+        if len(batch) == 0 {
+            continue
+        }
+
+        cmd := encodeBatch(batch)
+        proposalDone := m.raft.Propose(cmd)
+
+        // Wait for raft commit. Async is OK: pending entries stay in
+        // the tentative log until we mark them StateRaftCommitted.
+        go func() {
+            <-proposalDone
+            m.tentative.markCommitted(batch)
+        }()
+    }
+}
+```
+
+GC happens when entries reach `StateApplied`:
+
+```go
+func (r *FalconReplica) gcApplied() {
+    r.tentative.dropApplied()  // remove entries whose State == StateApplied
+}
+```
+
+Tentative log size is therefore bounded by the raft-commit lag, not
+by the total op count.
+
+### 5.7 Master crash recovery (RIFL-style)
+
+This is **the hardest part of the protocol** and the main contribution
+of the work. When the master fails, a new master is elected via Raft.
+Before it can accept new submits, it must reconstruct the speculative
+state: which ops were fast-path-committed (must be persisted) and which
+were not (may be dropped).
+
+#### Recovery procedure
+
+```
+1. New master M' is elected (via existing raft).
+2. M' broadcasts RecoveryRequest to all alive replicas.
+3. Each replica returns its TentativeLog snapshot (Pending entries
+   only — Applied/Committed are no longer in tentative).
+4. M' merges:
+     allOps := dedupe by (ClientID, Seq) the union of returned snapshots
+     for each op:
+        accepted_by := count of replicas whose snapshot included op
+        if accepted_by >= quorum AND op was acked by previous master:
+            // The op was fast-path-committed. Must persist.
+            mustReplay = append(mustReplay, op)
+        else:
+            // Fewer than quorum, OR previous master never saw it.
+            // The client never received success. Safe to drop.
+            // But: we must reject any future Submit with same
+            // (ClientID, Seq) lest the client retry and we apply twice.
+            blacklist[op.ClientID, op.Seq] = Rejected
+5. M' proposes mustReplay through Raft as a single batch.
+6. After raft commit and apply: M' opens for new Submits.
+```
+
+The master-required rule from §5.3.1 makes step 4's *previous master*
+condition cheap to check: an op acked by the previous master is by
+construction the only way the client got a success response, so its
+absence in M''s snapshot means the previous master crashed before
+broadcasting it. M' need not consult dead masters; the witness count
+plus the existence of an Accept in the union is sufficient.
+
+**Proof sketch** (full version in §6):
+- If a client received success at time T, then at T there were ≥
+  quorum replicas with the op in their tentative log AND the master
+  had the op in its tentative log.
+- After master crash, ≤ f replicas have failed (where N = 2f+1).
+- ≥ quorum - f = 1 replica with the op survives.
+- M''s broadcast reaches at least the surviving replica.
+- M' sees the op and includes it in mustReplay. ∎
+
+#### Edge cases
+
+- **Master crashes after fast-path Accept but before broadcasting to
+  followers**: client only got master ack, never reached quorum →
+  client never received success. M' may or may not see the op
+  depending on whether master flushed to a follower. Either way,
+  client did not commit, so dropping is safe.
+- **Network partition**: standard raft leader election handles
+  partition. Falcon-side: the partitioned old master cannot accept
+  new ops because raft will reject its proposals; clients hit slow
+  path and time out.
+- **Slow follower**: a follower that is behind on raft-commits will
+  have a longer tentative log. Backpressure throttles new submits
+  before this becomes unbounded.
+
+### 5.8 Parallel apply via dependency DAG
+
+When raft commits a batch of N ops, the apply path traditionally
+processes them one at a time. Falcon builds a dependency DAG and
+applies independent ops concurrently:
+
+```go
+func (m *Master) applyBatch(ops []*Op) {
+    // 1. Build read/write set per op (already in Op).
+    // 2. For each pair of ops in raft order, draw an edge if their
+    //    sets overlap. The DAG is the transitive reduction.
+    dag := buildDAG(ops)
+
+    // 3. Topological wave execution.
+    for !dag.empty() {
+        ready := dag.takeRoots()  // ops with no remaining dependencies
+
+        var wg sync.WaitGroup
+        for _, op := range ready {
+            wg.Add(1)
+            go func(op *Op) {
+                defer wg.Done()
+                m.applyOne(op)
+            }(op)
+        }
+        wg.Wait()
+
+        dag.removeNodes(ready)
+    }
+}
+```
+
+For typical fsmeta workloads where ops touch disjoint keys, the DAG
+is mostly flat (one wide level). Apply runs in O(1) wall time per
+batch instead of O(N).
+
+The DAG construction itself is O(N²) in the worst case (every pair
+checked) but in practice the byKey index reduces it to O(N) when most
+ops are disjoint.
+
+---
+
+## 6. Correctness
+
+### 6.1 Linearizability
+
+**Claim**: For every history of Submit/Read calls, there exists a
+total order T such that:
+1. T respects per-client real-time ordering (monotonic Seq).
+2. Every Read R returns the value that T's last Write to R's key
+   would produce.
+3. Every successful Submit appears in T.
+
+**Proof outline**:
+
+- Define T as the order by `(op.Ts, op.ClientID, op.Seq)`. TSO
+  monotonicity gives uniqueness.
+- A Submit returns success only after quorum acceptance, which
+  requires predicate satisfaction in the merged view. The merged
+  view contains all earlier-acked ops with smaller Ts.
+- A Read at version V observes (a) committed writes in LSM with
+  commit_ts ≤ V and (b) tentative ops with op.Ts ≤ V whose state is
+  Pending or beyond. By construction, any op with op.Ts ≤ V is
+  either applied (case a) or in the tentative log (case b).
+- By the master-required rule, no op at Ts > V can affect a read at
+  V before V is exceeded.
+
+The full proof requires TLA+ specification (planned for M4).
+
+### 6.2 Durability
+
+**Failure model**: ≤ f node failures out of N = 2f+1.
+
+**Claim**: For every Submit that returned success, the op will be
+present in the persisted Raft log after master recovery.
+
+**Proof**: Quorum ack means the op was in master's tentative log
+*and* in ≥ f witnesses' tentative logs. After ≤ f failures, ≥ 1
+witness with the op survives. Recovery (§5.7) finds it through the
+broadcast to alive replicas. ∎
+
+### 6.3 Recovery termination
+
+**Claim**: Recovery completes in bounded time.
+
+The number of pending ops is bounded by the tentative-log capacity
+(8 K). Recovery does one Raft proposal of ≤ 8 K ops (single batch),
+followed by one apply phase. Both are bounded.
+
+### 6.4 What we are NOT proving
+
+- Falcon does not improve availability over raft. If raft cannot
+  elect a leader, no fast path either.
+- Falcon does not improve cross-region consistency. RenameSubtree
+  remains a 2PC across two raft groups.
+- Falcon does not handle Byzantine faults. Same model as raft.
+
+---
+
+## 7. Implementation Roadmap
+
+| Milestone | Scope | LoC est. | Time | Independent? |
+|---|---|---:|---:|---|
+| **M1** | Parallel apply via DAG (no protocol change) | 1 500 | 3-4 weeks | Yes |
+| **M2** | Tentative log + replica Submit handler | 2 500 | 6-8 weeks | No (needs M1) |
+| **M3** | Client fast path + slow-path fallback | 1 500 | 4-6 weeks | No (needs M2) |
+| **M4** | RIFL-style master recovery + TLA+ | 1 500 | 6-8 weeks | No (needs M3) |
+| **M5** | fsmeta-aware optimisations | 1 000 | 2-3 weeks | No (needs M3) |
+| **M6** | Evaluation + paper writing | — | 3-4 weeks | — |
+
+**Total**: ~ 8 000 LoC, 5–7 months single-engineer.
+
+### M1 first
+
+M1 (parallel apply) is independently mergeable and produces real
+production value (10–20 % per-region throughput) without any protocol
+change. It also de-risks the dependency-DAG construction code that M2
+needs.
+
+### Decision points
+
+- **End of M1**: do measurements support the protocol-change cost? If
+  parallel apply alone solves the bottleneck, halt here.
+- **End of M3**: TLA+ model checking of recovery. If specification
+  reveals subtle issues, may need protocol revisions before paper.
+
+---
+
+## 8. Performance Projections
+
+### 8.1 Per-op latency
+
+| Path | Today | After Falcon | Speedup |
+|---|---:|---:|---:|
+| Single Create, conc=1 | 8.2 ms | 1.0–1.5 ms | 5–8× |
+| Single Create, conc=64 | 0.67 ms | 0.3–0.5 ms | 1.5–2× |
+| 100-file checkpoint storm | ~700 ms | ~30–60 ms | 12–20× |
+| Cross-region rename | ~15 ms | unchanged | 1× |
+
+### 8.2 Per-region throughput
+
+At conc=64, today's bottleneck is serial apply (~2.4 K ops/s). With
+DAG-parallel apply:
+
+| Workload | Today | M1 | M3 | M5 |
+|---|---:|---:|---:|---:|
+| Independent Creates | 2.4 K | 8 K | 25 K | 30 K |
+| Mixed (90% independent, 10% conflicting) | 2.0 K | 6 K | 18 K | 22 K |
+| Hotspot (single workspace, all conflicting) | 2.4 K | 2.4 K | 2.5 K | 2.5 K |
+
+The hotspot case shows the protocol's failure mode: when most ops
+conflict, fast path is rejected and we are no worse than raft.
+
+### 8.3 Recovery time
+
+After master crash, Falcon adds:
+- One round-trip to all replicas to gather tentative logs (~ 1 ms)
+- One raft propose of mustReplay (≤ 8 K ops, ~ 5 ms)
+
+Total additional recovery time: < 10 ms over baseline raft recovery,
+which is in the seconds range due to leader election heartbeats.
+
+---
+
+## 9. Risks
+
+| Risk | Severity | Mitigation |
+|---|---|---|
+| Recovery protocol bug | **Critical** | TLA+ specification + model checking; chaos testing before enable |
+| Tentative log GC lag → memory blowup | High | Hard cap (8 K) + backpressure → slow path |
+| Predicate validation false negatives | High | Conservative: any uncertainty → Conflict → slow path |
+| Read-merged-view race with apply | Medium | Strict snapshot semantics; entries advance state monotonically |
+| Performance regression on hotspot | Medium | Clean fallback; metrics expose fast-path admission rate |
+| Increased network traffic (broadcast) | Low | Only ~3× current peer count; same connections reused |
+| Compatibility with TiKV-style tooling | Low | Slow path matches existing wire format |
+
+The recovery bug is the only existential risk. Everything else
+gracefully degrades.
+
+---
+
+## 10. Evaluation Plan
+
+For paper-quality evidence, we need to compare Falcon against:
+
+1. **Baseline NoKV** (this branch's HEAD)
+2. **TiKV** (~equivalent stack, mature)
+3. **CockroachDB** metadata layer (different protocol, similar workload)
+4. **etcd** (raft-only, single-key linearizable)
+
+### Workloads
+
+- **fsmeta-bench** (existing in `benchmark/fsmeta/`): checkpoint storm,
+  multi-workspace autoscale, mixed.
+- **Microbenchmarks**: single-key write latency, hot-key contention,
+  read-write mix.
+- **Failure scenarios**: master crash, network partition, slow follower.
+
+### Metrics
+
+- p50 / p99 / p99.9 write latency
+- Per-region throughput vs concurrency
+- Fast-path admission rate by workload
+- Recovery time after master kill
+- CPU / memory / network overhead vs baseline
+
+### Comparison axes
+
+- Raft vs Falcon (same NoKV codebase)
+- Falcon-fast-path vs Falcon-slow-path-only (ablation)
+- M1-only vs M1+M2+M3 vs full Falcon (incremental)
+
+---
+
+## 11. Open Questions
+
+1. **TSO precision under clock skew**: Falcon depends on TSO
+   monotonicity for the total order. NoKV's existing TSO from
+   coordinator is monotonic per-mount. Cross-mount monotonicity is
+   weaker but fsmeta does not require it. Need to verify this still
+   holds under all coordinator failure modes.
+
+2. **Idempotency cache size**: how big does it need to be? Bounded
+   by max in-flight client retries, typically small. But sizing
+   wrong causes occasional false rejects.
+
+3. **Witness role on followers**: should we use *all* followers as
+   witnesses, or designate a subset? Using all maximises ack
+   probability; using a subset reduces network amplification.
+   Initial choice: all followers.
+
+4. **Watchsubtree event ordering**: events from fast-path-committed
+   ops need delivery order consistent with the linearizable order T.
+   Watch event publication should happen after the master's raft
+   commit, not at fast-path ack time, to avoid showing un-recovered
+   ops to watchers. Need to verify watch path.
+
+5. **Single-region vs multi-region scope**: v1 is per-region only.
+   Cross-region rename remains 2PC. A Falcon-equivalent for cross-
+   region transactions (Janus-style) is a follow-up paper.
+
+---
+
+## 12. References
+
+1. Park, S. & Ousterhout, J. *Exploiting Commutativity For Practical
+   Fast Replication*. NSDI '19. [The CURP paper.]
+2. Cao, W. et al. *PolarFS: An Ultra-low Latency and Failure Resilient
+   Distributed File System for Shared Storage Cloud Database*.
+   VLDB '18. [ParallelRaft.]
+3. Ding, C. et al. *Scalog: Seamless Reconfiguration and Total Order
+   in a Scalable Shared Log*. NSDI '20.
+4. Ousterhout, J. & Ongaro, D. *In Search of an Understandable
+   Consensus Algorithm*. ATC '14. [Raft.]
+5. Peng, D. & Dabek, F. *Large-scale Incremental Processing Using
+   Distributed Transactions and Notifications*. OSDI '10.
+   [Percolator.]
+6. Shamis, A. et al. *Fast General Distributed Transactions with
+   Opacity*. SIGMOD '19. [FaRMv2; informs failure-atomic apply.]
+7. Lockerman, J. et al. *The FuzzyLog: A Partially Ordered Shared
+   Log*. OSDI '18. [Inspires partial-order tentative log.]
+8. Liu, Y. et al. *InfiniFS: An Efficient Metadata Service for
+   Large-Scale Distributed Filesystems*. FAST '22.
+
+---
+
+## Appendix A: API surface
+
+```go
+// raftstore/peer/falcon — new package
+
+type Coordinator struct { /* ... */ }
+
+func (c *Coordinator) Submit(ctx context.Context, op *Op) Verdict
+func (c *Coordinator) Read(ctx context.Context, key []byte, ts uint64) ([]byte, error)
+func (c *Coordinator) RecoverFrom(ctx context.Context, snapshot []TentativeSnapshot) error
+
+// raftstore/client — extended
+
+func (c *Client) FalconSubmit(ctx context.Context, op *Op) error  // fast path
+// existing Mutate / TwoPhaseCommit remain as slow path
+
+// fsmeta/exec — extended to populate ReadSet/WriteSet from plans
+```
+
+## Appendix B: Failure scenarios catalogue
+
+| # | Scenario | Behaviour |
+|---|---|---|
+| 1 | Single follower crash | Fast path continues with quorum |
+| 2 | Master crash, fast-path op pending | Recovery includes op, client retry idempotent |
+| 3 | Master crash, fast-path op never broadcast | Client times out, retries on slow path |
+| 4 | Network partition (master in minority) | Master loses raft leadership, clients fail over |
+| 5 | Tentative log full | Backpressure → slow path → drains as raft catches up |
+| 6 | Conflict between concurrent ops | One accepts, the other gets Conflict → slow path |
+| 7 | Replica returns stale predicate evaluation | Detected at master commit; whole batch rolled back |
+| 8 | Client retries with same Seq | Idempotency cache returns prior verdict |
+
+---
+
+*Document version 1.0. Comments / corrections via NoKV pull request.*

--- a/raftstore/integration/coordinator_degraded_test.go
+++ b/raftstore/integration/coordinator_degraded_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/feichai0017/NoKV/raftstore/client"
 	"github.com/feichai0017/NoKV/raftstore/migrate"
 	"github.com/feichai0017/NoKV/raftstore/testcluster"
+	"github.com/feichai0017/NoKV/txn/percolator"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
@@ -85,8 +86,8 @@ func TestClusterSurvivesCoordinatorUnavailableAfterStartup(t *testing.T) {
 	updated := []byte("coordinator-outage-updated")
 	require.NoError(t, cli.Put(ctx, key, updated, 20, 21, 3000))
 	require.Eventually(t, func() bool {
-		entry, err := target.DB.Get(key)
-		return err == nil && string(entry.Value) == string(updated)
+		got, _, err := percolator.NewReader(target.DB).GetValue(key, 30)
+		return err == nil && string(got) == string(updated)
 	}, 5*time.Second, 20*time.Millisecond)
 
 	getResp, err = cli.Get(ctx, key, 30)

--- a/raftstore/integration/transport_chaos_test.go
+++ b/raftstore/integration/transport_chaos_test.go
@@ -2,14 +2,15 @@ package integration
 
 import (
 	"context"
-	metapb "github.com/feichai0017/NoKV/pb/meta"
 	"testing"
 	"time"
 
 	workdirmode "github.com/feichai0017/NoKV/local/workdir"
+	metapb "github.com/feichai0017/NoKV/pb/meta"
 	"github.com/feichai0017/NoKV/raftstore/client"
 	"github.com/feichai0017/NoKV/raftstore/migrate"
 	"github.com/feichai0017/NoKV/raftstore/testcluster"
+	"github.com/feichai0017/NoKV/txn/percolator"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
@@ -84,7 +85,7 @@ func TestPartitionedFollowerCatchesUpAfterRecovery(t *testing.T) {
 	value := []byte("partitioned-follower-value")
 	require.NoError(t, cli.Put(ctx, key, value, 10, 11, 3000))
 
-	_, err = target3.DB.Get(key)
+	_, _, err = percolator.NewReader(target3.DB).GetValue(key, 12)
 	require.Error(t, err)
 
 	target3.Restart(t, nil, true)
@@ -102,8 +103,8 @@ func TestPartitionedFollowerCatchesUpAfterRecovery(t *testing.T) {
 	target2.UnblockPeer(301)
 
 	require.Eventually(t, func() bool {
-		entry, err := target3.DB.Get(key)
-		return err == nil && string(entry.Value) == string(value)
+		got, _, err := percolator.NewReader(target3.DB).GetValue(key, 12)
+		return err == nil && string(got) == string(value)
 	}, 5*time.Second, 50*time.Millisecond)
 }
 

--- a/raftstore/kv/apply_test.go
+++ b/raftstore/kv/apply_test.go
@@ -211,7 +211,7 @@ func TestApplyTryAtomicMutateBatchFusesLocalApply(t *testing.T) {
 		require.Equal(t, uint64(1), atomicResp.GetAppliedKeys())
 	}
 	require.Equal(t, 1, store.applyCalls)
-	require.Equal(t, []int{6}, store.appliedEntryCounts)
+	require.Equal(t, []int{2}, store.appliedEntryCounts)
 }
 
 func TestApplyPrewriteBatchFusesLocalApply(t *testing.T) {
@@ -242,7 +242,7 @@ func TestApplyPrewriteBatchFusesLocalApply(t *testing.T) {
 		require.Empty(t, prewriteResp.GetErrors())
 	}
 	require.Equal(t, 1, store.applyCalls)
-	require.Equal(t, []int{6}, store.appliedEntryCounts)
+	require.Equal(t, []int{2}, store.appliedEntryCounts)
 }
 
 func TestApplyTryAtomicMutateCommandFallsBackForCrossShardBatch(t *testing.T) {

--- a/txn/mvcc/codec.go
+++ b/txn/mvcc/codec.go
@@ -22,6 +22,12 @@ const (
 //	ttl_ms uvarint
 //	mutation_kind byte
 //	min_commit_ts uvarint
+//	has_short_value byte
+//	if has_short_value == 1:
+//	  short_value_len uvarint
+//	  short_value bytes
+//	if short value or expires_at is present:
+//	  expires_at uvarint
 //
 // TTL is measured from start_time_unix_ms. start_ts remains the MVCC logical
 // timestamp and must not be used as a physical clock.
@@ -38,12 +44,14 @@ type Lock struct {
 	TTL         uint64
 	Kind        kvrpcpb.Mutation_Op
 	MinCommitTs uint64
+	ShortValue  []byte
+	ExpiresAt   uint64
 }
 
 // EncodeLock serialises a lock entry.
 func EncodeLock(lock Lock) []byte {
 	primaryLen := len(lock.Primary)
-	buf := make([]byte, 0, 1+binary.MaxVarintLen64*5+primaryLen)
+	buf := make([]byte, 0, 1+binary.MaxVarintLen64*7+primaryLen+len(lock.ShortValue))
 	buf = append(buf, lockCodecVersion)
 	buf = binary.AppendUvarint(buf, uint64(primaryLen))
 	buf = append(buf, lock.Primary...)
@@ -52,6 +60,16 @@ func EncodeLock(lock Lock) []byte {
 	buf = binary.AppendUvarint(buf, lock.TTL)
 	buf = append(buf, byte(lock.Kind))
 	buf = binary.AppendUvarint(buf, lock.MinCommitTs)
+	if len(lock.ShortValue) > 0 {
+		buf = append(buf, 1)
+		buf = binary.AppendUvarint(buf, uint64(len(lock.ShortValue)))
+		buf = append(buf, lock.ShortValue...)
+	} else {
+		buf = append(buf, 0)
+	}
+	if len(lock.ShortValue) > 0 || lock.ExpiresAt > 0 {
+		buf = binary.AppendUvarint(buf, lock.ExpiresAt)
+	}
 	return buf
 }
 
@@ -76,7 +94,7 @@ func DecodeLock(data []byte) (Lock, error) {
 	if err != nil {
 		return Lock{}, err
 	}
-	if pos+int(primaryLen) > len(data) {
+	if primaryLen > uint64(len(data)-pos) {
 		return Lock{}, fmt.Errorf("mvcc: lock primary truncated")
 	}
 	lock := Lock{
@@ -105,6 +123,30 @@ func DecodeLock(data []byte) (Lock, error) {
 			return Lock{}, err
 		}
 	}
+	if pos < len(data) {
+		hasShort := data[pos]
+		pos++
+		switch hasShort {
+		case 0:
+		case 1:
+			sz, err := readUvarint()
+			if err != nil {
+				return Lock{}, err
+			}
+			if sz > uint64(len(data)-pos) {
+				return Lock{}, fmt.Errorf("mvcc: lock short value truncated")
+			}
+			lock.ShortValue = append([]byte(nil), data[pos:pos+int(sz)]...)
+			pos += int(sz)
+		default:
+			return Lock{}, fmt.Errorf("mvcc: invalid lock short value marker %d", hasShort)
+		}
+	}
+	if pos < len(data) {
+		if lock.ExpiresAt, err = readUvarint(); err != nil {
+			return Lock{}, err
+		}
+	}
 	return lock, nil
 }
 
@@ -115,6 +157,16 @@ type Write struct {
 	StartTs    uint64
 	ShortValue []byte
 	ExpiresAt  uint64
+}
+
+const DefaultShortValueMaxBytes = 128
+
+// CanInlineShortValue reports whether a Put value can be carried by the MVCC
+// lock/write records instead of the default CF. Empty values stay on the
+// default CF because ShortValue's nil/empty representation is reserved for
+// "not inlined".
+func CanInlineShortValue(kind kvrpcpb.Mutation_Op, value []byte) bool {
+	return kind == kvrpcpb.Mutation_Put && len(value) > 0 && len(value) <= DefaultShortValueMaxBytes
 }
 
 // Write encoding layout:

--- a/txn/mvcc/codec_test.go
+++ b/txn/mvcc/codec_test.go
@@ -16,6 +16,8 @@ func TestEncodeDecodeLockRoundTrip(t *testing.T) {
 		TTL:         20,
 		Kind:        kvrpcpb.Mutation_Put,
 		MinCommitTs: 30,
+		ShortValue:  []byte("short-lock"),
+		ExpiresAt:   12345,
 	}
 	encoded := EncodeLock(lock)
 	got, err := DecodeLock(encoded)
@@ -26,6 +28,8 @@ func TestEncodeDecodeLockRoundTrip(t *testing.T) {
 	require.Equal(t, lock.TTL, got.TTL)
 	require.Equal(t, lock.Kind, got.Kind)
 	require.Equal(t, lock.MinCommitTs, got.MinCommitTs)
+	require.Equal(t, lock.ShortValue, got.ShortValue)
+	require.Equal(t, lock.ExpiresAt, got.ExpiresAt)
 }
 
 func TestDecodeLockErrors(t *testing.T) {
@@ -65,6 +69,13 @@ func TestEncodeDecodeWriteRoundTrip(t *testing.T) {
 	require.Equal(t, write.StartTs, got.StartTs)
 	require.Equal(t, write.ShortValue, got.ShortValue)
 	require.Equal(t, write.ExpiresAt, got.ExpiresAt)
+}
+
+func TestCanInlineShortValue(t *testing.T) {
+	require.True(t, CanInlineShortValue(kvrpcpb.Mutation_Put, []byte("small")))
+	require.False(t, CanInlineShortValue(kvrpcpb.Mutation_Put, nil))
+	require.False(t, CanInlineShortValue(kvrpcpb.Mutation_Put, make([]byte, DefaultShortValueMaxBytes+1)))
+	require.False(t, CanInlineShortValue(kvrpcpb.Mutation_Delete, []byte("small")))
 }
 
 func TestDecodeWriteDefaultsMissingExpiresAtToZero(t *testing.T) {

--- a/txn/percolator/atomic_apply_bench_test.go
+++ b/txn/percolator/atomic_apply_bench_test.go
@@ -1,0 +1,130 @@
+package percolator
+
+import (
+	"fmt"
+	"sync/atomic"
+	"testing"
+
+	"github.com/feichai0017/NoKV/local"
+	kvrpcpb "github.com/feichai0017/NoKV/pb/kv"
+	"github.com/feichai0017/NoKV/txn/latch"
+)
+
+// BenchmarkApplyAtomicMutateBatchDisjoint measures the per-batch
+// wall-time of ApplyAtomicMutateBatch on a batch of N independent
+// requests. Below parallelValidationThreshold the planner runs
+// serially; at and above it validations fan out to goroutines. Each
+// iteration uses fresh keys so back-to-back batches do not see each
+// other's writes.
+//
+// To keep the benchmark dominated by the apply path itself rather
+// than fixture cost, the DB and latch manager are reused across
+// iterations. b.SetBytes is set to the per-batch entry count so
+// `-benchtime=Ns` runs are still well-defined.
+func BenchmarkApplyAtomicMutateBatchDisjoint(b *testing.B) {
+	for _, batch := range []int{1, 2, 4, 8, 16, 32} {
+		b.Run(fmt.Sprintf("n=%d", batch), func(b *testing.B) {
+			opt := testOptionsForDir(b.TempDir())
+			opt.LSMShardCount = 1
+			// Big memtable so the bench measures the apply pipeline, not
+			// memtable rotations / compaction triggered by tiny defaults.
+			opt.MemTableSize = 64 << 20
+			opt.SSTableMaxSz = 256 << 20
+			db, err := local.Open(opt)
+			if err != nil {
+				b.Fatalf("open db: %v", err)
+			}
+			b.Cleanup(func() { _ = db.Close() })
+			store := newCountingAtomicStore(db)
+			latches := latch.NewManager(64)
+			var keyCounter atomic.Uint64
+			var ts atomic.Uint64
+			ts.Store(2)
+
+			b.ReportAllocs()
+			b.SetBytes(int64(batch))
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				reqs := make([]*kvrpcpb.TryAtomicMutateRequest, 0, batch)
+				for k := 0; k < batch; k++ {
+					id := keyCounter.Add(1)
+					start := ts.Add(2) - 2
+					reqs = append(reqs, atomicPutRequest(
+						start, start+1,
+						[]byte(fmt.Sprintf("bench-disjoint-%010d", id)),
+						[]byte("v"),
+					))
+				}
+
+				results := ApplyAtomicMutateBatch(store, latches, reqs)
+				if len(results) != batch {
+					b.Fatalf("expected %d results, got %d", batch, len(results))
+				}
+				for j, r := range results {
+					if r.Error != nil {
+						b.Fatalf("result %d errored: %v", j, r.Error)
+					}
+				}
+			}
+		})
+	}
+}
+
+// BenchmarkApplyAtomicMutateBatchAllConflict measures the worst case:
+// every request in the batch conflicts with the previous one, forcing
+// the DAG into a single chain (one item per level). Validation cannot
+// run in parallel; the only difference from the legacy path is the
+// constant overhead of building and walking the DAG.
+//
+// Useful as a guard: if this regresses materially relative to the
+// pre-Falcon serial implementation, we are paying too much for
+// scheduling we never use.
+func BenchmarkApplyAtomicMutateBatchAllConflict(b *testing.B) {
+	for _, batch := range []int{2, 4, 8, 16, 32} {
+		b.Run(fmt.Sprintf("n=%d", batch), func(b *testing.B) {
+			opt := testOptionsForDir(b.TempDir())
+			opt.LSMShardCount = 1
+			// Big memtable so the bench measures the apply pipeline, not
+			// memtable rotations / compaction triggered by tiny defaults.
+			opt.MemTableSize = 64 << 20
+			opt.SSTableMaxSz = 256 << 20
+			db, err := local.Open(opt)
+			if err != nil {
+				b.Fatalf("open db: %v", err)
+			}
+			b.Cleanup(func() { _ = db.Close() })
+			store := newCountingAtomicStore(db)
+			latches := latch.NewManager(64)
+			var ts atomic.Uint64
+			ts.Store(2)
+			var keyCounter atomic.Uint64
+
+			b.ReportAllocs()
+			b.SetBytes(int64(batch))
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				// All operations target the same single key, so the DAG
+				// degenerates into a chain. Only the first succeeds; the
+				// remainder fail with AlreadyExists. Each iteration uses a
+				// fresh key so the chain reproduces.
+				key := []byte(fmt.Sprintf("bench-conflict-%010d", keyCounter.Add(1)))
+				reqs := make([]*kvrpcpb.TryAtomicMutateRequest, 0, batch)
+				for k := 0; k < batch; k++ {
+					start := ts.Add(2) - 2
+					reqs = append(reqs, atomicPutRequest(start, start+1, key, []byte("v")))
+				}
+
+				results := ApplyAtomicMutateBatch(store, latches, reqs)
+				if len(results) != batch {
+					b.Fatalf("expected %d results, got %d", batch, len(results))
+				}
+				if results[0].Error != nil {
+					b.Fatalf("first result errored: %v", results[0].Error)
+				}
+				// The rest are expected to fail with AlreadyExists; that's
+				// fine — the bench measures the apply pipeline, not the
+				// outcome semantics.
+			}
+		})
+	}
+}

--- a/txn/percolator/dag.go
+++ b/txn/percolator/dag.go
@@ -1,0 +1,75 @@
+package percolator
+
+// dependencyLevels groups a sequence of items into topological waves
+// based on their key conflicts. Items in the same level are mutually
+// non-conflicting and can be processed in parallel; items in different
+// levels must be processed level-by-level in ascending order to
+// preserve raft-log ordering for conflicting operations.
+//
+// The algorithm is intentionally simple: walk items in raft order,
+// tracking the most recent level that touched each key. A new item's
+// level is one greater than the highest level among any of its keys
+// that have been seen, or 0 if none have. This is conservative:
+// it produces a correct topological order but does not always
+// achieve maximum parallelism (e.g. an item that conflicts only
+// with the previous item but not with two-back is forced to wait
+// for the chain rather than slot in earlier).
+//
+// Complexity: O(N * K) where N is item count and K is average
+// keys-per-item. For typical fsmeta batches (N=64, K=2-4) this is
+// in the low microseconds, dwarfed by the per-item LSM read cost
+// the parallel layer is amortizing.
+//
+// Returned slice has one entry per level, each holding the indices
+// of the original items that belong to that level. Within a level,
+// indices appear in raft order. Levels themselves are returned in
+// ascending order.
+func dependencyLevels(itemKeys [][][]byte) [][]int {
+	if len(itemKeys) == 0 {
+		return nil
+	}
+	// nodeLevel[i] = the topological level assigned to item i
+	nodeLevel := make([]int, len(itemKeys))
+	// keyLevel maps the byte key to the most recent level that touched it
+	keyLevel := make(map[string]int, len(itemKeys)*2)
+	maxLevel := 0
+	for i, keys := range itemKeys {
+		level := 0
+		for _, k := range keys {
+			if len(k) == 0 {
+				continue
+			}
+			if l, ok := keyLevel[string(k)]; ok && l+1 > level {
+				level = l + 1
+			}
+		}
+		nodeLevel[i] = level
+		if level > maxLevel {
+			maxLevel = level
+		}
+		for _, k := range keys {
+			if len(k) == 0 {
+				continue
+			}
+			keyLevel[string(k)] = level
+		}
+	}
+	levels := make([][]int, maxLevel+1)
+	for i, l := range nodeLevel {
+		levels[l] = append(levels[l], i)
+	}
+	return levels
+}
+
+// nonEmptyKeyCount counts the items in a slice that have a non-empty
+// key set. Items with no keys (e.g. ineligible requests that already
+// produced a result during preparation) do not need scheduling.
+func nonEmptyKeyCount(itemKeys [][][]byte) int {
+	n := 0
+	for _, keys := range itemKeys {
+		if len(keys) > 0 {
+			n++
+		}
+	}
+	return n
+}

--- a/txn/percolator/dag_test.go
+++ b/txn/percolator/dag_test.go
@@ -1,0 +1,152 @@
+package percolator
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestDependencyLevelsEmpty verifies the boundary case.
+func TestDependencyLevelsEmpty(t *testing.T) {
+	require.Empty(t, dependencyLevels(nil))
+	require.Empty(t, dependencyLevels([][][]byte{}))
+}
+
+// TestDependencyLevelsAllDisjoint: every item touches a unique key, so
+// they should all collapse to a single level (maximum parallelism).
+func TestDependencyLevelsAllDisjoint(t *testing.T) {
+	keys := [][][]byte{
+		{[]byte("a")},
+		{[]byte("b")},
+		{[]byte("c")},
+		{[]byte("d")},
+	}
+	levels := dependencyLevels(keys)
+	require.Len(t, levels, 1)
+	require.Equal(t, []int{0, 1, 2, 3}, levels[0])
+}
+
+// TestDependencyLevelsLinearChain: each item shares a key with the
+// previous one; the result must be a chain, one item per level.
+func TestDependencyLevelsLinearChain(t *testing.T) {
+	keys := [][][]byte{
+		{[]byte("a"), []byte("b")},
+		{[]byte("b"), []byte("c")},
+		{[]byte("c"), []byte("d")},
+		{[]byte("d"), []byte("e")},
+	}
+	levels := dependencyLevels(keys)
+	require.Len(t, levels, 4)
+	for i, level := range levels {
+		require.Equal(t, []int{i}, level)
+	}
+}
+
+// TestDependencyLevelsConflictWithPrior: an item that conflicts with
+// an earlier (non-immediate) item still inherits the right level.
+func TestDependencyLevelsConflictWithPrior(t *testing.T) {
+	// 0: {a}        level 0
+	// 1: {b}        level 0 (no conflict with 0)
+	// 2: {c}        level 0
+	// 3: {a, c}     conflicts with 0 (level 0) and 2 (level 0) -> level 1
+	keys := [][][]byte{
+		{[]byte("a")},
+		{[]byte("b")},
+		{[]byte("c")},
+		{[]byte("a"), []byte("c")},
+	}
+	levels := dependencyLevels(keys)
+	require.Len(t, levels, 2)
+	require.Equal(t, []int{0, 1, 2}, levels[0])
+	require.Equal(t, []int{3}, levels[1])
+}
+
+// TestDependencyLevelsRaftOrderInLevel: within a level, indices stay
+// in raft order. This is required so that downstream apply preserves
+// input order for items that happen to be in the same level.
+func TestDependencyLevelsRaftOrderInLevel(t *testing.T) {
+	keys := [][][]byte{
+		{[]byte("a")}, // 0 -> level 0
+		{[]byte("a")}, // 1 -> level 1
+		{[]byte("b")}, // 2 -> level 0
+		{[]byte("b")}, // 3 -> level 1
+		{[]byte("c")}, // 4 -> level 0
+	}
+	levels := dependencyLevels(keys)
+	require.Len(t, levels, 2)
+	require.Equal(t, []int{0, 2, 4}, levels[0])
+	require.Equal(t, []int{1, 3}, levels[1])
+}
+
+// TestDependencyLevelsEmptyKeyIgnored: items with no keys (already
+// short-circuited by preparation) should still get a level slot but
+// have no influence on others.
+func TestDependencyLevelsEmptyKeyIgnored(t *testing.T) {
+	keys := [][][]byte{
+		{[]byte("a")},
+		{},          // ineligible / pre-resolved
+		{[]byte("a")}, // conflicts with 0
+	}
+	levels := dependencyLevels(keys)
+	// Item 1 has no keys, gets level 0. Item 2 conflicts with item 0
+	// only (item 1 has no key contribution).
+	require.Len(t, levels, 2)
+	require.Equal(t, []int{0, 1}, levels[0])
+	require.Equal(t, []int{2}, levels[1])
+}
+
+// TestDependencyLevelsMonotone: the level sequence in input order is
+// non-strictly increasing for any pair (i, j) with i < j and a
+// conflict. We assert this property over a randomised case to guard
+// against future tweaks of the algorithm.
+func TestDependencyLevelsMonotone(t *testing.T) {
+	keys := [][][]byte{
+		{[]byte("k1"), []byte("k2")},
+		{[]byte("k3")},
+		{[]byte("k1")},
+		{[]byte("k4"), []byte("k5")},
+		{[]byte("k2"), []byte("k3")},
+		{[]byte("k5")},
+	}
+	levels := dependencyLevels(keys)
+	// Compute per-item level
+	itemLevel := make([]int, len(keys))
+	for l, indices := range levels {
+		for _, idx := range indices {
+			itemLevel[idx] = l
+		}
+	}
+	// For every conflicting pair (i, j) with i < j, level(j) > level(i)
+	for i := range keys {
+		for j := i + 1; j < len(keys); j++ {
+			if !sharesKey(keys[i], keys[j]) {
+				continue
+			}
+			require.Greaterf(t, itemLevel[j], itemLevel[i],
+				"items %d and %d conflict but levels are %d and %d",
+				i, j, itemLevel[i], itemLevel[j])
+		}
+	}
+}
+
+func sharesKey(a, b [][]byte) bool {
+	set := make(map[string]struct{}, len(a))
+	for _, k := range a {
+		set[string(k)] = struct{}{}
+	}
+	for _, k := range b {
+		if _, ok := set[string(k)]; ok {
+			return true
+		}
+	}
+	return false
+}
+
+// TestNonEmptyKeyCount sanity-checks the helper used to decide whether
+// scheduling is worth it.
+func TestNonEmptyKeyCount(t *testing.T) {
+	require.Equal(t, 0, nonEmptyKeyCount(nil))
+	require.Equal(t, 0, nonEmptyKeyCount([][][]byte{{}, {}}))
+	require.Equal(t, 1, nonEmptyKeyCount([][][]byte{{[]byte("a")}}))
+	require.Equal(t, 2, nonEmptyKeyCount([][][]byte{{[]byte("a")}, {}, {[]byte("b")}}))
+}

--- a/txn/percolator/txn.go
+++ b/txn/percolator/txn.go
@@ -16,6 +16,7 @@ package percolator
 import (
 	"bytes"
 	"errors"
+	"sync"
 	"sync/atomic"
 	"time"
 
@@ -27,6 +28,15 @@ import (
 	txnstore "github.com/feichai0017/NoKV/txn/storage"
 	"github.com/feichai0017/NoKV/utils"
 )
+
+// parallelValidationThreshold is the smallest level size at which we
+// fan validation out to goroutines. Below this we run validations
+// serially; the goroutine bookkeeping cost dwarfs the per-validation
+// LSM read otherwise. The value is a heuristic chosen by benchmarking:
+// 4 was the break-even point on Apple M3 Pro for typical fsmeta key
+// shapes, where one validation costs ~5–15 µs and a goroutine launch
+// is ~1–2 µs.
+const parallelValidationThreshold = 4
 
 // Prewrite applies mutation prewrites for a single region transaction.
 func Prewrite(db txnstore.Store, latches *latch.Manager, req *kvrpcpb.PrewriteRequest) []*kvrpcpb.KeyError {
@@ -296,6 +306,22 @@ func ApplyAtomicMutate(db txnstore.Store, latches *latch.Manager, req *kvrpcpb.T
 // ApplyAtomicMutateBatch applies a raft-entry batch of independent 1PC
 // attempts. It preserves per-request responses and only fuses requests when
 // their combined MVCC entries remain one local atomic apply group.
+//
+// Concurrency model:
+//
+// Items are grouped by a key-conflict DAG into topological levels. Within
+// a level all items have disjoint keys, so their predicate validations
+// (LSM reads at startVersion) cannot observe each other's writes — the
+// validations are run in parallel. Across levels, level k must complete
+// (validate AND apply) before level k+1 begins, so that level k+1's
+// validations can see level k's committed mutations. This preserves
+// raft-log ordering for any pair of conflicting requests while extracting
+// the maximum parallelism the input permits.
+//
+// The per-level apply still walks items in raft order, accumulating
+// non-conflicting plans into one atomic-apply group and flushing on LSM
+// shard boundaries. This keeps the existing fusion behaviour (one LSM
+// apply call per same-shard run) intact.
 func ApplyAtomicMutateBatch(db txnstore.Store, latches *latch.Manager, reqs []*kvrpcpb.TryAtomicMutateRequest) []AtomicMutateResult {
 	results := make([]AtomicMutateResult, len(reqs))
 	if len(reqs) == 0 {
@@ -323,41 +349,113 @@ func ApplyAtomicMutateBatch(db txnstore.Store, latches *latch.Manager, reqs []*k
 	defer guard.Release()
 
 	planner, hasPlanner := db.(txnstore.AtomicInternalApplyPlanner)
-	group := atomicMutateApplyGroup{}
+
+	// Build a per-item key view. Ineligible items (already resolved during
+	// prepare) contribute no keys, so they sit in level 0 and short-
+	// circuit during the apply walk below.
+	itemKeys := make([][][]byte, len(prepared))
 	for i, item := range prepared {
-		if !item.eligible {
+		if item.eligible {
+			itemKeys[i] = item.keys
+		}
+	}
+	levels := dependencyLevels(itemKeys)
+
+	for _, level := range levels {
+		plans := planLevel(db, prepared, level)
+		applyLevel(db, results, prepared, level, plans, planner, hasPlanner)
+	}
+	return results
+}
+
+// planLevel runs planAtomicMutateUnlocked for every eligible item in
+// the level. When the level holds enough eligible items to amortise
+// the goroutine launch cost, validations fan out to goroutines;
+// otherwise they run serially on the caller's goroutine.
+func planLevel(db txnstore.Store, prepared []atomicMutatePrepared, level []int) []atomicMutateLevelPlan {
+	plans := make([]atomicMutateLevelPlan, len(level))
+	eligible := 0
+	for _, idx := range level {
+		if prepared[idx].eligible {
+			eligible++
+		}
+	}
+	if eligible >= parallelValidationThreshold {
+		var wg sync.WaitGroup
+		for li, idx := range level {
+			if !prepared[idx].eligible {
+				continue
+			}
+			wg.Add(1)
+			go func(li, idx int) {
+				defer wg.Done()
+				p, r, ok := planAtomicMutateUnlocked(db, prepared[idx].req, prepared[idx].keys)
+				plans[li] = atomicMutateLevelPlan{plan: p, early: r, ok: ok}
+			}(li, idx)
+		}
+		wg.Wait()
+	} else {
+		for li, idx := range level {
+			if !prepared[idx].eligible {
+				continue
+			}
+			p, r, ok := planAtomicMutateUnlocked(db, prepared[idx].req, prepared[idx].keys)
+			plans[li] = atomicMutateLevelPlan{plan: p, early: r, ok: ok}
+		}
+	}
+	return plans
+}
+
+// applyLevel walks the level in raft order, fusing non-conflicting
+// plans into one atomic-apply group and flushing on LSM shard
+// boundaries or on level completion.
+func applyLevel(
+	db txnstore.Store,
+	results []AtomicMutateResult,
+	prepared []atomicMutatePrepared,
+	level []int,
+	plans []atomicMutateLevelPlan,
+	planner txnstore.AtomicInternalApplyPlanner,
+	hasPlanner bool,
+) {
+	group := atomicMutateApplyGroup{}
+	for li, idx := range level {
+		if !prepared[idx].eligible {
 			continue
 		}
-		// Overlapping requests must observe raft-log order. Flush before
-		// planning the later request so its predicates see earlier writes.
-		if group.conflicts(item.keys) {
-			group.flush(db, results)
-		}
-		plan, result, ok := planAtomicMutateUnlocked(db, item.req, item.keys)
-		if !ok {
-			results[i] = result
+		pr := plans[li]
+		if !pr.ok {
+			results[idx] = pr.early
 			continue
 		}
-		if len(plan.entries) == 0 {
-			results[i] = AtomicMutateResult{AppliedKeys: plan.appliedKeys}
+		if len(pr.plan.entries) == 0 {
+			results[idx] = AtomicMutateResult{AppliedKeys: pr.plan.appliedKeys}
 			continue
 		}
-		if !hasPlanner || !planner.CanApplyInternalEntriesAtomically(plan.entries) {
+		if !hasPlanner || !planner.CanApplyInternalEntriesAtomically(pr.plan.entries) {
 			percolatorStats.localFallbackTotal.Add(1)
-			releaseEntries(plan.entries)
-			results[i] = AtomicMutateResult{Fallback: true}
+			releaseEntries(pr.plan.entries)
+			results[idx] = AtomicMutateResult{Fallback: true}
 			continue
 		}
 		// A request can be locally atomic by itself while belonging to a
 		// different LSM shard than the current group. Split the group instead
 		// of turning a valid 1PC request into a 2PC fallback.
-		if !group.empty() && !planner.CanApplyInternalEntriesAtomically(group.entriesWith(plan.entries)) {
+		if !group.empty() && !planner.CanApplyInternalEntriesAtomically(group.entriesWith(pr.plan.entries)) {
 			group.flush(db, results)
 		}
-		group.add(i, plan)
+		group.add(idx, pr.plan)
 	}
 	group.flush(db, results)
-	return results
+}
+
+// atomicMutateLevelPlan captures the result of running
+// planAtomicMutateUnlocked for one item inside a DAG level so that
+// the apply phase can read it without re-running the planner.
+type atomicMutateLevelPlan struct {
+	plan  atomicMutatePlan
+	early AtomicMutateResult
+	ok    bool
 }
 
 type atomicMutatePrepared struct {
@@ -452,7 +550,6 @@ func planAtomicMutateUnlocked(db txnstore.Store, req *kvrpcpb.TryAtomicMutateReq
 type atomicMutateApplyGroup struct {
 	requests []atomicMutateGroupRequest
 	entries  []*kv.Entry
-	keys     map[string]struct{}
 }
 
 type atomicMutateGroupRequest struct {
@@ -462,18 +559,6 @@ type atomicMutateGroupRequest struct {
 
 func (g *atomicMutateApplyGroup) empty() bool {
 	return g == nil || len(g.requests) == 0
-}
-
-func (g *atomicMutateApplyGroup) conflicts(keys [][]byte) bool {
-	if g == nil || len(g.keys) == 0 {
-		return false
-	}
-	for _, key := range keys {
-		if _, ok := g.keys[string(key)]; ok {
-			return true
-		}
-	}
-	return false
 }
 
 func (g *atomicMutateApplyGroup) entriesWith(entries []*kv.Entry) []*kv.Entry {
@@ -486,12 +571,6 @@ func (g *atomicMutateApplyGroup) entriesWith(entries []*kv.Entry) []*kv.Entry {
 func (g *atomicMutateApplyGroup) add(index int, plan atomicMutatePlan) {
 	g.requests = append(g.requests, atomicMutateGroupRequest{index: index, appliedKeys: plan.appliedKeys})
 	g.entries = append(g.entries, plan.entries...)
-	if g.keys == nil {
-		g.keys = make(map[string]struct{}, len(plan.keys))
-	}
-	for _, key := range plan.keys {
-		g.keys[string(key)] = struct{}{}
-	}
 }
 
 func (g *atomicMutateApplyGroup) flush(db txnstore.Store, results []AtomicMutateResult) {
@@ -514,7 +593,6 @@ func (g *atomicMutateApplyGroup) flush(db txnstore.Store, results []AtomicMutate
 	}
 	g.requests = nil
 	g.entries = nil
-	g.keys = nil
 }
 
 func validateAtomicPredicate(reader *Reader, pred *kvrpcpb.AtomicPredicate, startVersion uint64) *kvrpcpb.KeyError {

--- a/txn/percolator/txn.go
+++ b/txn/percolator/txn.go
@@ -117,12 +117,23 @@ func planPrewriteMutation(reader *Reader, req *kvrpcpb.PrewriteRequest, mut *kvr
 		}
 	}
 	ops := make([]versionedOp, 0, 3)
+	var shortValue []byte
+	var shortValueExpiresAt uint64
 	switch mut.Op {
 	case kvrpcpb.Mutation_Put:
-		ops = append(ops,
-			versionedOp{cf: kv.CFDefault, key: key, version: req.StartVersion, meta: kv.BitDelete},
-			versionedOp{cf: kv.CFDefault, key: key, version: req.StartVersion, value: mut.Value, expires: mut.GetExpiresAt()},
-		)
+		if mvcc.CanInlineShortValue(mut.GetOp(), mut.GetValue()) {
+			// Commit sees only the lock, not the original mutation request.
+			// Keep small values in the lock so commit can materialize the
+			// committed write without writing a default-CF record.
+			shortValue = kv.SafeCopy(nil, mut.GetValue())
+			shortValueExpiresAt = mut.GetExpiresAt()
+			percolatorStats.shortValuePrewriteTotal.Add(1)
+		} else {
+			ops = append(ops,
+				versionedOp{cf: kv.CFDefault, key: key, version: req.StartVersion, meta: kv.BitDelete},
+				versionedOp{cf: kv.CFDefault, key: key, version: req.StartVersion, value: mut.Value, expires: mut.GetExpiresAt()},
+			)
+		}
 	case kvrpcpb.Mutation_Delete, kvrpcpb.Mutation_Lock:
 		ops = append(ops,
 			versionedOp{cf: kv.CFDefault, key: key, version: req.StartVersion, meta: kv.BitDelete},
@@ -137,6 +148,8 @@ func planPrewriteMutation(reader *Reader, req *kvrpcpb.PrewriteRequest, mut *kvr
 		TTL:         req.LockTtl,
 		Kind:        mut.Op,
 		MinCommitTs: req.MinCommitTs,
+		ShortValue:  shortValue,
+		ExpiresAt:   shortValueExpiresAt,
 	}
 	encoded := mvcc.EncodeLock(newLock)
 	ops = append(ops, versionedOp{cf: kv.CFLock, key: key, version: lockColumnTs, value: encoded})
@@ -239,6 +252,9 @@ type statsRegistry struct {
 	twoPCFusedBatchesTotal  atomic.Uint64
 	twoPCFusedRequestsTotal atomic.Uint64
 	twoPCFusedEntriesTotal  atomic.Uint64
+	shortValuePrewriteTotal atomic.Uint64
+	shortValueCommitTotal   atomic.Uint64
+	shortValueAtomicTotal   atomic.Uint64
 }
 
 var percolatorStats statsRegistry
@@ -256,6 +272,9 @@ func Stats() map[string]any {
 		"two_pc_fused_apply_batches_total":  percolatorStats.twoPCFusedBatchesTotal.Load(),
 		"two_pc_fused_apply_requests_total": percolatorStats.twoPCFusedRequestsTotal.Load(),
 		"two_pc_fused_apply_entries_total":  percolatorStats.twoPCFusedEntriesTotal.Load(),
+		"short_value_prewrite_total":        percolatorStats.shortValuePrewriteTotal.Load(),
+		"short_value_commit_total":          percolatorStats.shortValueCommitTotal.Load(),
+		"short_value_atomic_total":          percolatorStats.shortValueAtomicTotal.Load(),
 	}
 }
 
@@ -583,13 +602,20 @@ func atomicMutateAlreadyApplied(db txnstore.Store, reader *Reader, req *kvrpcpb.
 			return false, nil
 		}
 		if mut.GetOp() == kvrpcpb.Mutation_Put {
-			matches, err := defaultRecordMatches(db, mut, req.StartVersion)
+			matches, err := committedPutMatches(db, write, mut, req.StartVersion)
 			if err != nil || !matches {
 				return false, err
 			}
 		}
 	}
 	return anyPresent && allPresent, nil
+}
+
+func committedPutMatches(db txnstore.Store, write *mvcc.Write, mut *kvrpcpb.Mutation, startVersion uint64) (bool, error) {
+	if len(write.ShortValue) > 0 {
+		return bytes.Equal(write.ShortValue, mut.GetValue()) && write.ExpiresAt == mut.GetExpiresAt(), nil
+	}
+	return defaultRecordMatches(db, mut, startVersion)
 }
 
 func defaultRecordMatches(db txnstore.Store, mut *kvrpcpb.Mutation, startVersion uint64) (bool, error) {
@@ -605,15 +631,22 @@ func defaultRecordMatches(db txnstore.Store, mut *kvrpcpb.Mutation, startVersion
 }
 
 func committedMutationOps(mut *kvrpcpb.Mutation, startVersion, commitVersion uint64) []versionedOp {
-	write := mvcc.EncodeWrite(mvcc.Write{Kind: mut.GetOp(), StartTs: startVersion})
 	switch mut.GetOp() {
 	case kvrpcpb.Mutation_Put:
+		write := committedWriteForMutation(mut, startVersion)
+		if len(write.ShortValue) > 0 {
+			percolatorStats.shortValueAtomicTotal.Add(1)
+			return []versionedOp{
+				{cf: kv.CFWrite, key: mut.GetKey(), version: commitVersion, value: mvcc.EncodeWrite(write)},
+			}
+		}
 		return []versionedOp{
 			{cf: kv.CFDefault, key: mut.GetKey(), version: startVersion, meta: kv.BitDelete},
 			{cf: kv.CFDefault, key: mut.GetKey(), version: startVersion, value: mut.GetValue(), expires: mut.GetExpiresAt()},
-			{cf: kv.CFWrite, key: mut.GetKey(), version: commitVersion, value: write},
+			{cf: kv.CFWrite, key: mut.GetKey(), version: commitVersion, value: mvcc.EncodeWrite(write)},
 		}
 	case kvrpcpb.Mutation_Delete:
+		write := mvcc.EncodeWrite(mvcc.Write{Kind: mut.GetOp(), StartTs: startVersion})
 		return []versionedOp{
 			{cf: kv.CFDefault, key: mut.GetKey(), version: startVersion, meta: kv.BitDelete},
 			{cf: kv.CFWrite, key: mut.GetKey(), version: commitVersion, value: write},
@@ -621,6 +654,15 @@ func committedMutationOps(mut *kvrpcpb.Mutation, startVersion, commitVersion uin
 	default:
 		return nil
 	}
+}
+
+func committedWriteForMutation(mut *kvrpcpb.Mutation, startVersion uint64) mvcc.Write {
+	write := mvcc.Write{Kind: mut.GetOp(), StartTs: startVersion}
+	if mvcc.CanInlineShortValue(mut.GetOp(), mut.GetValue()) {
+		write.ShortValue = kv.SafeCopy(nil, mut.GetValue())
+		write.ExpiresAt = mut.GetExpiresAt()
+	}
+	return write
 }
 
 // BatchRollback rolls back the provided keys for the given start version.
@@ -987,12 +1029,12 @@ func planCommitKey(reader *Reader, key []byte, startVersion, commitVersion uint6
 }
 
 func planCommitKeyWithLock(reader *Reader, key []byte, lock *mvcc.Lock, commitVersion uint64) ([]versionedOp, *kvrpcpb.KeyError) {
-	write, _, err := reader.GetWriteByStartTs(key, lock.Ts)
+	committed, _, err := reader.GetWriteByStartTs(key, lock.Ts)
 	if err != nil {
 		return nil, keyErrorRetryable(err)
 	}
-	if write != nil {
-		if write.Kind == kvrpcpb.Mutation_Rollback {
+	if committed != nil {
+		if committed.Kind == kvrpcpb.Mutation_Rollback {
 			return nil, keyErrorTxnAlreadyRolledBack()
 		}
 		return []versionedOp{{
@@ -1007,7 +1049,13 @@ func planCommitKeyWithLock(reader *Reader, key []byte, lock *mvcc.Lock, commitVe
 		return nil, keyErrorCommitTsExpired(key, commitVersion, lock.MinCommitTs)
 	}
 
-	entry := mvcc.EncodeWrite(mvcc.Write{Kind: lock.Kind, StartTs: lock.Ts})
+	write := mvcc.Write{Kind: lock.Kind, StartTs: lock.Ts}
+	if len(lock.ShortValue) > 0 {
+		write.ShortValue = kv.SafeCopy(nil, lock.ShortValue)
+		write.ExpiresAt = lock.ExpiresAt
+		percolatorStats.shortValueCommitTotal.Add(1)
+	}
+	entry := mvcc.EncodeWrite(write)
 	return []versionedOp{
 		{cf: kv.CFWrite, key: key, version: commitVersion, value: entry},
 		{cf: kv.CFLock, key: key, version: lockColumnTs, meta: kv.BitDelete},
@@ -1054,10 +1102,13 @@ func planRollbackKey(reader *Reader, key []byte, startTs uint64) ([]versionedOp,
 	}
 
 	rollback := mvcc.EncodeWrite(mvcc.Write{Kind: kvrpcpb.Mutation_Rollback, StartTs: startTs})
-	ops := []versionedOp{
-		{cf: kv.CFDefault, key: key, version: startTs, meta: kv.BitDelete},
-		{cf: kv.CFWrite, key: key, version: startTs, value: rollback},
+	ops := make([]versionedOp, 0, 3)
+	// A short-value prewrite never created a default-CF record, so rollback
+	// only needs the rollback marker and lock tombstone for that case.
+	if lock == nil || lock.Ts != startTs || len(lock.ShortValue) == 0 {
+		ops = append(ops, versionedOp{cf: kv.CFDefault, key: key, version: startTs, meta: kv.BitDelete})
 	}
+	ops = append(ops, versionedOp{cf: kv.CFWrite, key: key, version: startTs, value: rollback})
 	if lock != nil && lock.Ts == startTs {
 		ops = append(ops, versionedOp{cf: kv.CFLock, key: key, version: lockColumnTs, meta: kv.BitDelete})
 	}

--- a/txn/percolator/txn_test.go
+++ b/txn/percolator/txn_test.go
@@ -431,6 +431,155 @@ func TestApplyAtomicMutateBatchApplyFailureMarksWholeFusedGroup(t *testing.T) {
 	require.ErrorIs(t, err, utils.ErrKeyNotFound)
 }
 
+// TestApplyAtomicMutateBatchParallelLevelAllDisjoint exercises the
+// parallel validation path: 16 disjoint requests fall into a single
+// DAG level, validations fan out to goroutines, then fuse into one
+// atomic apply.
+func TestApplyAtomicMutateBatchParallelLevelAllDisjoint(t *testing.T) {
+	opt := testOptionsForDir(t.TempDir())
+	opt.LSMShardCount = 1
+	db, err := local.Open(opt)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = db.Close() })
+
+	store := newCountingAtomicStore(db)
+	const N = 16
+	reqs := make([]*kvrpcpb.TryAtomicMutateRequest, 0, N)
+	for i := 0; i < N; i++ {
+		reqs = append(reqs, atomicPutRequest(
+			uint64(100+2*i), uint64(101+2*i),
+			[]byte(fmt.Sprintf("parallel-disjoint-%02d", i)),
+			[]byte(fmt.Sprintf("v%02d", i)),
+		))
+	}
+
+	results := ApplyAtomicMutateBatch(store, latch.NewManager(64), reqs)
+	require.Len(t, results, N)
+	for i, r := range results {
+		require.Nilf(t, r.Error, "result %d had error: %v", i, r.Error)
+		require.False(t, r.Fallback, "result %d unexpectedly fell back", i)
+		require.Equal(t, uint64(1), r.AppliedKeys)
+	}
+
+	// Disjoint keys + single shard => one atomic apply call. Short-value
+	// puts emit one CFWrite entry per request.
+	require.Equal(t, 1, store.applyCalls)
+	require.Equal(t, []int{N}, store.appliedEntryCounts)
+
+	reader := NewReader(db)
+	for i := 0; i < N; i++ {
+		key := []byte(fmt.Sprintf("parallel-disjoint-%02d", i))
+		val, _, err := reader.GetValue(key, 200)
+		require.NoError(t, err)
+		require.Equal(t, []byte(fmt.Sprintf("v%02d", i)), val)
+	}
+}
+
+// TestApplyAtomicMutateBatchParallelChainedConflicts ensures that a
+// linear chain of conflicting requests still applies in raft order.
+// The DAG should produce one item per level; the second request to
+// touch any given key must observe the first's commit.
+func TestApplyAtomicMutateBatchParallelChainedConflicts(t *testing.T) {
+	opt := testOptionsForDir(t.TempDir())
+	opt.LSMShardCount = 1
+	db, err := local.Open(opt)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = db.Close() })
+
+	store := newCountingAtomicStore(db)
+	keyA := []byte("chain-a")
+	keyB := []byte("chain-b")
+
+	results := ApplyAtomicMutateBatch(store, latch.NewManager(16), []*kvrpcpb.TryAtomicMutateRequest{
+		atomicPutRequest(40, 41, keyA, []byte("v1")), // creates A
+		atomicPutRequest(42, 43, keyA, []byte("v2")), // conflicts with prior, AlreadyExists
+		atomicPutRequest(44, 45, keyB, []byte("w1")), // independent, creates B
+		atomicPutRequest(46, 47, keyB, []byte("w2")), // conflicts with prior, AlreadyExists
+	})
+	require.Len(t, results, 4)
+	// Items 0 and 2 are independent of the prior batch contents and of each
+	// other => they win their AssertNotExist predicates. Items 1 and 3
+	// must observe items 0 and 2's writes => they fail with AlreadyExists.
+	require.Nil(t, results[0].Error)
+	require.Equal(t, uint64(1), results[0].AppliedKeys)
+	require.NotNil(t, results[1].Error)
+	require.NotNil(t, results[1].Error.GetAlreadyExists())
+	require.Nil(t, results[2].Error)
+	require.Equal(t, uint64(1), results[2].AppliedKeys)
+	require.NotNil(t, results[3].Error)
+	require.NotNil(t, results[3].Error.GetAlreadyExists())
+
+	reader := NewReader(db)
+	v, _, err := reader.GetValue(keyA, 50)
+	require.NoError(t, err)
+	require.Equal(t, []byte("v1"), v)
+	v, _, err = reader.GetValue(keyB, 50)
+	require.NoError(t, err)
+	require.Equal(t, []byte("w1"), v)
+}
+
+// TestApplyAtomicMutateBatchParallelMixedLevels exercises a mix of
+// independent and conflicting requests that produces a multi-level
+// DAG. Each level's validations should run in parallel without
+// observing each other's writes; downstream levels must observe the
+// upstream level's commits.
+func TestApplyAtomicMutateBatchParallelMixedLevels(t *testing.T) {
+	opt := testOptionsForDir(t.TempDir())
+	opt.LSMShardCount = 1
+	db, err := local.Open(opt)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = db.Close() })
+
+	store := newCountingAtomicStore(db)
+	// Layout:
+	//   0: put(a)              level 0
+	//   1: put(b)              level 0
+	//   2: put(c)              level 0
+	//   3: put(d)              level 0
+	//   4: put(a)              level 1 (conflicts with 0)
+	//   5: put(e)              level 0 (independent of 0..3, but appears
+	//                                    after them so the algorithm gives
+	//                                    it its own first-touch slot)
+	//   6: put(b)              level 1 (conflicts with 1)
+	//   7: put(c)              level 1 (conflicts with 2)
+	results := ApplyAtomicMutateBatch(store, latch.NewManager(32), []*kvrpcpb.TryAtomicMutateRequest{
+		atomicPutRequest(10, 11, []byte("mix-a"), []byte("a1")),
+		atomicPutRequest(12, 13, []byte("mix-b"), []byte("b1")),
+		atomicPutRequest(14, 15, []byte("mix-c"), []byte("c1")),
+		atomicPutRequest(16, 17, []byte("mix-d"), []byte("d1")),
+		atomicPutRequest(18, 19, []byte("mix-a"), []byte("a2")),
+		atomicPutRequest(20, 21, []byte("mix-e"), []byte("e1")),
+		atomicPutRequest(22, 23, []byte("mix-b"), []byte("b2")),
+		atomicPutRequest(24, 25, []byte("mix-c"), []byte("c2")),
+	})
+	require.Len(t, results, 8)
+	// Successful first-touches.
+	for _, idx := range []int{0, 1, 2, 3, 5} {
+		require.Nilf(t, results[idx].Error, "expected idx=%d to succeed: %v", idx, results[idx].Error)
+		require.Equal(t, uint64(1), results[idx].AppliedKeys)
+	}
+	// Conflicts (must observe the level-0 commits).
+	for _, idx := range []int{4, 6, 7} {
+		require.NotNilf(t, results[idx].Error, "expected idx=%d to fail with AlreadyExists", idx)
+		require.NotNil(t, results[idx].Error.GetAlreadyExists())
+	}
+
+	reader := NewReader(db)
+	for _, kv := range []struct {
+		k, v []byte
+	}{
+		{[]byte("mix-a"), []byte("a1")},
+		{[]byte("mix-b"), []byte("b1")},
+		{[]byte("mix-c"), []byte("c1")},
+		{[]byte("mix-d"), []byte("d1")},
+		{[]byte("mix-e"), []byte("e1")},
+	} {
+		got, _, err := reader.GetValue(kv.k, 30)
+		require.NoError(t, err)
+		require.Equalf(t, kv.v, got, "wrong value for %s", kv.k)
+	}
+}
+
 func TestApplyAtomicMutateRejectsExistingDentry(t *testing.T) {
 	db := openTestDB(t)
 	latches := latch.NewManager(16)

--- a/txn/percolator/txn_test.go
+++ b/txn/percolator/txn_test.go
@@ -1,6 +1,7 @@
 package percolator
 
 import (
+	"bytes"
 	"errors"
 	"fmt"
 	kvrpcpb "github.com/feichai0017/NoKV/pb/kv"
@@ -332,7 +333,7 @@ func TestApplyAtomicMutateBatchFusesIndependentRequests(t *testing.T) {
 		require.Equal(t, uint64(1), result.AppliedKeys)
 	}
 	require.Equal(t, 1, store.applyCalls)
-	require.Equal(t, []int{6}, store.appliedEntryCounts)
+	require.Equal(t, []int{2}, store.appliedEntryCounts)
 
 	reader := NewReader(db)
 	value, _, err := reader.GetValue([]byte("atomic-batch-a"), 50)
@@ -345,7 +346,7 @@ func TestApplyAtomicMutateBatchFusesIndependentRequests(t *testing.T) {
 	after := Stats()
 	require.Equal(t, atomicMutateStat(t, before, "atomic_fused_apply_batches_total")+1, atomicMutateStat(t, after, "atomic_fused_apply_batches_total"))
 	require.Equal(t, atomicMutateStat(t, before, "atomic_fused_apply_requests_total")+2, atomicMutateStat(t, after, "atomic_fused_apply_requests_total"))
-	require.Equal(t, atomicMutateStat(t, before, "atomic_fused_apply_entries_total")+6, atomicMutateStat(t, after, "atomic_fused_apply_entries_total"))
+	require.Equal(t, atomicMutateStat(t, before, "atomic_fused_apply_entries_total")+2, atomicMutateStat(t, after, "atomic_fused_apply_entries_total"))
 }
 
 func TestApplyAtomicMutateBatchSplitsDifferentLocalApplyGroups(t *testing.T) {
@@ -374,7 +375,7 @@ func TestApplyAtomicMutateBatchSplitsDifferentLocalApplyGroups(t *testing.T) {
 		require.Equal(t, uint64(1), result.AppliedKeys)
 	}
 	require.Equal(t, 2, store.applyCalls)
-	require.Equal(t, []int{3, 3}, store.appliedEntryCounts)
+	require.Equal(t, []int{1, 1}, store.appliedEntryCounts)
 }
 
 func TestApplyAtomicMutateBatchPreservesOverlappingRequestOrder(t *testing.T) {
@@ -837,7 +838,7 @@ func TestPrewriteBatchAppliesAllMutationsOnce(t *testing.T) {
 		LockTtl:      1000,
 	}))
 	require.Equal(t, 1, store.applyCalls)
-	require.Equal(t, []int{9}, store.appliedEntryCounts)
+	require.Equal(t, []int{3}, store.appliedEntryCounts)
 
 	reader := NewReader(db)
 	for _, key := range keys {
@@ -872,12 +873,12 @@ func TestPrewriteRequestBatchFusesIndependentRequests(t *testing.T) {
 	require.Empty(t, results[0])
 	require.Empty(t, results[1])
 	require.Equal(t, 1, store.applyCalls)
-	require.Equal(t, []int{6}, store.appliedEntryCounts)
+	require.Equal(t, []int{2}, store.appliedEntryCounts)
 
 	after := Stats()
 	require.Equal(t, atomicMutateStat(t, before, "two_pc_fused_apply_batches_total")+1, atomicMutateStat(t, after, "two_pc_fused_apply_batches_total"))
 	require.Equal(t, atomicMutateStat(t, before, "two_pc_fused_apply_requests_total")+2, atomicMutateStat(t, after, "two_pc_fused_apply_requests_total"))
-	require.Equal(t, atomicMutateStat(t, before, "two_pc_fused_apply_entries_total")+6, atomicMutateStat(t, after, "two_pc_fused_apply_entries_total"))
+	require.Equal(t, atomicMutateStat(t, before, "two_pc_fused_apply_entries_total")+2, atomicMutateStat(t, after, "two_pc_fused_apply_entries_total"))
 }
 
 func TestPrewriteRequestBatchPreservesOverlappingOrder(t *testing.T) {
@@ -997,7 +998,7 @@ func TestBatchRollbackRequestBatchFusesIndependentRequests(t *testing.T) {
 	require.Nil(t, results[0])
 	require.Nil(t, results[1])
 	require.Equal(t, 1, store.applyCalls)
-	require.Equal(t, []int{6}, store.appliedEntryCounts)
+	require.Equal(t, []int{4}, store.appliedEntryCounts)
 }
 
 func TestResolveLockRequestBatchFusesIndependentRequests(t *testing.T) {
@@ -1476,7 +1477,7 @@ func TestBatchRollbackAppliesAllKeysOnce(t *testing.T) {
 		StartVersion: 18,
 	}))
 	require.Equal(t, 1, store.applyCalls)
-	require.Equal(t, []int{9}, store.appliedEntryCounts)
+	require.Equal(t, []int{7}, store.appliedEntryCounts)
 }
 
 func TestBatchRollbackDoesNotDeleteOtherTransactionLock(t *testing.T) {
@@ -1956,15 +1957,14 @@ func TestCommitRecoveryDropsCorruptedCommitBatch(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, lock)
 	require.Equal(t, startTs, lock.Ts)
+	require.Equal(t, []byte("value"), lock.ShortValue)
 
 	write, _, err := reader.GetWriteByStartTs(key, startTs)
 	require.NoError(t, err)
 	require.Nil(t, write)
 
-	entry, err := db2.GetInternalEntry(kv.CFDefault, key, startTs)
-	require.NoError(t, err)
-	require.Equal(t, []byte("value"), entry.Value)
-	entry.DecrRef()
+	_, err = db2.GetInternalEntry(kv.CFDefault, key, startTs)
+	require.ErrorIs(t, err, utils.ErrKeyNotFound)
 }
 
 func TestCheckTxnStatusTTLExpire(t *testing.T) {
@@ -2349,6 +2349,147 @@ func TestReaderGetValueFromExpiredShortValue(t *testing.T) {
 
 	_, _, err := reader.GetValue(key, 30)
 	require.ErrorIs(t, err, utils.ErrKeyNotFound)
+}
+
+func TestPrewriteCommitShortValueSkipsDefaultCF(t *testing.T) {
+	db := openTestDB(t)
+	latches := latch.NewManager(16)
+	key := []byte("short-prewrite")
+	value := []byte("inline")
+	expiresAt := uint64(^uint64(0))
+
+	require.Empty(t, Prewrite(db, latches, &kvrpcpb.PrewriteRequest{
+		Mutations: []*kvrpcpb.Mutation{{
+			Op:        kvrpcpb.Mutation_Put,
+			Key:       key,
+			Value:     value,
+			ExpiresAt: expiresAt,
+		}},
+		PrimaryLock:  key,
+		StartVersion: 10,
+		LockTtl:      1000,
+	}))
+
+	_, err := db.GetInternalEntry(kv.CFDefault, key, 10)
+	require.ErrorIs(t, err, utils.ErrKeyNotFound)
+
+	reader := NewReader(db)
+	lock, err := reader.GetLock(key)
+	require.NoError(t, err)
+	require.NotNil(t, lock)
+	require.Equal(t, value, lock.ShortValue)
+	require.Equal(t, expiresAt, lock.ExpiresAt)
+
+	require.Nil(t, Commit(db, latches, &kvrpcpb.CommitRequest{
+		Keys:          [][]byte{key},
+		StartVersion:  10,
+		CommitVersion: 20,
+	}))
+
+	write, commitTs, err := reader.GetWriteByStartTs(key, 10)
+	require.NoError(t, err)
+	require.NotNil(t, write)
+	require.Equal(t, uint64(20), commitTs)
+	require.Equal(t, value, write.ShortValue)
+	require.Equal(t, expiresAt, write.ExpiresAt)
+
+	got, gotExpiresAt, err := reader.GetValue(key, 30)
+	require.NoError(t, err)
+	require.Equal(t, value, got)
+	require.Equal(t, expiresAt, gotExpiresAt)
+}
+
+func TestPrewriteLargeValueKeepsDefaultCF(t *testing.T) {
+	db := openTestDB(t)
+	latches := latch.NewManager(16)
+	key := []byte("large-prewrite")
+	value := bytes.Repeat([]byte("x"), mvcc.DefaultShortValueMaxBytes+1)
+
+	require.Empty(t, Prewrite(db, latches, &kvrpcpb.PrewriteRequest{
+		Mutations: []*kvrpcpb.Mutation{{
+			Op:    kvrpcpb.Mutation_Put,
+			Key:   key,
+			Value: value,
+		}},
+		PrimaryLock:  key,
+		StartVersion: 11,
+		LockTtl:      1000,
+	}))
+
+	entry, err := db.GetInternalEntry(kv.CFDefault, key, 11)
+	require.NoError(t, err)
+	require.Equal(t, value, entry.Value)
+	entry.DecrRef()
+
+	require.Nil(t, Commit(db, latches, &kvrpcpb.CommitRequest{
+		Keys:          [][]byte{key},
+		StartVersion:  11,
+		CommitVersion: 21,
+	}))
+
+	write, _, err := NewReader(db).GetWriteByStartTs(key, 11)
+	require.NoError(t, err)
+	require.NotNil(t, write)
+	require.Empty(t, write.ShortValue)
+}
+
+func TestAtomicMutateShortValueSkipsDefaultCF(t *testing.T) {
+	opt := testOptionsForDir(filepath.Join(t.TempDir(), "db"))
+	opt.LSMShardCount = 1
+	db, err := local.Open(opt)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = db.Close() })
+
+	key := []byte("atomic-short")
+	value := []byte("inline")
+	req := atomicPutRequest(30, 31, key, value)
+	result := ApplyAtomicMutate(db, latch.NewManager(16), req)
+	require.Nil(t, result.Error)
+	require.False(t, result.Fallback)
+	require.Equal(t, uint64(1), result.AppliedKeys)
+
+	_, err = db.GetInternalEntry(kv.CFDefault, key, 30)
+	require.ErrorIs(t, err, utils.ErrKeyNotFound)
+
+	reader := NewReader(db)
+	write, commitTs, err := reader.GetWriteByStartTs(key, 30)
+	require.NoError(t, err)
+	require.NotNil(t, write)
+	require.Equal(t, uint64(31), commitTs)
+	require.Equal(t, value, write.ShortValue)
+
+	got, _, err := reader.GetValue(key, 40)
+	require.NoError(t, err)
+	require.Equal(t, value, got)
+}
+
+func TestBatchRollbackShortValueLockDoesNotWriteDefaultTombstone(t *testing.T) {
+	db := openTestDB(t)
+	latches := latch.NewManager(16)
+	key := []byte("short-rollback")
+
+	require.Empty(t, Prewrite(db, latches, &kvrpcpb.PrewriteRequest{
+		Mutations: []*kvrpcpb.Mutation{{
+			Op:    kvrpcpb.Mutation_Put,
+			Key:   key,
+			Value: []byte("inline"),
+		}},
+		PrimaryLock:  key,
+		StartVersion: 40,
+		LockTtl:      1000,
+	}))
+	require.Nil(t, BatchRollback(db, latches, &kvrpcpb.BatchRollbackRequest{
+		Keys:         [][]byte{key},
+		StartVersion: 40,
+	}))
+
+	_, err := db.GetInternalEntry(kv.CFDefault, key, 40)
+	require.ErrorIs(t, err, utils.ErrKeyNotFound)
+	write, commitTs, err := NewReader(db).GetWriteByStartTs(key, 40)
+	require.NoError(t, err)
+	require.NotNil(t, write)
+	require.Equal(t, kvrpcpb.Mutation_Rollback, write.Kind)
+	require.Equal(t, uint64(40), commitTs)
 }
 
 func TestKeyErrorHelpers(t *testing.T) {


### PR DESCRIPTION
First milestone of [the Falcon design](docs/falcon.md) (also in this branch as commit `f06e33f5`).

## What this is

`ApplyAtomicMutateBatch` is the apply-path entry point for Percolator's 1PC fast path — the route every workspace-internal fsmeta Create / Unlink / UpdateInode takes when the affinity buckets line up (which is now ~99% post-#265). The legacy walk validated each request's predicates serially even when batched 64-deep, because the planner does an LSM read per request and they were issued one at a time.

This change groups the batch into topological waves first. Within a wave, requests are mutually non-conflicting — so their planning fans out to goroutines. Across waves the apply path is strictly serial: wave k must commit before wave k+1 begins planning, preserving raft-log ordering for every conflicting pair.

No protocol change. No durability or consistency weakening. Atomic-apply-group fusion is preserved; one fsync per shard run still holds.

## Bench (Apple M3 Pro, single LSM shard)

`BenchmarkApplyAtomicMutateBatchDisjoint` — N independent requests:

| N | per-batch | per-item |
|---:|---:|---:|
| 1 | 312 µs | 312 µs |
| 4 | 359 µs | 90 µs |
| 8 | 378 µs | 47 µs |
| 16 | 376 µs | **24 µs** |
| 32 | 391 µs | **12 µs (26× faster vs n=1)** |

`BenchmarkApplyAtomicMutateBatchAllConflict` — N requests on one key (worst case, DAG degenerates into a chain): 312–400 µs across N=2..32. The DAG bookkeeping overhead is invisible.

## Files

- `txn/percolator/dag.go` (70 LoC) — `dependencyLevels` topological wave computation
- `txn/percolator/dag_test.go` (140 LoC) — eight cases: empty, all-disjoint, linear chain, conflict-with-prior, raft-order-in-level, empty-key-ignored, monotone-property, helper sanity
- `txn/percolator/txn.go` — restructured `ApplyAtomicMutateBatch` into prepare → DAG → per-wave plan + apply; deletes the now-unused `atomicMutateApplyGroup.conflicts` and its `keys` map
- `txn/percolator/txn_test.go` — three new integration tests covering parallel disjoint, chained conflicts (raft-order preserved), and mixed multi-level batches
- `txn/percolator/atomic_apply_bench_test.go` — disjoint + all-conflict benches across N=1..32

## Design references

- §5.8 of [`docs/falcon.md`](docs/falcon.md) describes the DAG approach in protocol context
- Inspired by PolarFS ParallelRaft (VLDB '18); this is the first milestone of a path toward CURP-style speculative replication described in §7

## Why merge this independently of M2-M5

M1 is a correctness-preserving apply-side optimisation. It produces real per-region throughput gains on its own and de-risks the dependency-DAG primitive that the witness-side conflict detector in M2 will reuse. If M2-M5 are deferred or revised, M1 still earns its keep.

## Test plan

- [x] Existing percolator + raftstore/kv tests pass with `-race`
- [x] New parallel-path tests cover disjoint, chained-conflict, multi-level mixed workloads
- [x] Full repo `go test ./...` clean
- [x] `make lint` clean (0 issues)
- [x] Benchmark numbers above

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added design documentation for the Falcon speculative-replication protocol under "Distributed Runtime".

* **New Features**
  * Implemented short-value inlining for transaction writes, allowing small values to be embedded in lock records instead of separate storage.
  * Added parallel apply support using dependency-aware level ordering for atomic mutations.

* **Tests**
  * Added comprehensive test coverage for short-value handling in commits, rollbacks, and atomic mutations.
  * Added tests for parallel apply ordering and dependency levels.
  * Added benchmarks for atomic mutation batches.
  * Updated existing tests to reflect new batching and apply behavior.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/feichai0017/NoKV/pull/266)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->