### PR TITLE
ci: stabilize main DCO and fsmeta long gates

### DIFF
--- a/.github/workflows/dco.yml
+++ b/.github/workflows/dco.yml
@@ -11,6 +11,7 @@ on:
 
 permissions:
   contents: read
+  pull-requests: read
 
 jobs:
   signoff:
@@ -25,6 +26,8 @@ jobs:
 
       - name: Check commit sign-offs
         shell: bash
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
 
@@ -81,9 +84,66 @@ jobs:
             grep -Eiq '^Signed-off-by: .+ <[^>]+>$' <<<"$last_paragraph"
           }
 
+          verify_pr_commits_have_signoff() {
+            local pr="$1"
+            local page=1
+            local checked=0
+
+            while :; do
+              local response
+              response="$(curl -fsSL \
+                -H "Authorization: Bearer $GITHUB_TOKEN" \
+                -H "Accept: application/vnd.github+json" \
+                -H "X-GitHub-Api-Version: 2022-11-28" \
+                "$GITHUB_API_URL/repos/$GITHUB_REPOSITORY/pulls/$pr/commits?per_page=100&page=$page")"
+
+              local page_count
+              page_count="$(jq 'length' <<<"$response")"
+              if [[ "$page_count" -eq 0 ]]; then
+                break
+              fi
+
+              while IFS= read -r encoded; do
+                local message
+                message="$(base64 -d <<<"$encoded" | jq -r '.commit.message')"
+                checked=$((checked + 1))
+                if ! has_signoff "$message"; then
+                  return 1
+                fi
+              done < <(jq -r '.[] | select((.parents | length) <= 1) | @base64' <<<"$response")
+
+              if [[ "$page_count" -lt 100 ]]; then
+                break
+              fi
+              page=$((page + 1))
+            done
+
+            [[ "$checked" -gt 0 ]]
+          }
+
+          accepts_signed_pr_squash() {
+            local commit="$1"
+            local subject
+            subject="$(git show -s --format=%s "$commit")"
+
+            if [[ "${{ github.event_name }}" != "push" || "${{ github.ref }}" != "refs/heads/main" ]]; then
+              return 1
+            fi
+            if [[ ! "$subject" =~ \(\#([0-9]+)\)$ ]]; then
+              return 1
+            fi
+
+            local pr="${BASH_REMATCH[1]}"
+            if verify_pr_commits_have_signoff "$pr"; then
+              echo "::notice title=DCO checked on PR commits::Accepted unsigned squash commit $commit because PR #$pr commits include Signed-off-by trailers."
+              return 0
+            fi
+            return 1
+          }
+
           while IFS= read -r commit; do
             message="$(git show -s --format=%B "$commit")"
-            if ! has_signoff "$message"; then
+            if ! has_signoff "$message" && ! accepts_signed_pr_squash "$commit"; then
               echo "::error title=Missing DCO sign-off::Commit $commit is missing a Signed-off-by trailer."
               git show -s --format='%h %s' "$commit"
               missing=1

--- a/.github/workflows/fsmeta-benchmark.yml
+++ b/.github/workflows/fsmeta-benchmark.yml
@@ -99,7 +99,10 @@ jobs:
 
   fsmeta-long:
     name: Benchmark / fsmeta long
-    if: github.event_name == 'push' || github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && (github.event.inputs.profile == 'long' || github.event.inputs.profile == 'official'))
+    # Full long/official fsmeta matrices are performance evidence, not a fast
+    # main-push correctness gate. Keep push/PR coverage on the median job and
+    # reserve this job for scheduled runs or explicit operator dispatch.
+    if: github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && (github.event.inputs.profile == 'long' || github.event.inputs.profile == 'official'))
     runs-on: ubuntu-latest
     timeout-minutes: 180
     steps:
@@ -119,6 +122,10 @@ jobs:
           NOKV_FSMETA_RESET_BETWEEN_WORKLOADS: "1"
           NOKV_FSMETA_PERAS_IDLE_REQUIRE_PENDING: "0"
           NOKV_FSMETA_PERAS_IDLE_TIMEOUT_SECONDS: "600"
+          NOKV_FSMETA_PERAS_SEGMENT_INSTALL_PARALLELISM: "12"
+          NOKV_FSMETA_PERAS_SEGMENT_FLUSH_PARALLELISM: "12"
+          NOKV_FSMETA_PERAS_ADMISSION_PENDING_LIMIT: "24576"
+          NOKV_FSMETA_PERAS_BACKGROUND_FLUSH_TIMEOUT: "120s"
         run: make fsmeta-bench
 
       - name: Collect Docker diagnostics


### PR DESCRIPTION
## Summary
- accept GitHub-generated main squash commits only when the source PR non-merge commits are DCO signed
- keep fsmeta median as the push/PR benchmark gate and reserve the full long/official matrix for schedule or explicit dispatch
- set explicit Peras long-run capacity knobs for scheduled/manual fsmeta long runs

## Validation
- git diff --check
- parsed .github/workflows/dco.yml and .github/workflows/fsmeta-benchmark.yml with Ruby YAML
- simulated the DCO push check against main commit bfa935f95f1a54b0f32ca0e80711d348266dc60d / PR #308
- make lint


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Enhanced commit sign-off verification in the CI pipeline with improved validation logic for pull request commits.
  * Optimized long-running performance benchmark execution to run only on scheduled events and manual triggers, with updated performance tuning parameters.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/feichai0017/NoKV/pull/310)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->