### PR TITLE
bench: align official fsmeta scales and fix DCO parser

### DIFF
--- a/.github/workflows/dco.yml
+++ b/.github/workflows/dco.yml
@@ -49,9 +49,41 @@ jobs:
           fi
 
           missing=0
+          has_signoff() {
+            local message="$1"
+            local trailers
+            trailers="$(git interpret-trailers --parse <<<"$message")"
+            if grep -Eiq '^Signed-off-by: .+ <[^>]+>$' <<<"$trailers"; then
+              return 0
+            fi
+
+            # Dependabot messages contain an updated-dependencies YAML block that
+            # can make git interpret-trailers miss the final trailer paragraph.
+            # Keep the fallback trailer-shaped by checking only the last
+            # non-empty paragraph, not the whole commit body.
+            local last_paragraph
+            last_paragraph="$(awk '
+              NF {
+                block = block $0 "\n"
+                next
+              }
+              block != "" {
+                last = block
+                block = ""
+              }
+              END {
+                if (block != "") {
+                  last = block
+                }
+                printf "%s", last
+              }
+            ' <<<"$message")"
+            grep -Eiq '^Signed-off-by: .+ <[^>]+>$' <<<"$last_paragraph"
+          }
+
           while IFS= read -r commit; do
-            trailers="$(git show -s --format=%B "$commit" | git interpret-trailers --parse)"
-            if ! grep -Eiq '^Signed-off-by: .+ <[^>]+>$' <<<"$trailers"; then
+            message="$(git show -s --format=%B "$commit")"
+            if ! has_signoff "$message"; then
               echo "::error title=Missing DCO sign-off::Commit $commit is missing a Signed-off-by trailer."
               git show -s --format='%h %s' "$commit"
               missing=1

--- a/benchmark/fsmeta/profiles/official/workloads.yaml
+++ b/benchmark/fsmeta/profiles/official/workloads.yaml
@@ -1,10 +1,15 @@
 # Copyright 2024-2026 The NoKV Authors.
 # SPDX-License-Identifier: Apache-2.0
 #
-# This file records normalized fsmeta projections of public benchmark workload
+# This file records normalized fsmeta projections of public benchmark
 # definitions. It does not vendor third-party benchmark source files; it records
-# source URLs, the official shape, and the NoKV metadata-service projection used
+# source URLs, the upstream shape, and the NoKV metadata-service projection used
 # to make each run reproducible.
+#
+# The "official" scale profile uses upstream published parameters when the
+# source defines a fixed scale. For sources that define a model rather than one
+# fixed run size, the profile records the source scale and labels the NoKV
+# projection as model-derived.
 
 profiles:
   mdtest-easy:
@@ -18,6 +23,8 @@ profiles:
       file_size_bytes: "0"
       phases: create, stat, delete
       stonewall_seconds: "300"
+      n_per_rank: "1000000"
+      projected_rank_count: "16"
       reference_command: mdtest -n 1000000 -u -L -F -N 1 -C -W 1
     scale:
       median:
@@ -47,6 +54,9 @@ profiles:
       file_size_bytes: "3901"
       phases: create, stat, read, delete
       stonewall_seconds: "300"
+      n_per_rank: "1000000"
+      projected_rank_count: "16"
+      projected_total_files: "16000000"
       reference_command: mdtest -n 1000000 -t -w 3901 -e 3901 -N 1 -F -C -W 1
     scale:
       median:
@@ -62,7 +72,7 @@ profiles:
       official:
         clients: 16
         directories: 1
-        files_per_directory: 1000000
+        files_per_directory: 16000000
         page_limit: 1024
 
   filebench-varmail:
@@ -79,6 +89,7 @@ profiles:
       mean_dir_width: "1000000"
       prealloc_percent: "80"
       run_seconds: "60"
+      projected_total_messages: "1000"
     scale:
       median:
         clients: 12
@@ -94,9 +105,9 @@ profiles:
         session_ttl: 5m
       official:
         clients: 16
-        users: 16
-        messages_per_user: 63
-        page_limit: 128
+        users: 1
+        messages_per_user: 1000
+        page_limit: 1000
         session_ttl: 5m
 
   mimesis-namespace:
@@ -106,6 +117,10 @@ profiles:
     projection: fsmeta Create, Rename, UpdateInode, Lookup, ReadDirPlus, Unlink namespace churn
     official:
       source_detail: MimesisBench models namespace metadata behavior from large Yahoo Big Data clusters.
+      fixed_scale: unavailable
+      yahoo_trace_files: "150000000"
+      yahoo_trace_storage: 3.9PB
+      projection_note: MimesisBench publishes a model and workload profile, not one fixed official run size.
       operations: create, delete, rename, open/stat-like metadata accesses
       model: type-aware synthetic namespace metadata generator
     scale:
