### PR TITLE
fix(fsmeta): stabilize soak visible histories

### DIFF
--- a/.github/workflows/fsmeta-benchmark.yml
+++ b/.github/workflows/fsmeta-benchmark.yml
@@ -64,20 +64,19 @@ jobs:
 
       - name: Run median fsmeta workload matrix
         env:
+          NOKV_FSMETA_BENCH_MODE: local
           NOKV_FSMETA_PROFILE: median
           NOKV_FSMETA_OUTPUT_DIR: benchmark/data/fsmeta/results
+          NOKV_FSMETA_LOCAL_LOG_DIR: benchmark/data/fsmeta/ci
+          NOKV_FSMETA_LOCAL_WORKDIR: benchmark/data/fsmeta/local
           NOKV_FSMETA_RESET_BETWEEN_WORKLOADS: "1"
-          NOKV_FSMETA_PERAS_IDLE_REQUIRE_PENDING: "0"
         run: make fsmeta-bench
 
-      - name: Collect Docker diagnostics
+      - name: Collect local fsmeta diagnostics
         if: always()
         run: |
           mkdir -p benchmark/data/fsmeta/ci
-          docker compose ps > benchmark/data/fsmeta/ci/docker-ps.txt || true
-          docker compose logs --no-color --tail=500 > benchmark/data/fsmeta/ci/docker-compose.log || true
-          docker stats --no-stream > benchmark/data/fsmeta/ci/docker-stats.txt || true
-          curl -fsS http://127.0.0.1:9400/debug/vars > benchmark/data/fsmeta/ci/fsmeta-debug-vars.json || true
+          find benchmark/data/fsmeta/ci -maxdepth 1 -type f -print > benchmark/data/fsmeta/ci/files.txt || true
 
       - name: Upload fsmeta benchmark artifacts
         if: always()
