### PR TITLE
feat(fsmeta): add batch lookup plus

### DIFF
--- a/fsmeta/client/client.go
+++ b/fsmeta/client/client.go
@@ -41,6 +41,7 @@ type Client interface {
 	Create(ctx context.Context, req fsmeta.CreateRequest) (fsmeta.CreateResult, error)
 	UpdateInode(ctx context.Context, req fsmeta.UpdateInodeRequest) (fsmeta.InodeRecord, error)
 	Lookup(ctx context.Context, req fsmeta.LookupRequest) (fsmeta.DentryRecord, error)
+	BatchLookupPlus(ctx context.Context, req fsmeta.BatchLookupPlusRequest) ([]fsmeta.BatchLookupPlusResult, error)
 	ReadDir(ctx context.Context, req fsmeta.ReadDirRequest) ([]fsmeta.DentryRecord, error)
 	ReadDirPlus(ctx context.Context, req fsmeta.ReadDirRequest) ([]fsmeta.DentryAttrPair, error)
 	WatchSubtree(ctx context.Context, req fsmeta.WatchRequest) (WatchSubscription, error)
@@ -177,6 +178,25 @@ func (c *GRPCClient) Lookup(ctx context.Context, req fsmeta.LookupRequest) (fsme
 	record := dentryFromProto(resp.GetDentry())
 	c.lookup.Put(req.Mount, record)
 	return record, nil
+}
+
+func (c *GRPCClient) BatchLookupPlus(ctx context.Context, req fsmeta.BatchLookupPlusRequest) ([]fsmeta.BatchLookupPlusResult, error) {
+	if err := c.requireRPC(); err != nil {
+		return nil, err
+	}
+	resp, err := c.rpc.BatchLookupPlus(ctx, batchLookupPlusRequestToProto(req))
+	if err != nil {
+		return nil, translateRPCError(err)
+	}
+	out := make([]fsmeta.BatchLookupPlusResult, 0, len(resp.GetResults()))
+	for _, result := range resp.GetResults() {
+		typed := batchLookupPlusResultFromProto(result)
+		out = append(out, typed)
+		if req.SnapshotVersion == 0 && typed.Found {
+			c.lookup.Put(req.Mount, typed.Entry.Dentry)
+		}
+	}
+	return out, nil
 }
 
 func (c *GRPCClient) ReadDir(ctx context.Context, req fsmeta.ReadDirRequest) ([]fsmeta.DentryRecord, error) {

--- a/fsmeta/client/client_test.go
+++ b/fsmeta/client/client_test.go
@@ -59,6 +59,34 @@ func (e *fakeExecutor) Lookup(context.Context, fsmeta.LookupRequest) (fsmeta.Den
 	return fsmeta.DentryRecord{Parent: fsmeta.RootInode, Name: "checkpoint", Inode: 42, Type: fsmeta.InodeTypeFile}, nil
 }
 
+func (e *fakeExecutor) BatchLookupPlus(_ context.Context, req fsmeta.BatchLookupPlusRequest) ([]fsmeta.BatchLookupPlusResult, error) {
+	if e.err != nil {
+		return nil, e.err
+	}
+	results := make([]fsmeta.BatchLookupPlusResult, 0, len(req.Lookups))
+	for _, lookup := range req.Lookups {
+		if lookup.Name == "missing" {
+			results = append(results, fsmeta.BatchLookupPlusResult{})
+			continue
+		}
+		results = append(results, fsmeta.BatchLookupPlusResult{
+			Found: true,
+			Entry: fsmeta.DentryAttrPair{
+				Dentry: fsmeta.DentryRecord{Parent: lookup.Parent, Name: lookup.Name, Inode: 42, Type: fsmeta.InodeTypeFile},
+				Inode: fsmeta.InodeRecord{
+					Inode:       42,
+					Type:        fsmeta.InodeTypeFile,
+					Size:        4096,
+					Mode:        0o644,
+					LinkCount:   1,
+					OpaqueAttrs: []byte(`{"body_ref":"cas://checkpoint"}`),
+				},
+			},
+		})
+	}
+	return results, nil
+}
+
 func (e *fakeExecutor) ReadDir(context.Context, fsmeta.ReadDirRequest) ([]fsmeta.DentryRecord, error) {
 	if e.err != nil {
 		return nil, e.err
@@ -239,6 +267,32 @@ func TestTypedClientRoundTrip(t *testing.T) {
 		Inode:  42,
 		Type:   fsmeta.InodeTypeFile,
 	}, record)
+
+	batchResults, err := cli.BatchLookupPlus(context.Background(), fsmeta.BatchLookupPlusRequest{
+		Mount: "vol",
+		Lookups: []fsmeta.LookupKey{
+			{Parent: fsmeta.RootInode, Name: "checkpoint"},
+			{Parent: fsmeta.RootInode, Name: "missing"},
+		},
+	})
+	require.NoError(t, err)
+	require.Equal(t, []fsmeta.BatchLookupPlusResult{
+		{
+			Found: true,
+			Entry: fsmeta.DentryAttrPair{
+				Dentry: fsmeta.DentryRecord{Parent: fsmeta.RootInode, Name: "checkpoint", Inode: 42, Type: fsmeta.InodeTypeFile},
+				Inode: fsmeta.InodeRecord{
+					Inode:       42,
+					Type:        fsmeta.InodeTypeFile,
+					Size:        4096,
+					Mode:        0o644,
+					LinkCount:   1,
+					OpaqueAttrs: []byte(`{"body_ref":"cas://checkpoint"}`),
+				},
+			},
+		},
+		{},
+	}, batchResults)
 
 	records, err := cli.ReadDir(context.Background(), fsmeta.ReadDirRequest{
 		Mount:      "vol",

--- a/fsmeta/client/wire.go
+++ b/fsmeta/client/wire.go
@@ -50,6 +50,21 @@ func lookupRequestToProto(req fsmeta.LookupRequest) *fsmetapb.LookupRequest {
 	}
 }
 
+func batchLookupPlusRequestToProto(req fsmeta.BatchLookupPlusRequest) *fsmetapb.BatchLookupPlusRequest {
+	lookups := make([]*fsmetapb.LookupKey, 0, len(req.Lookups))
+	for _, lookup := range req.Lookups {
+		lookups = append(lookups, &fsmetapb.LookupKey{
+			Parent: uint64(lookup.Parent),
+			Name:   lookup.Name,
+		})
+	}
+	return &fsmetapb.BatchLookupPlusRequest{
+		Mount:           string(req.Mount),
+		Lookups:         lookups,
+		SnapshotVersion: req.SnapshotVersion,
+	}
+}
+
 func readDirRequestToProto(req fsmeta.ReadDirRequest) *fsmetapb.ReadDirRequest {
 	return &fsmetapb.ReadDirRequest{
 		Mount:           string(req.Mount),
@@ -221,6 +236,16 @@ func pairFromProto(pb *fsmetapb.DentryAttrPair) fsmeta.DentryAttrPair {
 	return fsmeta.DentryAttrPair{
 		Dentry: dentryFromProto(pb.GetDentry()),
 		Inode:  inodeFromProto(pb.GetInode()),
+	}
+}
+
+func batchLookupPlusResultFromProto(pb *fsmetapb.BatchLookupPlusResult) fsmeta.BatchLookupPlusResult {
+	if pb == nil {
+		return fsmeta.BatchLookupPlusResult{}
+	}
+	return fsmeta.BatchLookupPlusResult{
+		Found: pb.GetFound(),
+		Entry: pairFromProto(pb.GetEntry()),
 	}
 }
 

--- a/fsmeta/exec/runner.go
+++ b/fsmeta/exec/runner.go
@@ -714,6 +714,125 @@ func (e *Executor) Lookup(ctx context.Context, req fsmeta.LookupRequest) (fsmeta
 	return fsmeta.DecodeDentryValue(value)
 }
 
+// BatchLookupPlus returns dentry+inode pairs for many parent/name lookups at
+// one MVCC read version. Missing dentries are returned as found=false in their
+// original input slots; existing dentries whose inode rows are missing are
+// treated as metadata corruption and fail the whole batch.
+func (e *Executor) BatchLookupPlus(ctx context.Context, req fsmeta.BatchLookupPlusRequest) ([]fsmeta.BatchLookupPlusResult, error) {
+	mountRecord, err := e.resolveActiveMount(ctx, req.Mount)
+	if err != nil {
+		return nil, err
+	}
+	mount := mountRecord.Identity()
+	plan, err := fsmeta.PlanBatchLookupPlus(req, mount)
+	if err != nil {
+		return nil, err
+	}
+	if len(plan.ReadKeys) == 0 {
+		return []fsmeta.BatchLookupPlusResult{}, nil
+	}
+
+	var out []fsmeta.BatchLookupPlusResult
+	err = e.withReadRetry(ctx, req.SnapshotVersion, func(version uint64) error {
+		useNegativeCache := req.SnapshotVersion == 0 && e.negCache != nil
+		results := make([]fsmeta.BatchLookupPlusResult, len(plan.ReadKeys))
+
+		dentryKeys := make([][]byte, 0, len(plan.ReadKeys))
+		dentryIndexes := make(map[string][]int, len(plan.ReadKeys))
+		for i, key := range plan.ReadKeys {
+			if useNegativeCache && e.negCache.Has(key) {
+				continue
+			}
+			keyString := string(key)
+			if len(dentryIndexes[keyString]) == 0 {
+				dentryKeys = append(dentryKeys, key)
+			}
+			dentryIndexes[keyString] = append(dentryIndexes[keyString], i)
+		}
+
+		dentryValues := make(map[string][]byte, len(dentryKeys))
+		if len(dentryKeys) > 0 {
+			var err error
+			dentryValues, err = e.runner.BatchGet(ctx, dentryKeys, version)
+			if err != nil {
+				return err
+			}
+		}
+
+		dentries := make([]fsmeta.DentryRecord, len(plan.ReadKeys))
+		inodeKeys := make([][]byte, 0, len(dentryValues))
+		inodeIndexes := make(map[string][]int, len(dentryValues))
+		for keyString, indexes := range dentryIndexes {
+			value, ok := dentryValues[keyString]
+			if !ok {
+				if useNegativeCache {
+					e.negCache.Remember([]byte(keyString))
+				}
+				continue
+			}
+			dentry, err := fsmeta.DecodeDentryValue(value)
+			if err != nil {
+				return err
+			}
+			inodeKey, err := fsmeta.EncodeInodeKey(mount, dentry.Inode)
+			if err != nil {
+				return err
+			}
+			inodeKeyString := string(inodeKey)
+			if len(inodeIndexes[inodeKeyString]) == 0 {
+				inodeKeys = append(inodeKeys, inodeKey)
+			}
+			for _, index := range indexes {
+				dentries[index] = dentry
+				inodeIndexes[inodeKeyString] = append(inodeIndexes[inodeKeyString], index)
+			}
+		}
+
+		inodeValues := make(map[string][]byte, len(inodeKeys))
+		if len(inodeKeys) > 0 {
+			var err error
+			inodeValues, err = e.runner.BatchGet(ctx, inodeKeys, version)
+			if err != nil {
+				return err
+			}
+		}
+
+		for inodeKeyString, indexes := range inodeIndexes {
+			value, ok := inodeValues[inodeKeyString]
+			if !ok {
+				return fmt.Errorf("%w: inode %d", fsmeta.ErrNotFound, dentries[indexes[0]].Inode)
+			}
+			inode, err := fsmeta.DecodeInodeValue(value)
+			if err != nil {
+				return err
+			}
+			for _, index := range indexes {
+				dentry := dentries[index]
+				if inode.Inode != dentry.Inode {
+					return fmt.Errorf("%w: dentry inode=%d value inode=%d", fsmeta.ErrInvalidValue, dentry.Inode, inode.Inode)
+				}
+				if dentry.Type != inode.Type {
+					return fmt.Errorf("%w: dentry type=%s inode type=%s", fsmeta.ErrInvalidValue, dentry.Type, inode.Type)
+				}
+				results[index] = fsmeta.BatchLookupPlusResult{
+					Found: true,
+					Entry: fsmeta.DentryAttrPair{
+						Dentry: dentry,
+						Inode:  inode,
+					},
+				}
+			}
+		}
+
+		out = results
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 // invalidateNegative drops cached "missing" memos for every dentry key that
 // was just mutated, so the next Lookup re-issues against the runner instead
 // of returning a stale ErrNotFound. Safe with a nil cache.

--- a/fsmeta/exec/runner_test.go
+++ b/fsmeta/exec/runner_test.go
@@ -1601,6 +1601,101 @@ func TestExecutorLookupReturnsNotFound(t *testing.T) {
 	require.ErrorIs(t, err, fsmeta.ErrNotFound)
 }
 
+func TestExecutorBatchLookupPlusReturnsOrderedPartialMissesAtOneVersion(t *testing.T) {
+	runner := newFakeRunner()
+	seedDentry(t, runner, "vol", 7, "a", 21)
+	seedInode(t, runner, "vol", fsmeta.InodeRecord{
+		Inode:     21,
+		Type:      fsmeta.InodeTypeFile,
+		Size:      4096,
+		Mode:      0o644,
+		LinkCount: 1,
+	})
+	seedDentryType(t, runner, "vol", 7, "b", 22, fsmeta.InodeTypeDirectory)
+	seedInode(t, runner, "vol", fsmeta.InodeRecord{
+		Inode:     22,
+		Type:      fsmeta.InodeTypeDirectory,
+		Mode:      0o755,
+		LinkCount: 2,
+	})
+	executor, err := newTestExecutor(runner)
+	require.NoError(t, err)
+
+	results, err := executor.BatchLookupPlus(context.Background(), fsmeta.BatchLookupPlusRequest{
+		Mount: "vol",
+		Lookups: []fsmeta.LookupKey{
+			{Parent: 7, Name: "b"},
+			{Parent: 7, Name: "missing"},
+			{Parent: 7, Name: "a"},
+			{Parent: 7, Name: "a"},
+		},
+	})
+	require.NoError(t, err)
+	require.Equal(t, []fsmeta.BatchLookupPlusResult{
+		{
+			Found: true,
+			Entry: fsmeta.DentryAttrPair{
+				Dentry: fsmeta.DentryRecord{Parent: 7, Name: "b", Inode: 22, Type: fsmeta.InodeTypeDirectory},
+				Inode:  fsmeta.InodeRecord{Inode: 22, Type: fsmeta.InodeTypeDirectory, Mode: 0o755, LinkCount: 2},
+			},
+		},
+		{},
+		{
+			Found: true,
+			Entry: fsmeta.DentryAttrPair{
+				Dentry: fsmeta.DentryRecord{Parent: 7, Name: "a", Inode: 21, Type: fsmeta.InodeTypeFile},
+				Inode:  fsmeta.InodeRecord{Inode: 21, Type: fsmeta.InodeTypeFile, Size: 4096, Mode: 0o644, LinkCount: 1},
+			},
+		},
+		{
+			Found: true,
+			Entry: fsmeta.DentryAttrPair{
+				Dentry: fsmeta.DentryRecord{Parent: 7, Name: "a", Inode: 21, Type: fsmeta.InodeTypeFile},
+				Inode:  fsmeta.InodeRecord{Inode: 21, Type: fsmeta.InodeTypeFile, Size: 4096, Mode: 0o644, LinkCount: 1},
+			},
+		},
+	}, results)
+	require.Equal(t, []uint64{1, 1}, runner.batchVersions)
+}
+
+func TestExecutorBatchLookupPlusRetriesLiveLockAtSnapshotVersion(t *testing.T) {
+	runner := newFakeRunner()
+	runner.batchErrs = []error{txnLockedError("vol", 7, "a")}
+	seedDentry(t, runner, "vol", 7, "a", 21)
+	seedInode(t, runner, "vol", fsmeta.InodeRecord{
+		Inode:     21,
+		Type:      fsmeta.InodeTypeFile,
+		LinkCount: 1,
+	})
+	executor, err := newTestExecutor(runner)
+	require.NoError(t, err)
+
+	results, err := executor.BatchLookupPlus(context.Background(), fsmeta.BatchLookupPlusRequest{
+		Mount:           "vol",
+		Lookups:         []fsmeta.LookupKey{{Parent: 7, Name: "a"}},
+		SnapshotVersion: 100,
+	})
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+	require.True(t, results[0].Found)
+	require.Equal(t, []uint64{100, 100, 100}, runner.batchVersions)
+	requireStatUint(t, executor.Stats(), "read_retries_total", 1)
+	requireStatUint(t, executor.Stats(), "read_retry_exhausted_total", 0)
+}
+
+func TestExecutorBatchLookupPlusMissingInodeReturnsNotFound(t *testing.T) {
+	runner := newFakeRunner()
+	seedDentry(t, runner, "vol", 7, "a", 21)
+	executor, err := newTestExecutor(runner)
+	require.NoError(t, err)
+
+	_, err = executor.BatchLookupPlus(context.Background(), fsmeta.BatchLookupPlusRequest{
+		Mount:   "vol",
+		Lookups: []fsmeta.LookupKey{{Parent: 7, Name: "a"}},
+	})
+	require.ErrorIs(t, err, fsmeta.ErrNotFound)
+}
+
 func TestExecutorReadDirConsumesPlanCursorAndLimit(t *testing.T) {
 	runner := newFakeRunner()
 	seedDentry(t, runner, "vol", 7, "a", 21)

--- a/fsmeta/plan.go
+++ b/fsmeta/plan.go
@@ -16,6 +16,7 @@ const (
 	OperationCreate           OperationKind = "create"
 	OperationUpdateInode      OperationKind = "update_inode"
 	OperationLookup           OperationKind = "lookup"
+	OperationBatchLookupPlus  OperationKind = "batch_lookup_plus"
 	OperationReadDir          OperationKind = "readdir"
 	OperationSnapshotSubtree  OperationKind = "snapshot_subtree"
 	OperationRename           OperationKind = "rename"
@@ -83,6 +84,22 @@ type LookupRequest struct {
 	Mount  MountID
 	Parent InodeID
 	Name   string
+}
+
+type LookupKey struct {
+	Parent InodeID
+	Name   string
+}
+
+type BatchLookupPlusRequest struct {
+	Mount           MountID
+	Lookups         []LookupKey
+	SnapshotVersion uint64
+}
+
+type BatchLookupPlusResult struct {
+	Found bool
+	Entry DentryAttrPair
 }
 
 type ReadDirRequest struct {
@@ -262,6 +279,28 @@ func PlanLookup(req LookupRequest, mount MountIdentity) (OperationPlan, error) {
 		Mount:      req.Mount,
 		PrimaryKey: cloneBytes(dentry),
 		ReadKeys:   cloneKeySet(dentry),
+	}, nil
+}
+
+func PlanBatchLookupPlus(req BatchLookupPlusRequest, mount MountIdentity) (OperationPlan, error) {
+	if err := validateMountIdentityForRequest(mount, req.Mount); err != nil {
+		return OperationPlan{}, err
+	}
+	if len(req.Lookups) > int(MaxBatchLookupPlusLimit) {
+		return OperationPlan{}, ErrInvalidPageSize
+	}
+	readKeys := make([][]byte, 0, len(req.Lookups))
+	for _, lookup := range req.Lookups {
+		dentry, err := EncodeDentryKey(mount, lookup.Parent, lookup.Name)
+		if err != nil {
+			return OperationPlan{}, err
+		}
+		readKeys = append(readKeys, dentry)
+	}
+	return OperationPlan{
+		Kind:     OperationBatchLookupPlus,
+		Mount:    req.Mount,
+		ReadKeys: cloneKeySet(readKeys...),
 	}, nil
 }
 

--- a/fsmeta/server/service.go
+++ b/fsmeta/server/service.go
@@ -17,6 +17,7 @@ type Executor interface {
 	Create(ctx context.Context, req fsmeta.CreateRequest) (fsmeta.CreateResult, error)
 	UpdateInode(ctx context.Context, req fsmeta.UpdateInodeRequest) (fsmeta.InodeRecord, error)
 	Lookup(ctx context.Context, req fsmeta.LookupRequest) (fsmeta.DentryRecord, error)
+	BatchLookupPlus(ctx context.Context, req fsmeta.BatchLookupPlusRequest) ([]fsmeta.BatchLookupPlusResult, error)
 	ReadDir(ctx context.Context, req fsmeta.ReadDirRequest) ([]fsmeta.DentryRecord, error)
 	ReadDirPlus(ctx context.Context, req fsmeta.ReadDirRequest) ([]fsmeta.DentryAttrPair, error)
 	GetReadVersion(ctx context.Context, req fsmeta.ReadVersionRequest) (uint64, error)
@@ -120,6 +121,24 @@ func (s *Service) Lookup(ctx context.Context, req *fsmetapb.LookupRequest) (*fsm
 		return nil, rpcError(err)
 	}
 	return &fsmetapb.LookupResponse{Dentry: dentryToProto(record)}, nil
+}
+
+func (s *Service) BatchLookupPlus(ctx context.Context, req *fsmetapb.BatchLookupPlusRequest) (*fsmetapb.BatchLookupPlusResponse, error) {
+	if err := s.requireExecutor(); err != nil {
+		return nil, err
+	}
+	if req == nil {
+		return nil, rpcInvalidArgument("fsmeta batch lookupplus request is required")
+	}
+	results, err := s.executor.BatchLookupPlus(ctx, batchLookupPlusRequestFromProto(req))
+	if err != nil {
+		return nil, rpcError(err)
+	}
+	resp := &fsmetapb.BatchLookupPlusResponse{Results: make([]*fsmetapb.BatchLookupPlusResult, 0, len(results))}
+	for _, result := range results {
+		resp.Results = append(resp.Results, batchLookupPlusResultToProto(result))
+	}
+	return resp, nil
 }
 
 func (s *Service) ReadDir(ctx context.Context, req *fsmetapb.ReadDirRequest) (*fsmetapb.ReadDirResponse, error) {

--- a/fsmeta/server/service_test.go
+++ b/fsmeta/server/service_test.go
@@ -23,6 +23,7 @@ type fakeExecutor struct {
 	createReq        fsmeta.CreateRequest
 	createInode      fsmeta.InodeRecord
 	updateReq        fsmeta.UpdateInodeRequest
+	batchLookupReq   fsmeta.BatchLookupPlusRequest
 	readDirReq       fsmeta.ReadDirRequest
 	readVersionReq   fsmeta.ReadVersionRequest
 	snapshotReq      fsmeta.SnapshotSubtreeRequest
@@ -77,6 +78,39 @@ func (e *fakeExecutor) Lookup(context.Context, fsmeta.LookupRequest) (fsmeta.Den
 		Inode:  42,
 		Type:   fsmeta.InodeTypeFile,
 	}, nil
+}
+
+func (e *fakeExecutor) BatchLookupPlus(_ context.Context, req fsmeta.BatchLookupPlusRequest) ([]fsmeta.BatchLookupPlusResult, error) {
+	e.batchLookupReq = req
+	if e.err != nil {
+		return nil, e.err
+	}
+	results := make([]fsmeta.BatchLookupPlusResult, 0, len(req.Lookups))
+	for _, lookup := range req.Lookups {
+		if lookup.Name == "missing" {
+			results = append(results, fsmeta.BatchLookupPlusResult{})
+			continue
+		}
+		results = append(results, fsmeta.BatchLookupPlusResult{
+			Found: true,
+			Entry: fsmeta.DentryAttrPair{
+				Dentry: fsmeta.DentryRecord{
+					Parent: lookup.Parent,
+					Name:   lookup.Name,
+					Inode:  42,
+					Type:   fsmeta.InodeTypeFile,
+				},
+				Inode: fsmeta.InodeRecord{
+					Inode:     42,
+					Type:      fsmeta.InodeTypeFile,
+					Size:      4096,
+					Mode:      0o644,
+					LinkCount: 1,
+				},
+			},
+		})
+	}
+	return results, nil
 }
 
 func (e *fakeExecutor) ReadDir(_ context.Context, req fsmeta.ReadDirRequest) ([]fsmeta.DentryRecord, error) {
@@ -251,6 +285,29 @@ func TestGRPCServiceCreateAndReadDirPlus(t *testing.T) {
 	require.Equal(t, "checkpoint", resp.GetEntries()[0].GetDentry().GetName())
 	require.Equal(t, uint64(4096), resp.GetEntries()[0].GetInode().GetSize())
 	require.Equal(t, []byte(nil), resp.GetEntries()[0].GetInode().GetOpaqueAttrs())
+
+	batchResp, err := client.BatchLookupPlus(context.Background(), &fsmetapb.BatchLookupPlusRequest{
+		Mount: "vol",
+		Lookups: []*fsmetapb.LookupKey{
+			{Parent: uint64(fsmeta.RootInode), Name: "checkpoint"},
+			{Parent: uint64(fsmeta.RootInode), Name: "missing"},
+		},
+		SnapshotVersion: 55,
+	})
+	require.NoError(t, err)
+	require.Equal(t, fsmeta.BatchLookupPlusRequest{
+		Mount: "vol",
+		Lookups: []fsmeta.LookupKey{
+			{Parent: fsmeta.RootInode, Name: "checkpoint"},
+			{Parent: fsmeta.RootInode, Name: "missing"},
+		},
+		SnapshotVersion: 55,
+	}, executor.batchLookupReq)
+	require.Len(t, batchResp.GetResults(), 2)
+	require.True(t, batchResp.GetResults()[0].GetFound())
+	require.Equal(t, "checkpoint", batchResp.GetResults()[0].GetEntry().GetDentry().GetName())
+	require.False(t, batchResp.GetResults()[1].GetFound())
+	require.Nil(t, batchResp.GetResults()[1].GetEntry())
 }
 
 func TestGRPCServiceReadDirAndMutationRPCs(t *testing.T) {

--- a/fsmeta/server/wire.go
+++ b/fsmeta/server/wire.go
@@ -58,6 +58,24 @@ func lookupRequestFromProto(req *fsmetapb.LookupRequest) fsmeta.LookupRequest {
 	}
 }
 
+func batchLookupPlusRequestFromProto(req *fsmetapb.BatchLookupPlusRequest) fsmeta.BatchLookupPlusRequest {
+	if req == nil {
+		return fsmeta.BatchLookupPlusRequest{}
+	}
+	lookups := make([]fsmeta.LookupKey, 0, len(req.GetLookups()))
+	for _, lookup := range req.GetLookups() {
+		lookups = append(lookups, fsmeta.LookupKey{
+			Parent: fsmeta.InodeID(lookup.GetParent()),
+			Name:   lookup.GetName(),
+		})
+	}
+	return fsmeta.BatchLookupPlusRequest{
+		Mount:           fsmeta.MountID(req.GetMount()),
+		Lookups:         lookups,
+		SnapshotVersion: req.GetSnapshotVersion(),
+	}
+}
+
 func readDirRequestFromProto(req *fsmetapb.ReadDirRequest) fsmeta.ReadDirRequest {
 	return fsmeta.ReadDirRequest{
 		Mount:           fsmeta.MountID(req.GetMount()),
@@ -239,6 +257,14 @@ func pairToProto(pair fsmeta.DentryAttrPair) *fsmetapb.DentryAttrPair {
 		Dentry: dentryToProto(pair.Dentry),
 		Inode:  inodeToProto(pair.Inode),
 	}
+}
+
+func batchLookupPlusResultToProto(result fsmeta.BatchLookupPlusResult) *fsmetapb.BatchLookupPlusResult {
+	resp := &fsmetapb.BatchLookupPlusResult{Found: result.Found}
+	if result.Found {
+		resp.Entry = pairToProto(result.Entry)
+	}
+	return resp
 }
 
 func watchRequestFromProto(req *fsmetapb.WatchSubtreeRequest) fsmeta.WatchRequest {

--- a/fsmeta/types.go
+++ b/fsmeta/types.go
@@ -93,6 +93,10 @@ const (
 	// streaming API.
 	MaxReadDirLimit uint32 = 16 * 1024
 
+	// MaxBatchLookupPlusLimit keeps one batched point-read bounded before
+	// fsmeta grows streaming or shard-aware request splitting.
+	MaxBatchLookupPlusLimit uint32 = 16 * 1024
+
 	// DefaultSessionExpireLimit bounds one stale-session cleanup pass when the
 	// caller does not provide an explicit page size.
 	DefaultSessionExpireLimit uint32 = 1024

--- a/pb/fsmeta/fsmeta.pb.go
+++ b/pb/fsmeta/fsmeta.pb.go
@@ -885,6 +885,214 @@ func (x *LookupResponse) GetDentry() *DentryRecord {
 	return nil
 }
 
+type LookupKey struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Parent        uint64                 `protobuf:"varint,1,opt,name=parent,proto3" json:"parent,omitempty"`
+	Name          string                 `protobuf:"bytes,2,opt,name=name,proto3" json:"name,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *LookupKey) Reset() {
+	*x = LookupKey{}
+	mi := &file_fsmeta_fsmeta_proto_msgTypes[11]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *LookupKey) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*LookupKey) ProtoMessage() {}
+
+func (x *LookupKey) ProtoReflect() protoreflect.Message {
+	mi := &file_fsmeta_fsmeta_proto_msgTypes[11]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use LookupKey.ProtoReflect.Descriptor instead.
+func (*LookupKey) Descriptor() ([]byte, []int) {
+	return file_fsmeta_fsmeta_proto_rawDescGZIP(), []int{11}
+}
+
+func (x *LookupKey) GetParent() uint64 {
+	if x != nil {
+		return x.Parent
+	}
+	return 0
+}
+
+func (x *LookupKey) GetName() string {
+	if x != nil {
+		return x.Name
+	}
+	return ""
+}
+
+type BatchLookupPlusRequest struct {
+	state           protoimpl.MessageState `protogen:"open.v1"`
+	Mount           string                 `protobuf:"bytes,1,opt,name=mount,proto3" json:"mount,omitempty"`
+	Lookups         []*LookupKey           `protobuf:"bytes,2,rep,name=lookups,proto3" json:"lookups,omitempty"`
+	SnapshotVersion uint64                 `protobuf:"varint,3,opt,name=snapshot_version,json=snapshotVersion,proto3" json:"snapshot_version,omitempty"`
+	unknownFields   protoimpl.UnknownFields
+	sizeCache       protoimpl.SizeCache
+}
+
+func (x *BatchLookupPlusRequest) Reset() {
+	*x = BatchLookupPlusRequest{}
+	mi := &file_fsmeta_fsmeta_proto_msgTypes[12]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *BatchLookupPlusRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*BatchLookupPlusRequest) ProtoMessage() {}
+
+func (x *BatchLookupPlusRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_fsmeta_fsmeta_proto_msgTypes[12]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use BatchLookupPlusRequest.ProtoReflect.Descriptor instead.
+func (*BatchLookupPlusRequest) Descriptor() ([]byte, []int) {
+	return file_fsmeta_fsmeta_proto_rawDescGZIP(), []int{12}
+}
+
+func (x *BatchLookupPlusRequest) GetMount() string {
+	if x != nil {
+		return x.Mount
+	}
+	return ""
+}
+
+func (x *BatchLookupPlusRequest) GetLookups() []*LookupKey {
+	if x != nil {
+		return x.Lookups
+	}
+	return nil
+}
+
+func (x *BatchLookupPlusRequest) GetSnapshotVersion() uint64 {
+	if x != nil {
+		return x.SnapshotVersion
+	}
+	return 0
+}
+
+type BatchLookupPlusResult struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Found         bool                   `protobuf:"varint,1,opt,name=found,proto3" json:"found,omitempty"`
+	Entry         *DentryAttrPair        `protobuf:"bytes,2,opt,name=entry,proto3" json:"entry,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *BatchLookupPlusResult) Reset() {
+	*x = BatchLookupPlusResult{}
+	mi := &file_fsmeta_fsmeta_proto_msgTypes[13]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *BatchLookupPlusResult) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*BatchLookupPlusResult) ProtoMessage() {}
+
+func (x *BatchLookupPlusResult) ProtoReflect() protoreflect.Message {
+	mi := &file_fsmeta_fsmeta_proto_msgTypes[13]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use BatchLookupPlusResult.ProtoReflect.Descriptor instead.
+func (*BatchLookupPlusResult) Descriptor() ([]byte, []int) {
+	return file_fsmeta_fsmeta_proto_rawDescGZIP(), []int{13}
+}
+
+func (x *BatchLookupPlusResult) GetFound() bool {
+	if x != nil {
+		return x.Found
+	}
+	return false
+}
+
+func (x *BatchLookupPlusResult) GetEntry() *DentryAttrPair {
+	if x != nil {
+		return x.Entry
+	}
+	return nil
+}
+
+type BatchLookupPlusResponse struct {
+	state         protoimpl.MessageState   `protogen:"open.v1"`
+	Results       []*BatchLookupPlusResult `protobuf:"bytes,1,rep,name=results,proto3" json:"results,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *BatchLookupPlusResponse) Reset() {
+	*x = BatchLookupPlusResponse{}
+	mi := &file_fsmeta_fsmeta_proto_msgTypes[14]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *BatchLookupPlusResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*BatchLookupPlusResponse) ProtoMessage() {}
+
+func (x *BatchLookupPlusResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_fsmeta_fsmeta_proto_msgTypes[14]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use BatchLookupPlusResponse.ProtoReflect.Descriptor instead.
+func (*BatchLookupPlusResponse) Descriptor() ([]byte, []int) {
+	return file_fsmeta_fsmeta_proto_rawDescGZIP(), []int{14}
+}
+
+func (x *BatchLookupPlusResponse) GetResults() []*BatchLookupPlusResult {
+	if x != nil {
+		return x.Results
+	}
+	return nil
+}
+
 type ReadDirRequest struct {
 	state           protoimpl.MessageState `protogen:"open.v1"`
 	Mount           string                 `protobuf:"bytes,1,opt,name=mount,proto3" json:"mount,omitempty"`
@@ -898,7 +1106,7 @@ type ReadDirRequest struct {
 
 func (x *ReadDirRequest) Reset() {
 	*x = ReadDirRequest{}
-	mi := &file_fsmeta_fsmeta_proto_msgTypes[11]
+	mi := &file_fsmeta_fsmeta_proto_msgTypes[15]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -910,7 +1118,7 @@ func (x *ReadDirRequest) String() string {
 func (*ReadDirRequest) ProtoMessage() {}
 
 func (x *ReadDirRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_fsmeta_fsmeta_proto_msgTypes[11]
+	mi := &file_fsmeta_fsmeta_proto_msgTypes[15]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -923,7 +1131,7 @@ func (x *ReadDirRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ReadDirRequest.ProtoReflect.Descriptor instead.
 func (*ReadDirRequest) Descriptor() ([]byte, []int) {
-	return file_fsmeta_fsmeta_proto_rawDescGZIP(), []int{11}
+	return file_fsmeta_fsmeta_proto_rawDescGZIP(), []int{15}
 }
 
 func (x *ReadDirRequest) GetMount() string {
@@ -970,7 +1178,7 @@ type ReadDirResponse struct {
 
 func (x *ReadDirResponse) Reset() {
 	*x = ReadDirResponse{}
-	mi := &file_fsmeta_fsmeta_proto_msgTypes[12]
+	mi := &file_fsmeta_fsmeta_proto_msgTypes[16]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -982,7 +1190,7 @@ func (x *ReadDirResponse) String() string {
 func (*ReadDirResponse) ProtoMessage() {}
 
 func (x *ReadDirResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_fsmeta_fsmeta_proto_msgTypes[12]
+	mi := &file_fsmeta_fsmeta_proto_msgTypes[16]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -995,7 +1203,7 @@ func (x *ReadDirResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ReadDirResponse.ProtoReflect.Descriptor instead.
 func (*ReadDirResponse) Descriptor() ([]byte, []int) {
-	return file_fsmeta_fsmeta_proto_rawDescGZIP(), []int{12}
+	return file_fsmeta_fsmeta_proto_rawDescGZIP(), []int{16}
 }
 
 func (x *ReadDirResponse) GetEntries() []*DentryRecord {
@@ -1014,7 +1222,7 @@ type ReadDirPlusResponse struct {
 
 func (x *ReadDirPlusResponse) Reset() {
 	*x = ReadDirPlusResponse{}
-	mi := &file_fsmeta_fsmeta_proto_msgTypes[13]
+	mi := &file_fsmeta_fsmeta_proto_msgTypes[17]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1026,7 +1234,7 @@ func (x *ReadDirPlusResponse) String() string {
 func (*ReadDirPlusResponse) ProtoMessage() {}
 
 func (x *ReadDirPlusResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_fsmeta_fsmeta_proto_msgTypes[13]
+	mi := &file_fsmeta_fsmeta_proto_msgTypes[17]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1039,7 +1247,7 @@ func (x *ReadDirPlusResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ReadDirPlusResponse.ProtoReflect.Descriptor instead.
 func (*ReadDirPlusResponse) Descriptor() ([]byte, []int) {
-	return file_fsmeta_fsmeta_proto_rawDescGZIP(), []int{13}
+	return file_fsmeta_fsmeta_proto_rawDescGZIP(), []int{17}
 }
 
 func (x *ReadDirPlusResponse) GetEntries() []*DentryAttrPair {
@@ -1060,7 +1268,7 @@ type WatchCursor struct {
 
 func (x *WatchCursor) Reset() {
 	*x = WatchCursor{}
-	mi := &file_fsmeta_fsmeta_proto_msgTypes[14]
+	mi := &file_fsmeta_fsmeta_proto_msgTypes[18]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1072,7 +1280,7 @@ func (x *WatchCursor) String() string {
 func (*WatchCursor) ProtoMessage() {}
 
 func (x *WatchCursor) ProtoReflect() protoreflect.Message {
-	mi := &file_fsmeta_fsmeta_proto_msgTypes[14]
+	mi := &file_fsmeta_fsmeta_proto_msgTypes[18]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1085,7 +1293,7 @@ func (x *WatchCursor) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use WatchCursor.ProtoReflect.Descriptor instead.
 func (*WatchCursor) Descriptor() ([]byte, []int) {
-	return file_fsmeta_fsmeta_proto_rawDescGZIP(), []int{14}
+	return file_fsmeta_fsmeta_proto_rawDescGZIP(), []int{18}
 }
 
 func (x *WatchCursor) GetRegionId() uint64 {
@@ -1123,7 +1331,7 @@ type WatchSubtreeRequest struct {
 
 func (x *WatchSubtreeRequest) Reset() {
 	*x = WatchSubtreeRequest{}
-	mi := &file_fsmeta_fsmeta_proto_msgTypes[15]
+	mi := &file_fsmeta_fsmeta_proto_msgTypes[19]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1135,7 +1343,7 @@ func (x *WatchSubtreeRequest) String() string {
 func (*WatchSubtreeRequest) ProtoMessage() {}
 
 func (x *WatchSubtreeRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_fsmeta_fsmeta_proto_msgTypes[15]
+	mi := &file_fsmeta_fsmeta_proto_msgTypes[19]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1148,7 +1356,7 @@ func (x *WatchSubtreeRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use WatchSubtreeRequest.ProtoReflect.Descriptor instead.
 func (*WatchSubtreeRequest) Descriptor() ([]byte, []int) {
-	return file_fsmeta_fsmeta_proto_rawDescGZIP(), []int{15}
+	return file_fsmeta_fsmeta_proto_rawDescGZIP(), []int{19}
 }
 
 func (x *WatchSubtreeRequest) GetMount() string {
@@ -1205,7 +1413,7 @@ type WatchEvent struct {
 
 func (x *WatchEvent) Reset() {
 	*x = WatchEvent{}
-	mi := &file_fsmeta_fsmeta_proto_msgTypes[16]
+	mi := &file_fsmeta_fsmeta_proto_msgTypes[20]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1217,7 +1425,7 @@ func (x *WatchEvent) String() string {
 func (*WatchEvent) ProtoMessage() {}
 
 func (x *WatchEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_fsmeta_fsmeta_proto_msgTypes[16]
+	mi := &file_fsmeta_fsmeta_proto_msgTypes[20]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1230,7 +1438,7 @@ func (x *WatchEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use WatchEvent.ProtoReflect.Descriptor instead.
 func (*WatchEvent) Descriptor() ([]byte, []int) {
-	return file_fsmeta_fsmeta_proto_rawDescGZIP(), []int{16}
+	return file_fsmeta_fsmeta_proto_rawDescGZIP(), []int{20}
 }
 
 func (x *WatchEvent) GetRaftCursor() *WatchCursor {
@@ -1270,7 +1478,7 @@ type WatchAck struct {
 
 func (x *WatchAck) Reset() {
 	*x = WatchAck{}
-	mi := &file_fsmeta_fsmeta_proto_msgTypes[17]
+	mi := &file_fsmeta_fsmeta_proto_msgTypes[21]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1282,7 +1490,7 @@ func (x *WatchAck) String() string {
 func (*WatchAck) ProtoMessage() {}
 
 func (x *WatchAck) ProtoReflect() protoreflect.Message {
-	mi := &file_fsmeta_fsmeta_proto_msgTypes[17]
+	mi := &file_fsmeta_fsmeta_proto_msgTypes[21]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1295,7 +1503,7 @@ func (x *WatchAck) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use WatchAck.ProtoReflect.Descriptor instead.
 func (*WatchAck) Descriptor() ([]byte, []int) {
-	return file_fsmeta_fsmeta_proto_rawDescGZIP(), []int{17}
+	return file_fsmeta_fsmeta_proto_rawDescGZIP(), []int{21}
 }
 
 func (x *WatchAck) GetCursor() *WatchCursor {
@@ -1314,7 +1522,7 @@ type WatchCatchupComplete struct {
 
 func (x *WatchCatchupComplete) Reset() {
 	*x = WatchCatchupComplete{}
-	mi := &file_fsmeta_fsmeta_proto_msgTypes[18]
+	mi := &file_fsmeta_fsmeta_proto_msgTypes[22]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1326,7 +1534,7 @@ func (x *WatchCatchupComplete) String() string {
 func (*WatchCatchupComplete) ProtoMessage() {}
 
 func (x *WatchCatchupComplete) ProtoReflect() protoreflect.Message {
-	mi := &file_fsmeta_fsmeta_proto_msgTypes[18]
+	mi := &file_fsmeta_fsmeta_proto_msgTypes[22]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1339,7 +1547,7 @@ func (x *WatchCatchupComplete) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use WatchCatchupComplete.ProtoReflect.Descriptor instead.
 func (*WatchCatchupComplete) Descriptor() ([]byte, []int) {
-	return file_fsmeta_fsmeta_proto_rawDescGZIP(), []int{18}
+	return file_fsmeta_fsmeta_proto_rawDescGZIP(), []int{22}
 }
 
 func (x *WatchCatchupComplete) GetCursor() *WatchCursor {
@@ -1358,7 +1566,7 @@ type WatchReady struct {
 
 func (x *WatchReady) Reset() {
 	*x = WatchReady{}
-	mi := &file_fsmeta_fsmeta_proto_msgTypes[19]
+	mi := &file_fsmeta_fsmeta_proto_msgTypes[23]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1370,7 +1578,7 @@ func (x *WatchReady) String() string {
 func (*WatchReady) ProtoMessage() {}
 
 func (x *WatchReady) ProtoReflect() protoreflect.Message {
-	mi := &file_fsmeta_fsmeta_proto_msgTypes[19]
+	mi := &file_fsmeta_fsmeta_proto_msgTypes[23]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1383,7 +1591,7 @@ func (x *WatchReady) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use WatchReady.ProtoReflect.Descriptor instead.
 func (*WatchReady) Descriptor() ([]byte, []int) {
-	return file_fsmeta_fsmeta_proto_rawDescGZIP(), []int{19}
+	return file_fsmeta_fsmeta_proto_rawDescGZIP(), []int{23}
 }
 
 func (x *WatchReady) GetCursor() *WatchCursor {
@@ -1404,7 +1612,7 @@ type WatchThrottle struct {
 
 func (x *WatchThrottle) Reset() {
 	*x = WatchThrottle{}
-	mi := &file_fsmeta_fsmeta_proto_msgTypes[20]
+	mi := &file_fsmeta_fsmeta_proto_msgTypes[24]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1416,7 +1624,7 @@ func (x *WatchThrottle) String() string {
 func (*WatchThrottle) ProtoMessage() {}
 
 func (x *WatchThrottle) ProtoReflect() protoreflect.Message {
-	mi := &file_fsmeta_fsmeta_proto_msgTypes[20]
+	mi := &file_fsmeta_fsmeta_proto_msgTypes[24]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1429,7 +1637,7 @@ func (x *WatchThrottle) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use WatchThrottle.ProtoReflect.Descriptor instead.
 func (*WatchThrottle) Descriptor() ([]byte, []int) {
-	return file_fsmeta_fsmeta_proto_rawDescGZIP(), []int{20}
+	return file_fsmeta_fsmeta_proto_rawDescGZIP(), []int{24}
 }
 
 func (x *WatchThrottle) GetOutstanding() uint32 {
@@ -1468,7 +1676,7 @@ type WatchSubtreeResponse struct {
 
 func (x *WatchSubtreeResponse) Reset() {
 	*x = WatchSubtreeResponse{}
-	mi := &file_fsmeta_fsmeta_proto_msgTypes[21]
+	mi := &file_fsmeta_fsmeta_proto_msgTypes[25]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1480,7 +1688,7 @@ func (x *WatchSubtreeResponse) String() string {
 func (*WatchSubtreeResponse) ProtoMessage() {}
 
 func (x *WatchSubtreeResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_fsmeta_fsmeta_proto_msgTypes[21]
+	mi := &file_fsmeta_fsmeta_proto_msgTypes[25]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1493,7 +1701,7 @@ func (x *WatchSubtreeResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use WatchSubtreeResponse.ProtoReflect.Descriptor instead.
 func (*WatchSubtreeResponse) Descriptor() ([]byte, []int) {
-	return file_fsmeta_fsmeta_proto_rawDescGZIP(), []int{21}
+	return file_fsmeta_fsmeta_proto_rawDescGZIP(), []int{25}
 }
 
 func (x *WatchSubtreeResponse) GetPayload() isWatchSubtreeResponse_Payload {
@@ -1580,7 +1788,7 @@ type WatchAckOrSubscribe struct {
 
 func (x *WatchAckOrSubscribe) Reset() {
 	*x = WatchAckOrSubscribe{}
-	mi := &file_fsmeta_fsmeta_proto_msgTypes[22]
+	mi := &file_fsmeta_fsmeta_proto_msgTypes[26]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1592,7 +1800,7 @@ func (x *WatchAckOrSubscribe) String() string {
 func (*WatchAckOrSubscribe) ProtoMessage() {}
 
 func (x *WatchAckOrSubscribe) ProtoReflect() protoreflect.Message {
-	mi := &file_fsmeta_fsmeta_proto_msgTypes[22]
+	mi := &file_fsmeta_fsmeta_proto_msgTypes[26]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1605,7 +1813,7 @@ func (x *WatchAckOrSubscribe) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use WatchAckOrSubscribe.ProtoReflect.Descriptor instead.
 func (*WatchAckOrSubscribe) Descriptor() ([]byte, []int) {
-	return file_fsmeta_fsmeta_proto_rawDescGZIP(), []int{22}
+	return file_fsmeta_fsmeta_proto_rawDescGZIP(), []int{26}
 }
 
 func (x *WatchAckOrSubscribe) GetBody() isWatchAckOrSubscribe_Body {
@@ -1658,7 +1866,7 @@ type GetReadVersionRequest struct {
 
 func (x *GetReadVersionRequest) Reset() {
 	*x = GetReadVersionRequest{}
-	mi := &file_fsmeta_fsmeta_proto_msgTypes[23]
+	mi := &file_fsmeta_fsmeta_proto_msgTypes[27]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1670,7 +1878,7 @@ func (x *GetReadVersionRequest) String() string {
 func (*GetReadVersionRequest) ProtoMessage() {}
 
 func (x *GetReadVersionRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_fsmeta_fsmeta_proto_msgTypes[23]
+	mi := &file_fsmeta_fsmeta_proto_msgTypes[27]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1683,7 +1891,7 @@ func (x *GetReadVersionRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetReadVersionRequest.ProtoReflect.Descriptor instead.
 func (*GetReadVersionRequest) Descriptor() ([]byte, []int) {
-	return file_fsmeta_fsmeta_proto_rawDescGZIP(), []int{23}
+	return file_fsmeta_fsmeta_proto_rawDescGZIP(), []int{27}
 }
 
 func (x *GetReadVersionRequest) GetMount() string {
@@ -1702,7 +1910,7 @@ type GetReadVersionResponse struct {
 
 func (x *GetReadVersionResponse) Reset() {
 	*x = GetReadVersionResponse{}
-	mi := &file_fsmeta_fsmeta_proto_msgTypes[24]
+	mi := &file_fsmeta_fsmeta_proto_msgTypes[28]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1714,7 +1922,7 @@ func (x *GetReadVersionResponse) String() string {
 func (*GetReadVersionResponse) ProtoMessage() {}
 
 func (x *GetReadVersionResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_fsmeta_fsmeta_proto_msgTypes[24]
+	mi := &file_fsmeta_fsmeta_proto_msgTypes[28]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1727,7 +1935,7 @@ func (x *GetReadVersionResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetReadVersionResponse.ProtoReflect.Descriptor instead.
 func (*GetReadVersionResponse) Descriptor() ([]byte, []int) {
-	return file_fsmeta_fsmeta_proto_rawDescGZIP(), []int{24}
+	return file_fsmeta_fsmeta_proto_rawDescGZIP(), []int{28}
 }
 
 func (x *GetReadVersionResponse) GetReadVersion() uint64 {
@@ -1747,7 +1955,7 @@ type SnapshotSubtreeRequest struct {
 
 func (x *SnapshotSubtreeRequest) Reset() {
 	*x = SnapshotSubtreeRequest{}
-	mi := &file_fsmeta_fsmeta_proto_msgTypes[25]
+	mi := &file_fsmeta_fsmeta_proto_msgTypes[29]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1759,7 +1967,7 @@ func (x *SnapshotSubtreeRequest) String() string {
 func (*SnapshotSubtreeRequest) ProtoMessage() {}
 
 func (x *SnapshotSubtreeRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_fsmeta_fsmeta_proto_msgTypes[25]
+	mi := &file_fsmeta_fsmeta_proto_msgTypes[29]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1772,7 +1980,7 @@ func (x *SnapshotSubtreeRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SnapshotSubtreeRequest.ProtoReflect.Descriptor instead.
 func (*SnapshotSubtreeRequest) Descriptor() ([]byte, []int) {
-	return file_fsmeta_fsmeta_proto_rawDescGZIP(), []int{25}
+	return file_fsmeta_fsmeta_proto_rawDescGZIP(), []int{29}
 }
 
 func (x *SnapshotSubtreeRequest) GetMount() string {
@@ -1800,7 +2008,7 @@ type SnapshotSubtreeResponse struct {
 
 func (x *SnapshotSubtreeResponse) Reset() {
 	*x = SnapshotSubtreeResponse{}
-	mi := &file_fsmeta_fsmeta_proto_msgTypes[26]
+	mi := &file_fsmeta_fsmeta_proto_msgTypes[30]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1812,7 +2020,7 @@ func (x *SnapshotSubtreeResponse) String() string {
 func (*SnapshotSubtreeResponse) ProtoMessage() {}
 
 func (x *SnapshotSubtreeResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_fsmeta_fsmeta_proto_msgTypes[26]
+	mi := &file_fsmeta_fsmeta_proto_msgTypes[30]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1825,7 +2033,7 @@ func (x *SnapshotSubtreeResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SnapshotSubtreeResponse.ProtoReflect.Descriptor instead.
 func (*SnapshotSubtreeResponse) Descriptor() ([]byte, []int) {
-	return file_fsmeta_fsmeta_proto_rawDescGZIP(), []int{26}
+	return file_fsmeta_fsmeta_proto_rawDescGZIP(), []int{30}
 }
 
 func (x *SnapshotSubtreeResponse) GetMount() string {
@@ -1860,7 +2068,7 @@ type RetireSnapshotSubtreeRequest struct {
 
 func (x *RetireSnapshotSubtreeRequest) Reset() {
 	*x = RetireSnapshotSubtreeRequest{}
-	mi := &file_fsmeta_fsmeta_proto_msgTypes[27]
+	mi := &file_fsmeta_fsmeta_proto_msgTypes[31]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1872,7 +2080,7 @@ func (x *RetireSnapshotSubtreeRequest) String() string {
 func (*RetireSnapshotSubtreeRequest) ProtoMessage() {}
 
 func (x *RetireSnapshotSubtreeRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_fsmeta_fsmeta_proto_msgTypes[27]
+	mi := &file_fsmeta_fsmeta_proto_msgTypes[31]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1885,7 +2093,7 @@ func (x *RetireSnapshotSubtreeRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RetireSnapshotSubtreeRequest.ProtoReflect.Descriptor instead.
 func (*RetireSnapshotSubtreeRequest) Descriptor() ([]byte, []int) {
-	return file_fsmeta_fsmeta_proto_rawDescGZIP(), []int{27}
+	return file_fsmeta_fsmeta_proto_rawDescGZIP(), []int{31}
 }
 
 func (x *RetireSnapshotSubtreeRequest) GetMount() string {
@@ -1917,7 +2125,7 @@ type RetireSnapshotSubtreeResponse struct {
 
 func (x *RetireSnapshotSubtreeResponse) Reset() {
 	*x = RetireSnapshotSubtreeResponse{}
-	mi := &file_fsmeta_fsmeta_proto_msgTypes[28]
+	mi := &file_fsmeta_fsmeta_proto_msgTypes[32]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1929,7 +2137,7 @@ func (x *RetireSnapshotSubtreeResponse) String() string {
 func (*RetireSnapshotSubtreeResponse) ProtoMessage() {}
 
 func (x *RetireSnapshotSubtreeResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_fsmeta_fsmeta_proto_msgTypes[28]
+	mi := &file_fsmeta_fsmeta_proto_msgTypes[32]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1942,7 +2150,7 @@ func (x *RetireSnapshotSubtreeResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RetireSnapshotSubtreeResponse.ProtoReflect.Descriptor instead.
 func (*RetireSnapshotSubtreeResponse) Descriptor() ([]byte, []int) {
-	return file_fsmeta_fsmeta_proto_rawDescGZIP(), []int{28}
+	return file_fsmeta_fsmeta_proto_rawDescGZIP(), []int{32}
 }
 
 type QuotaUsageRequest struct {
@@ -1957,7 +2165,7 @@ type QuotaUsageRequest struct {
 
 func (x *QuotaUsageRequest) Reset() {
 	*x = QuotaUsageRequest{}
-	mi := &file_fsmeta_fsmeta_proto_msgTypes[29]
+	mi := &file_fsmeta_fsmeta_proto_msgTypes[33]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1969,7 +2177,7 @@ func (x *QuotaUsageRequest) String() string {
 func (*QuotaUsageRequest) ProtoMessage() {}
 
 func (x *QuotaUsageRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_fsmeta_fsmeta_proto_msgTypes[29]
+	mi := &file_fsmeta_fsmeta_proto_msgTypes[33]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1982,7 +2190,7 @@ func (x *QuotaUsageRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use QuotaUsageRequest.ProtoReflect.Descriptor instead.
 func (*QuotaUsageRequest) Descriptor() ([]byte, []int) {
-	return file_fsmeta_fsmeta_proto_rawDescGZIP(), []int{29}
+	return file_fsmeta_fsmeta_proto_rawDescGZIP(), []int{33}
 }
 
 func (x *QuotaUsageRequest) GetMount() string {
@@ -2009,7 +2217,7 @@ type QuotaUsageResponse struct {
 
 func (x *QuotaUsageResponse) Reset() {
 	*x = QuotaUsageResponse{}
-	mi := &file_fsmeta_fsmeta_proto_msgTypes[30]
+	mi := &file_fsmeta_fsmeta_proto_msgTypes[34]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2021,7 +2229,7 @@ func (x *QuotaUsageResponse) String() string {
 func (*QuotaUsageResponse) ProtoMessage() {}
 
 func (x *QuotaUsageResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_fsmeta_fsmeta_proto_msgTypes[30]
+	mi := &file_fsmeta_fsmeta_proto_msgTypes[34]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2034,7 +2242,7 @@ func (x *QuotaUsageResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use QuotaUsageResponse.ProtoReflect.Descriptor instead.
 func (*QuotaUsageResponse) Descriptor() ([]byte, []int) {
-	return file_fsmeta_fsmeta_proto_rawDescGZIP(), []int{30}
+	return file_fsmeta_fsmeta_proto_rawDescGZIP(), []int{34}
 }
 
 func (x *QuotaUsageResponse) GetBytes() uint64 {
@@ -2064,7 +2272,7 @@ type RenameRequest struct {
 
 func (x *RenameRequest) Reset() {
 	*x = RenameRequest{}
-	mi := &file_fsmeta_fsmeta_proto_msgTypes[31]
+	mi := &file_fsmeta_fsmeta_proto_msgTypes[35]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2076,7 +2284,7 @@ func (x *RenameRequest) String() string {
 func (*RenameRequest) ProtoMessage() {}
 
 func (x *RenameRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_fsmeta_fsmeta_proto_msgTypes[31]
+	mi := &file_fsmeta_fsmeta_proto_msgTypes[35]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2089,7 +2297,7 @@ func (x *RenameRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RenameRequest.ProtoReflect.Descriptor instead.
 func (*RenameRequest) Descriptor() ([]byte, []int) {
-	return file_fsmeta_fsmeta_proto_rawDescGZIP(), []int{31}
+	return file_fsmeta_fsmeta_proto_rawDescGZIP(), []int{35}
 }
 
 func (x *RenameRequest) GetMount() string {
@@ -2135,7 +2343,7 @@ type RenameResponse struct {
 
 func (x *RenameResponse) Reset() {
 	*x = RenameResponse{}
-	mi := &file_fsmeta_fsmeta_proto_msgTypes[32]
+	mi := &file_fsmeta_fsmeta_proto_msgTypes[36]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2147,7 +2355,7 @@ func (x *RenameResponse) String() string {
 func (*RenameResponse) ProtoMessage() {}
 
 func (x *RenameResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_fsmeta_fsmeta_proto_msgTypes[32]
+	mi := &file_fsmeta_fsmeta_proto_msgTypes[36]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2160,7 +2368,7 @@ func (x *RenameResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RenameResponse.ProtoReflect.Descriptor instead.
 func (*RenameResponse) Descriptor() ([]byte, []int) {
-	return file_fsmeta_fsmeta_proto_rawDescGZIP(), []int{32}
+	return file_fsmeta_fsmeta_proto_rawDescGZIP(), []int{36}
 }
 
 type RenameSubtreeRequest struct {
@@ -2176,7 +2384,7 @@ type RenameSubtreeRequest struct {
 
 func (x *RenameSubtreeRequest) Reset() {
 	*x = RenameSubtreeRequest{}
-	mi := &file_fsmeta_fsmeta_proto_msgTypes[33]
+	mi := &file_fsmeta_fsmeta_proto_msgTypes[37]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2188,7 +2396,7 @@ func (x *RenameSubtreeRequest) String() string {
 func (*RenameSubtreeRequest) ProtoMessage() {}
 
 func (x *RenameSubtreeRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_fsmeta_fsmeta_proto_msgTypes[33]
+	mi := &file_fsmeta_fsmeta_proto_msgTypes[37]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2201,7 +2409,7 @@ func (x *RenameSubtreeRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RenameSubtreeRequest.ProtoReflect.Descriptor instead.
 func (*RenameSubtreeRequest) Descriptor() ([]byte, []int) {
-	return file_fsmeta_fsmeta_proto_rawDescGZIP(), []int{33}
+	return file_fsmeta_fsmeta_proto_rawDescGZIP(), []int{37}
 }
 
 func (x *RenameSubtreeRequest) GetMount() string {
@@ -2247,7 +2455,7 @@ type RenameSubtreeResponse struct {
 
 func (x *RenameSubtreeResponse) Reset() {
 	*x = RenameSubtreeResponse{}
-	mi := &file_fsmeta_fsmeta_proto_msgTypes[34]
+	mi := &file_fsmeta_fsmeta_proto_msgTypes[38]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2259,7 +2467,7 @@ func (x *RenameSubtreeResponse) String() string {
 func (*RenameSubtreeResponse) ProtoMessage() {}
 
 func (x *RenameSubtreeResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_fsmeta_fsmeta_proto_msgTypes[34]
+	mi := &file_fsmeta_fsmeta_proto_msgTypes[38]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2272,7 +2480,7 @@ func (x *RenameSubtreeResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RenameSubtreeResponse.ProtoReflect.Descriptor instead.
 func (*RenameSubtreeResponse) Descriptor() ([]byte, []int) {
-	return file_fsmeta_fsmeta_proto_rawDescGZIP(), []int{34}
+	return file_fsmeta_fsmeta_proto_rawDescGZIP(), []int{38}
 }
 
 type LinkRequest struct {
@@ -2288,7 +2496,7 @@ type LinkRequest struct {
 
 func (x *LinkRequest) Reset() {
 	*x = LinkRequest{}
-	mi := &file_fsmeta_fsmeta_proto_msgTypes[35]
+	mi := &file_fsmeta_fsmeta_proto_msgTypes[39]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2300,7 +2508,7 @@ func (x *LinkRequest) String() string {
 func (*LinkRequest) ProtoMessage() {}
 
 func (x *LinkRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_fsmeta_fsmeta_proto_msgTypes[35]
+	mi := &file_fsmeta_fsmeta_proto_msgTypes[39]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2313,7 +2521,7 @@ func (x *LinkRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use LinkRequest.ProtoReflect.Descriptor instead.
 func (*LinkRequest) Descriptor() ([]byte, []int) {
-	return file_fsmeta_fsmeta_proto_rawDescGZIP(), []int{35}
+	return file_fsmeta_fsmeta_proto_rawDescGZIP(), []int{39}
 }
 
 func (x *LinkRequest) GetMount() string {
@@ -2359,7 +2567,7 @@ type LinkResponse struct {
 
 func (x *LinkResponse) Reset() {
 	*x = LinkResponse{}
-	mi := &file_fsmeta_fsmeta_proto_msgTypes[36]
+	mi := &file_fsmeta_fsmeta_proto_msgTypes[40]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2371,7 +2579,7 @@ func (x *LinkResponse) String() string {
 func (*LinkResponse) ProtoMessage() {}
 
 func (x *LinkResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_fsmeta_fsmeta_proto_msgTypes[36]
+	mi := &file_fsmeta_fsmeta_proto_msgTypes[40]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2384,7 +2592,7 @@ func (x *LinkResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use LinkResponse.ProtoReflect.Descriptor instead.
 func (*LinkResponse) Descriptor() ([]byte, []int) {
-	return file_fsmeta_fsmeta_proto_rawDescGZIP(), []int{36}
+	return file_fsmeta_fsmeta_proto_rawDescGZIP(), []int{40}
 }
 
 type UnlinkRequest struct {
@@ -2398,7 +2606,7 @@ type UnlinkRequest struct {
 
 func (x *UnlinkRequest) Reset() {
 	*x = UnlinkRequest{}
-	mi := &file_fsmeta_fsmeta_proto_msgTypes[37]
+	mi := &file_fsmeta_fsmeta_proto_msgTypes[41]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2410,7 +2618,7 @@ func (x *UnlinkRequest) String() string {
 func (*UnlinkRequest) ProtoMessage() {}
 
 func (x *UnlinkRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_fsmeta_fsmeta_proto_msgTypes[37]
+	mi := &file_fsmeta_fsmeta_proto_msgTypes[41]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2423,7 +2631,7 @@ func (x *UnlinkRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UnlinkRequest.ProtoReflect.Descriptor instead.
 func (*UnlinkRequest) Descriptor() ([]byte, []int) {
-	return file_fsmeta_fsmeta_proto_rawDescGZIP(), []int{37}
+	return file_fsmeta_fsmeta_proto_rawDescGZIP(), []int{41}
 }
 
 func (x *UnlinkRequest) GetMount() string {
@@ -2455,7 +2663,7 @@ type UnlinkResponse struct {
 
 func (x *UnlinkResponse) Reset() {
 	*x = UnlinkResponse{}
-	mi := &file_fsmeta_fsmeta_proto_msgTypes[38]
+	mi := &file_fsmeta_fsmeta_proto_msgTypes[42]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2467,7 +2675,7 @@ func (x *UnlinkResponse) String() string {
 func (*UnlinkResponse) ProtoMessage() {}
 
 func (x *UnlinkResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_fsmeta_fsmeta_proto_msgTypes[38]
+	mi := &file_fsmeta_fsmeta_proto_msgTypes[42]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2480,7 +2688,7 @@ func (x *UnlinkResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UnlinkResponse.ProtoReflect.Descriptor instead.
 func (*UnlinkResponse) Descriptor() ([]byte, []int) {
-	return file_fsmeta_fsmeta_proto_rawDescGZIP(), []int{38}
+	return file_fsmeta_fsmeta_proto_rawDescGZIP(), []int{42}
 }
 
 type OpenWriteSessionRequest struct {
@@ -2497,7 +2705,7 @@ type OpenWriteSessionRequest struct {
 
 func (x *OpenWriteSessionRequest) Reset() {
 	*x = OpenWriteSessionRequest{}
-	mi := &file_fsmeta_fsmeta_proto_msgTypes[39]
+	mi := &file_fsmeta_fsmeta_proto_msgTypes[43]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2509,7 +2717,7 @@ func (x *OpenWriteSessionRequest) String() string {
 func (*OpenWriteSessionRequest) ProtoMessage() {}
 
 func (x *OpenWriteSessionRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_fsmeta_fsmeta_proto_msgTypes[39]
+	mi := &file_fsmeta_fsmeta_proto_msgTypes[43]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2522,7 +2730,7 @@ func (x *OpenWriteSessionRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use OpenWriteSessionRequest.ProtoReflect.Descriptor instead.
 func (*OpenWriteSessionRequest) Descriptor() ([]byte, []int) {
-	return file_fsmeta_fsmeta_proto_rawDescGZIP(), []int{39}
+	return file_fsmeta_fsmeta_proto_rawDescGZIP(), []int{43}
 }
 
 func (x *OpenWriteSessionRequest) GetMount() string {
@@ -2562,7 +2770,7 @@ type OpenWriteSessionResponse struct {
 
 func (x *OpenWriteSessionResponse) Reset() {
 	*x = OpenWriteSessionResponse{}
-	mi := &file_fsmeta_fsmeta_proto_msgTypes[40]
+	mi := &file_fsmeta_fsmeta_proto_msgTypes[44]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2574,7 +2782,7 @@ func (x *OpenWriteSessionResponse) String() string {
 func (*OpenWriteSessionResponse) ProtoMessage() {}
 
 func (x *OpenWriteSessionResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_fsmeta_fsmeta_proto_msgTypes[40]
+	mi := &file_fsmeta_fsmeta_proto_msgTypes[44]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2587,7 +2795,7 @@ func (x *OpenWriteSessionResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use OpenWriteSessionResponse.ProtoReflect.Descriptor instead.
 func (*OpenWriteSessionResponse) Descriptor() ([]byte, []int) {
-	return file_fsmeta_fsmeta_proto_rawDescGZIP(), []int{40}
+	return file_fsmeta_fsmeta_proto_rawDescGZIP(), []int{44}
 }
 
 func (x *OpenWriteSessionResponse) GetSession() *SessionRecord {
@@ -2611,7 +2819,7 @@ type HeartbeatWriteSessionRequest struct {
 
 func (x *HeartbeatWriteSessionRequest) Reset() {
 	*x = HeartbeatWriteSessionRequest{}
-	mi := &file_fsmeta_fsmeta_proto_msgTypes[41]
+	mi := &file_fsmeta_fsmeta_proto_msgTypes[45]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2623,7 +2831,7 @@ func (x *HeartbeatWriteSessionRequest) String() string {
 func (*HeartbeatWriteSessionRequest) ProtoMessage() {}
 
 func (x *HeartbeatWriteSessionRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_fsmeta_fsmeta_proto_msgTypes[41]
+	mi := &file_fsmeta_fsmeta_proto_msgTypes[45]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2636,7 +2844,7 @@ func (x *HeartbeatWriteSessionRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use HeartbeatWriteSessionRequest.ProtoReflect.Descriptor instead.
 func (*HeartbeatWriteSessionRequest) Descriptor() ([]byte, []int) {
-	return file_fsmeta_fsmeta_proto_rawDescGZIP(), []int{41}
+	return file_fsmeta_fsmeta_proto_rawDescGZIP(), []int{45}
 }
 
 func (x *HeartbeatWriteSessionRequest) GetMount() string {
@@ -2676,7 +2884,7 @@ type HeartbeatWriteSessionResponse struct {
 
 func (x *HeartbeatWriteSessionResponse) Reset() {
 	*x = HeartbeatWriteSessionResponse{}
-	mi := &file_fsmeta_fsmeta_proto_msgTypes[42]
+	mi := &file_fsmeta_fsmeta_proto_msgTypes[46]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2688,7 +2896,7 @@ func (x *HeartbeatWriteSessionResponse) String() string {
 func (*HeartbeatWriteSessionResponse) ProtoMessage() {}
 
 func (x *HeartbeatWriteSessionResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_fsmeta_fsmeta_proto_msgTypes[42]
+	mi := &file_fsmeta_fsmeta_proto_msgTypes[46]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2701,7 +2909,7 @@ func (x *HeartbeatWriteSessionResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use HeartbeatWriteSessionResponse.ProtoReflect.Descriptor instead.
 func (*HeartbeatWriteSessionResponse) Descriptor() ([]byte, []int) {
-	return file_fsmeta_fsmeta_proto_rawDescGZIP(), []int{42}
+	return file_fsmeta_fsmeta_proto_rawDescGZIP(), []int{46}
 }
 
 func (x *HeartbeatWriteSessionResponse) GetSession() *SessionRecord {
@@ -2722,7 +2930,7 @@ type CloseWriteSessionRequest struct {
 
 func (x *CloseWriteSessionRequest) Reset() {
 	*x = CloseWriteSessionRequest{}
-	mi := &file_fsmeta_fsmeta_proto_msgTypes[43]
+	mi := &file_fsmeta_fsmeta_proto_msgTypes[47]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2734,7 +2942,7 @@ func (x *CloseWriteSessionRequest) String() string {
 func (*CloseWriteSessionRequest) ProtoMessage() {}
 
 func (x *CloseWriteSessionRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_fsmeta_fsmeta_proto_msgTypes[43]
+	mi := &file_fsmeta_fsmeta_proto_msgTypes[47]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2747,7 +2955,7 @@ func (x *CloseWriteSessionRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CloseWriteSessionRequest.ProtoReflect.Descriptor instead.
 func (*CloseWriteSessionRequest) Descriptor() ([]byte, []int) {
-	return file_fsmeta_fsmeta_proto_rawDescGZIP(), []int{43}
+	return file_fsmeta_fsmeta_proto_rawDescGZIP(), []int{47}
 }
 
 func (x *CloseWriteSessionRequest) GetMount() string {
@@ -2779,7 +2987,7 @@ type CloseWriteSessionResponse struct {
 
 func (x *CloseWriteSessionResponse) Reset() {
 	*x = CloseWriteSessionResponse{}
-	mi := &file_fsmeta_fsmeta_proto_msgTypes[44]
+	mi := &file_fsmeta_fsmeta_proto_msgTypes[48]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2791,7 +2999,7 @@ func (x *CloseWriteSessionResponse) String() string {
 func (*CloseWriteSessionResponse) ProtoMessage() {}
 
 func (x *CloseWriteSessionResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_fsmeta_fsmeta_proto_msgTypes[44]
+	mi := &file_fsmeta_fsmeta_proto_msgTypes[48]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2804,7 +3012,7 @@ func (x *CloseWriteSessionResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CloseWriteSessionResponse.ProtoReflect.Descriptor instead.
 func (*CloseWriteSessionResponse) Descriptor() ([]byte, []int) {
-	return file_fsmeta_fsmeta_proto_rawDescGZIP(), []int{44}
+	return file_fsmeta_fsmeta_proto_rawDescGZIP(), []int{48}
 }
 
 type ExpireWriteSessionsRequest struct {
@@ -2817,7 +3025,7 @@ type ExpireWriteSessionsRequest struct {
 
 func (x *ExpireWriteSessionsRequest) Reset() {
 	*x = ExpireWriteSessionsRequest{}
-	mi := &file_fsmeta_fsmeta_proto_msgTypes[45]
+	mi := &file_fsmeta_fsmeta_proto_msgTypes[49]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2829,7 +3037,7 @@ func (x *ExpireWriteSessionsRequest) String() string {
 func (*ExpireWriteSessionsRequest) ProtoMessage() {}
 
 func (x *ExpireWriteSessionsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_fsmeta_fsmeta_proto_msgTypes[45]
+	mi := &file_fsmeta_fsmeta_proto_msgTypes[49]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2842,7 +3050,7 @@ func (x *ExpireWriteSessionsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ExpireWriteSessionsRequest.ProtoReflect.Descriptor instead.
 func (*ExpireWriteSessionsRequest) Descriptor() ([]byte, []int) {
-	return file_fsmeta_fsmeta_proto_rawDescGZIP(), []int{45}
+	return file_fsmeta_fsmeta_proto_rawDescGZIP(), []int{49}
 }
 
 func (x *ExpireWriteSessionsRequest) GetMount() string {
@@ -2868,7 +3076,7 @@ type ExpireWriteSessionsResponse struct {
 
 func (x *ExpireWriteSessionsResponse) Reset() {
 	*x = ExpireWriteSessionsResponse{}
-	mi := &file_fsmeta_fsmeta_proto_msgTypes[46]
+	mi := &file_fsmeta_fsmeta_proto_msgTypes[50]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2880,7 +3088,7 @@ func (x *ExpireWriteSessionsResponse) String() string {
 func (*ExpireWriteSessionsResponse) ProtoMessage() {}
 
 func (x *ExpireWriteSessionsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_fsmeta_fsmeta_proto_msgTypes[46]
+	mi := &file_fsmeta_fsmeta_proto_msgTypes[50]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2893,7 +3101,7 @@ func (x *ExpireWriteSessionsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ExpireWriteSessionsResponse.ProtoReflect.Descriptor instead.
 func (*ExpireWriteSessionsResponse) Descriptor() ([]byte, []int) {
-	return file_fsmeta_fsmeta_proto_rawDescGZIP(), []int{46}
+	return file_fsmeta_fsmeta_proto_rawDescGZIP(), []int{50}
 }
 
 func (x *ExpireWriteSessionsResponse) GetExpired() uint64 {
@@ -2966,7 +3174,19 @@ const file_fsmeta_fsmeta_proto_rawDesc = "" +
 	"\x06parent\x18\x02 \x01(\x04R\x06parent\x12\x12\n" +
 	"\x04name\x18\x03 \x01(\tR\x04name\"F\n" +
 	"\x0eLookupResponse\x124\n" +
-	"\x06dentry\x18\x01 \x01(\v2\x1c.nokv.fsmeta.v1.DentryRecordR\x06dentry\"\xa0\x01\n" +
+	"\x06dentry\x18\x01 \x01(\v2\x1c.nokv.fsmeta.v1.DentryRecordR\x06dentry\"7\n" +
+	"\tLookupKey\x12\x16\n" +
+	"\x06parent\x18\x01 \x01(\x04R\x06parent\x12\x12\n" +
+	"\x04name\x18\x02 \x01(\tR\x04name\"\x8e\x01\n" +
+	"\x16BatchLookupPlusRequest\x12\x14\n" +
+	"\x05mount\x18\x01 \x01(\tR\x05mount\x123\n" +
+	"\alookups\x18\x02 \x03(\v2\x19.nokv.fsmeta.v1.LookupKeyR\alookups\x12)\n" +
+	"\x10snapshot_version\x18\x03 \x01(\x04R\x0fsnapshotVersion\"c\n" +
+	"\x15BatchLookupPlusResult\x12\x14\n" +
+	"\x05found\x18\x01 \x01(\bR\x05found\x124\n" +
+	"\x05entry\x18\x02 \x01(\v2\x1e.nokv.fsmeta.v1.DentryAttrPairR\x05entry\"Z\n" +
+	"\x17BatchLookupPlusResponse\x12?\n" +
+	"\aresults\x18\x01 \x03(\v2%.nokv.fsmeta.v1.BatchLookupPlusResultR\aresults\"\xa0\x01\n" +
 	"\x0eReadDirRequest\x12\x14\n" +
 	"\x05mount\x18\x01 \x01(\tR\x05mount\x12\x16\n" +
 	"\x06parent\x18\x02 \x01(\x04R\x06parent\x12\x1f\n" +
@@ -3104,12 +3324,13 @@ const file_fsmeta_fsmeta_proto_rawDesc = "" +
 	"\x10WatchEventSource\x12\"\n" +
 	"\x1eWATCH_EVENT_SOURCE_UNSPECIFIED\x10\x00\x12\x1d\n" +
 	"\x19WATCH_EVENT_SOURCE_COMMIT\x10\x01\x12#\n" +
-	"\x1fWATCH_EVENT_SOURCE_RESOLVE_LOCK\x10\x022\xf2\f\n" +
+	"\x1fWATCH_EVENT_SOURCE_RESOLVE_LOCK\x10\x022\xd6\r\n" +
 	"\n" +
 	"FSMetadata\x12G\n" +
 	"\x06Create\x12\x1d.nokv.fsmeta.v1.CreateRequest\x1a\x1e.nokv.fsmeta.v1.CreateResponse\x12V\n" +
 	"\vUpdateInode\x12\".nokv.fsmeta.v1.UpdateInodeRequest\x1a#.nokv.fsmeta.v1.UpdateInodeResponse\x12G\n" +
-	"\x06Lookup\x12\x1d.nokv.fsmeta.v1.LookupRequest\x1a\x1e.nokv.fsmeta.v1.LookupResponse\x12J\n" +
+	"\x06Lookup\x12\x1d.nokv.fsmeta.v1.LookupRequest\x1a\x1e.nokv.fsmeta.v1.LookupResponse\x12b\n" +
+	"\x0fBatchLookupPlus\x12&.nokv.fsmeta.v1.BatchLookupPlusRequest\x1a'.nokv.fsmeta.v1.BatchLookupPlusResponse\x12J\n" +
 	"\aReadDir\x12\x1e.nokv.fsmeta.v1.ReadDirRequest\x1a\x1f.nokv.fsmeta.v1.ReadDirResponse\x12R\n" +
 	"\vReadDirPlus\x12\x1e.nokv.fsmeta.v1.ReadDirRequest\x1a#.nokv.fsmeta.v1.ReadDirPlusResponse\x12]\n" +
 	"\fWatchSubtree\x12#.nokv.fsmeta.v1.WatchAckOrSubscribe\x1a$.nokv.fsmeta.v1.WatchSubtreeResponse(\x010\x01\x12_\n" +
@@ -3139,7 +3360,7 @@ func file_fsmeta_fsmeta_proto_rawDescGZIP() []byte {
 }
 
 var file_fsmeta_fsmeta_proto_enumTypes = make([]protoimpl.EnumInfo, 2)
-var file_fsmeta_fsmeta_proto_msgTypes = make([]protoimpl.MessageInfo, 47)
+var file_fsmeta_fsmeta_proto_msgTypes = make([]protoimpl.MessageInfo, 51)
 var file_fsmeta_fsmeta_proto_goTypes = []any{
 	(InodeType)(0),                        // 0: nokv.fsmeta.v1.InodeType
 	(WatchEventSource)(0),                 // 1: nokv.fsmeta.v1.WatchEventSource
@@ -3154,42 +3375,46 @@ var file_fsmeta_fsmeta_proto_goTypes = []any{
 	(*UpdateInodeResponse)(nil),           // 10: nokv.fsmeta.v1.UpdateInodeResponse
 	(*LookupRequest)(nil),                 // 11: nokv.fsmeta.v1.LookupRequest
 	(*LookupResponse)(nil),                // 12: nokv.fsmeta.v1.LookupResponse
-	(*ReadDirRequest)(nil),                // 13: nokv.fsmeta.v1.ReadDirRequest
-	(*ReadDirResponse)(nil),               // 14: nokv.fsmeta.v1.ReadDirResponse
-	(*ReadDirPlusResponse)(nil),           // 15: nokv.fsmeta.v1.ReadDirPlusResponse
-	(*WatchCursor)(nil),                   // 16: nokv.fsmeta.v1.WatchCursor
-	(*WatchSubtreeRequest)(nil),           // 17: nokv.fsmeta.v1.WatchSubtreeRequest
-	(*WatchEvent)(nil),                    // 18: nokv.fsmeta.v1.WatchEvent
-	(*WatchAck)(nil),                      // 19: nokv.fsmeta.v1.WatchAck
-	(*WatchCatchupComplete)(nil),          // 20: nokv.fsmeta.v1.WatchCatchupComplete
-	(*WatchReady)(nil),                    // 21: nokv.fsmeta.v1.WatchReady
-	(*WatchThrottle)(nil),                 // 22: nokv.fsmeta.v1.WatchThrottle
-	(*WatchSubtreeResponse)(nil),          // 23: nokv.fsmeta.v1.WatchSubtreeResponse
-	(*WatchAckOrSubscribe)(nil),           // 24: nokv.fsmeta.v1.WatchAckOrSubscribe
-	(*GetReadVersionRequest)(nil),         // 25: nokv.fsmeta.v1.GetReadVersionRequest
-	(*GetReadVersionResponse)(nil),        // 26: nokv.fsmeta.v1.GetReadVersionResponse
-	(*SnapshotSubtreeRequest)(nil),        // 27: nokv.fsmeta.v1.SnapshotSubtreeRequest
-	(*SnapshotSubtreeResponse)(nil),       // 28: nokv.fsmeta.v1.SnapshotSubtreeResponse
-	(*RetireSnapshotSubtreeRequest)(nil),  // 29: nokv.fsmeta.v1.RetireSnapshotSubtreeRequest
-	(*RetireSnapshotSubtreeResponse)(nil), // 30: nokv.fsmeta.v1.RetireSnapshotSubtreeResponse
-	(*QuotaUsageRequest)(nil),             // 31: nokv.fsmeta.v1.QuotaUsageRequest
-	(*QuotaUsageResponse)(nil),            // 32: nokv.fsmeta.v1.QuotaUsageResponse
-	(*RenameRequest)(nil),                 // 33: nokv.fsmeta.v1.RenameRequest
-	(*RenameResponse)(nil),                // 34: nokv.fsmeta.v1.RenameResponse
-	(*RenameSubtreeRequest)(nil),          // 35: nokv.fsmeta.v1.RenameSubtreeRequest
-	(*RenameSubtreeResponse)(nil),         // 36: nokv.fsmeta.v1.RenameSubtreeResponse
-	(*LinkRequest)(nil),                   // 37: nokv.fsmeta.v1.LinkRequest
-	(*LinkResponse)(nil),                  // 38: nokv.fsmeta.v1.LinkResponse
-	(*UnlinkRequest)(nil),                 // 39: nokv.fsmeta.v1.UnlinkRequest
-	(*UnlinkResponse)(nil),                // 40: nokv.fsmeta.v1.UnlinkResponse
-	(*OpenWriteSessionRequest)(nil),       // 41: nokv.fsmeta.v1.OpenWriteSessionRequest
-	(*OpenWriteSessionResponse)(nil),      // 42: nokv.fsmeta.v1.OpenWriteSessionResponse
-	(*HeartbeatWriteSessionRequest)(nil),  // 43: nokv.fsmeta.v1.HeartbeatWriteSessionRequest
-	(*HeartbeatWriteSessionResponse)(nil), // 44: nokv.fsmeta.v1.HeartbeatWriteSessionResponse
-	(*CloseWriteSessionRequest)(nil),      // 45: nokv.fsmeta.v1.CloseWriteSessionRequest
-	(*CloseWriteSessionResponse)(nil),     // 46: nokv.fsmeta.v1.CloseWriteSessionResponse
-	(*ExpireWriteSessionsRequest)(nil),    // 47: nokv.fsmeta.v1.ExpireWriteSessionsRequest
-	(*ExpireWriteSessionsResponse)(nil),   // 48: nokv.fsmeta.v1.ExpireWriteSessionsResponse
+	(*LookupKey)(nil),                     // 13: nokv.fsmeta.v1.LookupKey
+	(*BatchLookupPlusRequest)(nil),        // 14: nokv.fsmeta.v1.BatchLookupPlusRequest
+	(*BatchLookupPlusResult)(nil),         // 15: nokv.fsmeta.v1.BatchLookupPlusResult
+	(*BatchLookupPlusResponse)(nil),       // 16: nokv.fsmeta.v1.BatchLookupPlusResponse
+	(*ReadDirRequest)(nil),                // 17: nokv.fsmeta.v1.ReadDirRequest
+	(*ReadDirResponse)(nil),               // 18: nokv.fsmeta.v1.ReadDirResponse
+	(*ReadDirPlusResponse)(nil),           // 19: nokv.fsmeta.v1.ReadDirPlusResponse
+	(*WatchCursor)(nil),                   // 20: nokv.fsmeta.v1.WatchCursor
+	(*WatchSubtreeRequest)(nil),           // 21: nokv.fsmeta.v1.WatchSubtreeRequest
+	(*WatchEvent)(nil),                    // 22: nokv.fsmeta.v1.WatchEvent
+	(*WatchAck)(nil),                      // 23: nokv.fsmeta.v1.WatchAck
+	(*WatchCatchupComplete)(nil),          // 24: nokv.fsmeta.v1.WatchCatchupComplete
+	(*WatchReady)(nil),                    // 25: nokv.fsmeta.v1.WatchReady
+	(*WatchThrottle)(nil),                 // 26: nokv.fsmeta.v1.WatchThrottle
+	(*WatchSubtreeResponse)(nil),          // 27: nokv.fsmeta.v1.WatchSubtreeResponse
+	(*WatchAckOrSubscribe)(nil),           // 28: nokv.fsmeta.v1.WatchAckOrSubscribe
+	(*GetReadVersionRequest)(nil),         // 29: nokv.fsmeta.v1.GetReadVersionRequest
+	(*GetReadVersionResponse)(nil),        // 30: nokv.fsmeta.v1.GetReadVersionResponse
+	(*SnapshotSubtreeRequest)(nil),        // 31: nokv.fsmeta.v1.SnapshotSubtreeRequest
+	(*SnapshotSubtreeResponse)(nil),       // 32: nokv.fsmeta.v1.SnapshotSubtreeResponse
+	(*RetireSnapshotSubtreeRequest)(nil),  // 33: nokv.fsmeta.v1.RetireSnapshotSubtreeRequest
+	(*RetireSnapshotSubtreeResponse)(nil), // 34: nokv.fsmeta.v1.RetireSnapshotSubtreeResponse
+	(*QuotaUsageRequest)(nil),             // 35: nokv.fsmeta.v1.QuotaUsageRequest
+	(*QuotaUsageResponse)(nil),            // 36: nokv.fsmeta.v1.QuotaUsageResponse
+	(*RenameRequest)(nil),                 // 37: nokv.fsmeta.v1.RenameRequest
+	(*RenameResponse)(nil),                // 38: nokv.fsmeta.v1.RenameResponse
+	(*RenameSubtreeRequest)(nil),          // 39: nokv.fsmeta.v1.RenameSubtreeRequest
+	(*RenameSubtreeResponse)(nil),         // 40: nokv.fsmeta.v1.RenameSubtreeResponse
+	(*LinkRequest)(nil),                   // 41: nokv.fsmeta.v1.LinkRequest
+	(*LinkResponse)(nil),                  // 42: nokv.fsmeta.v1.LinkResponse
+	(*UnlinkRequest)(nil),                 // 43: nokv.fsmeta.v1.UnlinkRequest
+	(*UnlinkResponse)(nil),                // 44: nokv.fsmeta.v1.UnlinkResponse
+	(*OpenWriteSessionRequest)(nil),       // 45: nokv.fsmeta.v1.OpenWriteSessionRequest
+	(*OpenWriteSessionResponse)(nil),      // 46: nokv.fsmeta.v1.OpenWriteSessionResponse
+	(*HeartbeatWriteSessionRequest)(nil),  // 47: nokv.fsmeta.v1.HeartbeatWriteSessionRequest
+	(*HeartbeatWriteSessionResponse)(nil), // 48: nokv.fsmeta.v1.HeartbeatWriteSessionResponse
+	(*CloseWriteSessionRequest)(nil),      // 49: nokv.fsmeta.v1.CloseWriteSessionRequest
+	(*CloseWriteSessionResponse)(nil),     // 50: nokv.fsmeta.v1.CloseWriteSessionResponse
+	(*ExpireWriteSessionsRequest)(nil),    // 51: nokv.fsmeta.v1.ExpireWriteSessionsRequest
+	(*ExpireWriteSessionsResponse)(nil),   // 52: nokv.fsmeta.v1.ExpireWriteSessionsResponse
 }
 var file_fsmeta_fsmeta_proto_depIdxs = []int32{
 	0,  // 0: nokv.fsmeta.v1.InodeRecord.type:type_name -> nokv.fsmeta.v1.InodeType
@@ -3202,63 +3427,68 @@ var file_fsmeta_fsmeta_proto_depIdxs = []int32{
 	2,  // 7: nokv.fsmeta.v1.CreateResponse.inode:type_name -> nokv.fsmeta.v1.InodeRecord
 	2,  // 8: nokv.fsmeta.v1.UpdateInodeResponse.inode:type_name -> nokv.fsmeta.v1.InodeRecord
 	4,  // 9: nokv.fsmeta.v1.LookupResponse.dentry:type_name -> nokv.fsmeta.v1.DentryRecord
-	4,  // 10: nokv.fsmeta.v1.ReadDirResponse.entries:type_name -> nokv.fsmeta.v1.DentryRecord
-	5,  // 11: nokv.fsmeta.v1.ReadDirPlusResponse.entries:type_name -> nokv.fsmeta.v1.DentryAttrPair
-	16, // 12: nokv.fsmeta.v1.WatchSubtreeRequest.resume_cursor:type_name -> nokv.fsmeta.v1.WatchCursor
-	16, // 13: nokv.fsmeta.v1.WatchEvent.raft_cursor:type_name -> nokv.fsmeta.v1.WatchCursor
-	1,  // 14: nokv.fsmeta.v1.WatchEvent.source:type_name -> nokv.fsmeta.v1.WatchEventSource
-	16, // 15: nokv.fsmeta.v1.WatchAck.cursor:type_name -> nokv.fsmeta.v1.WatchCursor
-	16, // 16: nokv.fsmeta.v1.WatchCatchupComplete.cursor:type_name -> nokv.fsmeta.v1.WatchCursor
-	16, // 17: nokv.fsmeta.v1.WatchReady.cursor:type_name -> nokv.fsmeta.v1.WatchCursor
-	18, // 18: nokv.fsmeta.v1.WatchSubtreeResponse.event:type_name -> nokv.fsmeta.v1.WatchEvent
-	20, // 19: nokv.fsmeta.v1.WatchSubtreeResponse.catchup_complete:type_name -> nokv.fsmeta.v1.WatchCatchupComplete
-	22, // 20: nokv.fsmeta.v1.WatchSubtreeResponse.throttle:type_name -> nokv.fsmeta.v1.WatchThrottle
-	21, // 21: nokv.fsmeta.v1.WatchSubtreeResponse.ready:type_name -> nokv.fsmeta.v1.WatchReady
-	17, // 22: nokv.fsmeta.v1.WatchAckOrSubscribe.subscribe:type_name -> nokv.fsmeta.v1.WatchSubtreeRequest
-	19, // 23: nokv.fsmeta.v1.WatchAckOrSubscribe.ack:type_name -> nokv.fsmeta.v1.WatchAck
-	3,  // 24: nokv.fsmeta.v1.OpenWriteSessionResponse.session:type_name -> nokv.fsmeta.v1.SessionRecord
-	3,  // 25: nokv.fsmeta.v1.HeartbeatWriteSessionResponse.session:type_name -> nokv.fsmeta.v1.SessionRecord
-	7,  // 26: nokv.fsmeta.v1.FSMetadata.Create:input_type -> nokv.fsmeta.v1.CreateRequest
-	9,  // 27: nokv.fsmeta.v1.FSMetadata.UpdateInode:input_type -> nokv.fsmeta.v1.UpdateInodeRequest
-	11, // 28: nokv.fsmeta.v1.FSMetadata.Lookup:input_type -> nokv.fsmeta.v1.LookupRequest
-	13, // 29: nokv.fsmeta.v1.FSMetadata.ReadDir:input_type -> nokv.fsmeta.v1.ReadDirRequest
-	13, // 30: nokv.fsmeta.v1.FSMetadata.ReadDirPlus:input_type -> nokv.fsmeta.v1.ReadDirRequest
-	24, // 31: nokv.fsmeta.v1.FSMetadata.WatchSubtree:input_type -> nokv.fsmeta.v1.WatchAckOrSubscribe
-	25, // 32: nokv.fsmeta.v1.FSMetadata.GetReadVersion:input_type -> nokv.fsmeta.v1.GetReadVersionRequest
-	27, // 33: nokv.fsmeta.v1.FSMetadata.SnapshotSubtree:input_type -> nokv.fsmeta.v1.SnapshotSubtreeRequest
-	29, // 34: nokv.fsmeta.v1.FSMetadata.RetireSnapshotSubtree:input_type -> nokv.fsmeta.v1.RetireSnapshotSubtreeRequest
-	31, // 35: nokv.fsmeta.v1.FSMetadata.GetQuotaUsage:input_type -> nokv.fsmeta.v1.QuotaUsageRequest
-	33, // 36: nokv.fsmeta.v1.FSMetadata.Rename:input_type -> nokv.fsmeta.v1.RenameRequest
-	35, // 37: nokv.fsmeta.v1.FSMetadata.RenameSubtree:input_type -> nokv.fsmeta.v1.RenameSubtreeRequest
-	37, // 38: nokv.fsmeta.v1.FSMetadata.Link:input_type -> nokv.fsmeta.v1.LinkRequest
-	39, // 39: nokv.fsmeta.v1.FSMetadata.Unlink:input_type -> nokv.fsmeta.v1.UnlinkRequest
-	41, // 40: nokv.fsmeta.v1.FSMetadata.OpenWriteSession:input_type -> nokv.fsmeta.v1.OpenWriteSessionRequest
-	43, // 41: nokv.fsmeta.v1.FSMetadata.HeartbeatWriteSession:input_type -> nokv.fsmeta.v1.HeartbeatWriteSessionRequest
-	45, // 42: nokv.fsmeta.v1.FSMetadata.CloseWriteSession:input_type -> nokv.fsmeta.v1.CloseWriteSessionRequest
-	47, // 43: nokv.fsmeta.v1.FSMetadata.ExpireWriteSessions:input_type -> nokv.fsmeta.v1.ExpireWriteSessionsRequest
-	8,  // 44: nokv.fsmeta.v1.FSMetadata.Create:output_type -> nokv.fsmeta.v1.CreateResponse
-	10, // 45: nokv.fsmeta.v1.FSMetadata.UpdateInode:output_type -> nokv.fsmeta.v1.UpdateInodeResponse
-	12, // 46: nokv.fsmeta.v1.FSMetadata.Lookup:output_type -> nokv.fsmeta.v1.LookupResponse
-	14, // 47: nokv.fsmeta.v1.FSMetadata.ReadDir:output_type -> nokv.fsmeta.v1.ReadDirResponse
-	15, // 48: nokv.fsmeta.v1.FSMetadata.ReadDirPlus:output_type -> nokv.fsmeta.v1.ReadDirPlusResponse
-	23, // 49: nokv.fsmeta.v1.FSMetadata.WatchSubtree:output_type -> nokv.fsmeta.v1.WatchSubtreeResponse
-	26, // 50: nokv.fsmeta.v1.FSMetadata.GetReadVersion:output_type -> nokv.fsmeta.v1.GetReadVersionResponse
-	28, // 51: nokv.fsmeta.v1.FSMetadata.SnapshotSubtree:output_type -> nokv.fsmeta.v1.SnapshotSubtreeResponse
-	30, // 52: nokv.fsmeta.v1.FSMetadata.RetireSnapshotSubtree:output_type -> nokv.fsmeta.v1.RetireSnapshotSubtreeResponse
-	32, // 53: nokv.fsmeta.v1.FSMetadata.GetQuotaUsage:output_type -> nokv.fsmeta.v1.QuotaUsageResponse
-	34, // 54: nokv.fsmeta.v1.FSMetadata.Rename:output_type -> nokv.fsmeta.v1.RenameResponse
-	36, // 55: nokv.fsmeta.v1.FSMetadata.RenameSubtree:output_type -> nokv.fsmeta.v1.RenameSubtreeResponse
-	38, // 56: nokv.fsmeta.v1.FSMetadata.Link:output_type -> nokv.fsmeta.v1.LinkResponse
-	40, // 57: nokv.fsmeta.v1.FSMetadata.Unlink:output_type -> nokv.fsmeta.v1.UnlinkResponse
-	42, // 58: nokv.fsmeta.v1.FSMetadata.OpenWriteSession:output_type -> nokv.fsmeta.v1.OpenWriteSessionResponse
-	44, // 59: nokv.fsmeta.v1.FSMetadata.HeartbeatWriteSession:output_type -> nokv.fsmeta.v1.HeartbeatWriteSessionResponse
-	46, // 60: nokv.fsmeta.v1.FSMetadata.CloseWriteSession:output_type -> nokv.fsmeta.v1.CloseWriteSessionResponse
-	48, // 61: nokv.fsmeta.v1.FSMetadata.ExpireWriteSessions:output_type -> nokv.fsmeta.v1.ExpireWriteSessionsResponse
-	44, // [44:62] is the sub-list for method output_type
-	26, // [26:44] is the sub-list for method input_type
-	26, // [26:26] is the sub-list for extension type_name
-	26, // [26:26] is the sub-list for extension extendee
-	0,  // [0:26] is the sub-list for field type_name
+	13, // 10: nokv.fsmeta.v1.BatchLookupPlusRequest.lookups:type_name -> nokv.fsmeta.v1.LookupKey
+	5,  // 11: nokv.fsmeta.v1.BatchLookupPlusResult.entry:type_name -> nokv.fsmeta.v1.DentryAttrPair
+	15, // 12: nokv.fsmeta.v1.BatchLookupPlusResponse.results:type_name -> nokv.fsmeta.v1.BatchLookupPlusResult
+	4,  // 13: nokv.fsmeta.v1.ReadDirResponse.entries:type_name -> nokv.fsmeta.v1.DentryRecord
+	5,  // 14: nokv.fsmeta.v1.ReadDirPlusResponse.entries:type_name -> nokv.fsmeta.v1.DentryAttrPair
+	20, // 15: nokv.fsmeta.v1.WatchSubtreeRequest.resume_cursor:type_name -> nokv.fsmeta.v1.WatchCursor
+	20, // 16: nokv.fsmeta.v1.WatchEvent.raft_cursor:type_name -> nokv.fsmeta.v1.WatchCursor
+	1,  // 17: nokv.fsmeta.v1.WatchEvent.source:type_name -> nokv.fsmeta.v1.WatchEventSource
+	20, // 18: nokv.fsmeta.v1.WatchAck.cursor:type_name -> nokv.fsmeta.v1.WatchCursor
+	20, // 19: nokv.fsmeta.v1.WatchCatchupComplete.cursor:type_name -> nokv.fsmeta.v1.WatchCursor
+	20, // 20: nokv.fsmeta.v1.WatchReady.cursor:type_name -> nokv.fsmeta.v1.WatchCursor
+	22, // 21: nokv.fsmeta.v1.WatchSubtreeResponse.event:type_name -> nokv.fsmeta.v1.WatchEvent
+	24, // 22: nokv.fsmeta.v1.WatchSubtreeResponse.catchup_complete:type_name -> nokv.fsmeta.v1.WatchCatchupComplete
+	26, // 23: nokv.fsmeta.v1.WatchSubtreeResponse.throttle:type_name -> nokv.fsmeta.v1.WatchThrottle
+	25, // 24: nokv.fsmeta.v1.WatchSubtreeResponse.ready:type_name -> nokv.fsmeta.v1.WatchReady
+	21, // 25: nokv.fsmeta.v1.WatchAckOrSubscribe.subscribe:type_name -> nokv.fsmeta.v1.WatchSubtreeRequest
+	23, // 26: nokv.fsmeta.v1.WatchAckOrSubscribe.ack:type_name -> nokv.fsmeta.v1.WatchAck
+	3,  // 27: nokv.fsmeta.v1.OpenWriteSessionResponse.session:type_name -> nokv.fsmeta.v1.SessionRecord
+	3,  // 28: nokv.fsmeta.v1.HeartbeatWriteSessionResponse.session:type_name -> nokv.fsmeta.v1.SessionRecord
+	7,  // 29: nokv.fsmeta.v1.FSMetadata.Create:input_type -> nokv.fsmeta.v1.CreateRequest
+	9,  // 30: nokv.fsmeta.v1.FSMetadata.UpdateInode:input_type -> nokv.fsmeta.v1.UpdateInodeRequest
+	11, // 31: nokv.fsmeta.v1.FSMetadata.Lookup:input_type -> nokv.fsmeta.v1.LookupRequest
+	14, // 32: nokv.fsmeta.v1.FSMetadata.BatchLookupPlus:input_type -> nokv.fsmeta.v1.BatchLookupPlusRequest
+	17, // 33: nokv.fsmeta.v1.FSMetadata.ReadDir:input_type -> nokv.fsmeta.v1.ReadDirRequest
+	17, // 34: nokv.fsmeta.v1.FSMetadata.ReadDirPlus:input_type -> nokv.fsmeta.v1.ReadDirRequest
+	28, // 35: nokv.fsmeta.v1.FSMetadata.WatchSubtree:input_type -> nokv.fsmeta.v1.WatchAckOrSubscribe
+	29, // 36: nokv.fsmeta.v1.FSMetadata.GetReadVersion:input_type -> nokv.fsmeta.v1.GetReadVersionRequest
+	31, // 37: nokv.fsmeta.v1.FSMetadata.SnapshotSubtree:input_type -> nokv.fsmeta.v1.SnapshotSubtreeRequest
+	33, // 38: nokv.fsmeta.v1.FSMetadata.RetireSnapshotSubtree:input_type -> nokv.fsmeta.v1.RetireSnapshotSubtreeRequest
+	35, // 39: nokv.fsmeta.v1.FSMetadata.GetQuotaUsage:input_type -> nokv.fsmeta.v1.QuotaUsageRequest
+	37, // 40: nokv.fsmeta.v1.FSMetadata.Rename:input_type -> nokv.fsmeta.v1.RenameRequest
+	39, // 41: nokv.fsmeta.v1.FSMetadata.RenameSubtree:input_type -> nokv.fsmeta.v1.RenameSubtreeRequest
+	41, // 42: nokv.fsmeta.v1.FSMetadata.Link:input_type -> nokv.fsmeta.v1.LinkRequest
+	43, // 43: nokv.fsmeta.v1.FSMetadata.Unlink:input_type -> nokv.fsmeta.v1.UnlinkRequest
+	45, // 44: nokv.fsmeta.v1.FSMetadata.OpenWriteSession:input_type -> nokv.fsmeta.v1.OpenWriteSessionRequest
+	47, // 45: nokv.fsmeta.v1.FSMetadata.HeartbeatWriteSession:input_type -> nokv.fsmeta.v1.HeartbeatWriteSessionRequest
+	49, // 46: nokv.fsmeta.v1.FSMetadata.CloseWriteSession:input_type -> nokv.fsmeta.v1.CloseWriteSessionRequest
+	51, // 47: nokv.fsmeta.v1.FSMetadata.ExpireWriteSessions:input_type -> nokv.fsmeta.v1.ExpireWriteSessionsRequest
+	8,  // 48: nokv.fsmeta.v1.FSMetadata.Create:output_type -> nokv.fsmeta.v1.CreateResponse
+	10, // 49: nokv.fsmeta.v1.FSMetadata.UpdateInode:output_type -> nokv.fsmeta.v1.UpdateInodeResponse
+	12, // 50: nokv.fsmeta.v1.FSMetadata.Lookup:output_type -> nokv.fsmeta.v1.LookupResponse
+	16, // 51: nokv.fsmeta.v1.FSMetadata.BatchLookupPlus:output_type -> nokv.fsmeta.v1.BatchLookupPlusResponse
+	18, // 52: nokv.fsmeta.v1.FSMetadata.ReadDir:output_type -> nokv.fsmeta.v1.ReadDirResponse
+	19, // 53: nokv.fsmeta.v1.FSMetadata.ReadDirPlus:output_type -> nokv.fsmeta.v1.ReadDirPlusResponse
+	27, // 54: nokv.fsmeta.v1.FSMetadata.WatchSubtree:output_type -> nokv.fsmeta.v1.WatchSubtreeResponse
+	30, // 55: nokv.fsmeta.v1.FSMetadata.GetReadVersion:output_type -> nokv.fsmeta.v1.GetReadVersionResponse
+	32, // 56: nokv.fsmeta.v1.FSMetadata.SnapshotSubtree:output_type -> nokv.fsmeta.v1.SnapshotSubtreeResponse
+	34, // 57: nokv.fsmeta.v1.FSMetadata.RetireSnapshotSubtree:output_type -> nokv.fsmeta.v1.RetireSnapshotSubtreeResponse
+	36, // 58: nokv.fsmeta.v1.FSMetadata.GetQuotaUsage:output_type -> nokv.fsmeta.v1.QuotaUsageResponse
+	38, // 59: nokv.fsmeta.v1.FSMetadata.Rename:output_type -> nokv.fsmeta.v1.RenameResponse
+	40, // 60: nokv.fsmeta.v1.FSMetadata.RenameSubtree:output_type -> nokv.fsmeta.v1.RenameSubtreeResponse
+	42, // 61: nokv.fsmeta.v1.FSMetadata.Link:output_type -> nokv.fsmeta.v1.LinkResponse
+	44, // 62: nokv.fsmeta.v1.FSMetadata.Unlink:output_type -> nokv.fsmeta.v1.UnlinkResponse
+	46, // 63: nokv.fsmeta.v1.FSMetadata.OpenWriteSession:output_type -> nokv.fsmeta.v1.OpenWriteSessionResponse
+	48, // 64: nokv.fsmeta.v1.FSMetadata.HeartbeatWriteSession:output_type -> nokv.fsmeta.v1.HeartbeatWriteSessionResponse
+	50, // 65: nokv.fsmeta.v1.FSMetadata.CloseWriteSession:output_type -> nokv.fsmeta.v1.CloseWriteSessionResponse
+	52, // 66: nokv.fsmeta.v1.FSMetadata.ExpireWriteSessions:output_type -> nokv.fsmeta.v1.ExpireWriteSessionsResponse
+	48, // [48:67] is the sub-list for method output_type
+	29, // [29:48] is the sub-list for method input_type
+	29, // [29:29] is the sub-list for extension type_name
+	29, // [29:29] is the sub-list for extension extendee
+	0,  // [0:29] is the sub-list for field type_name
 }
 
 func init() { file_fsmeta_fsmeta_proto_init() }
@@ -3266,13 +3496,13 @@ func file_fsmeta_fsmeta_proto_init() {
 	if File_fsmeta_fsmeta_proto != nil {
 		return
 	}
-	file_fsmeta_fsmeta_proto_msgTypes[21].OneofWrappers = []any{
+	file_fsmeta_fsmeta_proto_msgTypes[25].OneofWrappers = []any{
 		(*WatchSubtreeResponse_Event)(nil),
 		(*WatchSubtreeResponse_CatchupComplete)(nil),
 		(*WatchSubtreeResponse_Throttle)(nil),
 		(*WatchSubtreeResponse_Ready)(nil),
 	}
-	file_fsmeta_fsmeta_proto_msgTypes[22].OneofWrappers = []any{
+	file_fsmeta_fsmeta_proto_msgTypes[26].OneofWrappers = []any{
 		(*WatchAckOrSubscribe_Subscribe)(nil),
 		(*WatchAckOrSubscribe_Ack)(nil),
 	}
@@ -3282,7 +3512,7 @@ func file_fsmeta_fsmeta_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_fsmeta_fsmeta_proto_rawDesc), len(file_fsmeta_fsmeta_proto_rawDesc)),
 			NumEnums:      2,
-			NumMessages:   47,
+			NumMessages:   51,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/pb/fsmeta/fsmeta.proto
+++ b/pb/fsmeta/fsmeta.proto
@@ -90,6 +90,26 @@ message LookupResponse {
   DentryRecord dentry = 1;
 }
 
+message LookupKey {
+  uint64 parent = 1;
+  string name = 2;
+}
+
+message BatchLookupPlusRequest {
+  string mount = 1;
+  repeated LookupKey lookups = 2;
+  uint64 snapshot_version = 3;
+}
+
+message BatchLookupPlusResult {
+  bool found = 1;
+  DentryAttrPair entry = 2;
+}
+
+message BatchLookupPlusResponse {
+  repeated BatchLookupPlusResult results = 1;
+}
+
 message ReadDirRequest {
   string mount = 1;
   uint64 parent = 2;
@@ -292,6 +312,7 @@ service FSMetadata {
   rpc Create(CreateRequest) returns (CreateResponse);
   rpc UpdateInode(UpdateInodeRequest) returns (UpdateInodeResponse);
   rpc Lookup(LookupRequest) returns (LookupResponse);
+  rpc BatchLookupPlus(BatchLookupPlusRequest) returns (BatchLookupPlusResponse);
   rpc ReadDir(ReadDirRequest) returns (ReadDirResponse);
   rpc ReadDirPlus(ReadDirRequest) returns (ReadDirPlusResponse);
   rpc WatchSubtree(stream WatchAckOrSubscribe) returns (stream WatchSubtreeResponse);

--- a/pb/fsmeta/fsmeta_grpc.pb.go
+++ b/pb/fsmeta/fsmeta_grpc.pb.go
@@ -24,6 +24,7 @@ const (
 	FSMetadata_Create_FullMethodName                = "/nokv.fsmeta.v1.FSMetadata/Create"
 	FSMetadata_UpdateInode_FullMethodName           = "/nokv.fsmeta.v1.FSMetadata/UpdateInode"
 	FSMetadata_Lookup_FullMethodName                = "/nokv.fsmeta.v1.FSMetadata/Lookup"
+	FSMetadata_BatchLookupPlus_FullMethodName       = "/nokv.fsmeta.v1.FSMetadata/BatchLookupPlus"
 	FSMetadata_ReadDir_FullMethodName               = "/nokv.fsmeta.v1.FSMetadata/ReadDir"
 	FSMetadata_ReadDirPlus_FullMethodName           = "/nokv.fsmeta.v1.FSMetadata/ReadDirPlus"
 	FSMetadata_WatchSubtree_FullMethodName          = "/nokv.fsmeta.v1.FSMetadata/WatchSubtree"
@@ -48,6 +49,7 @@ type FSMetadataClient interface {
 	Create(ctx context.Context, in *CreateRequest, opts ...grpc.CallOption) (*CreateResponse, error)
 	UpdateInode(ctx context.Context, in *UpdateInodeRequest, opts ...grpc.CallOption) (*UpdateInodeResponse, error)
 	Lookup(ctx context.Context, in *LookupRequest, opts ...grpc.CallOption) (*LookupResponse, error)
+	BatchLookupPlus(ctx context.Context, in *BatchLookupPlusRequest, opts ...grpc.CallOption) (*BatchLookupPlusResponse, error)
 	ReadDir(ctx context.Context, in *ReadDirRequest, opts ...grpc.CallOption) (*ReadDirResponse, error)
 	ReadDirPlus(ctx context.Context, in *ReadDirRequest, opts ...grpc.CallOption) (*ReadDirPlusResponse, error)
 	WatchSubtree(ctx context.Context, opts ...grpc.CallOption) (grpc.BidiStreamingClient[WatchAckOrSubscribe, WatchSubtreeResponse], error)
@@ -97,6 +99,16 @@ func (c *fSMetadataClient) Lookup(ctx context.Context, in *LookupRequest, opts .
 	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
 	out := new(LookupResponse)
 	err := c.cc.Invoke(ctx, FSMetadata_Lookup_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *fSMetadataClient) BatchLookupPlus(ctx context.Context, in *BatchLookupPlusRequest, opts ...grpc.CallOption) (*BatchLookupPlusResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(BatchLookupPlusResponse)
+	err := c.cc.Invoke(ctx, FSMetadata_BatchLookupPlus_FullMethodName, in, out, cOpts...)
 	if err != nil {
 		return nil, err
 	}
@@ -263,6 +275,7 @@ type FSMetadataServer interface {
 	Create(context.Context, *CreateRequest) (*CreateResponse, error)
 	UpdateInode(context.Context, *UpdateInodeRequest) (*UpdateInodeResponse, error)
 	Lookup(context.Context, *LookupRequest) (*LookupResponse, error)
+	BatchLookupPlus(context.Context, *BatchLookupPlusRequest) (*BatchLookupPlusResponse, error)
 	ReadDir(context.Context, *ReadDirRequest) (*ReadDirResponse, error)
 	ReadDirPlus(context.Context, *ReadDirRequest) (*ReadDirPlusResponse, error)
 	WatchSubtree(grpc.BidiStreamingServer[WatchAckOrSubscribe, WatchSubtreeResponse]) error
@@ -295,6 +308,9 @@ func (UnimplementedFSMetadataServer) UpdateInode(context.Context, *UpdateInodeRe
 }
 func (UnimplementedFSMetadataServer) Lookup(context.Context, *LookupRequest) (*LookupResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method Lookup not implemented")
+}
+func (UnimplementedFSMetadataServer) BatchLookupPlus(context.Context, *BatchLookupPlusRequest) (*BatchLookupPlusResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method BatchLookupPlus not implemented")
 }
 func (UnimplementedFSMetadataServer) ReadDir(context.Context, *ReadDirRequest) (*ReadDirResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method ReadDir not implemented")
@@ -411,6 +427,24 @@ func _FSMetadata_Lookup_Handler(srv interface{}, ctx context.Context, dec func(i
 	}
 	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
 		return srv.(FSMetadataServer).Lookup(ctx, req.(*LookupRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _FSMetadata_BatchLookupPlus_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(BatchLookupPlusRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(FSMetadataServer).BatchLookupPlus(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: FSMetadata_BatchLookupPlus_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(FSMetadataServer).BatchLookupPlus(ctx, req.(*BatchLookupPlusRequest))
 	}
 	return interceptor(ctx, in, info, handler)
 }
@@ -692,6 +726,10 @@ var FSMetadata_ServiceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "Lookup",
 			Handler:    _FSMetadata_Lookup_Handler,
+		},
+		{
+			MethodName: "BatchLookupPlus",
+			Handler:    _FSMetadata_BatchLookupPlus_Handler,
 		},
 		{
 			MethodName: "ReadDir",


### PR DESCRIPTION
## Summary
- Add fsmeta BatchLookupPlus request/result planning and bounded batch size.
- Wire BatchLookupPlus through gRPC client/server and generated fsmeta protobuf bindings.
- Implement ordered batched dentry+inode reads with partial dentry misses and corruption errors for missing inode rows.

## Validation
- Not run locally per request; GitHub Actions should validate this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced `BatchLookupPlus` API for performing batched directory-entry lookups at a single snapshot version. Enables efficient retrieval of multiple directory entries in a single request with found/missing status indication and optional metadata. Includes request validation, comprehensive error handling, and batch size limits (16,384 max).

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/feichai0017/NoKV/pull/274)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->