### PR TITLE
fix(raftstore): bound scan retry budget

### DIFF
--- a/raftstore/client/client_kv.go
+++ b/raftstore/client/client_kv.go
@@ -314,8 +314,30 @@ func (c *Client) ScanWithOptions(ctx context.Context, startKey []byte, limit uin
 	remaining := limit
 	lockAttempts := 0
 	lastLock := ""
+	retryKey := append([]byte(nil), currentKey...)
+	transportAttempts := 0
+	regionAttempts := 0
 	var lastKeyErr *kvrpcpb.KeyError
+	resetRetryBudget := func() {
+		if bytesCompare(retryKey, currentKey) == 0 {
+			return
+		}
+		retryKey = append(retryKey[:0], currentKey...)
+		transportAttempts = 0
+		regionAttempts = 0
+	}
+	waitScanRetry := func(attempts *int, kind retryKind, exhausted error) error {
+		*attempts = *attempts + 1
+		if *attempts >= c.retry.MaxAttempts {
+			if exhausted != nil {
+				return exhausted
+			}
+			return &RetryExhaustedError{Operation: "scan", Key: append([]byte(nil), currentKey...)}
+		}
+		return c.waitRetry(ctx, *attempts-1, kind)
+	}
 	for remaining > 0 {
+		resetRetryBudget()
 		region, err := c.routeKeyWithRetry(ctx, currentKey)
 		if err != nil {
 			return nil, err
@@ -323,7 +345,7 @@ func (c *Client) ScanWithOptions(ctx context.Context, startKey []byte, limit uin
 		resp, regionErr, err := c.callScanWithFallback(ctx, region, currentKey, remaining, version, opts)
 		if err != nil {
 			if isTransportUnavailable(err) {
-				if err := c.waitRetry(ctx, 0, retryTransportUnavailable); err != nil {
+				if err := waitScanRetry(&transportAttempts, retryTransportUnavailable, err); err != nil {
 					return nil, err
 				}
 				continue
@@ -334,7 +356,13 @@ func (c *Client) ScanWithOptions(ctx context.Context, startKey []byte, limit uin
 			if err := c.handleRegionError(region.desc.RegionID, regionErr); err != nil {
 				return nil, err
 			}
-			if err := c.waitRetry(ctx, 0, retryRegionError); err != nil {
+			retryErr := &RetryExhaustedError{
+				Operation: "scan",
+				RegionID:  region.desc.RegionID,
+				Key:       append([]byte(nil), currentKey...),
+				Detail:    "region error retry budget exhausted",
+			}
+			if err := waitScanRetry(&regionAttempts, retryRegionError, retryErr); err != nil {
 				return nil, err
 			}
 			continue

--- a/raftstore/client/client_kv_test.go
+++ b/raftstore/client/client_kv_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -338,6 +339,101 @@ func TestClientScanWithOptionsStrongFollowerPreferFallsBackToLeader(t *testing.T
 	require.NoError(t, err)
 	require.Len(t, resp, 2)
 	require.Equal(t, uint64(1), cluster.lastReadStore)
+}
+
+func TestClientScanWithOptionsExhaustsTransportUnavailableRetryBudget(t *testing.T) {
+	cluster := newMockCluster(clusterRegion{
+		meta: &metapb.RegionDescriptor{
+			RegionId: 1,
+			StartKey: []byte("a"),
+			EndKey:   []byte("z"),
+			Epoch:    &metapb.RegionEpoch{Version: 1, ConfVersion: 1},
+			Peers: []*metapb.RegionPeer{
+				{StoreId: 1, PeerId: 101},
+			},
+		},
+		leaderStore: 1,
+	})
+
+	var scanCalls atomic.Int32
+	addr, stop := startBlockingStore(t, &scriptedKVService{
+		mockService: mockService{storeID: 1, cluster: cluster},
+		scanFn: func(context.Context, *kvrpcpb.KvScanRequest) (*kvrpcpb.KvScanResponse, error) {
+			scanCalls.Add(1)
+			return nil, status.Error(codes.Unavailable, "store down")
+		},
+	})
+	defer stop()
+
+	cli, err := New(Config{
+		StoreResolver:  staticStoreResolver{{StoreID: 1, Addr: addr}},
+		RegionResolver: resolverFromCluster(cluster),
+		DialOptions:    []grpc.DialOption{grpc.WithTransportCredentials(insecure.NewCredentials())},
+		Retry: RetryPolicy{
+			MaxAttempts:                 3,
+			TransportUnavailableBackoff: time.Millisecond,
+		},
+	})
+	require.NoError(t, err)
+	defer func() { _ = cli.Close() }()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 250*time.Millisecond)
+	defer cancel()
+	kvs, err := cli.ScanWithOptions(ctx, []byte("alfa"), 1, 20, DefaultReadOptions())
+	require.Nil(t, kvs)
+	require.Error(t, err)
+	require.Equal(t, codes.Unavailable, status.Code(err))
+	require.Equal(t, int32(3), scanCalls.Load())
+	require.NoError(t, ctx.Err())
+}
+
+func TestClientScanWithOptionsExhaustsRegionErrorRetryBudget(t *testing.T) {
+	cluster := newMockCluster(clusterRegion{
+		meta: &metapb.RegionDescriptor{
+			RegionId: 1,
+			StartKey: []byte("a"),
+			EndKey:   []byte("z"),
+			Epoch:    &metapb.RegionEpoch{Version: 1, ConfVersion: 1},
+			Peers: []*metapb.RegionPeer{
+				{StoreId: 1, PeerId: 101},
+			},
+		},
+		leaderStore: 1,
+	})
+
+	var scanCalls atomic.Int32
+	addr, stop := startBlockingStore(t, &scriptedKVService{
+		mockService: mockService{storeID: 1, cluster: cluster},
+		scanFn: func(context.Context, *kvrpcpb.KvScanRequest) (*kvrpcpb.KvScanResponse, error) {
+			scanCalls.Add(1)
+			return &kvrpcpb.KvScanResponse{
+				RegionError: &errorpb.RegionError{NotLeader: &errorpb.NotLeader{}},
+			}, nil
+		},
+	})
+	defer stop()
+
+	cli, err := New(Config{
+		StoreResolver:  staticStoreResolver{{StoreID: 1, Addr: addr}},
+		RegionResolver: resolverFromCluster(cluster),
+		DialOptions:    []grpc.DialOption{grpc.WithTransportCredentials(insecure.NewCredentials())},
+		Retry: RetryPolicy{
+			MaxAttempts:        3,
+			RegionErrorBackoff: time.Millisecond,
+		},
+	})
+	require.NoError(t, err)
+	defer func() { _ = cli.Close() }()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 250*time.Millisecond)
+	defer cancel()
+	kvs, err := cli.ScanWithOptions(ctx, []byte("alfa"), 1, 20, DefaultReadOptions())
+	require.Nil(t, kvs)
+	require.Error(t, err)
+	require.True(t, IsRetryExhausted(err))
+	require.Equal(t, nokverrors.KindRetryExhausted, nokverrors.KindOf(err))
+	require.Equal(t, int32(3), scanCalls.Load())
+	require.NoError(t, ctx.Err())
 }
 
 func TestClientCallGetWithFallbackReturnsLeaderRegionError(t *testing.T) {


### PR DESCRIPTION
## Summary
- Bound raftstore Scan retry loops per current scan key for transport-unavailable and region-error cases.
- Add regression tests for retry budget exhaustion so catalog scans fail fast instead of waiting on the outer workload timeout.

## Root cause
Peras recovery catalog scan can enter Runner.Scan -> raftstore/client.ScanWithOptions while a store transport is unavailable. The previous scan loop continued indefinitely on unavailable transport, so the benchmark only escaped when the outer workload context hit the 5 minute timeout.

## Validation
- go mod tidy
- go test ./raftstore/client ./fsmeta/runtime/raftstore ./fsmeta/runtime/peras ./fsmeta/exec

Cherry-picked from local diagnostic commit fe545d6669782988fa11839bf06682885795be79.