### PR TITLE
fix: align error and metrics contracts

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,7 +253,7 @@ Full guide: [`docs/getting_started.md`](docs/getting_started.md) · CLI referenc
 
 ## 📡 Observability
 
-Five fsmeta expvar metric namespaces (per-domain admission visibility):
+FSMetadata exports per-domain expvar namespaces when `--metrics-addr` is enabled:
 
 | Endpoint | Metric namespace | Fields |
 |---|---|---|
@@ -261,6 +261,7 @@ Five fsmeta expvar metric namespaces (per-domain admission visibility):
 | | `nokv_fsmeta_watch` | `subscribers`, `events_total`, `delivered_total`, `dropped_total`, `overflow_total` |
 | | `nokv_fsmeta_quota` | `checks_total`, `rejects_total`, `cache_hits_total`, `cache_misses_total`, `fence_updates_total`, `usage_mutations_total` |
 | | `nokv_fsmeta_mount` | `cache_hits`, `cache_misses`, `admission_rejects_total` |
+| | `nokv_fsmeta_peras` | `commit_total`, `flush_total`, `segment_total`, `witness_latency_*` |
 | | `nokv_fsmeta_sessions` | stale writer-session cleanup runs, expired sessions, and last error |
 
 Plus structured logs from coordinator and each store. More: [`docs/stats.md`](docs/stats.md) · [`docs/cli.md`](docs/cli.md) · [`docs/testing.md`](docs/testing.md).

--- a/docs/errors.md
+++ b/docs/errors.md
@@ -68,6 +68,12 @@ Examples:
   `StoreNotMatch`, `RegionNotFound`, `KeyNotInRegion`, ...)
 - `engine/wal/errors.go`: WAL encode/decode and segment errors
 - `coordinator/catalog/errors.go`: Coordinator metadata and range validation errors
+- `fsmeta/exec/peras/errors.go`: Peras admission, segment, replay, and witness
+  sentinels used by holder/runtime control flow
+- `fsmeta/runtime/peras/errors.go` and `fsmeta/runtime/peras/authority.go`:
+  authority acquisition, active-authority view, and runtime lifecycle sentinels
+- `raftstore/peras/*.go`: Peras segment install and witness authority
+  protocol sentinels
 
 ---
 

--- a/docs/stats.md
+++ b/docs/stats.md
@@ -63,7 +63,7 @@ Representative fields:
 - `region.total`, `region.running`, `region.removing`, `region.tombstone`
 - `hot.write_keys`, `hot.write_ring`
 - `cache.block_l0_hit_rate`, `cache.bloom_hit_rate`, `cache.iterator_reused`
-- `lsm.levels`, `lsm.value_bytes_total`
+- `lsm.levels`, `lsm.value_bytes_total`, `lsm.mmap.*`, `lsm.prefetch.*`
 
 ---
 
@@ -83,6 +83,7 @@ Legacy scalar compatibility keys are removed. Consumers should read fields from 
 - `nokv_fsmeta_watch`
 - `nokv_fsmeta_quota`
 - `nokv_fsmeta_mount`
+- `nokv_fsmeta_peras`
 - `nokv_fsmeta_sessions`
 
 ---

--- a/engine/file/mmap_advise.go
+++ b/engine/file/mmap_advise.go
@@ -1,14 +1,10 @@
 package file
 
 import (
-	"expvar"
-
+	"github.com/feichai0017/NoKV/metrics"
 	"github.com/feichai0017/NoKV/utils"
 	"github.com/feichai0017/NoKV/utils/mmap"
 )
