### PR TITLE
fix(meta-root): avoid transport dial head-of-line blocking

### DIFF
--- a/benchmark/go.mod
+++ b/benchmark/go.mod
@@ -56,7 +56,7 @@ require (
 	golang.org/x/image v0.38.0 // indirect
 	golang.org/x/net v0.51.0 // indirect
 	golang.org/x/sync v0.20.0 // indirect
-	golang.org/x/sys v0.43.0 // indirect
+	golang.org/x/sys v0.44.0 // indirect
 	golang.org/x/text v0.35.0 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260401024825-9d38bb4040a9 // indirect
 	google.golang.org/protobuf v1.36.11 // indirect

--- a/benchmark/go.sum
+++ b/benchmark/go.sum
@@ -143,8 +143,8 @@ golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5h
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210119212857-b64e53b001e4/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.43.0 h1:Rlag2XtaFTxp19wS8MXlJwTvoh8ArU6ezoyFsMyCTNI=
-golang.org/x/sys v0.43.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
+golang.org/x/sys v0.44.0 h1:ildZl3J4uzeKP07r2F++Op7E9B29JRUy+a27EibtBTQ=
+golang.org/x/sys v0.44.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
 golang.org/x/text v0.35.0 h1:JOVx6vVDFokkpaq1AEptVzLTpDe9KGpj5tR4/X+ybL8=

--- a/meta/root/replicated/grpc_transport.go
+++ b/meta/root/replicated/grpc_transport.go
@@ -261,32 +261,65 @@ func (t *GRPCTransport) invalidatePeer(id uint64) {
 }
 
 func (t *GRPCTransport) clientFor(id uint64) (*rootTransportClientImpl, error) {
-	t.mu.Lock()
-	defer t.mu.Unlock()
-	if t.closed {
-		return nil, errTransportClosed
-	}
-	if client, ok := t.clients[id]; ok {
+	for {
+		t.mu.Lock()
+		if t.closed {
+			t.mu.Unlock()
+			return nil, errTransportClosed
+		}
+		if client, ok := t.clients[id]; ok {
+			t.mu.Unlock()
+			return client, nil
+		}
+		addr, ok := t.peers[id]
+		dialTimeout := t.dialTimeout
+		t.mu.Unlock()
+
+		if !ok || addr == "" {
+			return nil, errPeerAddressUnknown(id)
+		}
+
+		ctx, cancel := context.WithTimeout(context.Background(), dialTimeout)
+		conn, err := grpc.NewClient(addr, grpc.WithTransportCredentials(insecure.NewCredentials()))
+		if err == nil {
+			err = waitForTransportReady(ctx, conn)
+		}
+		cancel()
+		if err != nil {
+			if conn != nil {
+				_ = conn.Close()
+			}
+			return nil, err
+		}
+		client := &rootTransportClientImpl{cc: conn}
+
+		t.mu.Lock()
+		if t.closed {
+			t.mu.Unlock()
+			_ = conn.Close()
+			return nil, errTransportClosed
+		}
+		if cached, ok := t.clients[id]; ok {
+			t.mu.Unlock()
+			_ = conn.Close()
+			return cached, nil
+		}
+		currentAddr, ok := t.peers[id]
+		if !ok || currentAddr == "" {
+			t.mu.Unlock()
+			_ = conn.Close()
+			return nil, errPeerAddressUnknown(id)
+		}
+		if currentAddr != addr {
+			t.mu.Unlock()
+			_ = conn.Close()
+			continue
+		}
+		t.conns[id] = conn
+		t.clients[id] = client
+		t.mu.Unlock()
 		return client, nil
 	}
-	addr, ok := t.peers[id]
-	if !ok || addr == "" {
-		return nil, errPeerAddressUnknown(id)
-	}
-	ctx, cancel := context.WithTimeout(context.Background(), t.dialTimeout)
-	defer cancel()
-	conn, err := grpc.NewClient(addr, grpc.WithTransportCredentials(insecure.NewCredentials()))
-	if err != nil {
-		return nil, err
-	}
-	if err := waitForTransportReady(ctx, conn); err != nil {
-		_ = conn.Close()
-		return nil, err
-	}
-	client := &rootTransportClientImpl{cc: conn}
-	t.conns[id] = conn
-	t.clients[id] = client
-	return client, nil
 }
 
 func (t *GRPCTransport) Close() error {

--- a/meta/root/replicated/grpc_transport_test.go
+++ b/meta/root/replicated/grpc_transport_test.go
@@ -1,6 +1,7 @@
 package replicated
 
 import (
+	"net"
 	"sync"
 	"testing"
 	"time"
@@ -62,4 +63,90 @@ func TestGRPCTransportRejectsUnknownPeer(t *testing.T) {
 
 	err = t1.Send(myraft.Message{From: 1, To: 2, Type: myraft.MsgHeartbeat})
 	require.Error(t, err)
+}
+
+func TestGRPCTransportUnreachableDialDoesNotBlockLivePeer(t *testing.T) {
+	deadAddr, deadAccepted := startBlackholeListener(t)
+
+	t1, err := NewGRPCTransport(1, "127.0.0.1:0")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = t1.Close() })
+	t1.dialTimeout = 1200 * time.Millisecond
+
+	t3, err := NewGRPCTransport(3, "127.0.0.1:0")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = t3.Close() })
+
+	t1.SetPeer(2, deadAddr)
+	t1.SetPeer(3, t3.Addr())
+
+	deadDone := make(chan error, 1)
+	go func() {
+		_, err := t1.clientFor(2)
+		deadDone <- err
+	}()
+
+	select {
+	case <-deadAccepted:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for unreachable peer dial to start")
+	}
+
+	sendDone := make(chan error, 1)
+	start := time.Now()
+	go func() {
+		sendDone <- t1.Send(myraft.Message{From: 1, To: 3, Type: myraft.MsgHeartbeat, Term: 7})
+	}()
+
+	select {
+	case err := <-sendDone:
+		require.NoError(t, err)
+		require.Less(t, time.Since(start), 300*time.Millisecond)
+	case <-time.After(300 * time.Millisecond):
+		t.Fatal("live peer send was blocked behind unreachable peer dial")
+	}
+
+	select {
+	case err := <-deadDone:
+		require.Error(t, err)
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for unreachable peer dial to fail")
+	}
+}
+
+func startBlackholeListener(t *testing.T) (string, <-chan struct{}) {
+	t.Helper()
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+
+	accepted := make(chan struct{}, 1)
+	stop := make(chan struct{})
+	done := make(chan struct{})
+
+	go func() {
+		defer close(done)
+		for {
+			conn, err := ln.Accept()
+			if err != nil {
+				return
+			}
+			select {
+			case accepted <- struct{}{}:
+			default:
+			}
+			go func() {
+				defer func() { _ = conn.Close() }()
+				<-stop
+			}()
+		}
+	}()
+
+	t.Cleanup(func() {
+		close(stop)
+		_ = ln.Close()
+		<-done
+	})
+
+	return ln.Addr().String(), accepted
 }


