### PR TITLE
ci: add release image publishing workflow

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -7,6 +7,7 @@
 
 # Build artefacts
 /build
+/dist
 artifacts
 **/*.pprof
 benchmark/ycsb/data

--- a/.github/workflows/release-images.yml
+++ b/.github/workflows/release-images.yml
@@ -1,0 +1,105 @@
+# Copyright 2024-2026 The NoKV Authors.
+# SPDX-License-Identifier: Apache-2.0
+
+name: Release Images
+
+on:
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: "Git ref to build, for example v0.9.0"
+        required: true
+      version:
+        description: "Release version, for example v0.9.0"
+        required: true
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    env:
+      GHCR_IMAGE: ghcr.io/feichai0017/nokv
+      DOCKERHUB_IMAGE: docker.io/feichai0017/nokv
+      DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+      DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
+    steps:
+      - name: Checkout release ref
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.ref }}
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Resolve image tags
+        id: tags
+        shell: bash
+        run: |
+          set -euo pipefail
+          version="${{ inputs.version }}"
+          plain="${version#v}"
+          IFS=. read -r major minor patch <<<"$plain"
+          if [[ -z "${major:-}" || -z "${minor:-}" || -z "${patch:-}" ]]; then
+            echo "::error title=Invalid release version::Expected vMAJOR.MINOR.PATCH, got $version"
+            exit 1
+          fi
+
+          {
+            echo "ghcr<<EOF"
+            printf '%s:%s\n' "$GHCR_IMAGE" "$version"
+            printf '%s:%s\n' "$GHCR_IMAGE" "$plain"
+            printf '%s:%s.%s\n' "$GHCR_IMAGE" "$major" "$minor"
+            printf '%s:%s\n' "$GHCR_IMAGE" "$major"
+            printf '%s:latest\n' "$GHCR_IMAGE"
+            echo "EOF"
+          } >>"$GITHUB_OUTPUT"
+
+          {
+            echo "dockerhub<<EOF"
+            printf '%s:%s\n' "$DOCKERHUB_IMAGE" "$version"
+            printf '%s:%s\n' "$DOCKERHUB_IMAGE" "$plain"
+            printf '%s:%s.%s\n' "$DOCKERHUB_IMAGE" "$major" "$minor"
+            printf '%s:%s\n' "$DOCKERHUB_IMAGE" "$major"
+            printf '%s:latest\n' "$DOCKERHUB_IMAGE"
+            echo "EOF"
+          } >>"$GITHUB_OUTPUT"
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Publish GHCR image
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: ./Dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.tags.outputs.ghcr }}
+
+      - name: Log in to Docker Hub
+        if: env.DOCKERHUB_USERNAME != '' && env.DOCKERHUB_TOKEN != ''
+        uses: docker/login-action@v4
+        with:
+          registry: docker.io
+          username: ${{ env.DOCKERHUB_USERNAME }}
+          password: ${{ env.DOCKERHUB_TOKEN }}
+
+      - name: Publish Docker Hub image
+        if: env.DOCKERHUB_USERNAME != '' && env.DOCKERHUB_TOKEN != ''
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: ./Dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.tags.outputs.dockerhub }}


### PR DESCRIPTION
## Summary

- Add a manual release image workflow that can build a release tag and publish multi-arch GHCR images with semver tags.
- Add optional Docker Hub publishing when `DOCKERHUB_USERNAME` and `DOCKERHUB_TOKEN` repository secrets are configured.
- Ignore `/dist` in Docker build contexts so local release archives are not sent to BuildKit.

## Validation

```bash
ruby -e 'require "yaml"; YAML.load_file(".github/workflows/release-images.yml")'
git diff --check -- .github/workflows/release-images.yml .dockerignore
```

I attempted local GHCR push for `v0.9.0`, but the local GitHub token lacks `write:packages`; this workflow uses the repository `GITHUB_TOKEN` with `packages: write`.