-
-var madviseCount = expvar.NewInt("NoKV.Mmap.Madvise")
-var madviseFailed = expvar.NewInt("NoKV.Mmap.MadviseFailed")
 
 func toMmapAdvice(pattern utils.AccessPattern) mmap.Advice {
 	switch pattern {
@@ -33,10 +29,6 @@ func (m *MmapFile) Advise(pattern utils.AccessPattern) error {
 		return nil
 	}
 	err := mmap.MadvisePattern(m.Data, toMmapAdvice(pattern))
-	if err == nil {
-		madviseCount.Add(1)
-	} else {
-		madviseFailed.Add(1)
-	}
+	metrics.RecordMmapMadvise(err == nil)
 	return err
 }

--- a/engine/lsm/table/table.go
+++ b/engine/lsm/table/table.go
@@ -3,7 +3,6 @@ package table
 import (
 	"bytes"
 	stderrors "errors"
-	"expvar"
 	"fmt"
 	"io"
 	"log/slog"
@@ -20,16 +19,11 @@ import (
 	cachepkg "github.com/feichai0017/NoKV/engine/lsm/cache"
 	"github.com/feichai0017/NoKV/engine/lsm/rangefilter"
 	"github.com/feichai0017/NoKV/engine/vfs"
+	"github.com/feichai0017/NoKV/metrics"
 	storagepb "github.com/feichai0017/NoKV/pb/storage"
 	"github.com/feichai0017/NoKV/utils"
 	"github.com/golang/snappy"
 	"github.com/pkg/errors"
-)
-
-var (
-	prefetchLaunched  = expvar.NewInt("NoKV.Prefetch.Launched")
-	prefetchAborted   = expvar.NewInt("NoKV.Prefetch.Aborted")
-	prefetchCompleted = expvar.NewInt("NoKV.Prefetch.Completed")
 )
 
 // Table is one open SSTable plus its cached metadata.
@@ -612,9 +606,9 @@ func (it *Iterator) prefetchNext(idx int) {
 			return
 		default:
 			if ok := it.prefetchRing.Push(next); ok {
-				prefetchLaunched.Add(1)
+				metrics.RecordTablePrefetchLaunched()
 			} else {
-				prefetchAborted.Add(1)
+				metrics.RecordTablePrefetchAborted()
 				return
 			}
 		}
@@ -666,13 +660,13 @@ func (t *Table) NewIterator(options *index.Options) index.Iterator {
 						if err := it.prefetchPool.Submit(func() {
 							it.t.IncrRef()
 							if _, err := it.t.loadBlock(idx); err == nil {
-								prefetchCompleted.Add(1)
+								metrics.RecordTablePrefetchCompleted()
 							} else {
-								prefetchAborted.Add(1)
+								metrics.RecordTablePrefetchAborted()
 							}
 							_ = it.t.DecrRef()
 						}); err != nil {
-							prefetchAborted.Add(1)
+							metrics.RecordTablePrefetchAborted()
 						}
 					}
 				}

--- a/fsmeta/exec/peras/errors.go
+++ b/fsmeta/exec/peras/errors.go
@@ -1,18 +1,18 @@
 package peras
 
-import "errors"
+import nokverrors "github.com/feichai0017/NoKV/errors"
 
 var (
-	ErrInvalidPerasSegment             = errors.New("fsmeta peras: invalid peras segment")
-	ErrAdmissionRejected               = errors.New("fsmeta peras: admission rejected")
-	ErrHolderConfigInvalid             = errors.New("fsmeta peras: invalid holder config")
-	ErrIneligibleOperation             = errors.New("fsmeta peras: ineligible operation")
-	ErrInvalidOperationID              = errors.New("fsmeta peras: invalid operation id")
-	ErrDuplicateOperation              = errors.New("fsmeta peras: duplicate operation id")
-	ErrSegmentCatalogStoreRequired     = errors.New("fsmeta peras: segment catalog store required")
-	ErrReplayVersionRequired           = errors.New("fsmeta peras: replay version required")
-	ErrInvalidWitnessRecord            = errors.New("fsmeta peras: invalid witness record")
-	ErrWitnessLogRequired              = errors.New("fsmeta peras: witness log required")
-	ErrWitnessReplicaInvalid           = errors.New("fsmeta peras: invalid witness replica")
-	ErrSegmentWitnessQuorumUnavailable = errors.New("fsmeta peras: segment witness quorum unavailable")
+	ErrInvalidPerasSegment             = nokverrors.New(nokverrors.KindProtocolViolation, "fsmeta/exec/peras: invalid peras segment")
+	ErrAdmissionRejected               = nokverrors.New(nokverrors.KindConflict, "fsmeta/exec/peras: admission rejected")
+	ErrHolderConfigInvalid             = nokverrors.New(nokverrors.KindInvalidArgument, "fsmeta/exec/peras: invalid holder config")
+	ErrIneligibleOperation             = nokverrors.New(nokverrors.KindProtocolViolation, "fsmeta/exec/peras: ineligible operation")
+	ErrInvalidOperationID              = nokverrors.New(nokverrors.KindInvalidArgument, "fsmeta/exec/peras: invalid operation id")
+	ErrDuplicateOperation              = nokverrors.New(nokverrors.KindConflict, "fsmeta/exec/peras: duplicate operation id")
+	ErrSegmentCatalogStoreRequired     = nokverrors.New(nokverrors.KindInvalidArgument, "fsmeta/exec/peras: segment catalog store required")
+	ErrReplayVersionRequired           = nokverrors.New(nokverrors.KindProtocolViolation, "fsmeta/exec/peras: replay version required")
+	ErrInvalidWitnessRecord            = nokverrors.New(nokverrors.KindProtocolViolation, "fsmeta/exec/peras: invalid witness record")
+	ErrWitnessLogRequired              = nokverrors.New(nokverrors.KindInvalidArgument, "fsmeta/exec/peras: witness log required")
+	ErrWitnessReplicaInvalid           = nokverrors.New(nokverrors.KindInvalidArgument, "fsmeta/exec/peras: invalid witness replica")
+	ErrSegmentWitnessQuorumUnavailable = nokverrors.New(nokverrors.KindUnavailable, "fsmeta/exec/peras: segment witness quorum unavailable")
 )

--- a/fsmeta/exec/peras/errors_test.go
+++ b/fsmeta/exec/peras/errors_test.go
@@ -1,0 +1,40 @@
+package peras
+
+import (
+	"fmt"
+	"testing"
+
+	nokverrors "github.com/feichai0017/NoKV/errors"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPerasErrorsCarryStableKinds(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		kind nokverrors.Kind
+	}{
+		{name: "invalid segment", err: ErrInvalidPerasSegment, kind: nokverrors.KindProtocolViolation},
+		{name: "admission rejected", err: ErrAdmissionRejected, kind: nokverrors.KindConflict},
+		{name: "holder config", err: ErrHolderConfigInvalid, kind: nokverrors.KindInvalidArgument},
+		{name: "ineligible operation", err: ErrIneligibleOperation, kind: nokverrors.KindProtocolViolation},
+		{name: "invalid operation id", err: ErrInvalidOperationID, kind: nokverrors.KindInvalidArgument},
+		{name: "duplicate operation", err: ErrDuplicateOperation, kind: nokverrors.KindConflict},
+		{name: "catalog store", err: ErrSegmentCatalogStoreRequired, kind: nokverrors.KindInvalidArgument},
+		{name: "replay version", err: ErrReplayVersionRequired, kind: nokverrors.KindProtocolViolation},
+		{name: "witness record", err: ErrInvalidWitnessRecord, kind: nokverrors.KindProtocolViolation},
+		{name: "witness log", err: ErrWitnessLogRequired, kind: nokverrors.KindInvalidArgument},
+		{name: "witness replica", err: ErrWitnessReplicaInvalid, kind: nokverrors.KindInvalidArgument},
+		{name: "witness quorum", err: ErrSegmentWitnessQuorumUnavailable, kind: nokverrors.KindUnavailable},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.kind, nokverrors.KindOf(tt.err))
+			require.Equal(t, tt.kind, nokverrors.KindOf(fmt.Errorf("wrapped: %w", tt.err)))
+		})
+	}
+}
+
+func TestSegmentWitnessQuorumUnavailableIsRetryable(t *testing.T) {
+	require.True(t, nokverrors.Retryable(ErrSegmentWitnessQuorumUnavailable))
+}

