### PR TITLE
docs(site): rebase VitePress to nokv.io apex

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -4,12 +4,12 @@
 import { defineConfig } from 'vitepress'
 import { withMermaid } from 'vitepress-plugin-mermaid'
 
-const SITE_URL = 'https://feichai0017.github.io/NoKV'
+const SITE_URL = 'https://nokv.io'
 const OG_IMAGE = `${SITE_URL}/img/og.png`
 
 export default withMermaid(
   defineConfig({
-    base: '/NoKV/',
+    base: '/',
     title: 'NoKV',
     titleTemplate: ':title — NoKV',
     description:
@@ -23,7 +23,7 @@ export default withMermaid(
     ignoreDeadLinks: 'localhostLinks',
 
     head: [
-      ['link', { rel: 'icon', type: 'image/svg+xml', href: '/NoKV/img/logo.svg' }],
+      ['link', { rel: 'icon', type: 'image/svg+xml', href: '/img/logo.svg' }],
       ['link', { rel: 'preconnect', href: 'https://rsms.me/' }],
       ['link', { rel: 'stylesheet', href: 'https://rsms.me/inter/inter.css' }],
       ['meta', { name: 'theme-color', content: '#3b82f6' }],
@@ -201,7 +201,7 @@ export default withMermaid(
     },
 
     sitemap: {
-      hostname: 'https://feichai0017.github.io/NoKV/',
+      hostname: 'https://nokv.io/',
     },
 
     vite: {


### PR DESCRIPTION
## Summary

Phase 4 of the custom domain rollout. Restores the styled site after switching to the `nokv.io` apex — without this commit, `https://nokv.io/` serves the deploy HTML but every asset path still starts with `/NoKV/`, so the browser 404s the CSS bundle and we get an unstyled page.

## Changes (`docs/.vitepress/config.ts` only)

| field | before | after |
|---|---|---|
| `base` | `'/NoKV/'` | `'/'` |
| `SITE_URL` | `https://feichai0017.github.io/NoKV` | `https://nokv.io` |
| `sitemap.hostname` | `https://feichai0017.github.io/NoKV/` | `https://nokv.io/` |
| favicon href | `/NoKV/img/logo.svg` | `/img/logo.svg` |

`og:url` / `og:image` / `twitter:image` cascade from `SITE_URL` so they update automatically.

## Why nothing else needs to change

- All Vue components (`HomeHero`, `HomeRecognition`, `SiteFooter`, etc.) route asset URLs through `withBase()`, which auto-prepends whatever `base` resolves to.
- Markdown asset references like `/img/architecture.svg` are also rewritten by VitePress at build time.

## Verified locally

- [x] `npm run build` clean — 9s, no warnings beyond the existing chunk-size advisory
- [x] `dist/index.html`: asset paths `/assets/style.*.css` and `/img/logo.svg` (no `/NoKV/`)
- [x] `dist/index.html`: `<meta property="og:image" content="https://nokv.io/img/og.png">`
- [x] `git grep '/NoKV/' -- docs/` returns 0 results (excluding github.com URLs)

## Side note on Cloudflare

DNS for `nokv.io` is currently resolving to Cloudflare proxy IPs (orange cloud). That's why `gh api .../pages` shows `https_certificate: null` — GitHub can't reach the apex directly to provision Let's Encrypt. HTTPS still works via Cloudflare's own Universal SSL, so functionally fine; but if you want GitHub-issued certs (and the "Enforce HTTPS" toggle), switch the apex DNS records to DNS-only (gray cloud) for ~15 minutes until GitHub finishes provisioning, then optionally flip back to proxied with Cloudflare SSL set to **Full (Strict)**.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated site configuration to use `https://nokv.io` as the canonical URL
  * Updated base path configuration and favicon references
  * Updated sitemap hostname to reflect the new domain

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/feichai0017/NoKV/pull/313?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->