### PR TITLE
Fix Peras authority renewal before witness

### DIFF
--- a/fsmeta/runtime/peras/epoch_table.go
+++ b/fsmeta/runtime/peras/epoch_table.go
@@ -62,6 +62,18 @@ func (t *epochTable) grant(epochID uint64) (rootproto.PerasAuthorityGrant, bool)
 	return grant, ok
 }
 
+func (t *epochTable) updateGrant(grant rootproto.PerasAuthorityGrant) {
+	if t == nil || !grant.Valid() {
+		return
+	}
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	if t.holders[grant.EpochID] == nil {
+		return
+	}
+	t.grants[grant.EpochID] = grant
+}
+
 func (t *epochTable) holderSnapshot() []*fsperas.Holder {
 	if t == nil {
 		return nil

--- a/fsmeta/runtime/peras/flush_pipeline.go
+++ b/fsmeta/runtime/peras/flush_pipeline.go
@@ -63,6 +63,9 @@ func (p flushPipeline) runBatch(ctx context.Context, batch perasFlushBatch) (per
 	for idx := range started {
 		started[idx] = time.Now()
 	}
+	if err := p.renewBatchAuthority(ctx, batch); err != nil {
+		return perasFlushBatch{}, err
+	}
 	if err := p.witnessBatch(ctx, batch); err != nil {
 		return perasFlushBatch{}, err
 	}
@@ -79,6 +82,25 @@ func (p flushPipeline) runBatch(ctx context.Context, batch perasFlushBatch) (per
 		c.metrics.flushTotal.Add(uint64(len(batch.jobs)))
 	}
 	return batch, nil
+}
+
+func (p flushPipeline) renewBatchAuthority(ctx context.Context, batch perasFlushBatch) error {
+	c := p.runtime
+	if c == nil || c.authority == nil || batch.holder == nil {
+		return ErrRuntimeInvalid
+	}
+	grant, owned, err := c.authority.Acquire(ctx, batch.scope)
+	if err != nil {
+		return c.recordErrorf("renew peras authority for flush: %w", err)
+	}
+	if !owned {
+		return c.recordError(ErrNotHeld)
+	}
+	if grant.HolderID != batch.holder.HolderID() || grant.EpochID != batch.holder.EpochID() {
+		return c.recordErrorf("renew peras authority for flush: %w", ErrInvalidResponse)
+	}
+	c.epochs.updateGrant(grant)
+	return nil
 }
 
 func (p flushPipeline) witnessBatch(ctx context.Context, batch perasFlushBatch) error {

--- a/fsmeta/runtime/peras/flush_plan.go
+++ b/fsmeta/runtime/peras/flush_plan.go
@@ -22,6 +22,7 @@ func (c *Runtime) buildFlushBatches(plans []perasFrozenPlan, materialize bool) (
 	for _, frozen := range plans {
 		batch := perasFlushBatch{
 			holder: frozen.holder,
+			scope:  frozen.scope,
 			plan:   frozen.plan,
 			jobs:   make([]perasFlushJob, 0, 1),
 		}

--- a/fsmeta/runtime/peras/runtime.go
+++ b/fsmeta/runtime/peras/runtime.go
@@ -133,6 +133,7 @@ type perasFlushJob struct {
 
 type perasFlushBatch struct {
 	holder *fsperas.Holder
+	scope  compile.AuthorityScope
 	plan   fsperas.ReplayPlan
 	jobs   []perasFlushJob
 }

--- a/fsmeta/runtime/peras/runtime_test.go
+++ b/fsmeta/runtime/peras/runtime_test.go
@@ -402,6 +402,36 @@ func TestRuntimeShutdownFlushesPendingSegment(t *testing.T) {
 	require.ErrorIs(t, err, ErrRuntimeClosed)
 }
 
+func TestRuntimeFlushRenewsAuthorityBeforeWitness(t *testing.T) {
+	provider := &fakeRuntimePerasGrantProvider{holderID: "holder-a", grant: testRuntimeCommitterGrant()}
+	installer := &fakeRuntimePerasSegmentInstaller{}
+	witnesses := []fsperas.WitnessReplica{
+		&authorityRenewCheckingRuntimePerasWitness{id: "witness-1", provider: provider},
+		&authorityRenewCheckingRuntimePerasWitness{id: "witness-2", provider: provider},
+		&authorityRenewCheckingRuntimePerasWitness{id: "witness-3", provider: provider},
+	}
+	committer, err := NewRuntime(Config{
+		Authority:         provider,
+		Witnesses:         witnesses,
+		Installer:         installer,
+		SegmentBatchSize:  1024,
+		SegmentFlushEvery: time.Hour,
+	})
+	require.NoError(t, err)
+	defer committer.Close()
+
+	ctx := context.Background()
+	require.NoError(t, commitRuntimePeras(ctx, committer, 1, []byte("dentry/a"), []byte("inode/a")))
+	beforeFlush := provider.acquireCalls.Load()
+	for _, witness := range witnesses {
+		witness.(*authorityRenewCheckingRuntimePerasWitness).minAcquireCalls = beforeFlush + 1
+	}
+	require.NoError(t, committer.FlushDurable(ctx))
+	require.Greater(t, provider.acquireCalls.Load(), beforeFlush)
+	require.Equal(t, 0, committer.Stats()["pending"])
+	require.Equal(t, 1, installer.calls)
+}
+
 func TestRuntimeFlushPreservesCatalogSegmentAcrossFSMetaBuckets(t *testing.T) {
 	provider := &fakeRuntimePerasGrantProvider{holderID: "holder-a", grant: testRuntimeCommitterGrant()}
 	installer := &fakeRuntimePerasSegmentInstaller{}
@@ -1660,6 +1690,8 @@ type fakeRuntimePerasGrantProvider struct {
 	owned    bool
 	err      error
 	sealErr  error
+
+	acquireCalls atomic.Int64
 }
 
 func (p *fakeRuntimePerasGrantProvider) HolderID() string {
@@ -1667,6 +1699,7 @@ func (p *fakeRuntimePerasGrantProvider) HolderID() string {
 }
 
 func (p *fakeRuntimePerasGrantProvider) Acquire(context.Context, compile.AuthorityScope) (rootproto.PerasAuthorityGrant, bool, error) {
+	p.acquireCalls.Add(1)
 	owned := p.owned
 	if !owned {
 		owned = true
@@ -1753,6 +1786,23 @@ func (w *recordingRuntimePerasWitness) Probe(_ context.Context, epochID uint64) 
 		}
 	}
 	return out, nil
+}
+
+type authorityRenewCheckingRuntimePerasWitness struct {
+	id              string
+	provider        *fakeRuntimePerasGrantProvider
+	minAcquireCalls int64
+	recordingRuntimePerasWitness
+}
+
+func (w *authorityRenewCheckingRuntimePerasWitness) ID() string { return w.id }
+
+func (w *authorityRenewCheckingRuntimePerasWitness) AppendSegment(ctx context.Context, scope compile.AuthorityScope, record fsperas.SegmentWitnessRecord) error {
+	if w.provider.acquireCalls.Load() < w.minAcquireCalls {
+		return fmt.Errorf("witness started before authority renewal")
+	}
+	w.recordingRuntimePerasWitness.id = w.id
+	return w.recordingRuntimePerasWitness.AppendSegment(ctx, scope, record)
 }
 
 func testRuntimeCommitterGrant() rootproto.PerasAuthorityGrant {

--- a/meta/root/replicated/peras_test.go
+++ b/meta/root/replicated/peras_test.go
@@ -80,6 +80,14 @@ func TestReplicatedStoreApplyPerasAuthoritySealPublishesFrontier(t *testing.T) {
 	require.Len(t, state.PerasAuthoritySeals, 1)
 	require.Equal(t, root, state.PerasAuthoritySeals[0].SegmentRoot)
 
+	state, _, err = store.ApplyPerasAuthority(context.Background(), rootproto.PerasAuthorityCommand{
+		Kind:     rootproto.PerasAuthorityActRetire,
+		HolderID: grant.HolderID,
+		GrantID:  grant.GrantID,
+	})
+	require.NoError(t, err)
+	require.Empty(t, state.ActivePerasGrants)
+
 	expired := testPerasAcquireCommand("holder-b", 1)
 	expired.NowUnixNano = cmd.ExpiresUnixNano + 1
 	expired.ExpiresUnixNano = expired.NowUnixNano + 1_000
@@ -159,7 +167,30 @@ func TestReplicatedStoreApplyPerasAuthorityExpandsSameHolderGrant(t *testing.T) 
 	require.Equal(t, expanded, state.ActivePerasGrants[0])
 }
 
-func TestReplicatedStoreApplyPerasAuthorityReplacesExpiredGrant(t *testing.T) {
+func TestReplicatedStoreApplyPerasAuthorityRenewsExpiredSameHolderGrant(t *testing.T) {
+	stores, _, leaderID := openNetworkTestCluster(t, 4)
+	store := stores[leaderID]
+
+	expired := testPerasAcquireCommand("holder-a", 1)
+	expired.ExpiresUnixNano = 100
+	expired.NowUnixNano = 10
+	_, first, err := store.ApplyPerasAuthority(context.Background(), expired)
+	require.NoError(t, err)
+
+	next := testPerasAcquireCommand("holder-a", 1)
+	next.NowUnixNano = 101
+	next.ExpiresUnixNano = 500
+	state, renewed, err := store.ApplyPerasAuthority(context.Background(), next)
+	require.NoError(t, err)
+	require.Equal(t, first.GrantID, renewed.GrantID)
+	require.Equal(t, first.EpochID, renewed.EpochID)
+	require.Equal(t, int64(500), renewed.ExpiresUnixNano)
+	require.Equal(t, uint64(1), state.PerasAuthorityEpoch)
+	require.Len(t, state.ActivePerasGrants, 1)
+	require.Equal(t, renewed, state.ActivePerasGrants[0])
+}
+
+func TestReplicatedStoreApplyPerasAuthorityRejectsExpiredGrantTakeoverUntilRetired(t *testing.T) {
 	stores, _, leaderID := openNetworkTestCluster(t, 4)
 	store := stores[leaderID]
 
@@ -172,6 +203,20 @@ func TestReplicatedStoreApplyPerasAuthorityReplacesExpiredGrant(t *testing.T) {
 	next := testPerasAcquireCommand("holder-b", 1)
 	next.NowUnixNano = 101
 	state, second, err := store.ApplyPerasAuthority(context.Background(), next)
+	require.ErrorIs(t, err, rootstate.ErrPrimacy)
+	require.Empty(t, second.GrantID)
+	require.Len(t, state.ActivePerasGrants, 1)
+	require.Equal(t, first.GrantID, state.ActivePerasGrants[0].GrantID)
+
+	state, _, err = store.ApplyPerasAuthority(context.Background(), rootproto.PerasAuthorityCommand{
+		Kind:     rootproto.PerasAuthorityActRetire,
+		HolderID: first.HolderID,
+		GrantID:  first.GrantID,
+	})
+	require.NoError(t, err)
+	require.Empty(t, state.ActivePerasGrants)
+
+	state, second, err = store.ApplyPerasAuthority(context.Background(), next)
 	require.NoError(t, err)
 	require.NotEqual(t, first.GrantID, second.GrantID)
 	require.Equal(t, uint64(2), second.EpochID)

--- a/meta/root/replicated/store.go
+++ b/meta/root/replicated/store.go
@@ -436,34 +436,38 @@ func (s *Store) acquirePerasAuthorityLocked(ctx context.Context, cmd rootproto.P
 		}
 	}
 
-	events := make([]rootevent.Event, 0, 2)
-	var expansion rootproto.PerasAuthorityGrant
+	var renewal rootproto.PerasAuthorityGrant
 	for _, active := range s.state.ActivePerasGrants {
 		if !active.Overlaps(request) {
 			continue
 		}
-		if active.ActiveAt(cmd.NowUnixNano) {
-			if active.HolderID == holderID && active.Covers(cmd.Scope, cmd.NowUnixNano) {
-				return rootstate.CloneState(s.state), rootproto.ClonePerasAuthorityGrant(active), nil
-			}
-			if active.HolderID == holderID && !expansion.Valid() {
-				expansion = rootproto.ClonePerasAuthorityGrant(active)
-				continue
-			}
+		// Peras authority TTL is an admission freshness bound, not proof that
+		// the holder's visible overlay has been durably drained. Keep overlapping
+		// grants rooted until the holder explicitly retires them; otherwise old
+		// pending segments can be cut off by a newer epoch and fail witness
+		// authority checks.
+		if active.HolderID != holderID {
 			return rootstate.CloneState(s.state), rootproto.PerasAuthorityGrant{}, rootstate.ErrPrimacy
 		}
-		events = append(events, rootevent.PerasAuthorityRetired(active))
-	}
-	if expansion.Valid() {
-		expansion.Scope = mergePerasAuthorityScopes(expansion.Scope, cmd.Scope)
-		if cmd.ExpiresUnixNano > expansion.ExpiresUnixNano {
-			expansion.ExpiresUnixNano = cmd.ExpiresUnixNano
+		if active.ActiveAt(cmd.NowUnixNano) &&
+			active.Covers(cmd.Scope, cmd.NowUnixNano) &&
+			cmd.ExpiresUnixNano <= active.ExpiresUnixNano {
+			return rootstate.CloneState(s.state), rootproto.ClonePerasAuthorityGrant(active), nil
 		}
-		commit, err := s.appendLocked(ctx, rootevent.PerasAuthorityGranted(expansion))
+		if !renewal.Valid() {
+			renewal = rootproto.ClonePerasAuthorityGrant(active)
+		}
+	}
+	if renewal.Valid() {
+		renewal.Scope = mergePerasAuthorityScopes(renewal.Scope, cmd.Scope)
+		if cmd.ExpiresUnixNano > renewal.ExpiresUnixNano {
+			renewal.ExpiresUnixNano = cmd.ExpiresUnixNano
+		}
+		commit, err := s.appendLocked(ctx, rootevent.PerasAuthorityGranted(renewal))
 		if err != nil {
 			return rootstate.State{}, rootproto.PerasAuthorityGrant{}, err
 		}
-		committed, ok := commit.State.ActivePerasGrantByID(expansion.GrantID)
+		committed, ok := commit.State.ActivePerasGrantByID(renewal.GrantID)
 		if !ok || !committed.Covers(cmd.Scope, cmd.NowUnixNano) {
 			return rootstate.State{}, rootproto.PerasAuthorityGrant{}, rootstate.ErrFinality
 		}
@@ -490,8 +494,7 @@ func (s *Store) acquirePerasAuthorityLocked(ctx context.Context, cmd rootproto.P
 			grant.PredecessorDigest = predecessor.SegmentRoot
 		}
 	}
-	events = append(events, rootevent.PerasAuthorityGranted(grant))
-	commit, err := s.appendLocked(ctx, events...)
+	commit, err := s.appendLocked(ctx, rootevent.PerasAuthorityGranted(grant))
 	if err != nil {
 		return rootstate.State{}, rootproto.PerasAuthorityGrant{}, err
 	}

--- a/raftstore/peras/witness_test.go
+++ b/raftstore/peras/witness_test.go
@@ -121,6 +121,21 @@ func TestWitnessNodeRejectsExpiredAuthority(t *testing.T) {
 	require.ErrorIs(t, err, ErrWitnessAuthorityMissing)
 }
 
+func TestWitnessNodeAcceptsRenewedSameEpochAuthority(t *testing.T) {
+	now := time.Unix(100, 0)
+	authorities := runtimeperas.NewActiveAuthorities()
+	renewed := testAuthorityGrant()
+	renewed.ExpiresUnixNano = now.Add(time.Hour).UnixNano()
+	require.NoError(t, authorities.Replace([]rootproto.PerasAuthorityGrant{renewed}))
+	node, cleanup := openTestWitnessNodeWithAuthorityView(t, wal.DurabilityFsync, authorities, func() time.Time { return now })
+	defer cleanup()
+
+	record := testSegmentRecord()
+	require.Equal(t, renewed.EpochID, record.EpochID)
+	require.Equal(t, renewed.HolderID, record.HolderID)
+	require.NoError(t, node.AppendSegment(context.Background(), testAuthorityScope(), record))
+}
+
 func TestWitnessNodeDuplicateSegmentIsIdempotent(t *testing.T) {
 	node, cleanup := openTestWitnessNode(t, wal.DurabilityFsync)
 	defer cleanup()


### PR DESCRIPTION
## Summary
- keep overlapping Peras authority grants rooted until explicit retire instead of replacing expired same-holder grants with a new epoch
- renew the batch authority before witness and reject renewal responses that change holder or epoch
- add root/runtime/witness regressions for same-holder renewal, takeover rejection, and pre-witness renewal

## Validation
- go test -count=1 ./meta/root/... ./fsmeta/runtime/peras ./raftstore/peras
- git diff --check

## Notes
This fixes the stale-authority failure mode where pending Peras flush jobs can still carry an older holder epoch while stores have already advanced to a newer same-holder epoch. TTL remains a freshness bound; durable authority handoff still requires explicit retire/drain.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added authority renewal mechanism that activates before witness and install steps to maintain current authorization state.

* **Bug Fixes**
  * Improved grant validation and overlap handling in authority acquisition.
  * Enhanced scope tracking across flush operations for better authorization accuracy.

* **Tests**
  * Added test coverage for authority renewal ordering and same-epoch grant renewals.
  * Expanded test scenarios for grant expiration and holder takeover validation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/feichai0017/NoKV/pull/306)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->