--- a/fsmeta/runtime/peras/authority.go
+++ b/fsmeta/runtime/peras/authority.go
@@ -2,11 +2,11 @@
 package peras
 
 import (
-	"errors"
 	"slices"
 	"sync"
 	"time"
 
+	nokverrors "github.com/feichai0017/NoKV/errors"
 	"github.com/feichai0017/NoKV/fsmeta"
 	"github.com/feichai0017/NoKV/fsmeta/exec/compile"
 	rootevent "github.com/feichai0017/NoKV/meta/root/event"
@@ -14,10 +14,10 @@ import (
 )
 
 var (
-	ErrInvalidGrant       = errors.New("fsmeta peras: invalid authority grant")
-	ErrAmbiguousAuthority = errors.New("fsmeta peras: ambiguous active authority")
-	ErrConflictingGrant   = errors.New("fsmeta peras: conflicting authority grant")
-	ErrAuthorityViewStale = errors.New("fsmeta peras: active authority view stale")
+	ErrInvalidGrant       = nokverrors.New(nokverrors.KindInvalidArgument, "fsmeta/runtime/peras: invalid authority grant")
+	ErrAmbiguousAuthority = nokverrors.New(nokverrors.KindConflict, "fsmeta/runtime/peras: ambiguous active authority")
+	ErrConflictingGrant   = nokverrors.New(nokverrors.KindConflict, "fsmeta/runtime/peras: conflicting authority grant")
+	ErrAuthorityViewStale = nokverrors.New(nokverrors.KindStaleEpoch, "fsmeta/runtime/peras: active authority view stale")
 )
 
 // AuthorityGrant is the execution-side alias for the root-issued fsmeta

--- a/fsmeta/runtime/peras/errors_test.go
+++ b/fsmeta/runtime/peras/errors_test.go
@@ -1,0 +1,32 @@
+package peras
+
+import (
+	"fmt"
+	"testing"
+
+	nokverrors "github.com/feichai0017/NoKV/errors"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAuthorityErrorsCarryStableKinds(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		kind nokverrors.Kind
+	}{
+		{name: "invalid grant", err: ErrInvalidGrant, kind: nokverrors.KindInvalidArgument},
+		{name: "ambiguous authority", err: ErrAmbiguousAuthority, kind: nokverrors.KindConflict},
+		{name: "conflicting grant", err: ErrConflictingGrant, kind: nokverrors.KindConflict},
+		{name: "stale view", err: ErrAuthorityViewStale, kind: nokverrors.KindStaleEpoch},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.kind, nokverrors.KindOf(tt.err))
+			require.Equal(t, tt.kind, nokverrors.KindOf(fmt.Errorf("wrapped: %w", tt.err)))
+		})
+	}
+}
+
+func TestAuthorityViewStaleIsRetryable(t *testing.T) {
+	require.True(t, nokverrors.Retryable(ErrAuthorityViewStale))
+}

