### PR TITLE
fix(meta): restore meta-root-down liveness

### DIFF
--- a/fsmeta/runtime/peras/recovery.go
+++ b/fsmeta/runtime/peras/recovery.go
@@ -8,6 +8,7 @@ import (
 	"github.com/feichai0017/NoKV/fsmeta"
 	"github.com/feichai0017/NoKV/fsmeta/exec/compile"
 	fsperas "github.com/feichai0017/NoKV/fsmeta/exec/peras"
+	rootproto "github.com/feichai0017/NoKV/meta/root/protocol"
 )
 
 func (c *Runtime) RecoverWitnessSegments(ctx context.Context, scope compile.AuthorityScope, epochID uint64) error {
@@ -119,9 +120,61 @@ func (c *Runtime) LoadRootSealedSegments(ctx context.Context, scope compile.Auth
 			continue
 		}
 		c.metrics.rootSealMissingTotal.Add(1)
-		return c.recordErrorf("rooted peras segment seal missing installed catalog: %w", fsperas.ErrInvalidPerasSegment)
+		if err := c.recoverRootSealedSegment(ctx, scope, seal); err != nil {
+			return c.recordErrorf("rooted peras segment seal missing installed catalog: %w", err)
+		}
 	}
 	return nil
+}
+
+func (c *Runtime) recoverRootSealedSegment(ctx context.Context, scope compile.AuthorityScope, seal rootproto.PerasAuthoritySeal) error {
+	if c == nil || c.installer == nil || len(c.witnesses) == 0 {
+		return fsperas.ErrInvalidPerasSegment
+	}
+	records, err := c.collectWitnessSegments(ctx, seal.EpochID)
+	if err != nil {
+		return err
+	}
+	for _, record := range records {
+		if record.SegmentRoot != seal.SegmentRoot || record.SegmentPayloadDigest != seal.SegmentPayloadDigest {
+			continue
+		}
+		if err := fsperas.VerifySegmentWitnessRecord(record); err != nil {
+			return err
+		}
+		segment, err := fsperas.VerifyPerasSegmentPayload(record.SegmentPayload, record.SegmentRoot, record.SegmentPayloadDigest)
+		if err != nil {
+			return err
+		}
+		if !SegmentWithinScope(segment, scope) {
+			continue
+		}
+		stats := segment.Stats()
+		if record.OperationCount != stats.OperationCount || record.EntryCount != stats.EntryCount {
+			return fsperas.ErrInvalidWitnessRecord
+		}
+		if seal.OperationCount != 0 && seal.OperationCount != stats.OperationCount {
+			return fsperas.ErrInvalidPerasSegment
+		}
+		if seal.EntryCount != 0 && seal.EntryCount != stats.EntryCount {
+			return fsperas.ErrInvalidPerasSegment
+		}
+		job := perasFlushJob{
+			scope:   scope,
+			segment: segment,
+			payload: record.SegmentPayload,
+			digest:  record.SegmentPayloadDigest,
+		}
+		if _, err := c.submitInstallJob(ctx, job); err != nil {
+			return err
+		}
+		if err := c.installSegment(fsperas.ReplayPlan{}, segment); err != nil {
+			return err
+		}
+		c.metrics.recoveryInstallTotal.Add(1)
+		return nil
+	}
+	return fsperas.ErrInvalidPerasSegment
 }
 
 func (c *Runtime) scanInstalledSegmentCatalogs(ctx context.Context, scope compile.AuthorityScope) ([]fsperas.SegmentCatalogRecord, error) {

--- a/fsmeta/runtime/peras/runtime_test.go
+++ b/fsmeta/runtime/peras/runtime_test.go
@@ -640,6 +640,75 @@ func TestRuntimeRecoveryPrefersInstalledCatalog(t *testing.T) {
 	require.Equal(t, []byte("dentry-value"), value)
 }
 
+func TestRuntimeRecoversRootSealedSegmentFromWitnessWhenCatalogMissing(t *testing.T) {
+	mount := fsmeta.MountIdentity{MountID: "vol", MountKeyID: 1}
+	dentryKey, err := fsmeta.EncodeDentryKey(mount, fsmeta.RootInode, "rooted")
+	require.NoError(t, err)
+	inodeKey, err := fsmeta.EncodeInodeKey(mount, 11)
+	require.NoError(t, err)
+	witnesses := testRuntimePerasWitnesses(t, 3)
+	provider := &fakeRuntimePerasGrantProvider{holderID: "holder-a", grant: testRuntimeCommitterGrant()}
+	committer, err := NewRuntime(Config{
+		Authority:         provider,
+		Witnesses:         witnesses,
+		SegmentBatchSize:  1024,
+		SegmentFlushEvery: time.Hour,
+	})
+	require.NoError(t, err)
+	defer committer.Close()
+
+	holder, err := fsperas.NewHolder(fsperas.HolderConfig{EpochID: 1, HolderID: "holder-a"})
+	require.NoError(t, err)
+	delta := testRuntimePerasOp(dentryKey, inodeKey)
+	delta = testRuntimePerasOpWithScope(delta, compile.AuthorityScope{
+		Mount:      delta.Delta.Authority.Mount,
+		MountKeyID: delta.Delta.Authority.MountKeyID,
+		Parents:    []fsmeta.InodeID{fsmeta.RootInode},
+		Inodes:     []fsmeta.InodeID{11},
+	})
+	_, err = holder.Submit(context.Background(), fsperas.OperationID{ClientID: "client", Seq: 1}, delta)
+	require.NoError(t, err)
+	plan, scope, err := holder.BuildPendingReplayPlan(10)
+	require.NoError(t, err)
+	segment, err := fsperas.BuildPerasSegmentFromReplayPlan(plan)
+	require.NoError(t, err)
+	payload, err := fsperas.EncodePerasSegment(segment)
+	require.NoError(t, err)
+	digest, err := fsperas.PerasSegmentPayloadDigest(payload)
+	require.NoError(t, err)
+	require.NoError(t, committer.appendSegmentWitnesses(context.Background(), scope, holder, segment, payload, digest))
+
+	seal := testRuntimePerasRootSeal("grant-1", "holder-a", scope, time.Now())
+	seal.SegmentRoot = segment.Root
+	seal.SegmentPayloadDigest = digest
+	seal.OperationCount = segment.Stats().OperationCount
+	seal.EntryCount = segment.Stats().EntryCount
+	provider.seals = []rootproto.PerasAuthoritySeal{seal}
+	installer := &fakeRuntimePerasSegmentInstaller{}
+	recoverer, err := NewRuntime(Config{
+		Authority:         provider,
+		Witnesses:         witnesses,
+		Installer:         installer,
+		CatalogScanner:    &fakeRuntimePerasCatalogScanner{},
+		SegmentBatchSize:  1024,
+		SegmentFlushEvery: time.Hour,
+	})
+	require.NoError(t, err)
+	defer recoverer.Close()
+
+	require.NoError(t, recoverer.RecoverWitnessSegments(context.Background(), scope, holder.EpochID()))
+	require.Equal(t, 1, installer.calls)
+	require.Equal(t, segment.Root, installer.segment.Root)
+	stats := recoverer.Stats()
+	require.Equal(t, uint64(1), stats["root_sealed_segment_total"])
+	require.Equal(t, uint64(1), stats["root_sealed_segment_missing_total"])
+	require.Equal(t, uint64(1), stats["segment_recovery_install_total"])
+	value, deleted, ok := recoverer.GetPerasOverlay(dentryKey)
+	require.True(t, ok)
+	require.False(t, deleted)
+	require.Equal(t, []byte("dentry-value"), value)
+}
+
 func TestRuntimeLoadsInstalledSegmentCatalog(t *testing.T) {
 	mount := fsmeta.MountIdentity{MountID: "vol", MountKeyID: 1}
 	dentryKey, err := fsmeta.EncodeDentryKey(mount, fsmeta.RootInode, "restored")

--- a/meta/root/replicated/errors.go
+++ b/meta/root/replicated/errors.go
@@ -70,6 +70,17 @@ func errNodeNotLeader(id uint64) error {
 	return fmt.Errorf("meta/root/replicated: node %d is not leader", id)
 }
 
+func errRootWriteRequiresLeader(leaderID uint64) error {
+	if leaderID != 0 {
+		return nokverrors.New(nokverrors.KindNotLeader, fmt.Sprintf("meta/root/replicated: root write requires a caught-up leader; current leader is %d", leaderID))
+	}
+	return nokverrors.New(nokverrors.KindNotLeader, "meta/root/replicated: root write requires a caught-up leader")
+}
+
 func errAppendWaitTimedOut(target any) error {
 	return fmt.Errorf("meta/root/replicated: append wait timed out before committed cursor %v", target)
+}
+
+func errCommittedCursorDiscontinuity(expected, got any) error {
+	return fmt.Errorf("meta/root/replicated: committed cursor discontinuity: expected %v, got %v", expected, got)
 }

--- a/meta/root/replicated/network_virtual_log.go
+++ b/meta/root/replicated/network_virtual_log.go
@@ -77,11 +77,6 @@ func (d *NetworkDriver) AppendCommitted(ctx context.Context, records ...rootstor
 	if err := ctx.Err(); err != nil {
 		return 0, err
 	}
-	before, err := d.ObserveTail(rootstorage.TailToken{})
-	if err != nil {
-		return 0, err
-	}
-	target := records[len(records)-1].Cursor
 	d.mu.Lock()
 	if d.node == nil {
 		d.mu.Unlock()
@@ -91,6 +86,16 @@ func (d *NetworkDriver) AppendCommitted(ctx context.Context, records ...rootstor
 		d.mu.Unlock()
 		return 0, errNodeNotLeader(d.id)
 	}
+	before, err := d.ObserveTail(rootstorage.TailToken{})
+	if err != nil {
+		d.mu.Unlock()
+		return 0, err
+	}
+	if err := validateCommittedCursorContinuity(before.LastCursor(), records); err != nil {
+		d.mu.Unlock()
+		return 0, err
+	}
+	target := records[len(records)-1].Cursor
 	for _, rec := range records {
 		payload, err := marshalCommittedEvent(rec)
 		if err != nil {
@@ -118,6 +123,17 @@ func (d *NetworkDriver) AppendCommitted(ctx context.Context, records ...rootstor
 		return 0, err
 	}
 	return d.adapter.size()
+}
+
+func validateCommittedCursorContinuity(last rootstate.Cursor, records []rootstorage.CommittedEvent) error {
+	expected := rootstate.NextCursor(last)
+	for _, rec := range records {
+		if rec.Cursor != expected {
+			return errCommittedCursorDiscontinuity(expected, rec.Cursor)
+		}
+		expected = rootstate.NextCursor(rec.Cursor)
+	}
+	return nil
 }
 
 func (d *NetworkDriver) waitForCommittedCursor(ctx context.Context, after rootstorage.TailToken, target rootstate.Cursor, timeout time.Duration) error {

--- a/meta/root/replicated/network_virtual_log_test.go
+++ b/meta/root/replicated/network_virtual_log_test.go
@@ -84,3 +84,23 @@ func TestNetworkDriverAppendCommittedWaitsForCommittedTail(t *testing.T) {
 	require.Len(t, after.Observed.Tail.Records, 2)
 	require.Equal(t, records[len(records)-1].Cursor, after.Observed.Tail.Records[len(after.Observed.Tail.Records)-1].Cursor)
 }
+
+func TestNetworkDriverAppendCommittedRejectsStaleCursor(t *testing.T) {
+	_, drivers, leaderID := openNetworkTestCluster(t, 8)
+	driver := drivers[leaderID]
+
+	first := rootstorage.CommittedEvent{
+		Cursor: rootstate.Cursor{Term: 1, Index: 1},
+		Event:  rootevent.StoreJoined(1),
+	}
+	_, err := driver.AppendCommitted(context.Background(), first)
+	require.NoError(t, err)
+
+	_, err = driver.AppendCommitted(context.Background(), first)
+	require.ErrorContains(t, err, "committed cursor discontinuity")
+
+	after, err := driver.ObserveTail(rootstorage.TailToken{})
+	require.NoError(t, err)
+	require.Equal(t, first.Cursor, after.LastCursor())
+	require.Len(t, after.Observed.Tail.Records, 1)
+}

--- a/meta/root/replicated/peras_test.go
+++ b/meta/root/replicated/peras_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"testing"
+	"time"
 
 	rootproto "github.com/feichai0017/NoKV/meta/root/protocol"
 	rootstate "github.com/feichai0017/NoKV/meta/root/state"
@@ -101,6 +102,36 @@ func TestReplicatedStoreApplyPerasAuthorityRejectsConflicts(t *testing.T) {
 		GrantID:  grant.GrantID,
 	})
 	require.True(t, errors.Is(err, rootstate.ErrPrimacy))
+}
+
+func TestReplicatedStorePerasAuthorityCatchesUpAfterLeaderHandoff(t *testing.T) {
+	stores, drivers, leaderID := openNetworkTestCluster(t, 8)
+	followerID := uint64(1)
+	if followerID == leaderID {
+		followerID = 2
+	}
+
+	state, first, err := stores[leaderID].ApplyPerasAuthority(context.Background(), testPerasAcquireCommand("holder-a", 1))
+	require.NoError(t, err)
+	require.NotEqual(t, rootstate.Cursor{}, state.LastCommitted)
+	requireDriverObservedCursor(t, drivers[followerID], state.LastCommitted)
+
+	stale, err := stores[followerID].Current()
+	require.NoError(t, err)
+	require.Equal(t, rootstate.Cursor{}, stale.LastCommitted)
+
+	drivers[leaderID].PauseTicks()
+	defer drivers[leaderID].ResumeTicks()
+	require.NoError(t, drivers[followerID].Campaign())
+	require.Eventually(t, func() bool {
+		return drivers[followerID].IsLeader()
+	}, 5*time.Second, 50*time.Millisecond)
+
+	state, conflicting, err := stores[followerID].ApplyPerasAuthority(context.Background(), testPerasAcquireCommand("holder-b", 1))
+	require.ErrorIs(t, err, rootstate.ErrPrimacy)
+	require.Empty(t, conflicting.GrantID)
+	require.Len(t, state.ActivePerasGrants, 1)
+	require.Equal(t, first.GrantID, state.ActivePerasGrants[0].GrantID)
 }
 
 func TestReplicatedStoreApplyPerasAuthorityExpandsSameHolderGrant(t *testing.T) {

--- a/meta/root/replicated/store.go
+++ b/meta/root/replicated/store.go
@@ -115,6 +115,21 @@ func (s *Store) CanSubmitRootWrites() bool {
 	return s.IsLeader()
 }
 
+func (s *Store) PrepareRootWrite(ctx context.Context) error {
+	if s == nil {
+		return nil
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.ensureFreshForRootWriteLocked(ctx)
+}
+
 func (s *Store) LeaderID() uint64 {
 	if s == nil || s.driver == nil {
 		return 0
@@ -267,6 +282,9 @@ func (s *Store) Append(ctx context.Context, events ...rootevent.Event) (rootstat
 	}
 	s.mu.Lock()
 	defer s.mu.Unlock()
+	if err := s.ensureFreshForRootWriteLocked(ctx); err != nil {
+		return rootstate.CommitInfo{}, err
+	}
 	return s.appendLocked(ctx, events...)
 }
 
@@ -343,6 +361,9 @@ func (s *Store) ApplyGrant(ctx context.Context, cmd rootproto.GrantCommand) (roo
 	}
 	s.mu.Lock()
 	defer s.mu.Unlock()
+	if err := s.ensureFreshForRootWriteLocked(ctx); err != nil {
+		return rootstate.EunomiaState{}, rootproto.GrantCertificate{}, err
+	}
 
 	switch cmd.Kind {
 	case rootproto.GrantActIssue:
@@ -374,6 +395,9 @@ func (s *Store) ApplyPerasAuthority(ctx context.Context, cmd rootproto.PerasAuth
 	}
 	s.mu.Lock()
 	defer s.mu.Unlock()
+	if err := s.ensureFreshForRootWriteLocked(ctx); err != nil {
+		return rootstate.State{}, rootproto.PerasAuthorityGrant{}, err
+	}
 
 	switch cmd.Kind {
 	case rootproto.PerasAuthorityActAcquire:
@@ -962,9 +986,13 @@ func (s *Store) FenceAllocator(ctx context.Context, kind rootstate.AllocatorKind
 	if err := ctx.Err(); err != nil {
 		return 0, err
 	}
-	s.mu.RLock()
+	s.mu.Lock()
+	if err := s.ensureFreshForRootWriteLocked(ctx); err != nil {
+		s.mu.Unlock()
+		return 0, err
+	}
 	state := s.state
-	s.mu.RUnlock()
+	s.mu.Unlock()
 	switch kind {
 	case rootstate.AllocatorKindID:
 		if state.IDFence >= min {
@@ -1057,12 +1085,49 @@ func (s *Store) compactEunomiaState(state rootstate.State) rootstate.State {
 	return compacted
 }
 
+func (s *Store) ensureFreshForRootWriteLocked(ctx context.Context) error {
+	if s == nil || s.driver == nil {
+		return nil
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	if !s.driver.IsLeader() {
+		return errRootWriteRequiresLeader(s.driver.LeaderID())
+	}
+	observed, err := observeDriverCommitted(s.driver)
+	if err != nil {
+		return err
+	}
+	if rootstate.CursorAfter(observed.LastCursor(), s.state.LastCommitted) {
+		s.applyObservedLocked(observed)
+	}
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	if !s.driver.IsLeader() {
+		return errRootWriteRequiresLeader(s.driver.LeaderID())
+	}
+	return nil
+}
+
 func (s *Store) applyObserved(observed rootstorage.ObservedCommitted) {
 	if s == nil {
 		return
 	}
-	bootstrap := rootmaterialize.BootstrapFromObserved(observed)
 	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.applyObservedLocked(observed)
+}
+
+func (s *Store) applyObservedLocked(observed rootstorage.ObservedCommitted) {
+	bootstrap := rootmaterialize.BootstrapFromObserved(observed)
+	if !committedCursorReached(bootstrap.Snapshot.State.LastCommitted, s.state.LastCommitted) {
+		return
+	}
 	s.state = bootstrap.Snapshot.State
 	s.stores = bootstrap.Snapshot.Stores
 	if s.stores == nil {
@@ -1089,5 +1154,4 @@ func (s *Store) applyObserved(observed rootstorage.ObservedCommitted) {
 	s.pendingRange = bootstrap.Snapshot.PendingRangeChanges
 	s.records = bootstrap.Tail.Records
 	s.retainFrom = bootstrap.RetainFrom
-	s.mu.Unlock()
 }

--- a/meta/root/replicated/store_test.go
+++ b/meta/root/replicated/store_test.go
@@ -643,6 +643,112 @@ func TestReplicatedStoreGrantFenceSurvivesLeaderChange(t *testing.T) {
 	}
 }
 
+func TestReplicatedStoreGrantWriteCatchesUpAfterLeaderHandoff(t *testing.T) {
+	stores, drivers, leaderID := openNetworkTestCluster(t, 8)
+	followerID := uint64(1)
+	if followerID == leaderID {
+		followerID = 2
+	}
+
+	grant, _, err := issueGrant(stores[leaderID], "c1", 1_000, 100, 123, 456, 1)
+	require.NoError(t, err)
+	require.NotEqual(t, rootstate.Cursor{}, grant.IssuedAt)
+	requireDriverObservedCursor(t, drivers[followerID], grant.IssuedAt)
+
+	stale, err := stores[followerID].Current()
+	require.NoError(t, err)
+	require.Equal(t, rootstate.Cursor{}, stale.LastCommitted)
+
+	drivers[leaderID].PauseTicks()
+	defer drivers[leaderID].ResumeTicks()
+	require.NoError(t, drivers[followerID].Campaign())
+	require.Eventually(t, func() bool {
+		return drivers[followerID].IsLeader()
+	}, 5*time.Second, 50*time.Millisecond)
+
+	renewed, _, err := issueGrant(stores[followerID], "c1", 2_000, 500, 200, 600, 1)
+	require.NoError(t, err)
+	require.Equal(t, "c1", renewed.HolderID)
+	require.Equal(t, uint64(2), renewed.Era)
+	require.Len(t, renewed.PredecessorRetirements, 1)
+
+	current, err := stores[followerID].Current()
+	require.NoError(t, err)
+	require.Equal(t, renewed.IssuedAt, current.LastCommitted)
+	require.Equal(t, uint64(200), current.IDFence)
+	require.Equal(t, uint64(600), current.TSOFence)
+}
+
+func TestReplicatedStoreFenceAllocatorCatchesUpAfterLeaderHandoff(t *testing.T) {
+	stores, drivers, leaderID := openNetworkTestCluster(t, 8)
+	followerID := uint64(1)
+	if followerID == leaderID {
+		followerID = 2
+	}
+
+	firstFence, err := stores[leaderID].FenceAllocator(context.Background(), rootstate.AllocatorKindTSO, 1000)
+	require.NoError(t, err)
+	require.Equal(t, uint64(1000), firstFence)
+	require.Eventually(t, func() bool {
+		if err := stores[followerID].Refresh(); err != nil {
+			return false
+		}
+		current, err := stores[followerID].Current()
+		return err == nil && current.TSOFence == 1000
+	}, 5*time.Second, 50*time.Millisecond)
+
+	latestFence, err := stores[leaderID].FenceAllocator(context.Background(), rootstate.AllocatorKindTSO, 2000)
+	require.NoError(t, err)
+	require.Equal(t, uint64(2000), latestFence)
+	requireDriverObservedCursor(t, drivers[followerID], rootstate.Cursor{Term: 1, Index: 2})
+
+	stale, err := stores[followerID].Current()
+	require.NoError(t, err)
+	require.Equal(t, uint64(1000), stale.TSOFence)
+
+	drivers[leaderID].PauseTicks()
+	defer drivers[leaderID].ResumeTicks()
+	require.NoError(t, drivers[followerID].Campaign())
+	require.Eventually(t, func() bool {
+		return drivers[followerID].IsLeader()
+	}, 5*time.Second, 50*time.Millisecond)
+
+	fence, err := stores[followerID].FenceAllocator(context.Background(), rootstate.AllocatorKindTSO, 500)
+	require.NoError(t, err)
+	require.Equal(t, uint64(2000), fence)
+}
+
+func TestReplicatedStoreApplyObservedDoesNotRegressMaterializedState(t *testing.T) {
+	stores, _, leaderID := openNetworkTestCluster(t, 4)
+	store := stores[leaderID]
+
+	fence, err := store.FenceAllocator(context.Background(), rootstate.AllocatorKindTSO, 1000)
+	require.NoError(t, err)
+	require.Equal(t, uint64(1000), fence)
+	fence, err = store.FenceAllocator(context.Background(), rootstate.AllocatorKindTSO, 2000)
+	require.NoError(t, err)
+	require.Equal(t, uint64(2000), fence)
+	current, err := store.Current()
+	require.NoError(t, err)
+	require.Equal(t, uint64(2000), current.TSOFence)
+
+	store.applyObserved(rootstorage.ObservedCommitted{
+		Checkpoint: rootstorage.Checkpoint{
+			Snapshot: rootstate.Snapshot{
+				State: rootstate.State{
+					LastCommitted: rootstate.Cursor{Term: 1, Index: 1},
+					TSOFence:      1000,
+				},
+			},
+		},
+	})
+
+	after, err := store.Current()
+	require.NoError(t, err)
+	require.Equal(t, current.LastCommitted, after.LastCommitted)
+	require.Equal(t, uint64(2000), after.TSOFence)
+}
+
 func TestReplicatedStoreRetireExpiredGrant(t *testing.T) {
 	stores, _, leaderID := openNetworkTestCluster(t, 4)
 

--- a/meta/root/replicated/test_helpers_test.go
+++ b/meta/root/replicated/test_helpers_test.go
@@ -4,6 +4,8 @@ import (
 	"testing"
 	"time"
 
+	rootstate "github.com/feichai0017/NoKV/meta/root/state"
+	rootstorage "github.com/feichai0017/NoKV/meta/root/storage"
 	"github.com/stretchr/testify/require"
 )
 
@@ -64,4 +66,12 @@ func openNetworkTestCluster(t testing.TB, maxRetainedRecords int) (map[uint64]*S
 		stores[id] = store
 	}
 	return stores, drivers, leaderID
+}
+
+func requireDriverObservedCursor(t testing.TB, driver *NetworkDriver, cursor rootstate.Cursor) {
+	t.Helper()
+	require.Eventually(t, func() bool {
+		advance, err := driver.ObserveTail(rootstorage.TailToken{})
+		return err == nil && (advance.LastCursor() == cursor || rootstate.CursorAfter(advance.LastCursor(), cursor))
+	}, 5*time.Second, 50*time.Millisecond)
 }

--- a/meta/root/server/service.go
+++ b/meta/root/server/service.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"time"
 
+	nokverrors "github.com/feichai0017/NoKV/errors"
 	rootevent "github.com/feichai0017/NoKV/meta/root/event"
 	rootproto "github.com/feichai0017/NoKV/meta/root/protocol"
 	rootstate "github.com/feichai0017/NoKV/meta/root/state"
@@ -29,6 +30,10 @@ type Backend interface {
 type leaderBackend interface {
 	IsLeader() bool
 	LeaderID() uint64
+}
+
+type rootWriteReadyBackend interface {
+	PrepareRootWrite(ctx context.Context) error
 }
 
 type observedBackend interface {
@@ -90,7 +95,7 @@ func (s *Service) Append(ctx context.Context, req *metapb.MetadataRootAppendRequ
 	if s == nil || s.backend == nil {
 		return &metapb.MetadataRootAppendResponse{}, nil
 	}
-	if err := s.requireLeader(); err != nil {
+	if err := s.requireRootWriteReady(ctx); err != nil {
 		return nil, err
 	}
 	events := make([]rootevent.Event, 0, len(req.GetEvents()))
@@ -115,7 +120,7 @@ func (s *Service) FenceAllocator(ctx context.Context, req *metapb.MetadataRootFe
 	if s == nil || s.backend == nil {
 		return &metapb.MetadataRootFenceAllocatorResponse{}, nil
 	}
-	if err := s.requireLeader(); err != nil {
+	if err := s.requireRootWriteReady(ctx); err != nil {
 		return nil, err
 	}
 	kind, ok := metawire.RootAllocatorKindFromProto(req.GetKind())
@@ -143,7 +148,7 @@ func (s *Service) ApplyGrant(ctx context.Context, req *metapb.MetadataRootApplyG
 	if s == nil || s.backend == nil {
 		return &metapb.MetadataRootApplyGrantResponse{}, nil
 	}
-	backend, err := s.coordinatorProtocolBackend()
+	backend, err := s.coordinatorProtocolBackend(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -173,7 +178,7 @@ func (s *Service) ApplyPerasAuthority(ctx context.Context, req *metapb.MetadataR
 	if s == nil || s.backend == nil {
 		return &metapb.MetadataRootApplyPerasAuthorityResponse{}, nil
 	}
-	if err := s.requireLeader(); err != nil {
+	if err := s.requireRootWriteReady(ctx); err != nil {
 		return nil, err
 	}
 	backend, ok := s.backend.(perasAuthorityBackend)
@@ -296,8 +301,31 @@ func (s *Service) requireLeader() error {
 	return statusNotLeader(leaderID)
 }
 
-func (s *Service) coordinatorProtocolBackend() (leaseBackend, error) {
+func (s *Service) requireRootWriteReady(ctx context.Context) error {
 	if err := s.requireLeader(); err != nil {
+		return err
+	}
+	if s == nil || s.backend == nil {
+		return nil
+	}
+	ready, ok := s.backend.(rootWriteReadyBackend)
+	if !ok {
+		return nil
+	}
+	if err := ready.PrepareRootWrite(ctx); err != nil {
+		if nokverrors.IsKind(err, nokverrors.KindNotLeader) {
+			if leader, ok := s.backend.(leaderBackend); ok {
+				return statusNotLeader(leader.LeaderID())
+			}
+			return statusNotLeader(0)
+		}
+		return rpcError(err)
+	}
+	return nil
+}
+
+func (s *Service) coordinatorProtocolBackend(ctx context.Context) (leaseBackend, error) {
+	if err := s.requireRootWriteReady(ctx); err != nil {
 		return nil, err
 	}
 	backend, ok := s.backend.(leaseBackend)

--- a/meta/root/server/service_test.go
+++ b/meta/root/server/service_test.go
@@ -31,6 +31,7 @@ type fakeServiceBackend struct {
 	waitTailErr         error
 	applyGrantErr       error
 	applyPerasErr       error
+	prepareErr          error
 	observed            rootstorage.ObservedCommitted
 	observeAdvance      rootstorage.TailAdvance
 	waitAdvance         rootstorage.TailAdvance
@@ -40,7 +41,10 @@ type fakeServiceBackend struct {
 	applyPerasGrant     rootproto.PerasAuthorityGrant
 	isLeader            bool
 	leaderID            uint64
+	prepareCalls        int
 	appendCalls         int
+	applyGrantCalls     int
+	applyPerasCalls     int
 	fenceCalls          []rootstate.AllocatorKind
 	appendedEvents      []rootevent.Event
 }
@@ -95,6 +99,11 @@ func (f *fakeServiceBackend) FenceAllocator(_ context.Context, kind rootstate.Al
 func (f *fakeServiceBackend) IsLeader() bool   { return f.isLeader }
 func (f *fakeServiceBackend) LeaderID() uint64 { return f.leaderID }
 
+func (f *fakeServiceBackend) PrepareRootWrite(context.Context) error {
+	f.prepareCalls++
+	return f.prepareErr
+}
+
 func (f *fakeServiceBackend) ObserveCommitted() (rootstorage.ObservedCommitted, error) {
 	if f.observeCommittedErr != nil {
 		return rootstorage.ObservedCommitted{}, f.observeCommittedErr
@@ -117,10 +126,12 @@ func (f *fakeServiceBackend) WaitForTail(rootstorage.TailToken, time.Duration) (
 }
 
 func (f *fakeServiceBackend) ApplyGrant(context.Context, rootproto.GrantCommand) (rootstate.EunomiaState, rootproto.GrantCertificate, error) {
+	f.applyGrantCalls++
 	return f.applyGrantResult, f.applyGrantCert, f.applyGrantErr
 }
 
 func (f *fakeServiceBackend) ApplyPerasAuthority(context.Context, rootproto.PerasAuthorityCommand) (rootstate.State, rootproto.PerasAuthorityGrant, error) {
+	f.applyPerasCalls++
 	return f.applyPerasState, f.applyPerasGrant, f.applyPerasErr
 }
 
@@ -260,6 +271,19 @@ func TestServiceAppendPaths(t *testing.T) {
 		require.Equal(t, codes.Internal, status.Code(err))
 	})
 
+	t.Run("write readiness error", func(t *testing.T) {
+		backend := &fakeServiceBackend{
+			isLeader:   true,
+			prepareErr: nokverrors.New(nokverrors.KindUnavailable, "root state not ready"),
+		}
+		_, err := NewService(backend).Append(context.Background(), &metapb.MetadataRootAppendRequest{
+			Events: []*metapb.RootEvent{metawire.RootEventToProto(rootevent.IDAllocatorFenced(11))},
+		})
+		require.Equal(t, codes.Unavailable, status.Code(err))
+		require.Equal(t, 1, backend.prepareCalls)
+		require.Zero(t, backend.appendCalls)
+	})
+
 	t.Run("success", func(t *testing.T) {
 		backend := &fakeServiceBackend{
 			snapshot: testServerSnapshot(),
@@ -307,6 +331,20 @@ func TestServiceFenceAllocatorAndStatus(t *testing.T) {
 			Minimum: 77,
 		})
 		require.Equal(t, codes.Internal, status.Code(err))
+	})
+
+	t.Run("write readiness error", func(t *testing.T) {
+		backend := &fakeServiceBackend{
+			isLeader:   true,
+			prepareErr: nokverrors.New(nokverrors.KindUnavailable, "root state not ready"),
+		}
+		_, err := NewService(backend).FenceAllocator(context.Background(), &metapb.MetadataRootFenceAllocatorRequest{
+			Kind:    metapb.RootAllocatorKind_ROOT_ALLOCATOR_KIND_TSO,
+			Minimum: 99,
+		})
+		require.Equal(t, codes.Unavailable, status.Code(err))
+		require.Equal(t, 1, backend.prepareCalls)
+		require.Empty(t, backend.fenceCalls)
 	})
 
 	t.Run("success and status", func(t *testing.T) {
@@ -468,6 +506,19 @@ func TestServiceApplyGrant(t *testing.T) {
 		require.Equal(t, grantState, metawire.RootEunomiaStateFromProto(resp.State))
 	})
 
+	t.Run("write readiness error", func(t *testing.T) {
+		backend := &fakeServiceBackend{
+			isLeader:   true,
+			prepareErr: nokverrors.New(nokverrors.KindUnavailable, "root state not ready"),
+		}
+		_, err := NewService(backend).ApplyGrant(context.Background(), &metapb.MetadataRootApplyGrantRequest{
+			Command: metawire.RootGrantCommandToProto(cmd),
+		})
+		require.Equal(t, codes.Unavailable, status.Code(err))
+		require.Equal(t, 1, backend.prepareCalls)
+		require.Zero(t, backend.applyGrantCalls)
+	})
+
 	t.Run("success", func(t *testing.T) {
 		svc := NewService(&fakeServiceBackend{
 			isLeader:         true,
@@ -552,6 +603,19 @@ func TestServiceApplyPerasAuthority(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, metapb.RootPerasAuthorityApplyStatus_ROOT_PERAS_AUTHORITY_APPLY_STATUS_HELD, resp.Status)
 		require.Equal(t, state, metawire.RootStateFromProto(resp.State))
+	})
+
+	t.Run("write readiness error", func(t *testing.T) {
+		backend := &fakeServiceBackend{
+			isLeader:   true,
+			prepareErr: nokverrors.New(nokverrors.KindUnavailable, "root state not ready"),
+		}
+		_, err := NewService(backend).ApplyPerasAuthority(context.Background(), &metapb.MetadataRootApplyPerasAuthorityRequest{
+			Command: metawire.RootPerasAuthorityCommandToProto(cmd),
+		})
+		require.Equal(t, codes.Unavailable, status.Code(err))
+		require.Equal(t, 1, backend.prepareCalls)
+		require.Zero(t, backend.applyPerasCalls)
 	})
 
 	t.Run("success", func(t *testing.T) {


### PR DESCRIPTION
## Summary
- Catch up meta-root materialized state before serving root write paths after leader handoff.
- Recover root-sealed fsmeta Peras segments from witnesses when the installed catalog is missing.

## Scope guard
- No deploy changes.
- No LangGraph integration changes.

## Validation
- go mod tidy
- git diff --check
- go test ./fsmeta/runtime/peras ./meta/root/... ./meta/root/server -count=1