### PR DESCRIPTION
## Summary
- move meta-root gRPC transport dialing out of the transport mutex
- preserve cached-client reuse while safely handling concurrent dials, transport close, and peer address changes
- add a regression test proving an unreachable peer dial cannot block delivery to a live peer

## Root Cause
When a meta-root leader was stopped, survivors still tried to send raft vote traffic to the dead peer and the live peer in the same election round. `clientFor()` held `t.mu` while waiting for gRPC readiness, so a dead peer dial could block live-peer client lookup long enough to miss the short election window and trigger repeated split votes.

## Validation
- `go test ./meta/root/replicated -run TestGRPCTransportUnreachableDialDoesNotBlockLivePeer -count=1 -v`
- `go test ./meta/root/replicated -run TestGRPCTransport -count=1 -v`
- `go test ./meta/root/replicated -count=1`
- `go test ./meta/root/integration -run 'TestMetaRootNodeIsolationElectsNewLeaderAndHeals|TestMetaRootLeaderChangePreservesGrantLineage' -count=1`
- `go test ./meta/root/... -count=1`
- `go test -race ./meta/root/replicated -run TestGRPCTransportUnreachableDialDoesNotBlockLivePeer -count=1`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced gRPC transport's connection establishment to better handle scenarios where peer addresses change during connection setup. The transport now prevents blocking on unreachable peer connections while maintaining connections to available peers.

* **Chores**
  * Updated indirect dependency golang.org/x/sys to a newer version.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/feichai0017/NoKV/pull/275)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->