### PR TITLE
fix: improve Peras background drain capacity

### DIFF
--- a/cmd/nokv-fsmeta/main.go
+++ b/cmd/nokv-fsmeta/main.go
@@ -62,7 +62,7 @@ func main() {
 		perasWitnessQuorum              = flag.Int("peras-witness-quorum", 0, "Peras witness quorum; zero uses majority")
 		perasSegmentWitnessRetries      = flag.Int("peras-segment-witness-retries", 3, "Peras segment witness retries for transient authority lag")
 		perasSegmentWitnessRetryBackoff = flag.Duration("peras-segment-witness-retry-backoff", 20*time.Millisecond, "Peras segment witness retry backoff")
-		perasSegmentBatchSize           = flag.Int("peras-segment-batch-size", 0, "Peras visible operations per segment before background flush; zero uses runtime default")
+		perasSegmentBatchSize           = flag.Int("peras-segment-batch-size", 0, "Peras pending visible operations that trigger background flush; zero uses runtime default")
 		perasSegmentMaxReplayMutations  = flag.Int("peras-segment-max-replay-mutations", 0, "Peras replay mutations per installed segment; zero uses runtime default")
 		perasSegmentInstallParallelism  = flag.Int("peras-segment-install-parallelism", 0, "Peras segment installs per flush; zero uses GOMAXPROCS")
 		perasSegmentFlushEvery          = flag.Duration("peras-segment-flush-every", 0, "Peras opportunistic segment flush interval; zero uses runtime default")

--- a/fsmeta/exec/peras/detector.go
+++ b/fsmeta/exec/peras/detector.go
@@ -97,13 +97,55 @@ func (d *ConflictDetector) Remove(id OperationID) {
 	}
 	d.mu.Lock()
 	defer d.mu.Unlock()
-	if op, ok := d.pending[id]; ok {
-		d.unindexOperation(op)
+	if !d.removeLocked(id) {
+		return
 	}
-	delete(d.pending, id)
 	d.order = slices.DeleteFunc(d.order, func(current OperationID) bool {
 		return current == id
 	})
+}
+
+// RemoveMany retires pending operations and compacts detector order once.
+func (d *ConflictDetector) RemoveMany(ids ...OperationID) {
+	if d == nil {
+		return
+	}
+	if len(ids) == 0 {
+		return
+	}
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	removed := make(map[OperationID]struct{}, len(ids))
+	for _, id := range ids {
+		if d.removeLocked(id) {
+			removed[id] = struct{}{}
+		}
+	}
+	if len(removed) == 0 {
+		return
+	}
+	write := 0
+	for _, current := range d.order {
+		if _, ok := removed[current]; ok {
+			continue
+		}
+		d.order[write] = current
+		write++
+	}
+	for i := write; i < len(d.order); i++ {
+		d.order[i] = OperationID{}
+	}
+	d.order = d.order[:write]
+}
+
+func (d *ConflictDetector) removeLocked(id OperationID) bool {
+	op, ok := d.pending[id]
+	if !ok {
+		return false
+	}
+	d.unindexOperation(op)
+	delete(d.pending, id)
+	return true
 }
 
 func (d *ConflictDetector) Len() int {
@@ -116,15 +158,28 @@ func (d *ConflictDetector) Len() int {
 }
 
 func (d *ConflictDetector) IDs() []OperationID {
+	return d.IDsLimit(0)
+}
+
+// IDsLimit returns pending operation IDs in admission order. A non-positive
+// limit returns every pending ID.
+func (d *ConflictDetector) IDsLimit(maxIDs int) []OperationID {
 	if d == nil {
 		return nil
 	}
 	d.mu.Lock()
 	defer d.mu.Unlock()
-	out := make([]OperationID, 0, len(d.order))
+	capacity := len(d.order)
+	if maxIDs > 0 && maxIDs < capacity {
+		capacity = maxIDs
+	}
+	out := make([]OperationID, 0, capacity)
 	for _, id := range d.order {
 		if _, ok := d.pending[id]; ok {
 			out = append(out, id)
+			if maxIDs > 0 && len(out) >= maxIDs {
+				break
+			}
 		}
 	}
 	return out

--- a/fsmeta/exec/peras/detector_test.go
+++ b/fsmeta/exec/peras/detector_test.go
@@ -85,6 +85,41 @@ func TestConflictDetectorRemoveRetiresPendingOperation(t *testing.T) {
 	require.Equal(t, 1, detector.Len())
 }
 
+func TestConflictDetectorIDsLimitReturnsOldestPendingWindow(t *testing.T) {
+	detector := NewConflictDetector()
+	ids := []OperationID{
+		opID("c1", 1),
+		opID("c2", 1),
+		opID("c3", 1),
+	}
+	for idx, id := range ids {
+		require.NoError(t, mustAdmit(detector, id, opWithWrites(keyForBench(idx))))
+	}
+
+	require.Equal(t, ids[:2], detector.IDsLimit(2))
+	require.Equal(t, ids, detector.IDsLimit(0))
+}
+
+func TestConflictDetectorRemoveManyRetiresPendingWindow(t *testing.T) {
+	detector := NewConflictDetector()
+	first := opID("c1", 1)
+	second := opID("c2", 1)
+	third := opID("c3", 1)
+	fourth := opID("c4", 1)
+	require.NoError(t, mustAdmit(detector, first, opWithWrites("a")))
+	require.NoError(t, mustAdmit(detector, second, opWithWrites("b")))
+	require.NoError(t, mustAdmit(detector, third, opWithWrites("c")))
+
+	detector.RemoveMany(first, second)
+
+	require.Equal(t, []OperationID{third}, detector.IDs())
+	require.Equal(t, 1, detector.Len())
+	predecessors, err := detector.Admit(fourth, opWithWrites("a"))
+	require.NoError(t, err)
+	require.Empty(t, predecessors)
+	require.Equal(t, []OperationID{third, fourth}, detector.IDs())
+}
+
 func TestConflictDetectorRejectsInvalidAndDuplicateIDs(t *testing.T) {
 	detector := NewConflictDetector()
 	_, err := detector.Admit(OperationID{}, opWithWrites("a"))

--- a/fsmeta/exec/peras/holder.go
+++ b/fsmeta/exec/peras/holder.go
@@ -141,9 +141,7 @@ func (h *Holder) MarkAppliedIDs(ids ...OperationID) {
 	if h == nil || h.detector == nil {
 		return
 	}
-	for _, id := range ids {
-		h.detector.Remove(id)
-	}
+	h.detector.RemoveMany(ids...)
 	h.mu.Lock()
 	for _, id := range ids {
 		delete(h.pending, id)
@@ -179,12 +177,9 @@ func (h *Holder) BuildPendingReplayPlanForScope(firstVersion uint64, target comp
 }
 
 func (h *Holder) buildPendingReplayPlan(firstVersion uint64, include func(compile.AuthorityScope) bool, maxOps int) (ReplayPlan, compile.AuthorityScope, bool, error) {
-	ids := h.detector.IDs()
+	ids := h.detector.IDsLimit(maxOps)
 	if len(ids) == 0 {
 		return ReplayPlan{}, compile.AuthorityScope{}, false, nil
-	}
-	if maxOps > 0 && len(ids) > maxOps {
-		ids = ids[:maxOps]
 	}
 	plan := ReplayPlan{
 		EpochID:    h.epochID,

--- a/fsmeta/runtime/peras/flush_plan.go
+++ b/fsmeta/runtime/peras/flush_plan.go
@@ -224,15 +224,15 @@ func (c *Runtime) buildFlushPlan(holder *fsperas.Holder, target *compile.Authori
 		}
 		return plan, scope, ok, nil
 	}
-	pending := holder.PendingIDs()
-	if len(pending) == 0 {
+	pending := holder.Pending()
+	if pending == 0 {
 		return fsperas.ReplayPlan{}, compile.AuthorityScope{}, false, nil
 	}
 	plan, scope, err := holder.BuildPendingReplayPlanLimit(0, maxOps)
 	if err != nil {
 		return fsperas.ReplayPlan{}, compile.AuthorityScope{}, false, c.recordErrorf("build peras replay plan: %w", err)
 	}
-	if maxOps <= 0 && len(plan.Operations) != len(pending) {
+	if maxOps <= 0 && len(plan.Operations) != pending {
 		return fsperas.ReplayPlan{}, compile.AuthorityScope{}, false, c.recordError(fsperas.ErrInvalidPerasSegment)
 	}
 	return plan, scope, true, nil

--- a/fsmeta/runtime/peras/runtime.go
+++ b/fsmeta/runtime/peras/runtime.go
@@ -479,7 +479,7 @@ func (c *Runtime) flushBackground() {
 		defer cancel()
 	}
 	c.commitMu.Lock()
-	plans, err := c.freezeReplayPlansLocked(nil, c.batchSize)
+	plans, err := c.freezeReplayPlansLocked(nil, c.backgroundFlushMaxOpsPerHolder())
 	c.commitMu.Unlock()
 	var batches []perasFlushBatch
 	if err == nil {
@@ -508,6 +508,34 @@ func (c *Runtime) pendingOperations() int {
 		total += holder.Pending()
 	}
 	return total
+}
+
+func (c *Runtime) backgroundFlushMaxOpsPerHolder() int {
+	if c == nil {
+		return 0
+	}
+	maxOps := max(c.batchSize, 0)
+	workers := max(c.installN, 1)
+	segmentOps := c.maxOps
+	if segmentOps < 1 {
+		segmentOps = maxOps
+	}
+	parallelOps := multiplyIntSaturated(segmentOps, workers)
+	if parallelOps > maxOps {
+		maxOps = parallelOps
+	}
+	return maxOps
+}
+
+func multiplyIntSaturated(left, right int) int {
+	if left <= 0 || right <= 0 {
+		return 0
+	}
+	maxInt := int(^uint(0) >> 1)
+	if left > maxInt/right {
+		return maxInt
+	}
+	return left * right
 }
 
 func (c *Runtime) Close() {

--- a/fsmeta/runtime/peras/runtime_test.go
+++ b/fsmeta/runtime/peras/runtime_test.go
@@ -1173,6 +1173,40 @@ func TestRuntimeBackgroundFlushTimesOutAndBacksOff(t *testing.T) {
 	require.Equal(t, 2, committer.Stats()["pending"])
 }
 
+func TestRuntimeBackgroundFlushDrainsInstallParallelWindow(t *testing.T) {
+	provider := &fakeRuntimePerasGrantProvider{holderID: "holder-a", grant: testRuntimeCommitterGrant()}
+	installer := &fakeRuntimePerasSegmentInstaller{}
+	committer, err := NewRuntime(Config{
+		Authority:                  provider,
+		Witnesses:                  testRuntimePerasWitnesses(t, 3),
+		Installer:                  installer,
+		SegmentBatchSize:           1 << 30,
+		SegmentMaxReplayOperations: 2,
+		SegmentInstallParallelism:  3,
+		SegmentFlushEvery:          time.Hour,
+	})
+	require.NoError(t, err)
+	defer committer.Close()
+
+	ctx := context.Background()
+	for i := range 6 {
+		seq := uint64(i + 1)
+		require.NoError(t, commitRuntimePeras(ctx, committer, seq, appendUvarintKey("dentry/", seq), appendUvarintKey("inode/", seq)))
+	}
+	require.Equal(t, 6, committer.Stats()["pending"])
+
+	committer.batchSize = 2
+	committer.flushBackground()
+
+	stats := committer.Stats()
+	require.Equal(t, 0, stats["pending"])
+	require.Equal(t, uint64(1), stats["flush_batch_total"])
+	require.Equal(t, uint64(3), stats["flush_jobs_total"])
+	require.Equal(t, uint64(3), stats["flush_jobs_last"])
+	require.Equal(t, uint64(3), stats["flush_jobs_max"])
+	require.Equal(t, 3, installer.calls)
+}
+
 func TestRuntimeCloseCancelsInstallLane(t *testing.T) {
 	provider := &fakeRuntimePerasGrantProvider{holderID: "holder-a", grant: testRuntimeCommitterGrant()}
 	installer := &blockingRuntimePerasSegmentInstaller{}

--- a/fsmeta/runtime/raftstore/open.go
+++ b/fsmeta/runtime/raftstore/open.go
@@ -97,8 +97,9 @@ type Options struct {
 	// PerasSegmentWitnessRetryBackoff controls retry spacing for transient missing
 	// authority state on remote witnesses. Zero uses the default.
 	PerasSegmentWitnessRetryBackoff time.Duration
-	// PerasSegmentBatchSize controls how many visible Peras operations are
-	// compressed into one segment before opportunistic background flush starts.
+	// PerasSegmentBatchSize controls how many pending visible Peras operations
+	// trigger opportunistic background flush. SegmentMaxReplayOperations still
+	// bounds one installed segment.
 	// Zero uses the runtime default; negative is rejected.
 	PerasSegmentBatchSize int
 	// PerasSegmentMaxReplayOperations bounds one segment install by logical


### PR DESCRIPTION
## Summary
- increase Peras background flush capacity based on segment install parallelism
- avoid full pending-id copies in the flush freeze path when only bounded work is needed
- compact applied detector removals in batch to reduce pending/overlay drain overhead

## Why
The previous background drain path could keep producing one 512-operation segment per flush window even when install parallelism was available. Under official fsmeta create-heavy load this let pending and overlay memory grow faster than background flush could drain.

## Validation
- go mod tidy
- go test ./fsmeta/exec/peras ./fsmeta/runtime/peras ./fsmeta/runtime/raftstore ./cmd/nokv-fsmeta -count=1


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--peras-segment-batch-size` command-line flag to FSMetadata server for configuring background flush behavior.

* **Documentation**
  * Updated documentation for batch size configuration to clarify its role in triggering opportunistic background flush of pending operations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/feichai0017/NoKV/pull/307)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->