@@ -92,10 +91,6 @@ jobs:
             benchmark/data/fsmeta/ci/*.log
             benchmark/data/fsmeta/ci/*.json
           if-no-files-found: ignore
-
-      - name: Stop Docker Compose cluster
-        if: always()
-        run: docker compose down -v || true
 
   fsmeta-long:
     name: Benchmark / fsmeta long
@@ -115,27 +110,21 @@ jobs:
 
       - name: Run long fsmeta workload matrix
         env:
+          NOKV_FSMETA_BENCH_MODE: local
           NOKV_FSMETA_PROFILE: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.profile || 'long' }}
           NOKV_FSMETA_CAPTURE_PROFILES: "1"
           NOKV_FSMETA_PROFILE_SECONDS: "60"
           NOKV_FSMETA_OUTPUT_DIR: benchmark/data/fsmeta/results
+          NOKV_FSMETA_LOCAL_LOG_DIR: benchmark/data/fsmeta/ci
+          NOKV_FSMETA_LOCAL_WORKDIR: benchmark/data/fsmeta/local
           NOKV_FSMETA_RESET_BETWEEN_WORKLOADS: "1"
-          NOKV_FSMETA_PERAS_IDLE_REQUIRE_PENDING: "0"
-          NOKV_FSMETA_PERAS_IDLE_TIMEOUT_SECONDS: "600"
-          NOKV_FSMETA_PERAS_SEGMENT_INSTALL_PARALLELISM: "12"
-          NOKV_FSMETA_PERAS_SEGMENT_FLUSH_PARALLELISM: "12"
-          NOKV_FSMETA_PERAS_ADMISSION_PENDING_LIMIT: "24576"
-          NOKV_FSMETA_PERAS_BACKGROUND_FLUSH_TIMEOUT: "120s"
         run: make fsmeta-bench
 
-      - name: Collect Docker diagnostics
+      - name: Collect local fsmeta diagnostics
         if: always()
         run: |
           mkdir -p benchmark/data/fsmeta/ci
-          docker compose ps > benchmark/data/fsmeta/ci/docker-ps.txt || true
-          docker compose logs --no-color --tail=1000 > benchmark/data/fsmeta/ci/docker-compose.log || true
-          docker stats --no-stream > benchmark/data/fsmeta/ci/docker-stats.txt || true
-          curl -fsS http://127.0.0.1:9400/debug/vars > benchmark/data/fsmeta/ci/fsmeta-debug-vars.json || true
+          find benchmark/data/fsmeta/ci -maxdepth 1 -type f -print > benchmark/data/fsmeta/ci/files.txt || true
 
       - name: Upload fsmeta benchmark artifacts
         if: always()
@@ -150,7 +139,3 @@ jobs:
             benchmark/data/fsmeta/ci/*.log
             benchmark/data/fsmeta/ci/*.json
           if-no-files-found: ignore
-
-      - name: Stop Docker Compose cluster
-        if: always()
-        run: docker compose down -v || true

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -33,7 +33,16 @@ jobs:
       run: make install-tools
 
     - name: Proto check
-      run: make proto-check
+      run: |
+        for attempt in 1 2 3; do
+          if make proto-check; then
+            exit 0
+          fi
+          if [ "$attempt" -eq 3 ]; then
+            exit 1
+          fi
+          sleep $((attempt * 10))
+        done
 
     - name: Format
       run: |

--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,7 @@ help:
 	@echo "  make proto-check        - Verify proto format, lint, and generated code"
 	@echo "  make proto-breaking-check - Run Buf breaking checks against main"
 	@echo "  make bench              - Run benchmarks"
-	@echo "  make fsmeta-bench       - Run isolated Docker Compose fsmeta workload matrix"
+	@echo "  make fsmeta-bench       - Run fsmeta workload matrix (set NOKV_FSMETA_BENCH_MODE=local|compose)"
 	@echo "  make install-tools      - Install development tools"
 	@echo "  make install-tla-tools  - Install pinned TLC locally under third_party/"
 	@echo "  make test-tla-smoke     - Run bounded TLA protocol model checks"

--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -100,7 +100,7 @@ NoKV cluster. It is a service benchmark for fsmeta's server-side API surface:
   this benchmark measures the metadata side of checkpoint publication: artifact
   fan-out, manifest update/rename, watch, snapshot read, and snapshot retire.
 
-Prerequisites:
+Prerequisites for the default Compose mode:
 
 - a running NoKV Docker Compose cluster, or equivalent coordinator/store/fsmeta
   deployment
@@ -123,6 +123,18 @@ checkpointing source links, the official shape, and NoKV's metadata-service
 projection. It does not vendor third-party benchmark code or claim a certified
 IO500/Filebench/MLPerf score.
 
+For CI and single-node tuning, run the same workload driver against the embedded
+fsmeta backend:
+
+```bash
+NOKV_FSMETA_BENCH_MODE=local make fsmeta-bench
+```
+
+Local mode builds `cmd/nokv-fsmeta`, starts it with `--backend local`, skips
+coordinator mount bootstrap, and writes `fsmeta_local_*` CSV/manifests. It is
+the right benchmark for the single-node product shape; Compose mode remains the
+distributed raftstore/Peras benchmark.
+
 Default scale is the PR-oriented `median` service run from that profile: 12
 clients, 16 mdtest/mimesis directories x 256 files, 16 varmail users x 128
 messages, and 4 AI workspaces x 64 checkpoint publishes x 8 artifact files.
@@ -138,8 +150,9 @@ session leases do not dominate throughput measurements. The script also waits
 fresh Compose cluster can finish Raft leader election and coordinator grant
 publication; set `NOKV_FSMETA_STABILIZE_SECONDS=0` for an already-warm cluster.
 The underlying script is `scripts/run_fsmeta_benchmarks.sh`; set
-`NOKV_FSMETA_BENCH_MODE=derived-cache` to run the cache on/off slice with two
-temporary fsmeta gateways.
+`NOKV_FSMETA_BENCH_MODE=local`, `compose`, or `derived-cache` to choose the
+runtime shape. The cache on/off slice still requires a running distributed
+cluster because it compares two raftstore-backed gateways.
 
 By default the Compose matrix resets Docker volumes between workloads
 (`NOKV_FSMETA_RESET_BETWEEN_WORKLOADS=1`). This keeps each workload from

--- a/cmd/nokv-fsmeta-soak/main.go
+++ b/cmd/nokv-fsmeta-soak/main.go
@@ -54,7 +54,13 @@ func runRound(ctx context.Context, addr string, mount fsmeta.MountID, seed int64
 	roundCtx, cancel := context.WithTimeout(ctx, 90*time.Second)
 	defer cancel()
 
-	cli, err := fsmetaclient.NewGRPCClient(roundCtx, addr)
+	// The soak checker validates operation histories, so it must read through
+	// the authoritative service path instead of the client's positive lookup
+	// cache. A concurrent read can legitimately return an older dentry after a
+	// rename invalidated the cache, then repopulate that stale value.
+	cli, err := fsmetaclient.NewGRPCClientWithConfig(roundCtx, addr, fsmetaclient.ClientConfig{
+		DisableLookupCache: true,
+	})
 	if err != nil {
 		return fmt.Errorf("dial fsmeta: %w", err)
 	}

--- a/docs/guide/testing.md
+++ b/docs/guide/testing.md
@@ -237,9 +237,11 @@ Nightly policy:
 
 1. PR CI runs bounded smoke through `make test-correctness-smoke`, including
    `make test-history-smoke` and `make test-model-smoke`.
-2. PR benchmark CI also runs the median `make fsmeta-bench` profile as an
-   isolated Docker Compose matrix across all fsmeta workloads. Each workload gets
-   a fresh Compose data volume, its own CSV, and the script also emits a
+2. PR benchmark CI also runs the median `make fsmeta-bench` profile with
+   `NOKV_FSMETA_BENCH_MODE=local`, so the gating benchmark measures the
+   embedded fsmeta backend instead of spending runner budget on a full
+   raftstore/root/coordinator Compose cluster. Each workload gets a fresh local
+   workdir, its own CSV, and the script also emits a
    combined `_isolated.csv` summary so durable-barrier workloads do not absorb
    earlier visible-commit backlog. CSVs
    report both wall-clock `throughput_ops_sec` and per-operation
@@ -247,14 +249,14 @@ Nightly policy:
    active operation cost. The median, long, and official fsmeta scales are read
    from `benchmark/fsmeta/profiles/official/workloads.yaml`, and each run emits
    a manifest with the selected scale and official workload provenance. The
-   default CI idle check waits for install and seal queues, not Peras `pending`;
-   set `NOKV_FSMETA_PERAS_IDLE_REQUIRE_PENDING=1` only for explicit durable-drain
-   experiments.
+   default CI path does not exercise Peras witness/install queues; use Compose
+   mode explicitly for distributed durable-drain experiments.
 3. Nightly CI runs `make test-correctness-nightly`, which raises model seeds
    and steps, replays raftstore/fsmeta contract/history schedules with longer
    bounds, repeats crash-matrix boundaries, replays deterministic split-region
    fault simulation, and repeats failpoint-heavy coordinator/meta/raftstore suites.
-4. Scheduled fsmeta benchmark CI runs `NOKV_FSMETA_PROFILE=long make fsmeta-bench`
+4. Scheduled fsmeta benchmark CI runs
+   `NOKV_FSMETA_BENCH_MODE=local NOKV_FSMETA_PROFILE=long make fsmeta-bench`
    with the same isolated matrix shape, larger data volumes, and longer timeout,
    then uploads the same artifacts. Manual dispatch can select
    `NOKV_FSMETA_PROFILE=official`, but use it only when the runner budget can

--- a/fsmeta/contract/mapping.go
+++ b/fsmeta/contract/mapping.go
@@ -5,6 +5,7 @@ package contract
 
 import (
 	"context"
+	"errors"
 	"sync"
 
 	nokverrors "github.com/feichai0017/NoKV/errors"
@@ -25,6 +26,7 @@ func NewInodeMappingExecutor(base Executor) (Executor, error) {
 		base:            base,
 		plannedToActual: make(map[fsmeta.InodeID]fsmeta.InodeID),
 		actualToPlanned: make(map[fsmeta.InodeID]fsmeta.InodeID),
+		pendingCreates:  make(map[dentryKey]fsmeta.InodeID),
 	}
 	m.rememberLocked(fsmeta.RootInode, fsmeta.RootInode)
 	return m, nil
@@ -36,17 +38,26 @@ type inodeMappingExecutor struct {
 	mu              sync.RWMutex
 	plannedToActual map[fsmeta.InodeID]fsmeta.InodeID
 	actualToPlanned map[fsmeta.InodeID]fsmeta.InodeID
+	pendingCreates  map[dentryKey]fsmeta.InodeID
 }
 
 func (m *inodeMappingExecutor) Create(ctx context.Context, req fsmeta.CreateRequest) (fsmeta.CreateResult, error) {
 	planned, hasPlanned := plannedCreateInode(ctx)
 	req.Parent = m.actualInode(req.Parent)
+	pendingKey := dentryKey{parent: req.Parent, name: req.Name}
+	if hasPlanned {
+		m.rememberPendingCreate(pendingKey, planned)
+	}
 	result, err := m.base.Create(ctx, req)
 	if err != nil {
 		if hasPlanned && createOutcomeAmbiguous(err) {
 			if recovered, ok := m.recoverCreate(ctx, req, planned); ok {
+				m.clearPendingCreate(planned)
 				return recovered, nil
 			}
+		}
+		if hasPlanned {
+			m.clearPendingCreate(planned)
 		}
 		return fsmeta.CreateResult{}, err
 	}
@@ -54,6 +65,9 @@ func (m *inodeMappingExecutor) Create(ctx context.Context, req fsmeta.CreateRequ
 		planned = result.Inode.Inode
 	}
 	m.remember(planned, result.Inode.Inode)
+	if hasPlanned {
+		m.clearPendingCreate(planned)
+	}
 	return m.translateCreateResult(result), nil
 }
 
@@ -62,10 +76,24 @@ func createOutcomeAmbiguous(err error) bool {
 }
 
 func (m *inodeMappingExecutor) UpdateInode(ctx context.Context, req fsmeta.UpdateInodeRequest) (fsmeta.InodeRecord, error) {
+	planned := req.Inode
 	req.Parent = m.actualInode(req.Parent)
-	req.Inode = m.actualInode(req.Inode)
+	if actual, ok := m.resolvePendingCreateActual(ctx, req.Mount, req.Parent, req.Name, planned); ok {
+		req.Inode = actual
+	} else {
+		req.Inode = m.actualInode(planned)
+	}
 	record, err := m.base.UpdateInode(ctx, req)
 	if err != nil {
+		if (errors.Is(err, fsmeta.ErrInvalidRequest) || errors.Is(err, fsmeta.ErrNotFound)) && planned != 0 {
+			if actual, ok := m.resolvePendingCreateActual(ctx, req.Mount, req.Parent, req.Name, planned); ok && actual != req.Inode {
+				req.Inode = actual
+				record, err = m.base.UpdateInode(ctx, req)
+				if err == nil {
+					return m.translateInodeRecord(record), nil
+				}
+			}
+		}
 		return fsmeta.InodeRecord{}, err
 	}
 	return m.translateInodeRecord(record), nil
@@ -181,8 +209,9 @@ func (m *inodeMappingExecutor) translateCreateResult(result fsmeta.CreateResult)
 }
 
 func (m *inodeMappingExecutor) translateDentryRecord(record fsmeta.DentryRecord) fsmeta.DentryRecord {
-	record.Parent = m.plannedInode(record.Parent)
-	record.Inode = m.plannedInode(record.Inode)
+	actualParent := record.Parent
+	record.Parent = m.plannedInode(actualParent)
+	record.Inode = m.plannedInodeForDentry(actualParent, record.Name, record.Inode)
 	return record
 }
 
@@ -209,6 +238,49 @@ func (m *inodeMappingExecutor) actualInode(planned fsmeta.InodeID) fsmeta.InodeI
 	return planned
 }
 
+func (m *inodeMappingExecutor) resolvePendingCreateActual(ctx context.Context, mount fsmeta.MountID, parent fsmeta.InodeID, name string, planned fsmeta.InodeID) (fsmeta.InodeID, bool) {
+	if planned == 0 || name == "" {
+		return 0, false
+	}
+	if actual, ok := m.actualInodeIfKnown(planned); ok {
+		return actual, true
+	}
+	key := dentryKey{parent: parent, name: name}
+	if !m.pendingCreateMatches(key, planned) {
+		return 0, false
+	}
+	dentry, err := m.base.Lookup(ctx, fsmeta.LookupRequest{
+		Mount:  mount,
+		Parent: parent,
+		Name:   name,
+	})
+	if err != nil {
+		return 0, false
+	}
+	m.remember(planned, dentry.Inode)
+	return dentry.Inode, true
+}
+
+func (m *inodeMappingExecutor) actualInodeIfKnown(planned fsmeta.InodeID) (fsmeta.InodeID, bool) {
+	if planned == 0 {
+		return 0, false
+	}
+	m.mu.RLock()
+	actual, ok := m.plannedToActual[planned]
+	m.mu.RUnlock()
+	return actual, ok
+}
+
+func (m *inodeMappingExecutor) pendingCreateMatches(key dentryKey, planned fsmeta.InodeID) bool {
+	if planned == 0 {
+		return false
+	}
+	m.mu.RLock()
+	pending, ok := m.pendingCreates[key]
+	m.mu.RUnlock()
+	return ok && pending == planned
+}
+
 func (m *inodeMappingExecutor) plannedInode(actual fsmeta.InodeID) fsmeta.InodeID {
 	if actual == 0 {
 		return 0
@@ -217,6 +289,22 @@ func (m *inodeMappingExecutor) plannedInode(actual fsmeta.InodeID) fsmeta.InodeI
 	planned, ok := m.actualToPlanned[actual]
 	m.mu.RUnlock()
 	if ok {
+		return planned
+	}
+	return actual
+}
+
+func (m *inodeMappingExecutor) plannedInodeForDentry(parent fsmeta.InodeID, name string, actual fsmeta.InodeID) fsmeta.InodeID {
+	if actual == 0 {
+		return 0
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if planned, ok := m.actualToPlanned[actual]; ok {
+		return planned
+	}
+	if planned, ok := m.pendingCreates[dentryKey{parent: parent, name: name}]; ok {
+		m.rememberLocked(planned, actual)
 		return planned
 	}
 	return actual
@@ -234,4 +322,26 @@ func (m *inodeMappingExecutor) remember(planned, actual fsmeta.InodeID) {
 func (m *inodeMappingExecutor) rememberLocked(planned, actual fsmeta.InodeID) {
 	m.plannedToActual[planned] = actual
 	m.actualToPlanned[actual] = planned
+}
+
+func (m *inodeMappingExecutor) rememberPendingCreate(key dentryKey, planned fsmeta.InodeID) {
+	if planned == 0 {
+		return
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.pendingCreates[key] = planned
+}
+
+func (m *inodeMappingExecutor) clearPendingCreate(planned fsmeta.InodeID) {
+	if planned == 0 {
+		return
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	for key, pending := range m.pendingCreates {
+		if pending == planned {
+			delete(m.pendingCreates, key)
+		}
+	}
 }

--- a/fsmeta/contract/mapping_test.go
+++ b/fsmeta/contract/mapping_test.go
@@ -6,6 +6,7 @@ package contract
 import (
 	"context"
 	"errors"
+	"sync"
 	"testing"
 
 	"github.com/feichai0017/NoKV/fsmeta"
@@ -78,12 +79,114 @@ func TestInodeMappingExecutorDoesNotRecoverSemanticCreateError(t *testing.T) {
 	}
 }
 
+func TestInodeMappingExecutorTranslatesCreateObservedBeforeReturn(t *testing.T) {
+	base := newFakeExternalExecutor()
+	createCommitted := make(chan struct{})
+	releaseCreate := make(chan struct{})
+	base.createCommitted = createCommitted
+	base.releaseCreate = releaseCreate
+	exec, err := NewInodeMappingExecutor(base)
+	if err != nil {
+		t.Fatalf("NewInodeMappingExecutor: %v", err)
+	}
+
+	type createResult struct {
+		result fsmeta.CreateResult
+		err    error
+	}
+	done := make(chan createResult, 1)
+	go func() {
+		result, err := exec.Create(withPlannedCreateInode(context.Background(), 10), fsmeta.CreateRequest{
+			Mount:  "vol",
+			Parent: fsmeta.RootInode,
+			Name:   "alpha",
+			Attrs:  fsmeta.CreateAttrs{Type: fsmeta.InodeTypeFile, Mode: 0o644},
+		})
+		done <- createResult{result: result, err: err}
+	}()
+	<-createCommitted
+
+	pairs, err := exec.ReadDirPlus(context.Background(), fsmeta.ReadDirRequest{
+		Mount:  "vol",
+		Parent: fsmeta.RootInode,
+		Limit:  16,
+	})
+	if err != nil {
+		t.Fatalf("ReadDirPlus: %v", err)
+	}
+	if len(pairs) != 1 {
+		t.Fatalf("ReadDirPlus returned %d pairs, want 1: %#v", len(pairs), pairs)
+	}
+	if pairs[0].Dentry.Inode != 10 || pairs[0].Inode.Inode != 10 {
+		t.Fatalf("pending create was not translated to planned inode: %#v", pairs[0])
+	}
+
+	close(releaseCreate)
+	created := <-done
+	if created.err != nil {
+		t.Fatalf("Create: %v", created.err)
+	}
+	if created.result.Dentry.Inode != 10 || created.result.Inode.Inode != 10 {
+		t.Fatalf("Create result was not translated to planned inode: %+v", created.result)
+	}
+}
+
+func TestInodeMappingExecutorUpdatesCreateObservedBeforeReturn(t *testing.T) {
+	base := newFakeExternalExecutor()
+	createCommitted := make(chan struct{})
+	releaseCreate := make(chan struct{})
+	base.createCommitted = createCommitted
+	base.releaseCreate = releaseCreate
+	exec, err := NewInodeMappingExecutor(base)
+	if err != nil {
+		t.Fatalf("NewInodeMappingExecutor: %v", err)
+	}
+
+	done := make(chan error, 1)
+	go func() {
+		_, err := exec.Create(withPlannedCreateInode(context.Background(), 10), fsmeta.CreateRequest{
+			Mount:  "vol",
+			Parent: fsmeta.RootInode,
+			Name:   "alpha",
+			Attrs:  fsmeta.CreateAttrs{Type: fsmeta.InodeTypeFile, Mode: 0o644},
+		})
+		done <- err
+	}()
+	<-createCommitted
+
+	updated, err := exec.UpdateInode(context.Background(), fsmeta.UpdateInodeRequest{
+		Mount:   "vol",
+		Parent:  fsmeta.RootInode,
+		Name:    "alpha",
+		Inode:   10,
+		SetSize: true,
+		Size:    128,
+	})
+	if err != nil {
+		t.Fatalf("UpdateInode: %v", err)
+	}
+	if updated.Inode != 10 {
+		t.Fatalf("UpdateInode returned inode %d, want planned inode 10", updated.Inode)
+	}
+	if base.lastUpdated == 10 {
+		t.Fatalf("UpdateInode reached base with planned inode instead of actual inode")
+	}
+
+	close(releaseCreate)
+	if err := <-done; err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+}
+
 type fakeExternalExecutor struct {
+	mu                   sync.Mutex
 	next                 fsmeta.InodeID
 	dentries             map[[2]any]fsmeta.DentryRecord
 	inodes               map[fsmeta.InodeID]fsmeta.InodeRecord
 	lastUpdated          fsmeta.InodeID
 	createErrAfterCommit error
+	createCommitted      chan struct{}
+	releaseCreate        chan struct{}
 }
 
 func newFakeExternalExecutor() *fakeExternalExecutor {
@@ -96,8 +199,10 @@ func newFakeExternalExecutor() *fakeExternalExecutor {
 }
 
 func (f *fakeExternalExecutor) Create(_ context.Context, req fsmeta.CreateRequest) (fsmeta.CreateResult, error) {
+	f.mu.Lock()
 	key := [2]any{req.Parent, req.Name}
 	if _, ok := f.dentries[key]; ok {
+		f.mu.Unlock()
 		return fsmeta.CreateResult{}, fsmeta.ErrExists
 	}
 	inodeID := f.next
@@ -106,13 +211,25 @@ func (f *fakeExternalExecutor) Create(_ context.Context, req fsmeta.CreateReques
 	dentry := fsmeta.DentryRecord{Parent: req.Parent, Name: req.Name, Inode: inodeID, Type: req.Attrs.Type}
 	f.dentries[key] = dentry
 	f.inodes[inodeID] = inode
-	if f.createErrAfterCommit != nil {
-		return fsmeta.CreateResult{}, f.createErrAfterCommit
+	if f.createCommitted != nil {
+		close(f.createCommitted)
+		f.createCommitted = nil
+	}
+	release := f.releaseCreate
+	errAfterCommit := f.createErrAfterCommit
+	f.mu.Unlock()
+	if release != nil {
+		<-release
+	}
+	if errAfterCommit != nil {
+		return fsmeta.CreateResult{}, errAfterCommit
 	}
 	return fsmeta.CreateResult{Dentry: dentry, Inode: inode}, nil
 }
 
 func (f *fakeExternalExecutor) UpdateInode(_ context.Context, req fsmeta.UpdateInodeRequest) (fsmeta.InodeRecord, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
 	dentry, ok := f.dentries[[2]any{req.Parent, req.Name}]
 	if !ok || dentry.Inode != req.Inode {
 		return fsmeta.InodeRecord{}, fsmeta.ErrNotFound
@@ -126,6 +243,8 @@ func (f *fakeExternalExecutor) UpdateInode(_ context.Context, req fsmeta.UpdateI
 }
 
 func (f *fakeExternalExecutor) Lookup(_ context.Context, req fsmeta.LookupRequest) (fsmeta.DentryRecord, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
 	dentry, ok := f.dentries[[2]any{req.Parent, req.Name}]
 	if !ok {
 		return fsmeta.DentryRecord{}, fsmeta.ErrNotFound
@@ -134,6 +253,8 @@ func (f *fakeExternalExecutor) Lookup(_ context.Context, req fsmeta.LookupReques
 }
 
 func (f *fakeExternalExecutor) ReadDirPlus(_ context.Context, req fsmeta.ReadDirRequest) ([]fsmeta.DentryAttrPair, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
 	var out []fsmeta.DentryAttrPair
 	for key, dentry := range f.dentries {
 		if key[0] != req.Parent {

--- a/fsmeta/exec/errors.go
+++ b/fsmeta/exec/errors.go
@@ -11,4 +11,5 @@ var (
 	errAuditorRunnerRequired         = nokverrors.New(nokverrors.KindInvalidArgument, "fsmeta/exec: auditor runner required")
 	errSubtreeHandoffWithoutFrontier = nokverrors.New(nokverrors.KindProtocolViolation, "fsmeta/exec: subtree handoff started without committed frontier")
 	errPerasAuthorityNotHeld         = nokverrors.New(nokverrors.KindNotLeader, "fsmeta/exec: peras authority is held by another holder")
+	errPerasOverlayFallbackUnsafe    = nokverrors.New(nokverrors.KindUnavailable, "fsmeta/exec: peras overlay read cannot safely fall back to base mutation")
 )

--- a/fsmeta/exec/executor.go
+++ b/fsmeta/exec/executor.go
@@ -56,11 +56,21 @@ type TxnRunner interface {
 	MutateAtCommit(ctx context.Context, primary []byte, mutations []*kvrpcpb.Mutation, startVersion, commitVersion, lockTTL uint64) (uint64, error)
 }
 
-// AtomicMutateOnePhase is an optional TxnRunner extension. handled=false
-// means the runner could not keep the mutation in one proven-atomic local
-// apply group and the caller must fall back to Mutate.
+// AtomicMutateOnePhase is a raw one-phase mutation capability. It is not enough
+// by itself for fsmeta semantic execution: caller-allocated commit timestamps
+// can otherwise let a read at a later timestamp race ahead of a delayed 1PC
+// apply and observe a fractured directory/inode view.
 type AtomicMutateOnePhase interface {
 	TryAtomicMutate(ctx context.Context, primary []byte, predicates []*kvrpcpb.AtomicPredicate, mutations []*kvrpcpb.Mutation, startVersion, commitVersion uint64) (handled bool, err error)
+}
+
+// ReadOrderedAtomicMutateOnePhase is the one-phase mutation contract the
+// fsmeta executor may consume. Implementations must guarantee that a read at
+// version T cannot miss any successful 1PC write whose commit version is <= T
+// merely because the write had not reached the storage apply boundary yet.
+type ReadOrderedAtomicMutateOnePhase interface {
+	AtomicMutateOnePhase
+	AtomicMutatePreservesReadOrder() bool
 }
 
 // InodeAllocator assigns Create inode IDs. The executor allocates once before
@@ -130,6 +140,12 @@ type PerasOverlayReader interface {
 	// the returned value.
 	GetPerasOverlayView(key []byte) (value []byte, deleted bool, ok bool)
 	ScanPerasOverlay(start []byte, limit uint32) []fsperas.OverlayKV
+}
+
+type PerasOverlayReadSnapshotReader interface {
+	CapturePerasOverlayRead() (overlayGeneration, sealedGeneration uint64)
+	GetPerasOverlayViewAt(overlayGeneration, sealedGeneration uint64, key []byte) (value []byte, deleted bool, ok bool)
+	ScanPerasDirectoryAt(overlayGeneration, sealedGeneration uint64, prefix, start []byte, limit uint32) []fsperas.OverlayKV
 }
 
 type PerasDirectoryOverlayReader interface {

--- a/fsmeta/exec/executor_create_test.go
+++ b/fsmeta/exec/executor_create_test.go
@@ -434,6 +434,28 @@ func TestExecutorCreateUsesAtomicMutateOnePhaseWhenHandled(t *testing.T) {
 	require.Equal(t, fsmeta.InodeID(22), record.Inode)
 }
 
+func TestExecutorCreateSkipsSpeculativeAtomicMutateWithoutReadOrdering(t *testing.T) {
+	base := newFakeRunner()
+	runner := &fakeSpeculativeAtomicRunner{fakeRunner: base}
+	executor, err := newTestExecutor(runner, WithInodeAllocator(&fakeInodeAllocator{ids: []fsmeta.InodeID{22}}))
+	require.NoError(t, err)
+
+	_, err = executor.Create(context.Background(), fsmeta.CreateRequest{
+		Mount:  "vol",
+		Parent: fsmeta.RootInode,
+		Name:   "file",
+		Attrs:  fsmeta.CreateAttrs{Type: fsmeta.InodeTypeFile},
+	})
+	require.NoError(t, err)
+
+	require.Empty(t, runner.atomicCalls)
+	require.Len(t, base.mutations, 1)
+	stats := executor.Stats()
+	requireAtomicStatUint(t, stats, fsmeta.OperationCreate, "attempt_total", 0)
+	requireAtomicStatUint(t, stats, fsmeta.OperationCreate, "success_total", 0)
+	requireAtomicStatUint(t, stats, fsmeta.OperationCreate, "runner_unsupported_total", 1)
+}
+
 func TestExecutorCreateFallsBackWhenAtomicMutateNotHandled(t *testing.T) {
 	base := newFakeRunner()
 	runner := &fakeAtomicRunner{fakeRunner: base, handled: false}

--- a/fsmeta/exec/executor_inode.go
+++ b/fsmeta/exec/executor_inode.go
@@ -75,7 +75,7 @@ func (e *Executor) tryPerasVisibleUpdateInode(ctx context.Context, program compi
 	if err != nil {
 		return fsmeta.InodeRecord{}, false, err
 	}
-	committed, err := e.tryPerasVisibleCommit(ctx, concrete)
+	committed, err := e.tryPerasVisibleCommitAfterRead(ctx, view, concrete)
 	if err != nil {
 		return fsmeta.InodeRecord{}, committed, err
 	}

--- a/fsmeta/exec/executor_link.go
+++ b/fsmeta/exec/executor_link.go
@@ -84,7 +84,7 @@ func (e *Executor) tryPerasVisibleLink(ctx context.Context, program compile.Link
 	if err != nil {
 		return false, err
 	}
-	return e.tryPerasVisibleCommit(ctx, concrete)
+	return e.tryPerasVisibleCommitAfterRead(ctx, view, concrete)
 }
 
 // Link creates a second dentry for an existing non-directory inode and bumps

--- a/fsmeta/exec/executor_lookup.go
+++ b/fsmeta/exec/executor_lookup.go
@@ -24,11 +24,26 @@ func (e *Executor) Lookup(ctx context.Context, req fsmeta.LookupRequest) (fsmeta
 	if err != nil {
 		return fsmeta.DentryRecord{}, err
 	}
-	program, err := compile.CompileLookupReadProgram(req, mountRecord.Identity())
+	mount := mountRecord.Identity()
+	program, err := compile.CompileLookupReadProgram(req, mount)
 	if err != nil {
 		return fsmeta.DentryRecord{}, err
 	}
 	plan := program.Plan
+	if e.perasDirectoryHasOverlay(mount, req.Parent) {
+		record, found, err := e.lookupMergedDentry(ctx, mount, req.Parent, plan.PrimaryKey)
+		if err != nil {
+			return fsmeta.DentryRecord{}, err
+		}
+		if !found {
+			if e.negCache != nil {
+				e.negCache.Remember(plan.PrimaryKey)
+			}
+			return fsmeta.DentryRecord{}, fsmeta.ErrNotFound
+		}
+		e.invalidateNegative(plan.PrimaryKey)
+		return record, nil
+	}
 	if value, deleted, ok := e.readPerasProgram(program); ok {
 		e.invalidateNegative(plan.PrimaryKey)
 		if deleted {
@@ -54,6 +69,43 @@ func (e *Executor) Lookup(ctx context.Context, req fsmeta.LookupRequest) (fsmeta
 		return fsmeta.DentryRecord{}, fsmeta.ErrNotFound
 	}
 	return fsmeta.DecodeDentryValue(value)
+}
+
+func (e *Executor) lookupMergedDentry(ctx context.Context, mount fsmeta.MountIdentity, parent fsmeta.InodeID, key []byte) (fsmeta.DentryRecord, bool, error) {
+	prefix, err := fsmeta.EncodeDentryPrefix(mount, parent)
+	if err != nil {
+		return fsmeta.DentryRecord{}, false, err
+	}
+	plan := compile.DirectoryReadPlan{
+		Prefix:       prefix,
+		StartKey:     cloneBytes(key),
+		Limit:        1,
+		IncludePeras: true,
+	}
+	var record fsmeta.DentryRecord
+	var found bool
+	err = e.withReadRetry(ctx, 0, func(version uint64) error {
+		overlayGeneration, sealedGeneration := e.capturePerasOverlayRead(true)
+		kvs, _, _, _, err := e.scanMergedDirectoryRowsAt(ctx, plan, version, false, overlayGeneration, sealedGeneration)
+		if err != nil {
+			return err
+		}
+		if len(kvs) == 0 || !bytes.Equal(kvs[0].Key, key) {
+			found = false
+			return nil
+		}
+		decoded, err := fsmeta.DecodeDentryValue(kvs[0].Value)
+		if err != nil {
+			return err
+		}
+		record = decoded
+		found = true
+		return nil
+	})
+	if err != nil {
+		return fsmeta.DentryRecord{}, false, err
+	}
+	return record, found, nil
 }
 
 // LookupPlus returns one dentry and its inode attributes at the same read
@@ -260,11 +312,12 @@ func (e *Executor) ReadDirPlus(ctx context.Context, req fsmeta.ReadDirRequest) (
 		}
 	}
 	if overlayOnly {
-		dentries, err := e.scanDentries(ctx, plan, 0, false)
+		overlayGeneration, sealedGeneration := e.capturePerasOverlayRead(includeOverlay)
+		dentries, err := e.scanDentriesAt(ctx, plan, 0, false, overlayGeneration, sealedGeneration)
 		if err != nil {
 			return nil, err
 		}
-		if pairs, ok, err := e.readDirPlusFromPerasView(mount, dentries); err != nil {
+		if pairs, ok, err := e.readDirPlusFromPerasViewAt(mount, dentries, overlayGeneration, sealedGeneration); err != nil {
 			return nil, err
 		} else if ok {
 			if useDirPage {
@@ -277,7 +330,8 @@ func (e *Executor) ReadDirPlus(ctx context.Context, req fsmeta.ReadDirRequest) (
 	var out []fsmeta.DentryAttrPair
 	snapshotRead := req.SnapshotVersion != 0
 	err = e.withReadRetry(ctx, req.SnapshotVersion, func(version uint64) error {
-		dentries, err := e.scanDentries(ctx, plan, version, snapshotRead)
+		overlayGeneration, sealedGeneration := e.capturePerasOverlayRead(includeOverlay && !snapshotRead)
+		dentries, err := e.scanDentriesAt(ctx, plan, version, snapshotRead, overlayGeneration, sealedGeneration)
 		if err != nil {
 			return err
 		}
@@ -289,7 +343,7 @@ func (e *Executor) ReadDirPlus(ctx context.Context, req fsmeta.ReadDirRequest) (
 		if err != nil {
 			return err
 		}
-		inodeValues, inodePresent, err := e.batchGetMergedValuesOrdered(ctx, inodeKeys, version, includeOverlay, snapshotRead)
+		inodeValues, inodePresent, err := e.batchGetMergedValuesOrderedAt(ctx, inodeKeys, version, includeOverlay, snapshotRead, overlayGeneration, sealedGeneration)
 		if err != nil {
 			return err
 		}
@@ -325,6 +379,17 @@ func (e *Executor) ReadDirPlus(ctx context.Context, req fsmeta.ReadDirRequest) (
 	return out, nil
 }
 
+func (e *Executor) capturePerasOverlayRead(includeOverlay bool) (uint64, uint64) {
+	if !includeOverlay {
+		return 0, 0
+	}
+	reader := e.perasOverlayReadSnapshot()
+	if reader == nil {
+		return 0, 0
+	}
+	return reader.CapturePerasOverlayRead()
+}
+
 func (e *Executor) materializeDirPage(pageKey dirpage.PageKey, frontier uint64, pairs []fsmeta.DentryAttrPair) {
 	if e == nil || e.dirPages == nil {
 		return
@@ -337,6 +402,10 @@ func (e *Executor) materializeDirPage(pageKey dirpage.PageKey, frontier uint64, 
 }
 
 func (e *Executor) readDirPlusFromPerasView(mount fsmeta.MountIdentity, dentries []fsmeta.DentryRecord) ([]fsmeta.DentryAttrPair, bool, error) {
+	return e.readDirPlusFromPerasViewAt(mount, dentries, 0, 0)
+}
+
+func (e *Executor) readDirPlusFromPerasViewAt(mount fsmeta.MountIdentity, dentries []fsmeta.DentryRecord, overlayGeneration, sealedGeneration uint64) ([]fsmeta.DentryAttrPair, bool, error) {
 	if len(dentries) == 0 {
 		return []fsmeta.DentryAttrPair{}, true, nil
 	}
@@ -345,12 +414,20 @@ func (e *Executor) readDirPlusFromPerasView(mount fsmeta.MountIdentity, dentries
 		return nil, false, err
 	}
 	overlay := e.perasOverlay()
-	if overlay == nil {
+	readSnapshot := e.perasOverlayReadSnapshot()
+	useReadSnapshot := readSnapshot != nil && (overlayGeneration != 0 || sealedGeneration != 0)
+	if overlay == nil && !useReadSnapshot {
 		return nil, false, nil
 	}
 	pairs := make([]fsmeta.DentryAttrPair, 0, len(dentries))
 	for i, dentry := range dentries {
-		value, deleted, ok := overlay.GetPerasOverlayView(inodeKeys[i])
+		var value []byte
+		var deleted, ok bool
+		if useReadSnapshot {
+			value, deleted, ok = readSnapshot.GetPerasOverlayViewAt(overlayGeneration, sealedGeneration, inodeKeys[i])
+		} else {
+			value, deleted, ok = overlay.GetPerasOverlayView(inodeKeys[i])
+		}
 		if !ok || deleted {
 			return nil, false, nil
 		}
@@ -367,13 +444,18 @@ func (e *Executor) readDirPlusFromPerasView(mount fsmeta.MountIdentity, dentries
 }
 
 func (e *Executor) scanDentries(ctx context.Context, plan compile.DirectoryReadPlan, version uint64, snapshotRead bool) ([]fsmeta.DentryRecord, error) {
+	overlayGeneration, sealedGeneration := e.capturePerasOverlayRead(plan.IncludePeras && !snapshotRead)
+	return e.scanDentriesAt(ctx, plan, version, snapshotRead, overlayGeneration, sealedGeneration)
+}
+
+func (e *Executor) scanDentriesAt(ctx context.Context, plan compile.DirectoryReadPlan, version uint64, snapshotRead bool, overlayGeneration, sealedGeneration uint64) ([]fsmeta.DentryRecord, error) {
 	var kvs []KV
 	stats := compile.DirectoryReadStats{UsedPerasOnly: plan.PerasOnly}
 	if !plan.PerasOnly {
 		if plan.IncludePeras {
 			var perasRows uint32
 			var err error
-			kvs, stats.BaseRows, perasRows, stats.UsedDirIndex, err = e.scanMergedDirectoryRows(ctx, plan, version, snapshotRead)
+			kvs, stats.BaseRows, perasRows, stats.UsedDirIndex, err = e.scanMergedDirectoryRowsAt(ctx, plan, version, snapshotRead, overlayGeneration, sealedGeneration)
 			if err != nil {
 				return nil, err
 			}
@@ -388,7 +470,7 @@ func (e *Executor) scanDentries(ctx context.Context, plan compile.DirectoryReadP
 		}
 	} else if plan.IncludePeras {
 		var perasRows uint32
-		kvs, perasRows, stats.UsedDirIndex = e.mergePerasDirectoryOverlayScan(kvs, plan.Prefix, plan.StartKey, plan.Limit)
+		kvs, perasRows, stats.UsedDirIndex = e.mergePerasDirectoryOverlayScanAt(kvs, plan.Prefix, plan.StartKey, plan.Limit, overlayGeneration, sealedGeneration)
 		stats.PerasRows = perasRows
 	}
 	out := make([]fsmeta.DentryRecord, 0, len(kvs))

--- a/fsmeta/exec/executor_lookup_test.go
+++ b/fsmeta/exec/executor_lookup_test.go
@@ -7,6 +7,7 @@ import (
 	"bytes"
 	"context"
 	"strconv"
+	"sync"
 	"testing"
 	"time"
 
@@ -161,7 +162,7 @@ func TestExecutorReadDirPlusPerasOverlayPathBypassesDirPageCache(t *testing.T) {
 	defer func() { _ = cache.Close() }()
 	executor, err := newTestExecutor(
 		runner,
-		WithPerasCommitter(scanOverlayCommitter{}),
+		WithPerasCommitter(scanOverlayCommitter{directoryPresent: true}),
 		WithDirPageCache(cache),
 	)
 	require.NoError(t, err)
@@ -182,6 +183,55 @@ func TestExecutorReadDirPlusPerasOverlayPathBypassesDirPageCache(t *testing.T) {
 	require.Equal(t, uint64(0), stats.Hits)
 	require.Equal(t, uint64(0), stats.StoreOK)
 	require.Len(t, runner.scanVersions, 2, "Peras-backed ReadDirPlus must not materialize the persistent dirpage cache")
+}
+
+func TestExecutorReadDirPlusPinsPerasOverlayAcrossDentryAndInodeReads(t *testing.T) {
+	runner := newFakeRunner()
+	parent := fsmeta.InodeID(7)
+	seedDentry(t, runner, "vol", parent, "eta", 22)
+	seedInode(t, runner, "vol", fsmeta.InodeRecord{Inode: 22, Type: fsmeta.InodeTypeFile, LinkCount: 1})
+	committer := newTestPerasCommitter(t, runner)
+	executor, err := newTestExecutor(
+		runner,
+		WithInodeAllocator(&fakeInodeAllocator{ids: []fsmeta.InodeID{23}}),
+		WithPerasAuthorityAdmitter(ownedPerasAdmitter{}),
+		WithPerasCommitter(committer),
+	)
+	require.NoError(t, err)
+	_, err = executor.Create(context.Background(), fsmeta.CreateRequest{
+		Mount:  "vol",
+		Parent: parent,
+		Name:   "omega",
+		Attrs:  fsmeta.CreateAttrs{Type: fsmeta.InodeTypeFile},
+	})
+	require.NoError(t, err)
+
+	var once sync.Once
+	runner.beforeBatchGet = func() {
+		once.Do(func() {
+			require.NoError(t, executor.Link(context.Background(), fsmeta.LinkRequest{
+				Mount:      "vol",
+				FromParent: parent,
+				FromName:   "eta",
+				ToParent:   parent,
+				ToName:     "zeta",
+			}))
+		})
+	}
+
+	pairs, err := executor.ReadDirPlus(context.Background(), fsmeta.ReadDirRequest{
+		Mount:  "vol",
+		Parent: parent,
+		Limit:  1,
+	})
+	require.NoError(t, err)
+	require.Len(t, pairs, 1)
+	require.Equal(t, "eta", pairs[0].Dentry.Name)
+	require.Equal(t, uint32(1), pairs[0].Inode.LinkCount, "ReadDirPlus must not combine a pre-link dentry page with a post-link inode overlay")
+
+	record, err := executor.Lookup(context.Background(), fsmeta.LookupRequest{Mount: "vol", Parent: parent, Name: "zeta"})
+	require.NoError(t, err)
+	require.Equal(t, fsmeta.InodeID(22), record.Inode)
 }
 
 func TestExecutorReadDirPlusCachesSealedPerasDirectory(t *testing.T) {
@@ -606,6 +656,29 @@ func TestExecutorLookupUsesPerasOverlayWithoutTimestamp(t *testing.T) {
 	require.Equal(t, uint64(1), runner.nextTS, "overlay lookup must not reserve a read timestamp")
 }
 
+func TestExecutorLookupUsesMergedDirectoryWhenPerasTombstoneHidesBase(t *testing.T) {
+	runner := newFakeRunner()
+	parent := fsmeta.InodeID(7)
+	seedDentry(t, runner, "vol", parent, "alpha", 22)
+	alphaKey := dentryKeyForTest(t, "vol", parent, "alpha")
+	etaKey := dentryKeyForTest(t, "vol", parent, "eta")
+	rows := []fsperas.OverlayKV{
+		overlayDeleteForTest(alphaKey),
+		overlayValueForTest(etaKey, dentryValueForTest(t, parent, "eta", 22, fsmeta.InodeTypeFile)),
+	}
+	executor, err := newTestExecutor(runner, WithPerasCommitter(scanOverlayCommitter{
+		rows:   rows,
+		values: overlayMapForTest(rows...),
+	}))
+	require.NoError(t, err)
+
+	_, err = executor.Lookup(context.Background(), fsmeta.LookupRequest{Mount: "vol", Parent: parent, Name: "alpha"})
+	require.ErrorIs(t, err, fsmeta.ErrNotFound)
+	record, err := executor.Lookup(context.Background(), fsmeta.LookupRequest{Mount: "vol", Parent: parent, Name: "eta"})
+	require.NoError(t, err)
+	require.Equal(t, fsmeta.DentryRecord{Parent: parent, Name: "eta", Inode: 22, Type: fsmeta.InodeTypeFile}, record)
+}
+
 func TestExecutorLookupUsesPerasOverlayDeleteWithoutRunner(t *testing.T) {
 	runner := newFakeRunner()
 	key := dentryKeyForTest(t, "vol", fsmeta.RootInode, "deleted")
@@ -757,7 +830,8 @@ func TestExecutorReadDirPlusUsesPerasOverlayInodesWithoutBatchGet(t *testing.T) 
 		LinkCount: 1,
 	})
 	committer := scanOverlayCommitter{
-		values: overlayMapForTest(overlayValueForTest(inodeKey, inodeValue)),
+		directoryPresent: true,
+		values:           overlayMapForTest(overlayValueForTest(inodeKey, inodeValue)),
 	}
 	executor, err := newTestExecutor(runner, WithPerasCommitter(committer))
 	require.NoError(t, err)

--- a/fsmeta/exec/executor_peras_test.go
+++ b/fsmeta/exec/executor_peras_test.go
@@ -61,6 +61,24 @@ func TestExecutorPerasObservedPredicateRechecksExpectedValue(t *testing.T) {
 	require.Equal(t, 1, runner.getCalls, "known-present facts cannot replace byte-level observed-value recheck")
 }
 
+func TestExecutorPerasNotExistsKnownUsesCurrentDirectoryEmptiness(t *testing.T) {
+	runner := newFakeRunner()
+	committer := newTestPerasCommitter(t, runner)
+	committer.RememberEmptyDirectory(testMountIdentity, fsmeta.RootInode)
+	committer.ForgetEmptyDirectory(testMountIdentity, fsmeta.RootInode)
+	executor, err := newTestExecutor(runner, WithPerasCommitter(committer))
+	require.NoError(t, err)
+	key := dentryKeyForTest(t, "vol", fsmeta.RootInode, "eta")
+
+	knownAbsent := executor.perasNotExistsKnown(compile.AuthorityScope{
+		Mount:      testMountIdentity.MountID,
+		MountKeyID: testMountIdentity.MountKeyID,
+		Parents:    []fsmeta.InodeID{fsmeta.RootInode},
+	}, key, committer)
+
+	require.False(t, knownAbsent, "base-empty directory facts are not enough once visible writes made the current directory non-empty")
+}
+
 func TestExecutorPerasPredicateRejectsCorruptProof(t *testing.T) {
 	runner := newFakeRunner()
 	key := dentryKeyForTest(t, "vol", fsmeta.RootInode, "file")

--- a/fsmeta/exec/executor_rename.go
+++ b/fsmeta/exec/executor_rename.go
@@ -23,12 +23,19 @@ func (e *Executor) tryPerasVisibleRename(ctx context.Context, compiled compile.C
 	if err != nil {
 		return false, err
 	}
+	sourceFromPeras := view.observedKeyFromPerasOverlay(plan.ReadKeys[0])
 	if !e.perasNotExistsKnown(delta.Authority, plan.ReadKeys[1], e.perasPredicateIndex()) {
 		if _, err := view.readDentry(plan.ReadKeys[1]); err == nil {
 			return false, fsmeta.ErrExists
 		} else if !errors.Is(err, fsmeta.ErrNotFound) {
 			return false, err
 		}
+	}
+	if !sourceFromPeras {
+		if view.observedPerasOverlay() {
+			return false, errPerasOverlayFallbackUnsafe
+		}
+		return false, nil
 	}
 	if move.fromParent != move.toParent {
 		if inode, ok, err := view.readInode(move.identity, record.Inode); err != nil {
@@ -59,7 +66,7 @@ func (e *Executor) tryPerasVisibleRename(ctx context.Context, compiled compile.C
 	if err != nil {
 		return false, err
 	}
-	return e.tryPerasVisibleCommit(ctx, concrete)
+	return e.tryPerasVisibleCommitAfterRead(ctx, view, concrete)
 }
 
 type renameMove struct {

--- a/fsmeta/exec/executor_rename_test.go
+++ b/fsmeta/exec/executor_rename_test.go
@@ -6,6 +6,7 @@ package exec
 import (
 	"context"
 	"github.com/feichai0017/NoKV/fsmeta"
+	fsperas "github.com/feichai0017/NoKV/fsmeta/exec/peras"
 	kvrpcpb "github.com/feichai0017/NoKV/pb/kv"
 	"github.com/stretchr/testify/require"
 	"testing"
@@ -77,13 +78,20 @@ func TestExecutorRenameSubtreeMovesDentry(t *testing.T) {
 
 func TestExecutorRenamePerasVisibleCommitServesOverlay(t *testing.T) {
 	runner := newFakeRunner()
-	seedDentry(t, runner, "vol", 7, "old", 22)
 	committer := newTestPerasCommitter(t, runner)
 	executor, err := newTestExecutor(
 		runner,
+		WithInodeAllocator(&fakeInodeAllocator{ids: []fsmeta.InodeID{22}}),
 		WithPerasAuthorityAdmitter(ownedPerasAdmitter{}),
 		WithPerasCommitter(committer),
 	)
+	require.NoError(t, err)
+	_, err = executor.Create(context.Background(), fsmeta.CreateRequest{
+		Mount:  "vol",
+		Parent: 7,
+		Name:   "old",
+		Attrs:  fsmeta.CreateAttrs{Type: fsmeta.InodeTypeFile},
+	})
 	require.NoError(t, err)
 
 	err = executor.Rename(context.Background(), fsmeta.RenameRequest{
@@ -103,8 +111,68 @@ func TestExecutorRenamePerasVisibleCommitServesOverlay(t *testing.T) {
 	require.Empty(t, runner.mutations, "same-parent rename should stay inside Peras overlay")
 
 	stats := executor.Stats()
-	requirePerasVisibleStatUint(t, stats, "attempt_total", 1)
-	requirePerasVisibleStatUint(t, stats, "success_total", 1)
+	requirePerasVisibleStatUint(t, stats, "attempt_total", 2)
+	requirePerasVisibleStatUint(t, stats, "success_total", 2)
+}
+
+func TestExecutorRenameDoesNotFallbackAfterPerasOverlayReadAdmissionMiss(t *testing.T) {
+	runner := newFakeRunner()
+	committer := newTestPerasCommitter(t, runner)
+	executor, err := newTestExecutor(
+		runner,
+		WithInodeAllocator(&fakeInodeAllocator{ids: []fsmeta.InodeID{22}}),
+		WithPerasAuthorityAdmitter(ownedPerasAdmitter{}),
+		WithPerasCommitter(committer),
+	)
+	require.NoError(t, err)
+
+	_, err = executor.Create(context.Background(), fsmeta.CreateRequest{
+		Mount:  "vol",
+		Parent: 7,
+		Name:   "theta",
+		Attrs:  fsmeta.CreateAttrs{Type: fsmeta.InodeTypeFile},
+	})
+	require.NoError(t, err)
+	require.Empty(t, runner.mutations)
+
+	committer.submitErr = fsperas.ErrAdmissionRejected
+	err = executor.Rename(context.Background(), fsmeta.RenameRequest{
+		Mount:      "vol",
+		FromParent: 7,
+		FromName:   "theta",
+		ToParent:   7,
+		ToName:     "eta",
+	})
+	require.ErrorIs(t, err, errPerasOverlayFallbackUnsafe)
+	require.Empty(t, runner.mutations, "overlay-backed rename must not fall back to base mutation after admission changes")
+
+	_, err = executor.Lookup(context.Background(), fsmeta.LookupRequest{Mount: "vol", Parent: 7, Name: "theta"})
+	require.NoError(t, err)
+	_, err = executor.Lookup(context.Background(), fsmeta.LookupRequest{Mount: "vol", Parent: 7, Name: "eta"})
+	require.ErrorIs(t, err, fsmeta.ErrNotFound)
+}
+
+func TestExecutorRenameBaseSourceUsesDurablePath(t *testing.T) {
+	runner := newFakeRunner()
+	seedDentry(t, runner, "vol", 7, "old", 22)
+	committer := newTestPerasCommitter(t, runner)
+	executor, err := newTestExecutor(
+		runner,
+		WithPerasAuthorityAdmitter(ownedPerasAdmitter{}),
+		WithPerasCommitter(committer),
+	)
+	require.NoError(t, err)
+
+	err = executor.Rename(context.Background(), fsmeta.RenameRequest{
+		Mount:      "vol",
+		FromParent: 7,
+		FromName:   "old",
+		ToParent:   7,
+		ToName:     "new",
+	})
+	require.NoError(t, err)
+	require.Len(t, runner.mutations, 1)
+	require.Equal(t, uint64(0), committer.Stats()["commit_total"])
 }
 
 func TestExecutorCrossParentSameBucketRenameUsesPerasVisibleCommit(t *testing.T) {
@@ -113,15 +181,21 @@ func TestExecutorCrossParentSameBucketRenameUsesPerasVisibleCommit(t *testing.T)
 	toParent := testInodeForParentBucket(t, fromParent, fromParent)
 	require.NotEqual(t, fromParent, toParent)
 	require.Equal(t, fsmeta.BucketForInodeID(fromParent), fsmeta.BucketForInodeID(toParent))
-	seedDentry(t, runner, "vol", 7, "old", 22)
-	seedInode(t, runner, "vol", fsmeta.InodeRecord{Inode: 22, Type: fsmeta.InodeTypeFile, Size: 4096, LinkCount: 1})
 	committer := newTestPerasCommitter(t, runner)
 	executor, err := newTestExecutor(
 		runner,
+		WithInodeAllocator(&fakeInodeAllocator{ids: []fsmeta.InodeID{22}}),
 		WithSubtreeAuthorityResolver(&fakeAuthorityResolver{same: true}),
 		WithPerasAuthorityAdmitter(ownedPerasAdmitter{}),
 		WithPerasCommitter(committer),
 	)
+	require.NoError(t, err)
+	_, err = executor.Create(context.Background(), fsmeta.CreateRequest{
+		Mount:  "vol",
+		Parent: fromParent,
+		Name:   "old",
+		Attrs:  fsmeta.CreateAttrs{Type: fsmeta.InodeTypeFile, Size: 4096},
+	})
 	require.NoError(t, err)
 
 	err = executor.Rename(context.Background(), fsmeta.RenameRequest{
@@ -139,27 +213,30 @@ func TestExecutorCrossParentSameBucketRenameUsesPerasVisibleCommit(t *testing.T)
 	require.NoError(t, err)
 	require.Equal(t, fsmeta.DentryRecord{Parent: toParent, Name: "new", Inode: 22, Type: fsmeta.InodeTypeFile}, record)
 	require.Empty(t, runner.mutations, "bucket-local cross-parent rename should stay inside Peras overlay")
-	require.Equal(t, uint64(1), committer.Stats()["commit_total"])
+	require.Equal(t, uint64(2), committer.Stats()["commit_total"])
 }
 
 func TestExecutorRenamePerasUsesEmptyDirectoryFactForDestination(t *testing.T) {
 	runner := newFakeRunner()
 	fromParent := fsmeta.InodeID(7)
 	toParent := testInodeForParentBucket(t, fromParent, fromParent)
-	seedDentry(t, runner, "vol", fromParent, "old", 22)
-	seedInode(t, runner, "vol", fsmeta.InodeRecord{Inode: 22, Type: fsmeta.InodeTypeFile, Size: 4096, LinkCount: 1})
 	committer := newTestPerasCommitter(t, runner)
-	sourceKey, err := fsmeta.EncodeDentryKey(testMountIdentity, fromParent, "old")
-	require.NoError(t, err)
-	committer.RememberKey(sourceKey, true)
-	committer.RememberEmptyDirectory(testMountIdentity, toParent)
 	executor, err := newTestExecutor(
 		runner,
+		WithInodeAllocator(&fakeInodeAllocator{ids: []fsmeta.InodeID{22}}),
 		WithSubtreeAuthorityResolver(&fakeAuthorityResolver{same: true}),
 		WithPerasAuthorityAdmitter(ownedPerasAdmitter{}),
 		WithPerasCommitter(committer),
 	)
 	require.NoError(t, err)
+	_, err = executor.Create(context.Background(), fsmeta.CreateRequest{
+		Mount:  "vol",
+		Parent: fromParent,
+		Name:   "old",
+		Attrs:  fsmeta.CreateAttrs{Type: fsmeta.InodeTypeFile, Size: 4096},
+	})
+	require.NoError(t, err)
+	committer.RememberEmptyDirectory(testMountIdentity, toParent)
 
 	runner.getCalls = 0
 	err = executor.Rename(context.Background(), fsmeta.RenameRequest{
@@ -171,7 +248,7 @@ func TestExecutorRenamePerasUsesEmptyDirectoryFactForDestination(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	require.Equal(t, 4, runner.getCalls, "rename must recheck observed source values, but still avoid reading a destination key proven absent by the Peras directory fact")
+	require.Equal(t, 0, runner.getCalls, "rename should use Peras overlay source values and the destination directory fact without base probes")
 	require.Empty(t, runner.mutations)
 }
 

--- a/fsmeta/exec/executor_session.go
+++ b/fsmeta/exec/executor_session.go
@@ -71,7 +71,7 @@ func (e *Executor) tryPerasVisibleOpenWriteSession(ctx context.Context, program 
 	if err != nil {
 		return fsmeta.SessionRecord{}, false, err
 	}
-	committed, err := e.tryPerasVisibleCommit(ctx, concrete)
+	committed, err := e.tryPerasVisibleCommitAfterRead(ctx, view, concrete)
 	if err != nil {
 		return fsmeta.SessionRecord{}, committed, err
 	}
@@ -121,7 +121,7 @@ func (e *Executor) tryPerasVisibleHeartbeatWriteSession(ctx context.Context, pro
 	if err != nil {
 		return fsmeta.SessionRecord{}, false, err
 	}
-	committed, err := e.tryPerasVisibleCommit(ctx, concrete)
+	committed, err := e.tryPerasVisibleCommitAfterRead(ctx, view, concrete)
 	if err != nil {
 		return fsmeta.SessionRecord{}, committed, err
 	}
@@ -163,7 +163,7 @@ func (e *Executor) tryPerasVisibleCloseWriteSession(ctx context.Context, program
 	if err != nil {
 		return false, err
 	}
-	return e.tryPerasVisibleCommit(ctx, concrete)
+	return e.tryPerasVisibleCommitAfterRead(ctx, view, concrete)
 }
 
 func (e *Executor) tryPerasVisibleExpireWriteSession(ctx context.Context, mount fsmeta.MountIdentity, record fsmeta.SessionRecord) (bool, error) {

--- a/fsmeta/exec/executor_test.go
+++ b/fsmeta/exec/executor_test.go
@@ -33,6 +33,7 @@ type fakeRunner struct {
 	scanErrs            []error
 	batchErrs           []error
 	timestampErrs       []error
+	beforeBatchGet      func()
 	mutateErr           error
 	mutateErrs          []error
 	actualCommitVersion uint64
@@ -50,6 +51,11 @@ type fakeAtomicRunner struct {
 	*fakeRunner
 	handled     bool
 	err         error
+	atomicCalls []atomicMutateCall
+}
+
+type fakeSpeculativeAtomicRunner struct {
+	*fakeRunner
 	atomicCalls []atomicMutateCall
 }
 
@@ -204,9 +210,10 @@ type testVersionAllocator interface {
 }
 
 type testPerasCommitter struct {
-	holder   *fsperas.Holder
-	versions testVersionAllocator
-	view     *fsperas.OverlayView
+	holder    *fsperas.Holder
+	versions  testVersionAllocator
+	view      *fsperas.OverlayView
+	submitErr error
 
 	mu          sync.Mutex
 	commitTotal uint64
@@ -233,8 +240,9 @@ type ownedPerasAdmitter struct{}
 
 type scanOverlayCommitter struct {
 	noopPerasCommitter
-	rows   []fsperas.OverlayKV
-	values map[string]fsperas.OverlayKV
+	rows             []fsperas.OverlayKV
+	values           map[string]fsperas.OverlayKV
+	directoryPresent bool
 }
 
 var _ PerasOverlayReader = scanOverlayCommitter{}
@@ -433,6 +441,9 @@ func (c *testPerasCommitter) SubmitVisible(ctx context.Context, id fsperas.Opera
 		return fsperas.VisibleAck{}, err
 	}
 	op = admitted
+	if c.submitErr != nil {
+		return fsperas.VisibleAck{}, c.submitErr
+	}
 	ack, _, err := c.holder.Submit(ctx, id, op)
 	if err != nil {
 		return fsperas.VisibleAck{}, err
@@ -490,11 +501,32 @@ func (c *testPerasCommitter) GetPerasOverlayView(key []byte) ([]byte, bool, bool
 	return c.view.GetView(key)
 }
 
+func (c *testPerasCommitter) CapturePerasOverlayRead() (uint64, uint64) {
+	if c == nil || c.view == nil {
+		return 0, 0
+	}
+	return c.view.Generation(), 0
+}
+
+func (c *testPerasCommitter) GetPerasOverlayViewAt(overlayGeneration, _ uint64, key []byte) ([]byte, bool, bool) {
+	if c == nil || c.view == nil {
+		return nil, false, false
+	}
+	return c.view.GetViewAt(overlayGeneration, key)
+}
+
 func (c *testPerasCommitter) ScanPerasOverlay(start []byte, limit uint32) []fsperas.OverlayKV {
 	if c == nil || c.view == nil {
 		return nil
 	}
 	return c.view.Scan(start, limit)
+}
+
+func (c *testPerasCommitter) ScanPerasDirectoryAt(overlayGeneration, _ uint64, prefix, start []byte, limit uint32) []fsperas.OverlayKV {
+	if c == nil || c.view == nil {
+		return nil
+	}
+	return c.view.ScanDirectoryAt(overlayGeneration, prefix, start, limit)
 }
 
 func (c *testPerasCommitter) HasPerasDirectory(prefix []byte) bool {
@@ -690,6 +722,32 @@ func (c scanOverlayCommitter) ScanPerasOverlay(start []byte, limit uint32) []fsp
 	return out
 }
 
+func (c scanOverlayCommitter) ScanPerasDirectory(prefix, start []byte, limit uint32) []fsperas.OverlayKV {
+	out := make([]fsperas.OverlayKV, 0, len(c.rows))
+	for _, row := range c.rows {
+		if !bytes.HasPrefix(row.Key, prefix) || bytes.Compare(row.Key, start) < 0 {
+			continue
+		}
+		out = append(out, row)
+		if uint32(len(out)) == limit {
+			break
+		}
+	}
+	return out
+}
+
+func (c scanOverlayCommitter) HasPerasDirectory(prefix []byte) bool {
+	if c.directoryPresent {
+		return true
+	}
+	for _, row := range c.rows {
+		if bytes.HasPrefix(row.Key, prefix) {
+			return true
+		}
+	}
+	return false
+}
+
 func (ownedPerasAdmitter) AcquirePerasAuthority(context.Context, compile.AuthorityScope) (bool, error) {
 	return true, nil
 }
@@ -728,6 +786,9 @@ func (r *fakeRunner) Get(_ context.Context, key []byte, _ uint64) ([]byte, bool,
 
 func (r *fakeRunner) BatchGet(_ context.Context, keys [][]byte, version uint64) (map[string][]byte, error) {
 	r.batchVersions = append(r.batchVersions, version)
+	if r.beforeBatchGet != nil {
+		r.beforeBatchGet()
+	}
 	if len(r.batchErrs) > 0 {
 		err := r.batchErrs[0]
 		r.batchErrs = r.batchErrs[1:]
@@ -881,6 +942,21 @@ func (r *fakeAtomicRunner) TryAtomicMutate(_ context.Context, primary []byte, pr
 			delete(r.data, string(mut.GetKey()))
 		}
 	}
+	return true, nil
+}
+
+func (r *fakeAtomicRunner) AtomicMutatePreservesReadOrder() bool {
+	return true
+}
+
+func (r *fakeSpeculativeAtomicRunner) TryAtomicMutate(_ context.Context, primary []byte, predicates []*kvrpcpb.AtomicPredicate, mutations []*kvrpcpb.Mutation, startVersion, commitVersion uint64) (bool, error) {
+	r.atomicCalls = append(r.atomicCalls, atomicMutateCall{
+		primary:       cloneBytes(primary),
+		predicates:    cloneAtomicPredicates(predicates),
+		mutations:     cloneMutations(mutations),
+		startVersion:  startVersion,
+		commitVersion: commitVersion,
+	})
 	return true, nil
 }
 

--- a/fsmeta/exec/executor_txn.go
+++ b/fsmeta/exec/executor_txn.go
@@ -18,8 +18,8 @@ import (
 
 func (e *Executor) mutateWithAtomicOnePhase(ctx context.Context, kind fsmeta.OperationKind, primary []byte, predicates []*kvrpcpb.AtomicPredicate, mutations []*kvrpcpb.Mutation, startVersion, commitVersion uint64) error {
 	stats := e.atomicOnePhaseCounters(kind)
-	onePhase, ok := e.runner.(AtomicMutateOnePhase)
-	if !ok {
+	onePhase, ok := e.runner.(ReadOrderedAtomicMutateOnePhase)
+	if !ok || !onePhase.AtomicMutatePreservesReadOrder() {
 		if stats != nil {
 			stats.runnerUnsupportedTotal.Add(1)
 		}

--- a/fsmeta/exec/executor_unlink.go
+++ b/fsmeta/exec/executor_unlink.go
@@ -64,7 +64,7 @@ func (e *Executor) tryPerasVisibleUnlink(ctx context.Context, program compile.Un
 	if err != nil {
 		return false, err
 	}
-	return e.tryPerasVisibleCommit(ctx, concrete)
+	return e.tryPerasVisibleCommitAfterRead(ctx, view, concrete)
 }
 
 // Unlink removes one dentry, decrements its inode link count, and deletes the

--- a/fsmeta/exec/peras/overlay_view.go
+++ b/fsmeta/exec/peras/overlay_view.go
@@ -316,6 +316,15 @@ func (s *OverlaySnapshot) Generation() uint64 {
 	return s.generation
 }
 
+func (v *OverlayView) Generation() uint64 {
+	if v == nil {
+		return 0
+	}
+	v.mu.RLock()
+	defer v.mu.RUnlock()
+	return v.epoch
+}
+
 func (v *OverlayView) Get(key []byte) (value []byte, deleted bool, ok bool) {
 	value, deleted, ok = v.GetView(key)
 	if !ok {

--- a/fsmeta/exec/peras_admission.go
+++ b/fsmeta/exec/peras_admission.go
@@ -90,6 +90,17 @@ func (e *Executor) tryPerasVisibleCommit(ctx context.Context, op compile.Materia
 	return true, nil
 }
 
+func (e *Executor) tryPerasVisibleCommitAfterRead(ctx context.Context, view *perasReadView, op compile.MaterializedOp) (bool, error) {
+	committed, err := e.tryPerasVisibleCommit(ctx, op)
+	if err != nil || committed {
+		return committed, err
+	}
+	if view.observedPerasOverlay() {
+		return false, errPerasOverlayFallbackUnsafe
+	}
+	return false, nil
+}
+
 func (e *Executor) perasPredicatesHold(ctx context.Context, op compile.MaterializedOp, admissionCtx fsperas.AdmissionContext) (fsperas.AdmissionResult, bool, error) {
 	delta := op.Delta
 	if !perasPredicateProofsValid(op.PredicateProofs) {
@@ -311,7 +322,7 @@ func (e *Executor) perasNotExistsKnown(scope compile.AuthorityScope, key []byte,
 	if parts.Kind != fsmeta.KeyKindDentry {
 		return false
 	}
-	return index.DirectoryBaseEmpty(fsmeta.MountIdentity{
+	return index.DirectoryEmpty(fsmeta.MountIdentity{
 		MountID:    scope.Mount,
 		MountKeyID: scope.MountKeyID,
 	}, parts.Parent)

--- a/fsmeta/exec/peras_read_view.go
+++ b/fsmeta/exec/peras_read_view.go
@@ -117,6 +117,17 @@ func (e *Executor) perasSnapshotOverlay() PerasSnapshotOverlayReader {
 	return reader
 }
 
+func (e *Executor) perasOverlayReadSnapshot() PerasOverlayReadSnapshotReader {
+	if e == nil || e.perasCommitter == nil {
+		return nil
+	}
+	reader, ok := e.perasCommitter.(PerasOverlayReadSnapshotReader)
+	if !ok {
+		return nil
+	}
+	return reader
+}
+
 func (e *Executor) readPerasProgram(program compile.ReadProgram) ([]byte, bool, bool) {
 	if len(program.Key) == 0 {
 		return nil, false, false
@@ -145,12 +156,13 @@ func (e *Executor) getMergedProgramValue(ctx context.Context, program compile.Re
 }
 
 type perasReadView struct {
-	executor    *Executor
-	ctx         context.Context
-	version     uint64
-	haveVersion bool
-	observed    map[string]int
-	proofs      []proof.PredicateProof
+	executor      *Executor
+	ctx           context.Context
+	version       uint64
+	haveVersion   bool
+	observedPeras bool
+	observed      map[string]int
+	proofs        []proof.PredicateProof
 }
 
 func (e *Executor) newPerasReadView(ctx context.Context) *perasReadView {
@@ -169,6 +181,7 @@ func (v *perasReadView) get(key []byte) ([]byte, bool, error) {
 		return nil, false, fsmeta.ErrInvalidRequest
 	}
 	if value, deleted, ok := v.executor.perasOverlayGet(key); ok {
+		v.observedPeras = true
 		if deleted {
 			v.remember(key, nil, false, proof.ReadSourceOverlay, 0)
 			return nil, false, nil
@@ -197,6 +210,21 @@ func (v *perasReadView) get(key []byte) ([]byte, bool, error) {
 	}
 	v.remember(key, value, ok, proof.ReadSourceBase, v.version)
 	return value, ok, nil
+}
+
+func (v *perasReadView) observedPerasOverlay() bool {
+	return v != nil && v.observedPeras
+}
+
+func (v *perasReadView) observedKeyFromPerasOverlay(key []byte) bool {
+	if v == nil {
+		return false
+	}
+	index, ok := v.observed[string(key)]
+	if !ok || index < 0 || index >= len(v.proofs) {
+		return false
+	}
+	return v.proofs[index].Source == proof.ReadSourceOverlay
 }
 
 func (v *perasReadView) remember(key, value []byte, present bool, source proof.ReadSource, version uint64) {
@@ -316,13 +344,15 @@ func (v *perasReadView) readSession(mount fsmeta.MountIdentity, key []byte) (fsm
 	return session, true, nil
 }
 
-func (e *Executor) batchGetMergedValuesOrdered(ctx context.Context, keys [][]byte, version uint64, includeOverlay, snapshotRead bool) ([][]byte, []bool, error) {
+func (e *Executor) batchGetMergedValuesOrderedAt(ctx context.Context, keys [][]byte, version uint64, includeOverlay, snapshotRead bool, overlayGeneration, sealedGeneration uint64) ([][]byte, []bool, error) {
 	values := make([][]byte, len(keys))
 	present := make([]bool, len(keys))
 
 	overlay := e.perasOverlay()
 	snapshot := e.perasSnapshotOverlay()
-	if !includeOverlay || (!snapshotRead && overlay == nil) || (snapshotRead && snapshot == nil) {
+	readSnapshot := e.perasOverlayReadSnapshot()
+	useReadSnapshot := !snapshotRead && readSnapshot != nil && (overlayGeneration != 0 || sealedGeneration != 0)
+	if !includeOverlay || (!snapshotRead && overlay == nil && !useReadSnapshot) || (snapshotRead && snapshot == nil) {
 		base, err := e.runner.BatchGet(ctx, keys, version)
 		if err != nil {
 			return nil, nil, err
@@ -344,6 +374,8 @@ func (e *Executor) batchGetMergedValuesOrdered(ctx context.Context, keys [][]byt
 		var deleted, ok bool
 		if snapshotRead {
 			value, deleted, ok = snapshot.GetPerasSnapshotOverlayView(version, key)
+		} else if useReadSnapshot {
+			value, deleted, ok = readSnapshot.GetPerasOverlayViewAt(overlayGeneration, sealedGeneration, key)
 		} else {
 			value, deleted, ok = overlay.GetPerasOverlayView(key)
 		}
@@ -388,7 +420,11 @@ func (e *Executor) mergePerasOverlayScan(kvs []KV, start []byte, limit uint32) [
 }
 
 func (e *Executor) mergePerasDirectoryOverlayScan(kvs []KV, prefix, start []byte, limit uint32) ([]KV, uint32, bool) {
-	overlayKVs, usedIndex := e.scanPerasDirectoryOverlayRows(prefix, start, limit)
+	return e.mergePerasDirectoryOverlayScanAt(kvs, prefix, start, limit, 0, 0)
+}
+
+func (e *Executor) mergePerasDirectoryOverlayScanAt(kvs []KV, prefix, start []byte, limit uint32, overlayGeneration, sealedGeneration uint64) ([]KV, uint32, bool) {
+	overlayKVs, usedIndex := e.scanPerasDirectoryOverlayRowsAt(overlayGeneration, sealedGeneration, prefix, start, limit)
 	if len(overlayKVs) == 0 {
 		return kvs, 0, usedIndex
 	}
@@ -396,14 +432,14 @@ func (e *Executor) mergePerasDirectoryOverlayScan(kvs []KV, prefix, start []byte
 	return out, uint32(len(overlayKVs)), usedIndex
 }
 
-func (e *Executor) scanPerasDirectoryOverlayRows(prefix, start []byte, limit uint32) ([]fsperas.OverlayKV, bool) {
+func (e *Executor) scanPerasDirectoryOverlayRowsAt(overlayGeneration, sealedGeneration uint64, prefix, start []byte, limit uint32) ([]fsperas.OverlayKV, bool) {
 	var (
 		out       []fsperas.OverlayKV
 		startKey  = cloneBytes(start)
 		usedIndex bool
 	)
 	for {
-		batch, batchUsedIndex := e.scanPerasDirectoryOverlayBatch(prefix, startKey, limit)
+		batch, batchUsedIndex := e.scanPerasDirectoryOverlayBatchAt(overlayGeneration, sealedGeneration, prefix, startKey, limit)
 		usedIndex = usedIndex || batchUsedIndex
 		if len(batch) == 0 {
 			return out, usedIndex
@@ -450,7 +486,11 @@ func (e *Executor) scanPerasSnapshotDirectoryOverlayRows(version uint64, prefix,
 	}
 }
 
-func (e *Executor) scanPerasDirectoryOverlayBatch(prefix, start []byte, limit uint32) ([]fsperas.OverlayKV, bool) {
+func (e *Executor) scanPerasDirectoryOverlayBatchAt(overlayGeneration, sealedGeneration uint64, prefix, start []byte, limit uint32) ([]fsperas.OverlayKV, bool) {
+	if readSnapshot := e.perasOverlayReadSnapshot(); readSnapshot != nil && (overlayGeneration != 0 || sealedGeneration != 0) {
+		overlayKVs := readSnapshot.ScanPerasDirectoryAt(overlayGeneration, sealedGeneration, prefix, start, limit)
+		return trimPerasDirectoryOverlayBatch(prefix, overlayKVs), true
+	}
 	overlay := e.perasOverlay()
 	if overlay == nil || limit == 0 {
 		return nil, false
@@ -465,8 +505,12 @@ func (e *Executor) scanPerasDirectoryOverlayBatch(prefix, start []byte, limit ui
 	} else {
 		overlayKVs = overlay.ScanPerasOverlay(start, limit)
 	}
+	return trimPerasDirectoryOverlayBatch(prefix, overlayKVs), usedIndex
+}
+
+func trimPerasDirectoryOverlayBatch(prefix []byte, overlayKVs []fsperas.OverlayKV) []fsperas.OverlayKV {
 	if len(overlayKVs) == 0 {
-		return nil, usedIndex
+		return nil
 	}
 	out := overlayKVs[:0]
 	for _, row := range overlayKVs {
@@ -475,16 +519,16 @@ func (e *Executor) scanPerasDirectoryOverlayBatch(prefix, start []byte, limit ui
 		}
 		out = append(out, row)
 	}
-	return out, usedIndex
+	return out
 }
 
-func (e *Executor) scanMergedDirectoryRows(ctx context.Context, plan compile.DirectoryReadPlan, version uint64, snapshotRead bool) ([]KV, uint32, uint32, bool, error) {
+func (e *Executor) scanMergedDirectoryRowsAt(ctx context.Context, plan compile.DirectoryReadPlan, version uint64, snapshotRead bool, overlayGeneration, sealedGeneration uint64) ([]KV, uint32, uint32, bool, error) {
 	var overlayKVs []fsperas.OverlayKV
 	var usedIndex bool
 	if snapshotRead {
 		overlayKVs, usedIndex = e.scanPerasSnapshotDirectoryOverlayRows(version, plan.Prefix, plan.StartKey, plan.Limit)
 	} else {
-		overlayKVs, usedIndex = e.scanPerasDirectoryOverlayRows(plan.Prefix, plan.StartKey, plan.Limit)
+		overlayKVs, usedIndex = e.scanPerasDirectoryOverlayRowsAt(overlayGeneration, sealedGeneration, plan.Prefix, plan.StartKey, plan.Limit)
 	}
 	start := cloneBytes(plan.StartKey)
 	baseRows := make([]KV, 0, plan.Limit)

--- a/fsmeta/runtime/peras/overlay_view.go
+++ b/fsmeta/runtime/peras/overlay_view.go
@@ -157,6 +157,32 @@ func (c *Runtime) GetPerasOverlayView(key []byte) ([]byte, bool, bool) {
 	return c.read.sealed.GetView(key)
 }
 
+func (c *Runtime) CapturePerasOverlayRead() (uint64, uint64) {
+	if c == nil || c.read == nil {
+		return 0, 0
+	}
+	c.read.mu.RLock()
+	overlayGeneration := c.read.overlay.Generation()
+	sealedGeneration := c.read.sealed.Generation()
+	c.read.mu.RUnlock()
+	return overlayGeneration, sealedGeneration
+}
+
+func (c *Runtime) GetPerasOverlayViewAt(overlayGeneration, sealedGeneration uint64, key []byte) ([]byte, bool, bool) {
+	if c == nil || c.read == nil {
+		return nil, false, false
+	}
+	if overlayGeneration != 0 {
+		if value, deleted, ok := c.read.overlay.GetViewAt(overlayGeneration, key); ok {
+			return value, deleted, true
+		}
+	}
+	if sealedGeneration == 0 {
+		return nil, false, false
+	}
+	return c.read.sealed.GetViewAt(sealedGeneration, key)
+}
+
 // CapturePerasSnapshot records the installed catalog overlay visible to one
 // MVCC snapshot version.
 func (c *Runtime) CapturePerasSnapshot(version uint64) error {
@@ -488,14 +514,14 @@ func (c *Runtime) DirectoryEmpty(mount fsmeta.MountIdentity, inode fsmeta.InodeI
 	if c == nil || c.read == nil {
 		return false
 	}
-	return c.read.overlay.DirectoryEmpty(mount, inode)
+	return c.read.overlay.DirectoryEmpty(mount, inode) && !c.sealedDirectoryHasRows(mount, inode)
 }
 
 func (c *Runtime) DirectoryBaseEmpty(mount fsmeta.MountIdentity, inode fsmeta.InodeID) bool {
 	if c == nil || c.read == nil {
 		return false
 	}
-	return c.read.overlay.DirectoryBaseEmpty(mount, inode)
+	return c.read.overlay.DirectoryBaseEmpty(mount, inode) && !c.sealedDirectoryHasRows(mount, inode)
 }
 
 func (c *Runtime) SessionNamespaceEmpty(mount fsmeta.MountIdentity, inode fsmeta.InodeID) bool {
@@ -533,6 +559,17 @@ func (c *Runtime) RememberEmptySessionNamespace(mount fsmeta.MountIdentity, inod
 	c.read.overlay.RememberEmptySessionNamespace(mount, inode)
 }
 
+func (c *Runtime) sealedDirectoryHasRows(mount fsmeta.MountIdentity, inode fsmeta.InodeID) bool {
+	if c == nil || c.read == nil || c.read.sealed == nil {
+		return false
+	}
+	prefix, err := fsmeta.EncodeDentryPrefix(mount, inode)
+	if err != nil {
+		return false
+	}
+	return c.read.sealed.HasDirectory(prefix)
+}
+
 func (c *Runtime) ScanPerasOverlay(start []byte, limit uint32) []fsperas.OverlayKV {
 	if c == nil || c.read == nil || limit == 0 {
 		return nil
@@ -545,6 +582,21 @@ func (c *Runtime) ScanPerasDirectory(prefix, start []byte, limit uint32) []fsper
 		return nil
 	}
 	return fsperas.MergeOverlayScans(c.read.sealed.ScanDirectory(prefix, start, limit), c.read.overlay.ScanDirectory(prefix, start, limit), limit)
+}
+
+func (c *Runtime) ScanPerasDirectoryAt(overlayGeneration, sealedGeneration uint64, prefix, start []byte, limit uint32) []fsperas.OverlayKV {
+	if c == nil || c.read == nil || limit == 0 {
+		return nil
+	}
+	var overlayRows []fsperas.OverlayKV
+	if overlayGeneration != 0 {
+		overlayRows = c.read.overlay.ScanDirectoryAt(overlayGeneration, prefix, start, limit)
+	}
+	var sealedRows []fsperas.OverlayKV
+	if sealedGeneration != 0 {
+		sealedRows = c.read.sealed.ScanDirectoryAt(sealedGeneration, prefix, start, limit)
+	}
+	return fsperas.MergeOverlayScans(sealedRows, overlayRows, limit)
 }
 
 func (c *Runtime) HasPerasDirectory(prefix []byte) bool {

--- a/fsmeta/runtime/peras/runtime_test.go
+++ b/fsmeta/runtime/peras/runtime_test.go
@@ -169,6 +169,32 @@ func TestRuntimeFlushesSegmentAndKeepsReadsVisible(t *testing.T) {
 
 }
 
+func TestRuntimeDirectoryEmptyFactsDoNotIgnoreSealedRows(t *testing.T) {
+	provider := &fakeRuntimePerasGrantProvider{holderID: "holder-a", grant: testRuntimeCommitterGrant()}
+	committer, err := NewRuntime(Config{
+		Authority:         provider,
+		Witnesses:         testRuntimePerasWitnesses(t, 3),
+		Installer:         &fakeRuntimePerasSegmentInstaller{},
+		VisibleLog:        &recordingVisibleLog{},
+		SegmentBatchSize:  1024,
+		SegmentFlushEvery: time.Hour,
+	})
+	require.NoError(t, err)
+	defer committer.Close()
+
+	ctx := context.Background()
+	committer.RememberEmptyDirectory(testRuntimeMount, fsmeta.RootInode)
+	require.True(t, committer.DirectoryEmpty(testRuntimeMount, fsmeta.RootInode))
+	require.True(t, committer.DirectoryBaseEmpty(testRuntimeMount, fsmeta.RootInode))
+
+	require.NoError(t, commitRuntimePeras(ctx, committer, 1, testRuntimeDentryKeyForLabel("sealed"), testRuntimeDentryKeyForLabel("sealed-inode")))
+	committer.ForgetEmptyDirectory(testRuntimeMount, fsmeta.RootInode)
+	require.NoError(t, committer.FlushDurable(ctx))
+
+	require.False(t, committer.DirectoryEmpty(testRuntimeMount, fsmeta.RootInode))
+	require.False(t, committer.DirectoryBaseEmpty(testRuntimeMount, fsmeta.RootInode))
+}
+
 func TestRuntimeWithoutWitnessLayerFlushesVisibleLogToInstall(t *testing.T) {
 	provider := &nonSealingRuntimePerasGrantProvider{holderID: "holder-a", grant: testRuntimeCommitterGrant()}
 	installer := &fakeRuntimePerasSegmentInstaller{}

--- a/scripts/run_fsmeta_benchmarks.sh
+++ b/scripts/run_fsmeta_benchmarks.sh
@@ -29,9 +29,14 @@ profile_targets="${NOKV_FSMETA_PROFILE_TARGETS:-fsmeta=127.0.0.1:9400,store1=127
 cache_tmp_dir=""
 plain_pid=""
 cached_pid=""
+local_pid=""
+local_tools_dir=""
+local_tmp_dir=""
 profile_pids=()
 profile_root_dir=""
 compose_built=0
+local_mount_key_id="${NOKV_FSMETA_LOCAL_MOUNT_KEY_ID:-2}"
+local_log_dir="${NOKV_FSMETA_LOCAL_LOG_DIR:-$ROOT/benchmark/data/fsmeta/ci}"
 
 case "$profile" in
 	median)
@@ -73,6 +78,12 @@ case "$output_dir" in
 	*) output_dir="$ROOT/$output_dir" ;;
 esac
 mkdir -p "$output_dir"
+
+case "$local_log_dir" in
+	/*) ;;
+	*) local_log_dir="$ROOT/$local_log_dir" ;;
+esac
+mkdir -p "$local_log_dir"
 
 case "$profile_dir" in
 	/*) ;;
@@ -220,6 +231,7 @@ write_profile_manifest() {
 	local workloads="$1"
 	cat >"$profile_dir/manifest.txt" <<EOF
 run_id=$run_id
+bench_mode=$mode
 benchmark_profile=$profile
 profile_file=benchmark/fsmeta/profiles/official/workloads.yaml
 workloads=$workloads
@@ -246,6 +258,7 @@ write_benchmark_manifest() {
 	local workloads="$2"
 	cat >"${output}.manifest.txt" <<EOF
 run_id=$run_id
+bench_mode=$mode
 scale_profile=$profile
 profile_file=benchmark/fsmeta/profiles/official/workloads.yaml
 workloads=$workloads
@@ -451,6 +464,142 @@ run_compose_benchmarks() {
 	fi
 }
 
+ensure_local_gateway_binary() {
+	if [[ -n "$local_tools_dir" ]]; then
+		return
+	fi
+	local_tools_dir="$(mktemp -d "${TMPDIR:-/tmp}/nokv-fsmeta-local-tools.XXXXXX")"
+	go build -o "$local_tools_dir/nokv-fsmeta" ./cmd/nokv-fsmeta
+}
+
+stop_local_gateway() {
+	if [[ -n "$local_pid" ]]; then
+		kill "$local_pid" 2>/dev/null || true
+		wait "$local_pid" 2>/dev/null || true
+		local_pid=""
+	fi
+	if [[ -z "${NOKV_FSMETA_LOCAL_WORKDIR:-}" && -n "$local_tmp_dir" ]]; then
+		rm -rf "$local_tmp_dir"
+		local_tmp_dir=""
+	fi
+}
+
+cleanup_local_gateway() {
+	stop_local_gateway
+	if [[ -n "$local_tools_dir" ]]; then
+		rm -rf "$local_tools_dir"
+		local_tools_dir=""
+	fi
+}
+
+start_local_gateway() {
+	local suffix="$1"
+	ensure_local_gateway_binary
+	stop_local_gateway
+
+	local work_dir
+	if [[ -n "${NOKV_FSMETA_LOCAL_WORKDIR:-}" ]]; then
+		work_dir="$NOKV_FSMETA_LOCAL_WORKDIR"
+		if enabled "$reset_between_workloads"; then
+			work_dir="$work_dir/$suffix"
+			rm -rf "$work_dir"
+		fi
+	else
+		local_tmp_dir="$(mktemp -d "${TMPDIR:-/tmp}/nokv-fsmeta-local.XXXXXX")"
+		work_dir="$local_tmp_dir/db"
+	fi
+	mkdir -p "$work_dir"
+
+	local log_file="$local_log_dir/fsmeta-local-${profile}-${run_id}-${suffix}.log"
+	echo "starting local fsmeta gateway on $fsmeta_addr work_dir=$work_dir"
+	"$local_tools_dir/nokv-fsmeta" \
+		--backend local \
+		--addr "$fsmeta_addr" \
+		--metrics-addr "$fsmeta_metrics_addr" \
+		--local-work-dir "$work_dir" \
+		--local-mount-id "$mount" \
+		--local-mount-key-id "$local_mount_key_id" \
+		>"$log_file" 2>&1 &
+	local_pid="$!"
+	if ! wait_port "${fsmeta_addr%%,*}"; then
+		cat "$log_file" >&2 || true
+		return 1
+	fi
+	wait_port "${fsmeta_metrics_addr%%,*}"
+}
+
+run_local_benchmarks() {
+	local workloads="${NOKV_FSMETA_WORKLOADS:-mdtest-easy,mdtest-hard,filebench-varmail,mimesis-namespace,ai-checkpoint-agent}"
+	local output="${NOKV_FSMETA_OUTPUT:-$output_dir/fsmeta_local_${profile}_${run_id}_isolated.csv}"
+	local coord_addr=""
+	local profile_targets="${NOKV_FSMETA_PROFILE_TARGETS:-fsmeta=$fsmeta_metrics_addr}"
+	trap cleanup_local_gateway EXIT
+	case "$output" in
+		/*) ;;
+		*) output="$ROOT/$output" ;;
+	esac
+	if ! enabled "$reset_between_workloads"; then
+		start_local_gateway "shared"
+		profile_dir="$profile_root_dir"
+		profile_pids=()
+		start_profile_capture "$workloads"
+	fi
+	local combined_tmp="$output.tmp"
+	local wrote_header=0
+	local bench_status=0
+	rm -f "$combined_tmp" "$output"
+	IFS=',' read -r -a workload_list <<<"$workloads"
+	for workload in "${workload_list[@]}"; do
+		workload="${workload//[[:space:]]/}"
+		if [[ -z "$workload" ]]; then
+			continue
+		fi
+		local safe_workload="${workload//[^A-Za-z0-9_-]/_}"
+		local workload_output="$output_dir/fsmeta_local_${profile}_${run_id}_${safe_workload}.csv"
+		echo "running isolated local fsmeta workload: $workload"
+		if enabled "$reset_between_workloads"; then
+			start_local_gateway "$safe_workload"
+			profile_dir="$profile_root_dir/$safe_workload"
+			profile_pids=()
+			start_profile_capture "$workload"
+		fi
+		set +e
+		run_bench "$fsmeta_addr" "$workload" "$workload_output"
+		bench_status=$?
+		set -e
+		if enabled "$reset_between_workloads"; then
+			finish_profile_capture
+			stop_local_gateway
+		fi
+		if [[ "$bench_status" -ne 0 ]]; then
+			break
+		fi
+		if [[ "$wrote_header" -eq 0 ]]; then
+			cat "$workload_output" >"$combined_tmp"
+			wrote_header=1
+		else
+			tail -n +2 "$workload_output" >>"$combined_tmp"
+		fi
+		print_bench_summary "$workload_output"
+	done
+	if ! enabled "$reset_between_workloads"; then
+		finish_profile_capture
+	fi
+	if [[ "$bench_status" -ne 0 ]]; then
+		rm -f "$combined_tmp"
+		exit "$bench_status"
+	fi
+	if [[ "$wrote_header" -eq 0 ]]; then
+		echo "no fsmeta workloads selected" >&2
+		rm -f "$combined_tmp"
+		exit 2
+	fi
+	mv "$combined_tmp" "$output"
+	write_benchmark_manifest "$output" "$workloads"
+	print_bench_summary "$output"
+	echo "wrote isolated local fsmeta benchmark summary: $output"
+}
+
 cleanup_cache_gateways() {
 	if [[ -n "$plain_pid" ]]; then
 		kill "$plain_pid" 2>/dev/null || true
@@ -507,11 +656,14 @@ case "$mode" in
 	compose)
 		run_compose_benchmarks
 		;;
+	local)
+		run_local_benchmarks
+		;;
 	derived-cache|cache)
 		run_derived_cache_benchmarks
 		;;
 	*)
-		echo "unknown NOKV_FSMETA_BENCH_MODE=$mode; use compose or derived-cache" >&2
+		echo "unknown NOKV_FSMETA_BENCH_MODE=$mode; use compose, local, or derived-cache" >&2
 		exit 2
 		;;
 esac


### PR DESCRIPTION
## Summary

Fix the fsmeta soak correctness failure by tightening visible-read and inode-mapping semantics under concurrent create/rename/read histories.

## Root Cause

The failing soak history exposed several visibility races:

- the contract wrapper only learned actual-to-planned inode mappings after `Create` returned, so concurrent reads could observe the actual committed inode first;
- fsmeta exec could observe Peras overlay state and then fall back to base mutation, making stale base decisions after a visible read;
- `ReadDirPlus` could scan dentries at one Peras overlay generation and then read inode attributes at a newer generation;
- the soak correctness client used the positive lookup cache as if it were an authority source.

## Changes

- Track pending create inode mappings in `fsmeta/contract` so concurrent observations map actual inode IDs back to planned IDs.
- Require read-ordered one-phase mutation support before using atomic one-phase execution.
- Add Peras overlay generation snapshots and generation-pinned lookup/read-dir paths.
- Prevent unsafe base fallback after Peras overlay observations.
- Make lookup respect Peras tombstone/merge semantics.
- Disable the fsmeta soak client's lookup cache for linearizability validation.
- Add regression tests for the observed races.

## Validation

- `git diff --check`
- `make lint`
- `make test`
- `go test -count=1 ./fsmeta/client ./fsmeta/exec ./fsmeta/contract ./fsmeta/runtime/peras ./cmd/nokv-fsmeta-soak`
- `NOKV_SOAK_DURATION=30s NOKV_SOAK_STEPS=64 NOKV_SOAK_BATCH=3 NOKV_SOAK_SEED_START=52 NOKV_SOAK_ROLLING_RESTARTS=0 NOKV_SOAK_DOWN=1 NOKV_SOAK_LOG_TAIL=120 ./scripts/soak/fsmeta_soak.sh`
- `NOKV_SOAK_DURATION=45s NOKV_SOAK_STEPS=64 NOKV_SOAK_BATCH=3 NOKV_SOAK_SEED_START=1 NOKV_SOAK_ROLLING_RESTARTS=0 NOKV_SOAK_DOWN=1 NOKV_SOAK_LOG_TAIL=120 ./scripts/soak/fsmeta_soak.sh`
- `NOKV_SOAK_DURATION=45s NOKV_SOAK_STEPS=64 NOKV_SOAK_BATCH=3 NOKV_SOAK_SEED_START=1 NOKV_SOAK_ROLLING_RESTARTS=1 NOKV_SOAK_DOWN=1 NOKV_SOAK_LOG_TAIL=120 ./scripts/soak/fsmeta_soak.sh`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added overlay-aware snapshot reading for directory entries and values with generation tracking.
  * Enhanced atomic mutation support with read-order preservation guarantees.

* **Bug Fixes**
  * Fixed create operation timing to ensure committed entries appear in directory listings.
  * Improved directory emptiness tracking to correctly account for sealed entries.
  * Enhanced Peras overlay fallback handling to prevent unsafe fallback scenarios during mutations.
  * Improved pending inode allocation handling during concurrent create and update operations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/feichai0017/NoKV/pull/317?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->