### PR TITLE
docs: switch maintainer contacts to nokv.io addresses

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,8 +61,8 @@ NoKV is that layer, open-sourced and namespace-native: server-side `ReadDirPlus`
 
 We are looking for design partners, contributors, and research collaborators working on distributed filesystems, object-storage namespace layers, AI dataset infrastructure, or agent workspace metadata.
 
-- **Eric** — [songguocheng348@gmail.com](mailto:songguocheng348@gmail.com)
-- **Jason** — [wch19961116@gmail.com](mailto:wch19961116@gmail.com)
+- **Eric** — [eric@nokv.io](mailto:eric@nokv.io)
+- **Jason** — [jason@nokv.io](mailto:jason@nokv.io)
 
 <br/>
 

--- a/docs/.vitepress/theme/components/HomeCTA.vue
+++ b/docs/.vitepress/theme/components/HomeCTA.vue
@@ -38,7 +38,7 @@ import { withBase } from 'vitepress'
           >
             View on GitHub
           </a>
-          <a class="nokv-btn nokv-btn--ghost" href="mailto:eric@nokv.io">
+          <a class="nokv-btn nokv-btn--ghost" href="mailto:contact@nokv.io">
             Contact the team
           </a>
         </div>

--- a/docs/.vitepress/theme/components/HomeCTA.vue
+++ b/docs/.vitepress/theme/components/HomeCTA.vue
@@ -38,7 +38,7 @@ import { withBase } from 'vitepress'
           >
             View on GitHub
           </a>
-          <a class="nokv-btn nokv-btn--ghost" href="mailto:songguocheng348@gmail.com">
+          <a class="nokv-btn nokv-btn--ghost" href="mailto:eric@nokv.io">
             Contact the team
           </a>
         </div>
@@ -49,11 +49,11 @@ import { withBase } from 'vitepress'
         <ul class="cta-side-list">
           <li>
             <strong>Eric</strong>
-            <a href="mailto:songguocheng348@gmail.com">songguocheng348@gmail.com</a>
+            <a href="mailto:eric@nokv.io">eric@nokv.io</a>
           </li>
           <li>
             <strong>Jason</strong>
-            <a href="mailto:wch19961116@gmail.com">wch19961116@gmail.com</a>
+            <a href="mailto:jason@nokv.io">jason@nokv.io</a>
           </li>
         </ul>
       </aside>


### PR DESCRIPTION
## Summary

Replace personal gmail addresses with the project's `nokv.io` addresses everywhere they are surfaced publicly:

| | Before | After |
|---|---|---|
| Eric | `songguocheng348@gmail.com` | `eric@nokv.io` |
| Jason | `wch19961116@gmail.com` | `jason@nokv.io` |

Cloudflare Email Routing forwards both apex addresses to the existing personal inboxes, so messages still land the same place — the public surface just stops leaking personal accounts.

## Touched

- `README.md` — Contact Us section
- `docs/.vitepress/theme/components/HomeCTA.vue` — maintainer card (Eric / Jason rows) + "Contact the team" button

## One thing worth a second look

The "Contact the team" CTA button in `HomeCTA.vue` now points at `mailto:eric@nokv.io` (it pointed at Eric's gmail before, kept 1:1). If you'd rather it go to a shared inbox like `mailto:contact@nokv.io`, say the word and I'll flip it — just need a Cloudflare Email Routing rule for the new alias.

## Verify

- [x] `git grep songguocheng348|wch19961116` returns 0
- [ ] Both `eric@nokv.io` / `jason@nokv.io` aliases configured in Cloudflare Email Routing → forwards arrive