### PR TITLE
ci(fsmeta): extend benchmark idle drain diagnostics

### DIFF
--- a/.github/workflows/fsmeta-benchmark.yml
+++ b/.github/workflows/fsmeta-benchmark.yml
@@ -74,6 +74,7 @@ jobs:
           docker compose ps > benchmark/data/fsmeta/ci/docker-ps.txt || true
           docker compose logs --no-color --tail=500 > benchmark/data/fsmeta/ci/docker-compose.log || true
           docker stats --no-stream > benchmark/data/fsmeta/ci/docker-stats.txt || true
+          curl -fsS http://127.0.0.1:9400/debug/vars > benchmark/data/fsmeta/ci/fsmeta-debug-vars.json || true
 
       - name: Upload fsmeta benchmark artifacts
         if: always()
@@ -85,6 +86,7 @@ jobs:
             benchmark/data/fsmeta/profiles/**
             benchmark/data/fsmeta/ci/*.txt
             benchmark/data/fsmeta/ci/*.log
+            benchmark/data/fsmeta/ci/*.json
           if-no-files-found: ignore
 
       - name: Stop Docker Compose cluster
@@ -110,6 +112,7 @@ jobs:
           NOKV_FSMETA_CAPTURE_PROFILES: "1"
           NOKV_FSMETA_PROFILE_SECONDS: "60"
           NOKV_FSMETA_OUTPUT_DIR: benchmark/data/fsmeta/results
+          NOKV_FSMETA_PERAS_IDLE_TIMEOUT_SECONDS: "600"
         run: make fsmeta-bench
 
       - name: Collect Docker diagnostics
@@ -119,6 +122,7 @@ jobs:
           docker compose ps > benchmark/data/fsmeta/ci/docker-ps.txt || true
           docker compose logs --no-color --tail=1000 > benchmark/data/fsmeta/ci/docker-compose.log || true
           docker stats --no-stream > benchmark/data/fsmeta/ci/docker-stats.txt || true
+          curl -fsS http://127.0.0.1:9400/debug/vars > benchmark/data/fsmeta/ci/fsmeta-debug-vars.json || true
 
       - name: Upload fsmeta benchmark artifacts
         if: always()
@@ -130,6 +134,7 @@ jobs:
             benchmark/data/fsmeta/profiles/**
             benchmark/data/fsmeta/ci/*.txt
             benchmark/data/fsmeta/ci/*.log
+            benchmark/data/fsmeta/ci/*.json
           if-no-files-found: ignore
 
       - name: Stop Docker Compose cluster

--- a/scripts/run_fsmeta_benchmarks.sh
+++ b/scripts/run_fsmeta_benchmarks.sh
@@ -156,9 +156,15 @@ wait_fsmeta_peras_idle() {
 	local last=""
 	local stable=0
 	local snapshot=""
+	local status=0
 
 	while (( SECONDS < deadline )); do
 		if snapshot="$(peras_idle_snapshot 2>/dev/null)"; then
+			status=0
+		else
+			status=$?
+		fi
+		if (( status == 0 )); then
 			if [[ "$snapshot" == "$last" ]]; then
 				stable=$((stable + 1))
 			else
@@ -170,7 +176,9 @@ wait_fsmeta_peras_idle() {
 			fi
 		else
 			stable=0
-			last=""
+			if [[ -n "$snapshot" ]]; then
+				last="$snapshot"
+			fi
 		fi
 		sleep "$interval_seconds"
 	done


### PR DESCRIPTION
## Summary

- extend the long fsmeta benchmark Peras idle drain timeout from 180s to 600s
- preserve the last non-idle Peras snapshot in `run_fsmeta_benchmarks.sh` timeout errors
- upload fsmeta `/debug/vars` JSON with benchmark diagnostics so future idle-drain failures are actionable

## Context

The latest `main` Benchmark workflow failed only in `Benchmark / fsmeta long` after the workload matrix completed:

```text
timed out waiting for fsmeta Peras idle state; last=
make: *** [Makefile:349: fsmeta-bench] Error 1
```

The median benchmark and other main CI jobs passed on the same SHA. This keeps the fix scoped to the benchmark harness and workflow diagnostics.

## Validation

- `git diff --check`
- `bash -n scripts/run_fsmeta_benchmarks.sh`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Enhanced benchmark job configuration to capture additional runtime debug information and preserve it in artifacts.
  * Added environment configuration for benchmark timeout settings.

* **Bug Fixes**
  * Improved idle state detection logic in benchmark polling to better handle transient failures and improve stability detection accuracy.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/feichai0017/NoKV/pull/300)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->