@@ -122,7 +137,7 @@ profiles:
       official:
         clients: 16
         directories: 32
-        files_per_directory: 1000000
+        files_per_directory: 4687500
         page_limit: 1024
 
   ai-checkpoint-agent:
@@ -138,6 +153,8 @@ profiles:
       process_counts: 8, 64, 512, 1024
       checkpoint_sizes: 105GB, 912GB, 5.29TB, 15TB
       subset_processes: "8"
+      selected_projection: 8B closed/subset process count
+      projection_note: metadata-only; checkpoint bytes and PyTorch save/load data path are outside fsmeta
     scale:
       median:
         clients: 12
@@ -154,9 +171,9 @@ profiles:
         page_limit: 11
         session_ttl: 5m
       official:
-        clients: 16
+        clients: 8
         workspaces: 8
         checkpoints_per_workspace: 10
-        files_per_checkpoint: 8
-        page_limit: 9
+        files_per_checkpoint: 1
+        page_limit: 2
         session_ttl: 5m

--- a/benchmark/fsmeta/workload/workload_test.go
+++ b/benchmark/fsmeta/workload/workload_test.go
@@ -169,16 +169,27 @@ func TestScaleForLoadsOfficialProfileFile(t *testing.T) {
 
 	hard := ProfileFor(MDTestHard)
 	require.Equal(t, "3901", hard.Official["file_size_bytes"])
-	require.Equal(t, 1000000, ScaleFor(MDTestHard, "official").FilesPerDirectory)
+	require.Equal(t, "1000000", hard.Official["n_per_rank"])
+	require.Equal(t, "16000000", hard.Official["projected_total_files"])
+	require.Equal(t, 16000000, ScaleFor(MDTestHard, "official").FilesPerDirectory)
 
 	varmail := ProfileFor(FilebenchVarmail)
 	require.Equal(t, "1000", varmail.Official["nfiles"])
 	require.Equal(t, "16", varmail.Official["nthreads"])
-	require.Equal(t, 63, ScaleFor(FilebenchVarmail, "official").MessagesPerUser)
+	require.Equal(t, "1000", varmail.Official["projected_total_messages"])
+	require.Equal(t, 1, ScaleFor(FilebenchVarmail, "official").Users)
+	require.Equal(t, 1000, ScaleFor(FilebenchVarmail, "official").MessagesPerUser)
+
+	mimesis := ProfileFor(MimesisNamespace)
+	require.Equal(t, "unavailable", mimesis.Official["fixed_scale"])
+	require.Equal(t, "150000000", mimesis.Official["yahoo_trace_files"])
 
 	mlperf := ProfileFor(AICheckpointAgent)
 	require.Equal(t, "10", mlperf.Official["save_operations"])
+	require.Equal(t, "8, 64, 512, 1024", mlperf.Official["process_counts"])
+	require.Equal(t, 8, ScaleFor(AICheckpointAgent, "official").Clients)
 	require.Equal(t, 10, ScaleFor(AICheckpointAgent, "official").CheckpointsPerWorkspace)
+	require.Equal(t, 1, ScaleFor(AICheckpointAgent, "official").FilesPerCheckpoint)
 }
 
 func TestTimeCallRetriesStableRetryableOperationError(t *testing.T) {


### PR DESCRIPTION
## Summary

- Align fsmeta official workload profile scales with upstream published parameters or explicitly mark model-derived projections.
- Update workload profile tests for mdtest hard, Filebench varmail, Mimesis, and MLPerf checkpoint projections.
- Harden the DCO workflow so Dependabot commits with `updated-dependencies` YAML blocks still pass when the final trailer paragraph contains a valid `Signed-off-by` line.

## Validation

```bash
cd benchmark && go test ./fsmeta/workload -count=1
cd benchmark && go test ./fsmeta -run TestWriteBenchmarkManifestDocumentsOfficialSources -count=1
git diff --check -- .github/workflows/dco.yml benchmark/fsmeta/profiles/official/workloads.yaml benchmark/fsmeta/workload/workload_test.go
```

Also locally simulated the patched DCO check against the recent Dependabot commits that failed on `main`, and against an unsigned synthetic message.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced commit sign-off verification to handle edge cases in message parsing.

* **Chores**
  * Updated benchmark workload parameters and projection metadata for improved accuracy and reproducibility in official benchmark configurations.

* **Tests**
  * Updated benchmark scaling tests to align with configuration changes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/feichai0017/NoKV/pull/302)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->