### PR TITLE
chore: ignore deploy and integration workspaces

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,13 @@ benchmark.test
 
 AGENTS.md
 
+# Strictly keep local deploy and external integration work out of commits.
+/deploy/**
+/integration/**
+/integrations/**
+/intergration/**
+/intergrations/**
+
 ./artifacts/
 
 work_redis


### PR DESCRIPTION
## Summary
- Add root `.gitignore` guardrails for top-level `deploy/`, `integration/`, and `integrations/` workspaces.
- Also cover the common misspellings `intergration/` and `intergrations/`.

## Scope guard
- This PR changes only `.gitignore`.
- It does not include deploy files, integration files, or previous feature work.

## Validation
- go mod tidy
- git diff --check
- git check-ignore -v --no-index deploy/foo integrations/foo integration/foo intergration/foo intergrations/foo coordinator/integration/foo fsmeta/integration/foo raftstore/integration/foo