### PR TITLE
ci(bench): drop gh-pages micro-bench tracking

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -11,9 +11,6 @@ jobs:
   micro-bench:
     runs-on: ubuntu-latest
     timeout-minutes: 20
-    permissions:
-      contents: write
-      pull-requests: write
     steps:
       - uses: actions/checkout@v6
 
@@ -22,20 +19,12 @@ jobs:
         with:
           go-version: '1.26.2'
 
+      # Smoke-only: just run the micro benchmarks to catch crashes / build
+      # breaks. Historical tracking via benchmark-action/github-action-benchmark
+      # used a `gh-pages` branch that no longer exists after migrating the docs
+      # site to actions/deploy-pages; removed instead of being reintroduced.
       - name: Run micro benchmarks
-        run: |
-          go test -bench=. -run=^$ -benchtime=100ms -count=1 ./... | tee benchmark.txt
-
-      - name: Track benchmark results
-        uses: benchmark-action/github-action-benchmark@v1
-        with:
-          tool: 'go'
-          output-file-path: benchmark.txt
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          auto-push: ${{ github.event_name == 'push' }}
-          comment-on-alert: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository }}
-          alert-threshold: '115%'
-          fail-on-alert: false
+        run: go test -bench=. -run=^$ -benchtime=100ms -count=1 ./...
 
   ycsb-bench:
     if: github.event_name == 'push' || contains(github.event.pull_request.labels.*.name, 'run-benchmark')


### PR DESCRIPTION
## Summary

- The `Track benchmark results` step in `micro-bench` has been failing on every push since #289 merged, with `fatal: couldn't find remote ref gh-pages`. It used `benchmark-action/github-action-benchmark@v1`, which expects the `gh-pages` branch — that branch is gone now that the docs site deploys via `actions/deploy-pages` straight from a Pages artifact.
- Drop the step instead of recreating the branch. The micro-bench history isn't being consumed anywhere (the old public dashboard at `/NoKV/dev/bench/` is no longer served), and `ycsb-bench` remains the production-grade performance signal.
- Clean up the `contents: write` / `pull-requests: write` permissions and the `| tee benchmark.txt` artifact that only existed to feed the tracking action.

## What still runs

| Job | Behavior |
|---|---|
| **micro-bench** | `go test -bench=.` on every push and PR — fails CI if benchmarks crash or no longer compile (smoke validation). No history persisted. |
| **ycsb-bench** | Unchanged — runs on main push and on PRs labeled `run-benchmark`. |

## Test plan

- [x] `yaml` parses cleanly
- [ ] Next push/PR run: `Benchmark / micro-bench` job completes green
- [ ] `Benchmark / ycsb-bench` job behavior unchanged

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Simplified the benchmark workflow to run as a smoke test, performing quick validation to catch build failures rather than tracking detailed performance metrics.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/feichai0017/NoKV/pull/291)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->