### PR TITLE
fix(meta): catch up root leader before writes

### DIFF
--- a/meta/root/replicated/errors.go
+++ b/meta/root/replicated/errors.go
@@ -70,6 +70,17 @@ func errNodeNotLeader(id uint64) error {
 	return fmt.Errorf("meta/root/replicated: node %d is not leader", id)
 }
 
+func errRootWriteRequiresLeader(leaderID uint64) error {
+	if leaderID != 0 {
+		return fmt.Errorf("meta/root/replicated: root write requires a caught-up leader; current leader is %d", leaderID)
+	}
+	return errors.New("meta/root/replicated: root write requires a caught-up leader")
+}
+
 func errAppendWaitTimedOut(target any) error {
 	return fmt.Errorf("meta/root/replicated: append wait timed out before committed cursor %v", target)
+}
+
+func errCommittedCursorDiscontinuity(expected, got any) error {
+	return fmt.Errorf("meta/root/replicated: committed cursor discontinuity: expected %v, got %v", expected, got)
 }

--- a/meta/root/replicated/network_virtual_log.go
+++ b/meta/root/replicated/network_virtual_log.go
@@ -77,11 +77,6 @@ func (d *NetworkDriver) AppendCommitted(ctx context.Context, records ...rootstor
 	if err := ctx.Err(); err != nil {
 		return 0, err
 	}
-	before, err := d.ObserveTail(rootstorage.TailToken{})
-	if err != nil {
-		return 0, err
-	}
-	target := records[len(records)-1].Cursor
 	d.mu.Lock()
 	if d.node == nil {
 		d.mu.Unlock()
@@ -91,6 +86,16 @@ func (d *NetworkDriver) AppendCommitted(ctx context.Context, records ...rootstor
 		d.mu.Unlock()
 		return 0, errNodeNotLeader(d.id)
 	}
+	before, err := d.ObserveTail(rootstorage.TailToken{})
+	if err != nil {
+		d.mu.Unlock()
+		return 0, err
+	}
+	if err := validateCommittedCursorContinuity(before.LastCursor(), records); err != nil {
+		d.mu.Unlock()
+		return 0, err
+	}
+	target := records[len(records)-1].Cursor
 	for _, rec := range records {
 		payload, err := marshalCommittedEvent(rec)
 		if err != nil {
@@ -118,6 +123,17 @@ func (d *NetworkDriver) AppendCommitted(ctx context.Context, records ...rootstor
 		return 0, err
 	}
 	return d.adapter.size()
+}
+
+func validateCommittedCursorContinuity(last rootstate.Cursor, records []rootstorage.CommittedEvent) error {
+	expected := rootstate.NextCursor(last)
+	for _, rec := range records {
+		if rec.Cursor != expected {
+			return errCommittedCursorDiscontinuity(expected, rec.Cursor)
+		}
+		expected = rootstate.NextCursor(rec.Cursor)
+	}
+	return nil
 }
 
 func (d *NetworkDriver) waitForCommittedCursor(ctx context.Context, after rootstorage.TailToken, target rootstate.Cursor, timeout time.Duration) error {

--- a/meta/root/replicated/network_virtual_log_test.go
+++ b/meta/root/replicated/network_virtual_log_test.go
@@ -84,3 +84,23 @@ func TestNetworkDriverAppendCommittedWaitsForCommittedTail(t *testing.T) {
 	require.Len(t, after.Observed.Tail.Records, 2)
 	require.Equal(t, records[len(records)-1].Cursor, after.Observed.Tail.Records[len(after.Observed.Tail.Records)-1].Cursor)
 }
+
+func TestNetworkDriverAppendCommittedRejectsStaleCursor(t *testing.T) {
+	_, drivers, leaderID := openNetworkTestCluster(t, 8)
+	driver := drivers[leaderID]
+
+	first := rootstorage.CommittedEvent{
+		Cursor: rootstate.Cursor{Term: 1, Index: 1},
+		Event:  rootevent.StoreJoined(1),
+	}
+	_, err := driver.AppendCommitted(context.Background(), first)
+	require.NoError(t, err)
+
+	_, err = driver.AppendCommitted(context.Background(), first)
+	require.ErrorContains(t, err, "committed cursor discontinuity")
+
+	after, err := driver.ObserveTail(rootstorage.TailToken{})
+	require.NoError(t, err)
+	require.Equal(t, first.Cursor, after.LastCursor())
+	require.Len(t, after.Observed.Tail.Records, 1)
+}

--- a/meta/root/replicated/peras_test.go
+++ b/meta/root/replicated/peras_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"testing"
+	"time"
 
 	rootproto "github.com/feichai0017/NoKV/meta/root/protocol"
 	rootstate "github.com/feichai0017/NoKV/meta/root/state"
@@ -101,6 +102,36 @@ func TestReplicatedStoreApplyPerasAuthorityRejectsConflicts(t *testing.T) {
 		GrantID:  grant.GrantID,
 	})
 	require.True(t, errors.Is(err, rootstate.ErrPrimacy))
+}
+
+func TestReplicatedStorePerasAuthorityCatchesUpAfterLeaderHandoff(t *testing.T) {
+	stores, drivers, leaderID := openNetworkTestCluster(t, 8)
+	followerID := uint64(1)
+	if followerID == leaderID {
+		followerID = 2
+	}
+
+	state, first, err := stores[leaderID].ApplyPerasAuthority(context.Background(), testPerasAcquireCommand("holder-a", 1))
+	require.NoError(t, err)
+	require.NotEqual(t, rootstate.Cursor{}, state.LastCommitted)
+	requireDriverObservedCursor(t, drivers[followerID], state.LastCommitted)
+
+	stale, err := stores[followerID].Current()
+	require.NoError(t, err)
+	require.Equal(t, rootstate.Cursor{}, stale.LastCommitted)
+
+	drivers[leaderID].PauseTicks()
+	defer drivers[leaderID].ResumeTicks()
+	require.NoError(t, drivers[followerID].Campaign())
+	require.Eventually(t, func() bool {
+		return drivers[followerID].IsLeader()
+	}, 5*time.Second, 50*time.Millisecond)
+
+	state, conflicting, err := stores[followerID].ApplyPerasAuthority(context.Background(), testPerasAcquireCommand("holder-b", 1))
+	require.ErrorIs(t, err, rootstate.ErrPrimacy)
+	require.Empty(t, conflicting.GrantID)
+	require.Len(t, state.ActivePerasGrants, 1)
+	require.Equal(t, first.GrantID, state.ActivePerasGrants[0].GrantID)
 }
 
 func TestReplicatedStoreApplyPerasAuthorityExpandsSameHolderGrant(t *testing.T) {

--- a/meta/root/replicated/store.go
+++ b/meta/root/replicated/store.go
@@ -267,6 +267,9 @@ func (s *Store) Append(ctx context.Context, events ...rootevent.Event) (rootstat
 	}
 	s.mu.Lock()
 	defer s.mu.Unlock()
+	if err := s.ensureFreshForRootWriteLocked(ctx); err != nil {
+		return rootstate.CommitInfo{}, err
+	}
 	return s.appendLocked(ctx, events...)
 }
 
@@ -343,6 +346,9 @@ func (s *Store) ApplyGrant(ctx context.Context, cmd rootproto.GrantCommand) (roo
 	}
 	s.mu.Lock()
 	defer s.mu.Unlock()
+	if err := s.ensureFreshForRootWriteLocked(ctx); err != nil {
+		return rootstate.EunomiaState{}, rootproto.GrantCertificate{}, err
+	}
 
 	switch cmd.Kind {
 	case rootproto.GrantActIssue:
@@ -374,6 +380,9 @@ func (s *Store) ApplyPerasAuthority(ctx context.Context, cmd rootproto.PerasAuth
 	}
 	s.mu.Lock()
 	defer s.mu.Unlock()
+	if err := s.ensureFreshForRootWriteLocked(ctx); err != nil {
+		return rootstate.State{}, rootproto.PerasAuthorityGrant{}, err
+	}
 
 	switch cmd.Kind {
 	case rootproto.PerasAuthorityActAcquire:
@@ -1057,12 +1066,46 @@ func (s *Store) compactEunomiaState(state rootstate.State) rootstate.State {
 	return compacted
 }
 
+func (s *Store) ensureFreshForRootWriteLocked(ctx context.Context) error {
+	if s == nil || s.driver == nil {
+		return nil
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	if !s.driver.IsLeader() {
+		return errRootWriteRequiresLeader(s.driver.LeaderID())
+	}
+	observed, err := observeDriverCommitted(s.driver)
+	if err != nil {
+		return err
+	}
+	if rootstate.CursorAfter(observed.LastCursor(), s.state.LastCommitted) {
+		s.applyObservedLocked(observed)
+	}
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	if !s.driver.IsLeader() {
+		return errRootWriteRequiresLeader(s.driver.LeaderID())
+	}
+	return nil
+}
+
 func (s *Store) applyObserved(observed rootstorage.ObservedCommitted) {
 	if s == nil {
 		return
 	}
-	bootstrap := rootmaterialize.BootstrapFromObserved(observed)
 	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.applyObservedLocked(observed)
+}
+
+func (s *Store) applyObservedLocked(observed rootstorage.ObservedCommitted) {
+	bootstrap := rootmaterialize.BootstrapFromObserved(observed)
 	s.state = bootstrap.Snapshot.State
 	s.stores = bootstrap.Snapshot.Stores
 	if s.stores == nil {
@@ -1089,5 +1132,4 @@ func (s *Store) applyObserved(observed rootstorage.ObservedCommitted) {
 	s.pendingRange = bootstrap.Snapshot.PendingRangeChanges
 	s.records = bootstrap.Tail.Records
 	s.retainFrom = bootstrap.RetainFrom
-	s.mu.Unlock()
 }

--- a/meta/root/replicated/store_test.go
+++ b/meta/root/replicated/store_test.go
@@ -643,6 +643,42 @@ func TestReplicatedStoreGrantFenceSurvivesLeaderChange(t *testing.T) {
 	}
 }
 
+func TestReplicatedStoreGrantWriteCatchesUpAfterLeaderHandoff(t *testing.T) {
+	stores, drivers, leaderID := openNetworkTestCluster(t, 8)
+	followerID := uint64(1)
+	if followerID == leaderID {
+		followerID = 2
+	}
+
+	grant, _, err := issueGrant(stores[leaderID], "c1", 1_000, 100, 123, 456, 1)
+	require.NoError(t, err)
+	require.NotEqual(t, rootstate.Cursor{}, grant.IssuedAt)
+	requireDriverObservedCursor(t, drivers[followerID], grant.IssuedAt)
+
+	stale, err := stores[followerID].Current()
+	require.NoError(t, err)
+	require.Equal(t, rootstate.Cursor{}, stale.LastCommitted)
+
+	drivers[leaderID].PauseTicks()
+	defer drivers[leaderID].ResumeTicks()
+	require.NoError(t, drivers[followerID].Campaign())
+	require.Eventually(t, func() bool {
+		return drivers[followerID].IsLeader()
+	}, 5*time.Second, 50*time.Millisecond)
+
+	renewed, _, err := issueGrant(stores[followerID], "c1", 2_000, 500, 200, 600, 1)
+	require.NoError(t, err)
+	require.Equal(t, "c1", renewed.HolderID)
+	require.Equal(t, uint64(2), renewed.Era)
+	require.Len(t, renewed.PredecessorRetirements, 1)
+
+	current, err := stores[followerID].Current()
+	require.NoError(t, err)
+	require.Equal(t, renewed.IssuedAt, current.LastCommitted)
+	require.Equal(t, uint64(200), current.IDFence)
+	require.Equal(t, uint64(600), current.TSOFence)
+}
+
 func TestReplicatedStoreRetireExpiredGrant(t *testing.T) {
 	stores, _, leaderID := openNetworkTestCluster(t, 4)
 

--- a/meta/root/replicated/test_helpers_test.go
+++ b/meta/root/replicated/test_helpers_test.go
@@ -4,6 +4,8 @@ import (
 	"testing"
 	"time"
 
+	rootstate "github.com/feichai0017/NoKV/meta/root/state"
+	rootstorage "github.com/feichai0017/NoKV/meta/root/storage"
 	"github.com/stretchr/testify/require"
 )
 
@@ -64,4 +66,12 @@ func openNetworkTestCluster(t testing.TB, maxRetainedRecords int) (map[uint64]*S
 		stores[id] = store
 	}
 	return stores, drivers, leaderID
+}
+
+func requireDriverObservedCursor(t testing.TB, driver *NetworkDriver, cursor rootstate.Cursor) {
+	t.Helper()
+	require.Eventually(t, func() bool {
+		advance, err := driver.ObserveTail(rootstorage.TailToken{})
+		return err == nil && (advance.LastCursor() == cursor || rootstate.CursorAfter(advance.LastCursor(), cursor))
+	}, 5*time.Second, 50*time.Millisecond)
 }


### PR DESCRIPTION
## Summary
- require root write paths to observe and materialize committed root state before generating new events
- reject non-contiguous committed cursors in the network root driver so stale stores cannot get false append success
- add leader-handoff regressions for Eunomia grants and Peras authority writes

## Compatibility
- No public API, protobuf, or CLI contract changes.
- Behavioral tightening only: direct root writes now fail closed unless the local node is still leader and caught up to its committed root log.

## Tests
- go test -count=1 ./meta/root/replicated ./meta/root/... ./coordinator/rootview ./coordinator/server
- make test