### PR TITLE
fix(root): defer grant key loading until authority use

### DIFF
--- a/meta/root/protocol/types.go
+++ b/meta/root/protocol/types.go
@@ -9,6 +9,7 @@ import (
 	"encoding/base64"
 	"os"
 	"strings"
+	"sync"
 )
 
 // Cursor identifies one committed position in the metadata-root log.
@@ -187,31 +188,44 @@ type grantKeyMaterial struct {
 	public  ed25519.PublicKey
 }
 
-var rootGrantKeys = loadGrantKeyMaterial()
+var rootGrantKeys = struct {
+	sync.Once
+	material grantKeyMaterial
+}{}
 
 func SignGrantBytes(payload []byte) []byte {
-	if len(rootGrantKeys.private) != ed25519.PrivateKeySize {
+	keys := cachedRootGrantKeys()
+	if len(keys.private) != ed25519.PrivateKeySize {
 		return nil
 	}
-	return ed25519.Sign(rootGrantKeys.private, payload)
+	return ed25519.Sign(keys.private, payload)
 }
 
 func VerifyGrantBytes(payload, signature []byte) bool {
-	if len(rootGrantKeys.public) != ed25519.PublicKeySize {
+	keys := cachedRootGrantKeys()
+	if len(keys.public) != ed25519.PublicKeySize {
 		return false
 	}
-	return ed25519.Verify(rootGrantKeys.public, payload, signature)
+	return ed25519.Verify(keys.public, payload, signature)
+}
+
+func cachedRootGrantKeys() grantKeyMaterial {
+	rootGrantKeys.Do(func() {
+		rootGrantKeys.material = loadGrantKeyMaterial()
+	})
+	return rootGrantKeys.material
 }
 
 func loadGrantKeyMaterial() grantKeyMaterial {
+	return loadGrantKeyMaterialWithEphemeral(allowEphemeralGrantKeys())
+}
+
+func loadGrantKeyMaterialWithEphemeral(allowEphemeral bool) grantKeyMaterial {
 	private := parseEd25519PrivateKeyEnv(GrantSigningPrivateKeyEnv)
 	public := parseEd25519PublicKeyEnv(GrantVerificationPublicKeyEnv)
 	if private == nil && public == nil {
-		if !allowEphemeralGrantKeys() {
-			panic("meta/root/protocol: " + GrantSigningPrivateKeyEnv +
-				" and/or " + GrantVerificationPublicKeyEnv +
-				" must be provided; set " + GrantAllowEphemeralKeysEnv +
-				"=1 only for local dev/test")
+		if !allowEphemeral {
+			return grantKeyMaterial{}
 		}
 		generatedPublic, generatedPrivate, err := ed25519.GenerateKey(rand.Reader)
 		if err != nil {

--- a/meta/root/protocol/types_test.go
+++ b/meta/root/protocol/types_test.go
@@ -4,6 +4,7 @@
 package protocol
 
 import (
+	"crypto/ed25519"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -64,4 +65,24 @@ func TestCloneAuthorityRetiredEraFloorsIsIsolated(t *testing.T) {
 	require.Zero(t, AuthorityRetiredEraFloorFor(cloned, DutyTSO, global))
 	cloned[0].RetiredEraFloor = 100
 	require.Equal(t, uint64(7), original[0].RetiredEraFloor)
+}
+
+func TestGrantKeyMaterialCanBeAbsentUntilAuthorityUse(t *testing.T) {
+	t.Setenv(GrantSigningPrivateKeyEnv, "")
+	t.Setenv(GrantVerificationPublicKeyEnv, "")
+	t.Setenv(GrantAllowEphemeralKeysEnv, "")
+
+	keys := loadGrantKeyMaterialWithEphemeral(false)
+	require.Empty(t, keys.private)
+	require.Empty(t, keys.public)
+}
+
+func TestGrantKeyMaterialCanUseEphemeralDevKey(t *testing.T) {
+	t.Setenv(GrantSigningPrivateKeyEnv, "")
+	t.Setenv(GrantVerificationPublicKeyEnv, "")
+	t.Setenv(GrantAllowEphemeralKeysEnv, "")
+
+	keys := loadGrantKeyMaterialWithEphemeral(true)
+	require.Len(t, keys.private, ed25519.PrivateKeySize)
+	require.Len(t, keys.public, ed25519.PublicKeySize)
 }


### PR DESCRIPTION
## Summary

- Defer Eunomia grant key loading until a grant is actually signed or verified.
- Keep production safety by returning no signature when no signing key is configured; authority issuance already surfaces that as `root grant signing key is not configured`.
- Prevent read-only CLI commands such as `nokv help` from panicking when release binaries are run without grant key environment variables.

## Validation

```bash
go test ./meta/root/protocol ./meta/root/replicated -count=1
go build -o /tmp/nokv-release-help-check ./cmd/nokv
/tmp/nokv-release-help-check help
make build
```

Release packaging validation was also run on this branch for `v0.9.0` binary archives and checksums.