--- a/local/stats/stats.go
+++ b/local/stats/stats.go
@@ -296,11 +296,13 @@ type CacheStatsSnapshot struct {
 
 // LSMStatsSnapshot summarizes per-level storage shape and value-density signals.
 type LSMStatsSnapshot struct {
-	Levels            []LSMLevelStats          `json:"levels,omitempty"`
-	ValueBytesTotal   int64                    `json:"value_bytes_total"`
-	ValueDensityMax   float64                  `json:"value_density_max"`
-	ValueDensityAlert bool                     `json:"value_density_alert"`
-	RangeFilter       RangeFilterStatsSnapshot `json:"range_filter"`
+	Levels            []LSMLevelStats               `json:"levels,omitempty"`
+	ValueBytesTotal   int64                         `json:"value_bytes_total"`
+	ValueDensityMax   float64                       `json:"value_density_max"`
+	ValueDensityAlert bool                          `json:"value_density_alert"`
+	RangeFilter       RangeFilterStatsSnapshot      `json:"range_filter"`
+	Mmap              metrics.MmapAdviceSnapshot    `json:"mmap"`
+	Prefetch          metrics.TablePrefetchSnapshot `json:"prefetch"`
 }
 
 // RangeFilterStatsSnapshot summarizes range-filter pruning activity on read paths.
@@ -512,6 +514,8 @@ func (s *Stats) Snapshot() StatsSnapshot {
 		snap.Write.ThrottlePressure = lsmSrc.ThrottlePressurePermille()
 		snap.Write.ThrottleRate = lsmSrc.ThrottleRateBytesPerSec()
 	}
+	snap.LSM.Mmap = metrics.MmapAdviceStats()
+	snap.LSM.Prefetch = metrics.TablePrefetchStats()
 
 	if wm := s.host.WriteMetrics(); wm != nil {
 		wsnap := wm.Snapshot()

--- a/local/stats/stats_test.go
+++ b/local/stats/stats_test.go
@@ -47,6 +47,13 @@ func TestStatsCollectSnapshots(t *testing.T) {
 	db.SetRegionMetrics(rm)
 	rm.RecordState(1, metaregion.ReplicaStateRunning)
 	rm.RecordState(2, metaregion.ReplicaStateRemoving)
+	mmapBefore := metrics.MmapAdviceStats()
+	prefetchBefore := metrics.TablePrefetchStats()
+	metrics.RecordMmapMadvise(true)
+	metrics.RecordMmapMadvise(false)
+	metrics.RecordTablePrefetchLaunched()
+	metrics.RecordTablePrefetchCompleted()
+	metrics.RecordTablePrefetchAborted()
 
 	require.NoError(t, db.Set([]byte("stats-key"), []byte("stats-value")))
 	entry, err := db.Get([]byte("stats-key"))
@@ -64,6 +71,11 @@ func TestStatsCollectSnapshots(t *testing.T) {
 	require.Greater(t, snap.Write.BatchesTotal, int64(0))
 	require.False(t, snap.Write.ThrottleActive)
 	require.Equal(t, db.IteratorReused(), snap.Cache.IteratorReused)
+	require.GreaterOrEqual(t, snap.LSM.Mmap.Madvise, mmapBefore.Madvise+1)
+	require.GreaterOrEqual(t, snap.LSM.Mmap.MadviseFailed, mmapBefore.MadviseFailed+1)
+	require.GreaterOrEqual(t, snap.LSM.Prefetch.Launched, prefetchBefore.Launched+1)
+	require.GreaterOrEqual(t, snap.LSM.Prefetch.Completed, prefetchBefore.Completed+1)
+	require.GreaterOrEqual(t, snap.LSM.Prefetch.Aborted, prefetchBefore.Aborted+1)
 
 	require.Equal(t, int64(2), snap.Region.Total)
 	require.Equal(t, int64(1), snap.Region.Running)
@@ -78,12 +90,19 @@ func TestStatsCollectSnapshots(t *testing.T) {
 	require.Equal(t, snap.WAL.ActiveSegment, exported.WAL.ActiveSegment)
 	require.Equal(t, snap.WAL.SegmentsRemoved, exported.WAL.SegmentsRemoved)
 	require.Equal(t, snap.Region.Total, exported.Region.Total)
+	require.Equal(t, snap.LSM.Mmap, exported.LSM.Mmap)
+	require.Equal(t, snap.LSM.Prefetch, exported.LSM.Prefetch)
 
 	// Legacy scalar keys are intentionally removed.
 	require.Nil(t, expvar.Get("NoKV.Local.Stats.Flush.Pending"))
 	require.Nil(t, expvar.Get("NoKV.Local.Stats.WAL.ActiveSegment"))
 	require.Nil(t, expvar.Get("NoKV.Txns.Active"))
 	require.Nil(t, expvar.Get("NoKV.Stats"))
+	require.Nil(t, expvar.Get("NoKV.Mmap.Madvise"))
+	require.Nil(t, expvar.Get("NoKV.Mmap.MadviseFailed"))
+	require.Nil(t, expvar.Get("NoKV.Prefetch.Launched"))
+	require.Nil(t, expvar.Get("NoKV.Prefetch.Aborted"))
+	require.Nil(t, expvar.Get("NoKV.Prefetch.Completed"))
 }
 
 func TestStatsSnapshotTracksThrottleAndWalRemovals(t *testing.T) {

--- a/metrics/runtime.go
+++ b/metrics/runtime.go
@@ -1,0 +1,66 @@
+package metrics
+
+import "sync/atomic"
+
+// MmapAdviceSnapshot captures mmap access-hint calls from the file layer.
+type MmapAdviceSnapshot struct {
+	Madvise       uint64 `json:"madvise"`
+	MadviseFailed uint64 `json:"madvise_failed"`
+}
+
+// TablePrefetchSnapshot captures iterator block-prefetch scheduling counters.
+type TablePrefetchSnapshot struct {
+	Launched  uint64 `json:"launched"`
+	Aborted   uint64 `json:"aborted"`
+	Completed uint64 `json:"completed"`
+}
+
+var (
+	mmapMadvise       atomic.Uint64
+	mmapMadviseFailed atomic.Uint64
+
+	tablePrefetchLaunched  atomic.Uint64
+	tablePrefetchAborted   atomic.Uint64
+	tablePrefetchCompleted atomic.Uint64
+)
+
+// RecordMmapMadvise records the outcome of one mmap access-hint call.
+func RecordMmapMadvise(ok bool) {
+	if ok {
+		mmapMadvise.Add(1)
+		return
+	}
+	mmapMadviseFailed.Add(1)
+}
+
+// MmapAdviceStats returns process-wide mmap access-hint counters.
+func MmapAdviceStats() MmapAdviceSnapshot {
+	return MmapAdviceSnapshot{
+		Madvise:       mmapMadvise.Load(),
+		MadviseFailed: mmapMadviseFailed.Load(),
+	}
+}
+
+// RecordTablePrefetchLaunched records one successfully queued prefetch block.
+func RecordTablePrefetchLaunched() {
+	tablePrefetchLaunched.Add(1)
+}
+
+// RecordTablePrefetchAborted records one prefetch that was skipped or failed.
+func RecordTablePrefetchAborted() {
+	tablePrefetchAborted.Add(1)
+}
+
+// RecordTablePrefetchCompleted records one prefetch that loaded a block.
+func RecordTablePrefetchCompleted() {
+	tablePrefetchCompleted.Add(1)
+}
+
+// TablePrefetchStats returns process-wide iterator prefetch counters.
+func TablePrefetchStats() TablePrefetchSnapshot {
+	return TablePrefetchSnapshot{
+		Launched:  tablePrefetchLaunched.Load(),
+		Aborted:   tablePrefetchAborted.Load(),
+		Completed: tablePrefetchCompleted.Load(),
+	}
+}

--- a/raftstore/peras/errors_test.go
+++ b/raftstore/peras/errors_test.go
@@ -1,0 +1,33 @@
+package peras
+
+import (
+	"fmt"
+	"testing"
+
+	nokverrors "github.com/feichai0017/NoKV/errors"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRaftstorePerasErrorsCarryStableKinds(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		kind nokverrors.Kind
+	}{
+		{name: "witness config", err: ErrWitnessNodeConfigInvalid, kind: nokverrors.KindInvalidArgument},
+		{name: "missing authority", err: ErrWitnessAuthorityMissing, kind: nokverrors.KindStaleEpoch},
+		{name: "authority mismatch", err: ErrWitnessAuthorityMismatch, kind: nokverrors.KindStaleEpoch},
+		{name: "install request", err: ErrInvalidInstallRequest, kind: nokverrors.KindProtocolViolation},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.kind, nokverrors.KindOf(tt.err))
+			require.Equal(t, tt.kind, nokverrors.KindOf(fmt.Errorf("wrapped: %w", tt.err)))
+		})
+	}
+}
+
+func TestWitnessAuthorityLagIsRetryable(t *testing.T) {
+	require.True(t, nokverrors.Retryable(ErrWitnessAuthorityMissing))
+	require.True(t, nokverrors.Retryable(ErrWitnessAuthorityMismatch))
+}

--- a/raftstore/peras/install_request.go
+++ b/raftstore/peras/install_request.go
@@ -1,13 +1,12 @@
 package peras
 
 import (
-	"errors"
-
+	nokverrors "github.com/feichai0017/NoKV/errors"
 	fsperas "github.com/feichai0017/NoKV/fsmeta/exec/peras"
 	kvrpcpb "github.com/feichai0017/NoKV/pb/kv"
 )
 
-var ErrInvalidInstallRequest = errors.New("raftstore/peras: invalid install request")
+var ErrInvalidInstallRequest = nokverrors.New(nokverrors.KindProtocolViolation, "raftstore/peras: invalid install request")
 
 type InstallRequestInfo struct {
 	RoutingKey         []byte

--- a/raftstore/peras/witness.go
+++ b/raftstore/peras/witness.go
@@ -7,14 +7,15 @@ import (
 	"sync"
 	"time"
 
+	nokverrors "github.com/feichai0017/NoKV/errors"
 	"github.com/feichai0017/NoKV/fsmeta/exec/compile"
 	fsperas "github.com/feichai0017/NoKV/fsmeta/exec/peras"
 )
 
 var (
-	ErrWitnessNodeConfigInvalid = errors.New("raftstore peras: invalid witness node config")
-	ErrWitnessAuthorityMissing  = errors.New("raftstore peras: missing active authority")
-	ErrWitnessAuthorityMismatch = errors.New("raftstore peras: authority mismatch")
+	ErrWitnessNodeConfigInvalid = nokverrors.New(nokverrors.KindInvalidArgument, "raftstore/peras: invalid witness node config")
+	ErrWitnessAuthorityMissing  = nokverrors.New(nokverrors.KindStaleEpoch, "raftstore/peras: missing active authority")
+	ErrWitnessAuthorityMismatch = nokverrors.New(nokverrors.KindStaleEpoch, "raftstore/peras: authority mismatch")
 )
 
 type WitnessNodeConfig struct {

--- a/utils/pool.go
+++ b/utils/pool.go
@@ -1,17 +1,13 @@
 package utils
 
 import (
-	"expvar"
-
 	"github.com/panjf2000/ants/v2"
 )
 
-// Pool wraps ants.Pool with lightweight metrics.
+// Pool wraps ants.Pool without owning hidden global state.
 type Pool struct {
-	p           *ants.Pool
-	submitTotal *expvar.Int
-	active      *expvar.Int
-	size        int
+	p    *ants.Pool
+	size int
 }
 
 // NewPool creates a pool with the given size. If size<=0, defaults to 1.
@@ -21,10 +17,8 @@ func NewPool(size int, name string) *Pool {
 	}
 	p, _ := ants.NewPool(size, ants.WithPreAlloc(true))
 	return &Pool{
-		p:           p,
-		submitTotal: getOrCreateInt("NoKV.Pool." + name + ".Submit"),
-		active:      getOrCreateInt("NoKV.Pool." + name + ".Active"),
-		size:        size,
+		p:    p,
+		size: size,
 	}
 }
 
@@ -33,10 +27,7 @@ func (pl *Pool) Submit(fn func()) error {
 	if pl == nil || pl.p == nil || fn == nil {
 		return nil
 	}
-	pl.submitTotal.Add(1)
-	pl.active.Add(1)
 	return pl.p.Submit(func() {
-		defer pl.active.Add(-1)
 		fn()
 	})
 }
@@ -51,12 +42,3 @@ func (pl *Pool) Release() {
 
 // Size reports configured worker count.
 func (pl *Pool) Size() int { return pl.size }
-
-func getOrCreateInt(name string) *expvar.Int {
-	if v := expvar.Get(name); v != nil {
-		if iv, ok := v.(*expvar.Int); ok {
-			return iv
-		}
-	}
-	return expvar.NewInt(name)
-}

--- a/utils/pool_test.go
+++ b/utils/pool_test.go
@@ -1,6 +1,7 @@
 package utils
 
 import (
+	"expvar"
 	"testing"
 	"time"
 
@@ -21,7 +22,8 @@ func TestPoolSubmitAndSize(t *testing.T) {
 	}
 
 	require.Equal(t, 1, pool.Size())
-	require.NotNil(t, getOrCreateInt("NoKV.Pool.test.Submit"))
+	require.Nil(t, expvar.Get("NoKV.Pool.test.Submit"))
+	require.Nil(t, expvar.Get("NoKV.Pool.test.Active"))
 	require.NoError(t, pool.Submit(nil))
 	pool.Release()
 }


### PR DESCRIPTION
## Summary

- classify Peras and raftstore-peras exported sentinels with stable `errors.Kind`
- move mmap and table prefetch counters out of package-level product expvar keys and into `NoKV.Local.Stats.lsm.*`
- remove hidden `NoKV.Pool.*` expvar state from `utils.Pool`
- update errors/stats/README docs and add focused tests for kind classification and removed legacy expvar keys

## Validation

- `go test ./...`
- `make fmt`
- `make lint`

## Notes

This branch was created from `origin/main` and does not include local unpushed main changes.
