### PR TITLE
feat(fsmeta): add rename replace primitive

### DIFF
--- a/fsmeta/client/client.go
+++ b/fsmeta/client/client.go
@@ -53,6 +53,7 @@ type Client interface {
 	RetireSnapshotSubtree(ctx context.Context, token fsmeta.SnapshotSubtreeToken) error
 	GetQuotaUsage(ctx context.Context, req fsmeta.QuotaUsageRequest) (fsmeta.UsageRecord, error)
 	Rename(ctx context.Context, req fsmeta.RenameRequest) error
+	RenameReplace(ctx context.Context, req fsmeta.RenameReplaceRequest) (fsmeta.RenameReplaceResult, error)
 	RenameSubtree(ctx context.Context, req fsmeta.RenameSubtreeRequest) error
 	Link(ctx context.Context, req fsmeta.LinkRequest) error
 	Unlink(ctx context.Context, req fsmeta.UnlinkRequest) error
@@ -320,6 +321,27 @@ func (c *GRPCClient) Rename(ctx context.Context, req fsmeta.RenameRequest) error
 		c.lookup.Put(req.Mount, record)
 	}
 	return nil
+}
+
+func (c *GRPCClient) RenameReplace(ctx context.Context, req fsmeta.RenameReplaceRequest) (fsmeta.RenameReplaceResult, error) {
+	if err := c.requireRPC(); err != nil {
+		return fsmeta.RenameReplaceResult{}, err
+	}
+	from := lookupCacheKey{mount: req.Mount, parent: req.FromParent, name: req.FromName}
+	to := lookupCacheKey{mount: req.Mount, parent: req.ToParent, name: req.ToName}
+	record, hadSource := c.lookup.peek(from)
+	resp, err := c.rpc.RenameReplace(ctx, renameReplaceRequestToProto(req))
+	if err != nil {
+		return fsmeta.RenameReplaceResult{}, translateRPCError(err)
+	}
+	c.lookup.invalidate(from)
+	c.lookup.invalidate(to)
+	if hadSource {
+		record.Parent = req.ToParent
+		record.Name = req.ToName
+		c.lookup.Put(req.Mount, record)
+	}
+	return renameReplaceResultFromProto(resp), nil
 }
 
 func (c *GRPCClient) RenameSubtree(ctx context.Context, req fsmeta.RenameSubtreeRequest) error {

--- a/fsmeta/client/client_test.go
+++ b/fsmeta/client/client_test.go
@@ -213,6 +213,18 @@ func (e *fakeExecutor) Rename(context.Context, fsmeta.RenameRequest) error {
 	return e.err
 }
 
+func (e *fakeExecutor) RenameReplace(_ context.Context, req fsmeta.RenameReplaceRequest) (fsmeta.RenameReplaceResult, error) {
+	if e.err != nil {
+		return fsmeta.RenameReplaceResult{}, e.err
+	}
+	return fsmeta.RenameReplaceResult{
+		Replaced:        true,
+		OldDentry:       fsmeta.DentryRecord{Parent: req.ToParent, Name: req.ToName, Inode: 41, Type: fsmeta.InodeTypeFile},
+		OldInode:        fsmeta.InodeRecord{Inode: 41, Type: fsmeta.InodeTypeFile, LinkCount: 1},
+		OldInodeDeleted: true,
+	}, nil
+}
+
 func (e *fakeExecutor) RenameSubtree(context.Context, fsmeta.RenameSubtreeRequest) error {
 	return e.err
 }
@@ -351,6 +363,17 @@ func TestTypedClientMutationRPCs(t *testing.T) {
 		ToParent:   2,
 		ToName:     "new",
 	}))
+	replaced, err := cli.RenameReplace(context.Background(), fsmeta.RenameReplaceRequest{
+		Mount:      "vol",
+		FromParent: 1,
+		FromName:   ".stage-new",
+		ToParent:   2,
+		ToName:     "new",
+	})
+	require.NoError(t, err)
+	require.True(t, replaced.Replaced)
+	require.True(t, replaced.OldInodeDeleted)
+	require.Equal(t, fsmeta.InodeID(41), replaced.OldDentry.Inode)
 	require.NoError(t, cli.Link(context.Background(), fsmeta.LinkRequest{
 		Mount:      "vol",
 		FromParent: 1,

--- a/fsmeta/client/wire.go
+++ b/fsmeta/client/wire.go
@@ -155,6 +155,28 @@ func renameRequestToProto(req fsmeta.RenameRequest) *fsmetapb.RenameRequest {
 	}
 }
 
+func renameReplaceRequestToProto(req fsmeta.RenameReplaceRequest) *fsmetapb.RenameReplaceRequest {
+	return &fsmetapb.RenameReplaceRequest{
+		Mount:      string(req.Mount),
+		FromParent: uint64(req.FromParent),
+		FromName:   req.FromName,
+		ToParent:   uint64(req.ToParent),
+		ToName:     req.ToName,
+	}
+}
+
+func renameReplaceResultFromProto(resp *fsmetapb.RenameReplaceResponse) fsmeta.RenameReplaceResult {
+	if resp == nil {
+		return fsmeta.RenameReplaceResult{}
+	}
+	return fsmeta.RenameReplaceResult{
+		Replaced:        resp.GetReplaced(),
+		OldDentry:       dentryFromProto(resp.GetOldDentry()),
+		OldInode:        inodeFromProto(resp.GetOldInode()),
+		OldInodeDeleted: resp.GetOldInodeDeleted(),
+	}
+}
+
 func renameSubtreeRequestToProto(req fsmeta.RenameSubtreeRequest) *fsmetapb.RenameSubtreeRequest {
 	return &fsmetapb.RenameSubtreeRequest{
 		Mount:      string(req.Mount),

--- a/fsmeta/contract/harness.go
+++ b/fsmeta/contract/harness.go
@@ -21,6 +21,7 @@ type Executor interface {
 	ReadDirPlus(context.Context, fsmeta.ReadDirRequest) ([]fsmeta.DentryAttrPair, error)
 	SnapshotSubtree(context.Context, fsmeta.SnapshotSubtreeRequest) (fsmeta.SnapshotSubtreeToken, error)
 	Rename(context.Context, fsmeta.RenameRequest) error
+	RenameReplace(context.Context, fsmeta.RenameReplaceRequest) (fsmeta.RenameReplaceResult, error)
 	RenameSubtree(context.Context, fsmeta.RenameSubtreeRequest) error
 	Link(context.Context, fsmeta.LinkRequest) error
 	Unlink(context.Context, fsmeta.UnlinkRequest) error
@@ -142,6 +143,15 @@ func execute(ctx context.Context, exec Executor, model *Model, op Operation) Res
 			ToName:     op.ToName,
 		})
 		return Result{Err: err}
+	case OpRenameReplace:
+		result, err := exec.RenameReplace(ctx, fsmeta.RenameReplaceRequest{
+			Mount:      op.Mount,
+			FromParent: op.FromParent,
+			FromName:   op.FromName,
+			ToParent:   op.ToParent,
+			ToName:     op.ToName,
+		})
+		return Result{Err: err, RenameReplace: result}
 	case OpRenameSubtree:
 		err := exec.RenameSubtree(ctx, fsmeta.RenameSubtreeRequest{
 			Mount:      op.Mount,
@@ -229,6 +239,9 @@ func compareResult(got, want Result) error {
 	if !reflect.DeepEqual(got.Inode, want.Inode) {
 		return fmt.Errorf("inode mismatch: got %+v want %+v", got.Inode, want.Inode)
 	}
+	if !reflect.DeepEqual(got.RenameReplace, want.RenameReplace) {
+		return fmt.Errorf("rename replace mismatch: got %+v want %+v", got.RenameReplace, want.RenameReplace)
+	}
 	if got.Session != want.Session {
 		return fmt.Errorf("session mismatch: got %+v want %+v", got.Session, want.Session)
 	}
@@ -257,6 +270,9 @@ func summarize(result Result) string {
 	}
 	if result.Inode.Inode != 0 {
 		return fmt.Sprintf("inode=%d size=%d links=%d", result.Inode.Inode, result.Inode.Size, result.Inode.LinkCount)
+	}
+	if result.RenameReplace.Replaced {
+		return fmt.Sprintf("rename_replace old=%s:%d deleted=%t", result.RenameReplace.OldDentry.Name, result.RenameReplace.OldDentry.Inode, result.RenameReplace.OldInodeDeleted)
 	}
 	if result.Session.Session != "" {
 		return fmt.Sprintf("session=%s inode=%d expires=%d", result.Session.Session, result.Session.Inode, result.Session.ExpiresUnixNs)

--- a/fsmeta/contract/history.go
+++ b/fsmeta/contract/history.go
@@ -370,7 +370,7 @@ func isIndeterminateHistoryError(err error) bool {
 
 func operationMayMutate(kind OperationKind) bool {
 	switch kind {
-	case OpCreate, OpUpdateInode, OpRename, OpRenameSubtree, OpLink, OpUnlink, OpOpenWriteSession, OpHeartbeatSession, OpCloseSession, OpExpireSessions:
+	case OpCreate, OpUpdateInode, OpRename, OpRenameReplace, OpRenameSubtree, OpLink, OpUnlink, OpOpenWriteSession, OpHeartbeatSession, OpCloseSession, OpExpireSessions:
 		return true
 	default:
 		return false

--- a/fsmeta/contract/history_test.go
+++ b/fsmeta/contract/history_test.go
@@ -113,6 +113,10 @@ func (unavailableCreateExecutor) Rename(context.Context, fsmeta.RenameRequest) e
 	return fsmeta.ErrInvalidRequest
 }
 
+func (unavailableCreateExecutor) RenameReplace(context.Context, fsmeta.RenameReplaceRequest) (fsmeta.RenameReplaceResult, error) {
+	return fsmeta.RenameReplaceResult{}, fsmeta.ErrInvalidRequest
+}
+
 func (unavailableCreateExecutor) RenameSubtree(context.Context, fsmeta.RenameSubtreeRequest) error {
 	return fsmeta.ErrInvalidRequest
 }

--- a/fsmeta/contract/mapping.go
+++ b/fsmeta/contract/mapping.go
@@ -140,6 +140,20 @@ func (m *inodeMappingExecutor) Rename(ctx context.Context, req fsmeta.RenameRequ
 	return m.base.Rename(ctx, req)
 }
 
+func (m *inodeMappingExecutor) RenameReplace(ctx context.Context, req fsmeta.RenameReplaceRequest) (fsmeta.RenameReplaceResult, error) {
+	req.FromParent = m.actualInode(req.FromParent)
+	req.ToParent = m.actualInode(req.ToParent)
+	result, err := m.base.RenameReplace(ctx, req)
+	if err != nil {
+		return fsmeta.RenameReplaceResult{}, err
+	}
+	if result.Replaced {
+		result.OldDentry = m.translateDentryRecord(result.OldDentry)
+		result.OldInode = m.translateInodeRecord(result.OldInode)
+	}
+	return result, nil
+}
+
 func (m *inodeMappingExecutor) RenameSubtree(ctx context.Context, req fsmeta.RenameSubtreeRequest) error {
 	req.FromParent = m.actualInode(req.FromParent)
 	req.ToParent = m.actualInode(req.ToParent)

--- a/fsmeta/contract/mapping_test.go
+++ b/fsmeta/contract/mapping_test.go
@@ -178,6 +178,56 @@ func TestInodeMappingExecutorUpdatesCreateObservedBeforeReturn(t *testing.T) {
 	}
 }
 
+func TestInodeMappingExecutorTranslatesRenameReplaceResult(t *testing.T) {
+	base := newFakeExternalExecutor()
+	exec, err := NewInodeMappingExecutor(base)
+	if err != nil {
+		t.Fatalf("NewInodeMappingExecutor: %v", err)
+	}
+	_, err = exec.Create(withPlannedCreateInode(context.Background(), 10), fsmeta.CreateRequest{
+		Mount:  "vol",
+		Parent: fsmeta.RootInode,
+		Name:   "old",
+		Attrs:  fsmeta.CreateAttrs{Type: fsmeta.InodeTypeFile, Mode: 0o644},
+	})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	actualDentry, err := base.Lookup(context.Background(), fsmeta.LookupRequest{Mount: "vol", Parent: fsmeta.RootInode, Name: "old"})
+	if err != nil {
+		t.Fatalf("base Lookup: %v", err)
+	}
+	base.renameReplaceResult = fsmeta.RenameReplaceResult{
+		Replaced: true,
+		OldDentry: fsmeta.DentryRecord{
+			Parent: fsmeta.RootInode,
+			Name:   "old",
+			Inode:  actualDentry.Inode,
+			Type:   fsmeta.InodeTypeFile,
+		},
+		OldInode: fsmeta.InodeRecord{
+			Inode:     actualDentry.Inode,
+			Type:      fsmeta.InodeTypeFile,
+			LinkCount: 1,
+		},
+		OldInodeDeleted: true,
+	}
+
+	result, err := exec.RenameReplace(context.Background(), fsmeta.RenameReplaceRequest{
+		Mount:      "vol",
+		FromParent: fsmeta.RootInode,
+		FromName:   "stage",
+		ToParent:   fsmeta.RootInode,
+		ToName:     "old",
+	})
+	if err != nil {
+		t.Fatalf("RenameReplace: %v", err)
+	}
+	if result.OldDentry.Inode != 10 || result.OldInode.Inode != 10 {
+		t.Fatalf("RenameReplace result was not translated to planned inode: %+v", result)
+	}
+}
+
 type fakeExternalExecutor struct {
 	mu                   sync.Mutex
 	next                 fsmeta.InodeID
@@ -187,6 +237,7 @@ type fakeExternalExecutor struct {
 	createErrAfterCommit error
 	createCommitted      chan struct{}
 	releaseCreate        chan struct{}
+	renameReplaceResult  fsmeta.RenameReplaceResult
 }
 
 func newFakeExternalExecutor() *fakeExternalExecutor {
@@ -271,6 +322,10 @@ func (f *fakeExternalExecutor) SnapshotSubtree(_ context.Context, req fsmeta.Sna
 
 func (f *fakeExternalExecutor) Rename(context.Context, fsmeta.RenameRequest) error {
 	return nil
+}
+
+func (f *fakeExternalExecutor) RenameReplace(context.Context, fsmeta.RenameReplaceRequest) (fsmeta.RenameReplaceResult, error) {
+	return f.renameReplaceResult, nil
 }
 
 func (f *fakeExternalExecutor) RenameSubtree(context.Context, fsmeta.RenameSubtreeRequest) error {

--- a/fsmeta/contract/model.go
+++ b/fsmeta/contract/model.go
@@ -23,6 +23,7 @@ const (
 	OpReadDirPlus      OperationKind = "readdir_plus"
 	OpSnapshotSubtree  OperationKind = "snapshot_subtree"
 	OpRename           OperationKind = "rename"
+	OpRenameReplace    OperationKind = "rename_replace"
 	OpRenameSubtree    OperationKind = "rename_subtree"
 	OpLink             OperationKind = "link"
 	OpUnlink           OperationKind = "unlink"
@@ -69,13 +70,14 @@ func (op Operation) String() string {
 // Result is the comparable response shape returned by both the reference model
 // and the system under test.
 type Result struct {
-	Err     error
-	Dentry  fsmeta.DentryRecord
-	Pairs   []fsmeta.DentryAttrPair
-	Token   fsmeta.SnapshotSubtreeToken
-	Inode   fsmeta.InodeRecord
-	Session fsmeta.SessionRecord
-	Expired uint64
+	Err           error
+	Dentry        fsmeta.DentryRecord
+	Pairs         []fsmeta.DentryAttrPair
+	Token         fsmeta.SnapshotSubtreeToken
+	Inode         fsmeta.InodeRecord
+	RenameReplace fsmeta.RenameReplaceResult
+	Session       fsmeta.SessionRecord
+	Expired       uint64
 }
 
 type dentryKey struct {
@@ -150,6 +152,8 @@ func (m *Model) Apply(op Operation) Result {
 		return m.readDirPlus(op)
 	case OpRename, OpRenameSubtree:
 		return m.renameSubtree(op)
+	case OpRenameReplace:
+		return m.renameReplace(op)
 	case OpLink:
 		return m.link(op)
 	case OpUnlink:
@@ -348,6 +352,65 @@ func (m *Model) renameSubtree(op Operation) Result {
 	record.Name = op.ToName
 	m.dentries[to] = record
 	return Result{}
+}
+
+func (m *Model) renameReplace(op Operation) Result {
+	if op.FromParent == op.ToParent && op.FromName == op.ToName {
+		return Result{Err: fsmeta.ErrInvalidRequest}
+	}
+	from := dentryKey{parent: op.FromParent, name: op.FromName}
+	to := dentryKey{parent: op.ToParent, name: op.ToName}
+	record, ok := m.dentries[from]
+	if !ok {
+		return Result{Err: fsmeta.ErrNotFound}
+	}
+	if record.Type == fsmeta.InodeTypeDirectory {
+		return Result{Err: fsmeta.ErrInvalidRequest}
+	}
+	sourceInode, ok := m.inodes[record.Inode]
+	if !ok {
+		return Result{Err: fsmeta.ErrNotFound}
+	}
+	if sourceInode.Type != record.Type {
+		return Result{Err: fsmeta.ErrInvalidValue}
+	}
+	if sourceInode.Type == fsmeta.InodeTypeDirectory {
+		return Result{Err: fsmeta.ErrInvalidRequest}
+	}
+	result := fsmeta.RenameReplaceResult{}
+	if existing, ok := m.dentries[to]; ok {
+		if existing.Type == fsmeta.InodeTypeDirectory {
+			return Result{Err: fsmeta.ErrInvalidRequest}
+		}
+		existingInode, ok := m.inodes[existing.Inode]
+		if !ok {
+			return Result{Err: fsmeta.ErrNotFound}
+		}
+		if existingInode.Type != existing.Type {
+			return Result{Err: fsmeta.ErrInvalidValue}
+		}
+		if existingInode.Type == fsmeta.InodeTypeDirectory {
+			return Result{Err: fsmeta.ErrInvalidRequest}
+		}
+		if existingInode.Inode == sourceInode.Inode && existingInode.LinkCount <= 1 {
+			return Result{Err: fsmeta.ErrInvalidValue}
+		}
+		result.Replaced = true
+		result.OldDentry = existing
+		result.OldInode = existingInode
+		if existingInode.LinkCount <= 1 {
+			result.OldInodeDeleted = true
+			delete(m.inodes, existingInode.Inode)
+		} else {
+			existingInode.LinkCount--
+			m.inodes[existingInode.Inode] = existingInode
+		}
+	}
+	delete(m.dentries, from)
+	record.Parent = op.ToParent
+	record.Name = op.ToName
+	m.dentries[to] = record
+	return Result{RenameReplace: result}
 }
 
 func (m *Model) link(op Operation) Result {

--- a/fsmeta/contract/model_test.go
+++ b/fsmeta/contract/model_test.go
@@ -233,6 +233,97 @@ func TestModelLinkRenameUnlinkMaintainsLinkCounts(t *testing.T) {
 	require.NoError(t, model.CheckInvariants())
 }
 
+func TestModelRenameReplaceMaintainsReplacedLinkCounts(t *testing.T) {
+	model := NewModel("vol")
+	require.NoError(t, model.Apply(Operation{
+		Kind:   OpCreate,
+		Mount:  "vol",
+		Parent: model.Root,
+		Name:   "old",
+		Inode:  10,
+		Type:   fsmeta.InodeTypeFile,
+		Mode:   0o600,
+	}).Err)
+	require.NoError(t, model.Apply(Operation{
+		Kind:       OpLink,
+		Mount:      "vol",
+		FromParent: model.Root,
+		FromName:   "old",
+		ToParent:   model.Root,
+		ToName:     "old-alias",
+	}).Err)
+	require.NoError(t, model.Apply(Operation{
+		Kind:   OpCreate,
+		Mount:  "vol",
+		Parent: model.Root,
+		Name:   "stage",
+		Inode:  11,
+		Type:   fsmeta.InodeTypeFile,
+		Mode:   0o600,
+	}).Err)
+
+	result := model.Apply(Operation{
+		Kind:       OpRenameReplace,
+		Mount:      "vol",
+		FromParent: model.Root,
+		FromName:   "stage",
+		ToParent:   model.Root,
+		ToName:     "old",
+	})
+	require.NoError(t, result.Err)
+
+	require.True(t, result.RenameReplace.Replaced)
+	require.False(t, result.RenameReplace.OldInodeDeleted)
+	require.Equal(t, fsmeta.InodeID(10), result.RenameReplace.OldDentry.Inode)
+	require.Equal(t, uint32(2), result.RenameReplace.OldInode.LinkCount)
+	require.Equal(t, fsmeta.InodeID(11), model.dentries[dentryKey{parent: model.Root, name: "old"}].Inode)
+	require.Equal(t, uint32(1), model.inodes[10].LinkCount)
+	require.Contains(t, model.dentries, dentryKey{parent: model.Root, name: "old-alias"})
+	require.NotContains(t, model.dentries, dentryKey{parent: model.Root, name: "stage"})
+	require.NoError(t, model.CheckInvariants())
+}
+
+func TestModelRenameReplaceDeletesSingleLinkReplacedInode(t *testing.T) {
+	model := NewModel("vol")
+	require.NoError(t, model.Apply(Operation{
+		Kind:   OpCreate,
+		Mount:  "vol",
+		Parent: model.Root,
+		Name:   "old",
+		Inode:  10,
+		Type:   fsmeta.InodeTypeFile,
+		Mode:   0o600,
+	}).Err)
+	require.NoError(t, model.Apply(Operation{
+		Kind:   OpCreate,
+		Mount:  "vol",
+		Parent: model.Root,
+		Name:   "stage",
+		Inode:  11,
+		Type:   fsmeta.InodeTypeFile,
+		Mode:   0o600,
+	}).Err)
+
+	result := model.Apply(Operation{
+		Kind:       OpRenameReplace,
+		Mount:      "vol",
+		FromParent: model.Root,
+		FromName:   "stage",
+		ToParent:   model.Root,
+		ToName:     "old",
+	})
+	require.NoError(t, result.Err)
+
+	require.True(t, result.RenameReplace.Replaced)
+	require.True(t, result.RenameReplace.OldInodeDeleted)
+	require.Equal(t, fsmeta.InodeID(10), result.RenameReplace.OldDentry.Inode)
+	require.Equal(t, uint32(1), result.RenameReplace.OldInode.LinkCount)
+	require.Equal(t, fsmeta.InodeID(11), model.dentries[dentryKey{parent: model.Root, name: "old"}].Inode)
+	require.NotContains(t, model.inodes, fsmeta.InodeID(10))
+	require.NotContains(t, model.dentries, dentryKey{parent: model.Root, name: "stage"})
+	require.NoError(t, model.CheckInvariants())
+}
+
 func TestModelSnapshotReadDirStaysStableAcrossNamespaceMutation(t *testing.T) {
 	model := NewModel("vol")
 	require.NoError(t, model.Apply(Operation{

--- a/fsmeta/contract/script.go
+++ b/fsmeta/contract/script.go
@@ -56,14 +56,16 @@ func chooseOperation(rng *rand.Rand, model *Model, names []string, sessions []fs
 	case 26, 27, 28, 29, 30, 31, 32, 33:
 		return renameOperation(rng, model, names)
 	case 34, 35, 36, 37, 38, 39, 40:
+		return renameReplaceOperation(rng, model, names)
+	case 41, 42, 43, 44:
 		return linkOperation(rng, model, names)
-	case 41, 42, 43, 44, 45, 46, 47:
+	case 45, 46, 47:
 		return unlinkOperation(rng, model, names)
 	case 48, 49, 50:
 		return removeOperation(rng, model, names)
 	case 51, 52, 53:
 		return updateOperation(rng, model, names)
-	case 54, 55, 56, 57, 58:
+	case 55, 56, 57, 58, 59:
 		if len(files) == 0 {
 			return createOperation(rng, model, names, nextInode)
 		}
@@ -75,7 +77,7 @@ func chooseOperation(rng *rand.Rand, model *Model, names []string, sessions []fs
 			Session:   sessions[rng.Intn(len(sessions))],
 			ExpiresNs: model.NowUnixNs + int64(1+rng.Intn(10))*int64(time.Second),
 		}
-	case 59, 60, 61, 62:
+	case 60, 61, 62, 63:
 		if len(liveSessions) == 0 {
 			return readDirPlusOperation(rng, model, names)
 		}
@@ -87,21 +89,21 @@ func chooseOperation(rng *rand.Rand, model *Model, names []string, sessions []fs
 			Session:   session.Session,
 			ExpiresNs: model.NowUnixNs + int64(10+rng.Intn(10))*int64(time.Second),
 		}
-	case 63, 64, 65:
+	case 64, 65, 66:
 		if len(liveSessions) == 0 {
 			return lookupOperation(rng, model, names)
 		}
 		session := liveSessions[rng.Intn(len(liveSessions))]
 		return Operation{Kind: OpCloseSession, Mount: model.Mount, Inode: session.Inode, Session: session.Session}
-	case 66, 67:
+	case 67, 68:
 		return Operation{
 			Kind:      OpAdvanceTime,
 			Mount:     model.Mount,
 			AdvanceNs: int64(1+rng.Intn(6)) * int64(time.Second),
 		}
-	case 68, 69:
+	case 69, 70:
 		return Operation{Kind: OpExpireSessions, Mount: model.Mount, Limit: 16}
-	case 70, 71, 72:
+	case 71, 72, 73:
 		ref := *nextSnapshotRef
 		*nextSnapshotRef++
 		return Operation{Kind: OpSnapshotSubtree, Mount: model.Mount, Parent: model.Root, SnapshotRef: ref}
@@ -176,6 +178,29 @@ func renameOperation(rng *rand.Rand, model *Model, names []string) Operation {
 	}
 	return Operation{
 		Kind:       OpRename,
+		Mount:      model.Mount,
+		FromParent: model.Root,
+		FromName:   fromName,
+		ToParent:   model.Root,
+		ToName:     toName,
+	}
+}
+
+func renameReplaceOperation(rng *rand.Rand, model *Model, names []string) Operation {
+	fromName := names[rng.Intn(len(names))]
+	if files := model.ExistingFileDentries(); len(files) > 0 && rng.Intn(100) < 85 {
+		fromName = files[rng.Intn(len(files))].Name
+	} else if existing := model.ExistingDentries(); len(existing) > 0 {
+		fromName = existing[rng.Intn(len(existing))].Name
+	}
+	toName := names[rng.Intn(len(names))]
+	if existing := model.ExistingDentries(); len(existing) > 0 && rng.Intn(100) < 70 {
+		toName = existing[rng.Intn(len(existing))].Name
+	} else if free := freeNames(model, names); len(free) > 0 {
+		toName = free[rng.Intn(len(free))]
+	}
+	return Operation{
+		Kind:       OpRenameReplace,
 		Mount:      model.Mount,
 		FromParent: model.Root,
 		FromName:   fromName,

--- a/fsmeta/exec/compile/compile_test.go
+++ b/fsmeta/exec/compile/compile_test.go
@@ -121,6 +121,15 @@ func testRenameDelta(tb testing.TB, req fsmeta.RenameRequest, mount fsmeta.Mount
 	return cloneDelta(program.Compiled.Delta), nil
 }
 
+func testRenameReplaceDelta(tb testing.TB, req fsmeta.RenameReplaceRequest, mount fsmeta.MountIdentity) (SemanticDelta, error) {
+	tb.Helper()
+	program, err := CompileRenameReplaceProgram(req, mount)
+	if err != nil {
+		return SemanticDelta{}, err
+	}
+	return cloneDelta(program.Compiled.Delta), nil
+}
+
 func testSnapshotSubtreeDelta(tb testing.TB, req fsmeta.SnapshotSubtreeRequest, mount fsmeta.MountIdentity) (SemanticDelta, error) {
 	tb.Helper()
 	program, err := CompileSnapshotSubtreeProgram(req, mount)
@@ -490,6 +499,13 @@ func TestGeneratedProgramEntriesAreCanonical(t *testing.T) {
 			},
 		},
 		{
+			name: "rename_replace",
+			compile: func() (CompiledOp, error) {
+				program, err := CompileRenameReplaceProgram(fsmeta.RenameReplaceRequest{Mount: "vol", FromParent: fsmeta.RootInode, FromName: "old", ToParent: renameToParent, ToName: "new"}, testMount)
+				return program.Compiled, err
+			},
+		},
+		{
 			name: "rename_subtree",
 			compile: func() (CompiledOp, error) {
 				program, err := CompileRenameSubtreeProgram(fsmeta.RenameSubtreeRequest{Mount: "vol", FromParent: fsmeta.RootInode, FromName: "old", ToParent: crossBucketParent, ToName: "new"}, testMount)
@@ -819,6 +835,39 @@ func TestRenameBucketLocalVisibleCrossBucketSlow(t *testing.T) {
 	require.Equal(t, SlowReasonCrossBucket, crossBucket.SlowReason)
 	require.Equal(t, []fsmeta.InodeID{8, differentBucketParent}, crossBucket.Authority.Parents)
 	require.Len(t, crossBucket.Authority.Buckets, 2)
+}
+
+func TestRenameReplaceCompilesSlowPathWithoutBarrier(t *testing.T) {
+	delta, err := testRenameReplaceDelta(t, fsmeta.RenameReplaceRequest{
+		Mount:      "vol",
+		FromParent: 8,
+		FromName:   ".stage-artifact",
+		ToParent:   8,
+		ToName:     "artifact",
+	}, testMount)
+	require.NoError(t, err)
+
+	require.Equal(t, fsmeta.OperationRenameReplace, delta.Kind)
+	require.Equal(t, EligibilitySlowPath, delta.Eligibility)
+	require.Equal(t, SlowReasonDynamicWriteSet, delta.SlowReason)
+	require.False(t, delta.DurabilityBarrier)
+	require.False(t, delta.WatchAtSeal)
+	require.Equal(t, []fsmeta.InodeID{8}, delta.Authority.Parents)
+	require.Len(t, delta.ReadPredicates, 4)
+	for _, predicate := range delta.ReadPredicates {
+		require.Equal(t, PredicateObservedValue, predicate.Kind)
+	}
+	require.Len(t, delta.WriteEffects, 4)
+	require.Equal(t, EffectDelete, delta.WriteEffects[0].Kind)
+	require.Equal(t, EffectDerivedPut, delta.WriteEffects[1].Kind)
+	require.Equal(t, EffectDerivedPut, delta.WriteEffects[2].Kind)
+	require.Equal(t, EffectDerivedPut, delta.WriteEffects[3].Kind)
+
+	compiled := testCompileAOT(t, delta)
+	require.Equal(t, DurabilityVisibleOnly, compiled.Durability)
+	require.False(t, compiled.Authority.Required)
+	require.Equal(t, FenceNone, compiled.Authority.Fence)
+	require.False(t, compiled.Placement.CanSegment)
 }
 
 func TestSlowPathBoundariesStayExplicit(t *testing.T) {

--- a/fsmeta/exec/compile/dispatch.program.go
+++ b/fsmeta/exec/compile/dispatch.program.go
@@ -21,6 +21,8 @@ func compileAOTDelta(delta SemanticDelta) (CompiledOp, error) {
 		return compileSnapshotSubtreeCompiledOp(delta)
 	case fsmeta.OperationRename:
 		return compileRenameCompiledOp(delta)
+	case fsmeta.OperationRenameReplace:
+		return compileRenameReplaceCompiledOp(delta)
 	case fsmeta.OperationRenameSubtree:
 		return compileRenameSubtreeCompiledOp(delta)
 	case fsmeta.OperationLink:

--- a/fsmeta/exec/compile/generate_test.go
+++ b/fsmeta/exec/compile/generate_test.go
@@ -51,6 +51,11 @@ func TestGeneratedProgramsMatchSemanticSpecs(t *testing.T) {
 			require.NoError(t, err)
 			return program.Compiled
 		}},
+		{spec: compilespecs.RenameReplace, compile: func(t *testing.T) CompiledOp {
+			program, err := CompileRenameReplaceProgram(fsmeta.RenameReplaceRequest{Mount: "vol", FromParent: fsmeta.RootInode, FromName: "old", ToParent: renameToParent, ToName: "new"}, testMount)
+			require.NoError(t, err)
+			return program.Compiled
+		}},
 		{spec: compilespecs.RenameSubtree, compile: func(t *testing.T) CompiledOp {
 			program, err := CompileRenameSubtreeProgram(fsmeta.RenameSubtreeRequest{Mount: "vol", FromParent: fsmeta.RootInode, FromName: "old", ToParent: crossBucketParent, ToName: "new"}, testMount)
 			require.NoError(t, err)
@@ -181,6 +186,8 @@ func operationKindSpecName(kind fsmeta.OperationKind) string {
 		return "fsmeta.OperationSnapshotSubtree"
 	case fsmeta.OperationRename:
 		return "fsmeta.OperationRename"
+	case fsmeta.OperationRenameReplace:
+		return "fsmeta.OperationRenameReplace"
 	case fsmeta.OperationRenameSubtree:
 		return "fsmeta.OperationRenameSubtree"
 	case fsmeta.OperationLink:

--- a/fsmeta/exec/compile/operation.go
+++ b/fsmeta/exec/compile/operation.go
@@ -646,7 +646,7 @@ func watchEventKind(delta SemanticDelta, effect WriteEffect) WatchEventKind {
 	switch delta.Kind {
 	case fsmeta.OperationCreate:
 		return WatchEventCreate
-	case fsmeta.OperationRename, fsmeta.OperationRenameSubtree:
+	case fsmeta.OperationRename, fsmeta.OperationRenameReplace, fsmeta.OperationRenameSubtree:
 		return WatchEventRename
 	case fsmeta.OperationUnlink, fsmeta.OperationRemove:
 		return WatchEventDelete

--- a/fsmeta/exec/compile/rename.program.go
+++ b/fsmeta/exec/compile/rename.program.go
@@ -15,6 +15,10 @@ type RenameProgram struct {
 	Compiled CompiledOp
 }
 
+type RenameReplaceProgram struct {
+	Compiled CompiledOp
+}
+
 type RenameSubtreeProgram struct {
 	Compiled CompiledOp
 }
@@ -50,6 +54,35 @@ func CompileRenameProgram(req fsmeta.RenameRequest, mount fsmeta.MountIdentity) 
 		return RenameProgram{}, err
 	}
 	return RenameProgram{Compiled: compiled}, nil
+}
+
+func CompileRenameReplaceProgram(req fsmeta.RenameReplaceRequest, mount fsmeta.MountIdentity) (RenameReplaceProgram, error) {
+	plan, err := fsmeta.PlanRenameReplace(req, mount)
+	if err != nil {
+		return RenameReplaceProgram{}, err
+	}
+	plan = canonicalPlan(plan)
+	predicates := []Predicate{
+		{Kind: PredicateObservedValue, Key: plan.ReadKeys[0]},
+		{Kind: PredicateObservedValue, Key: plan.ReadKeys[1]},
+		{Kind: PredicateObservedValue, Key: plan.ReadKeys[2]},
+		{Kind: PredicateObservedValue, Key: plan.ReadKeys[3]},
+	}
+	effects := []WriteEffect{
+		{Kind: EffectDelete, Key: plan.MutateKeys[0]},
+		{Kind: EffectDerivedPut, Key: plan.MutateKeys[1]},
+		{Kind: EffectDerivedPut, Key: plan.MutateKeys[2]},
+		{Kind: EffectDerivedPut, Key: plan.MutateKeys[3]},
+	}
+	delta := SemanticDelta{Kind: plan.Kind, Plan: plan, Authority: scopeFor(mount, []fsmeta.InodeID{req.FromParent, req.ToParent}, nil), ReadPredicates: predicates, WriteEffects: effects, Eligibility: EligibilitySlowPath, SlowReason: SlowReasonDynamicWriteSet}
+	if !validateRenameReplaceSemanticDelta(delta) {
+		return RenameReplaceProgram{}, fsmeta.ErrInvalidRequest
+	}
+	compiled, err := compileRenameReplaceCompiledOp(delta)
+	if err != nil {
+		return RenameReplaceProgram{}, err
+	}
+	return RenameReplaceProgram{Compiled: compiled}, nil
 }
 
 func CompileRenameSubtreeProgram(req fsmeta.RenameSubtreeRequest, mount fsmeta.MountIdentity) (RenameSubtreeProgram, error) {
@@ -119,6 +152,93 @@ func validateRenameSemanticDelta(delta SemanticDelta) bool {
 		return false
 	}
 	if delta.ReadPredicates[1].Kind != PredicateNotExists {
+		return false
+	}
+	if !semanticKeyBindingMatches(delta, delta.ReadPredicates[1].Key, "read[1]") {
+		return false
+	}
+	if delta.ReadPredicates[2].Kind != PredicateObservedValue {
+		return false
+	}
+	if !semanticKeyBindingMatches(delta, delta.ReadPredicates[2].Key, "read[2]") {
+		return false
+	}
+	if delta.ReadPredicates[3].Kind != PredicateObservedValue {
+		return false
+	}
+	if !semanticKeyBindingMatches(delta, delta.ReadPredicates[3].Key, "read[3]") {
+		return false
+	}
+	if len(delta.WriteEffects) != 4 {
+		return false
+	}
+	if delta.WriteEffects[0].Kind != EffectDelete {
+		return false
+	}
+	if !semanticKeyBindingMatches(delta, delta.WriteEffects[0].Key, "mutate[0]") {
+		return false
+	}
+	if delta.WriteEffects[1].Kind != EffectDerivedPut {
+		return false
+	}
+	if !semanticKeyBindingMatches(delta, delta.WriteEffects[1].Key, "mutate[1]") {
+		return false
+	}
+	if delta.WriteEffects[2].Kind != EffectDerivedPut {
+		return false
+	}
+	if !semanticKeyBindingMatches(delta, delta.WriteEffects[2].Key, "mutate[2]") {
+		return false
+	}
+	if delta.WriteEffects[3].Kind != EffectDerivedPut {
+		return false
+	}
+	if !semanticKeyBindingMatches(delta, delta.WriteEffects[3].Key, "mutate[3]") {
+		return false
+	}
+	if len(delta.RuntimeGuards) != 0 {
+		return false
+	}
+	return true
+}
+
+func validateRenameReplaceSemanticDelta(delta SemanticDelta) bool {
+	if delta.Kind != fsmeta.OperationRenameReplace {
+		return false
+	}
+	switch {
+	case delta.Eligibility == EligibilitySlowPath && delta.SlowReason == SlowReasonDynamicWriteSet:
+	default:
+		return false
+	}
+	if delta.DurabilityBarrier {
+		return false
+	}
+	if delta.WatchAtSeal {
+		return false
+	}
+	if len(delta.Authority.Parents) == 0 || len(delta.Authority.Parents) > 2 {
+		return false
+	}
+	if len(delta.Authority.Inodes) != 0 {
+		return false
+	}
+	if delta.Authority.Broad {
+		return false
+	}
+	if delta.Authority.AllowOpaqueKeys {
+		return false
+	}
+	if len(delta.ReadPredicates) < 4 {
+		return false
+	}
+	if delta.ReadPredicates[0].Kind != PredicateObservedValue {
+		return false
+	}
+	if !semanticKeyBindingMatches(delta, delta.ReadPredicates[0].Key, "read[0]") {
+		return false
+	}
+	if delta.ReadPredicates[1].Kind != PredicateObservedValue {
 		return false
 	}
 	if !semanticKeyBindingMatches(delta, delta.ReadPredicates[1].Key, "read[1]") {
@@ -258,6 +378,215 @@ func validateRenameSubtreeSemanticDelta(delta SemanticDelta) bool {
 
 func compileRenameCompiledOp(delta SemanticDelta) (CompiledOp, error) {
 	if delta.Kind != fsmeta.OperationRename || len(delta.WriteEffects) != 4 {
+		return CompiledOp{}, fsmeta.ErrInvalidRequest
+	}
+	digest := descriptorDigest(delta)
+	durability := DurabilityVisibleOnly
+	placement := PlacementPlan{MountKeyID: delta.Authority.MountKeyID, Buckets: delta.Authority.Buckets, SlowReason: delta.SlowReason}
+	placement.SingleBucket = len(placement.Buckets) == 1
+	if delta.Eligibility == EligibilityVisibleCommit && !delta.DurabilityBarrier && len(delta.WriteEffects) > 0 {
+		var mount fsmeta.MountKeyID
+		var fsmetaKeys bool
+		var opaqueKeys bool
+		buckets := make([]fsmeta.AffinityBucket, 0, len(delta.WriteEffects))
+		for _, effect := range delta.WriteEffects {
+			switch effect.Kind {
+			case EffectPut:
+				if len(effect.Key) == 0 || effect.Value == nil {
+					placement.RequiresMaterialize = true
+					goto placementDone
+				}
+			case EffectDelete:
+				if len(effect.Key) == 0 {
+					placement.RequiresMaterialize = true
+					goto placementDone
+				}
+			case EffectDerivedPut, EffectDerivedDelete:
+				placement.RequiresMaterialize = true
+				goto placementDone
+			default:
+				placement.SlowReason = SlowReasonDynamicWriteSet
+				goto placementDone
+			}
+			parts, ok := fsmeta.InspectKey(effect.Key)
+			if !ok {
+				if fsmetaKeys {
+					placement.SlowReason = SlowReasonDynamicWriteSet
+					goto placementDone
+				}
+				opaqueKeys = true
+				continue
+			}
+			if opaqueKeys {
+				placement.SlowReason = SlowReasonDynamicWriteSet
+				goto placementDone
+			}
+			if !fsmetaKeys {
+				mount = parts.MountKeyID
+				fsmetaKeys = true
+			} else if mount != parts.MountKeyID {
+				placement.SlowReason = SlowReasonCrossBucket
+				goto placementDone
+			}
+			buckets = append(buckets, parts.Bucket)
+		}
+		if fsmetaKeys {
+			placement.MountKeyID = mount
+			placement.Buckets = uniqueBuckets(buckets)
+			placement.SingleBucket = len(placement.Buckets) == 1
+			placement.CanSegment = true
+			placement.Install = SegmentInstallCatalog
+			placement.MergeKey = SegmentMergeKey{MountKeyID: mount, Install: placement.Install, Durability: durability, FormatVersion: segmentFormatVersion}
+		} else if opaqueKeys {
+			placement.CanSegment = true
+			placement.Install = SegmentInstallSingleBucket
+			placement.MergeKey = SegmentMergeKey{MountKeyID: placement.MountKeyID, Install: placement.Install, Durability: durability, FormatVersion: segmentFormatVersion}
+		}
+	}
+placementDone:
+	footprint := KeyFootprint{Reads: make([]KeyRef, 0, len(delta.ReadPredicates)), Writes: make([]KeyRef, 0, len(delta.WriteEffects)), ConflictKeys: make([]KeyRef, 0, len(delta.ReadPredicates)+len(delta.WriteEffects))}
+	for _, predicate := range delta.ReadPredicates {
+		mode := KeyAccessRead
+		if predicate.Kind == PredicatePrefixScan {
+			mode = KeyAccessReadPrefix
+			footprint.HasPrefixRead = true
+		}
+		ref := keyRef(mode, predicate.Key)
+		footprint.Reads = append(footprint.Reads, ref)
+		footprint.ConflictKeys = append(footprint.ConflictKeys, ref)
+		footprint.EstimatedBytes += uint64(len(predicate.Key) + len(predicate.ExpectedValue))
+		if ref.Opaque {
+			footprint.HasOpaqueKeys = true
+		}
+	}
+	for _, effect := range delta.WriteEffects {
+		ref := keyRef(KeyAccessWrite, effect.Key)
+		footprint.Writes = append(footprint.Writes, ref)
+		footprint.ConflictKeys = append(footprint.ConflictKeys, ref)
+		footprint.EstimatedBytes += uint64(len(effect.Key) + len(effect.Value))
+		if ref.Opaque {
+			footprint.HasOpaqueKeys = true
+		}
+	}
+	predicates := make([]PredicateObligation, 0, len(delta.ReadPredicates))
+	for _, predicate := range delta.ReadPredicates {
+		obligation := PredicateObligation{Kind: predicate.Kind, Key: predicate.Key, HasExpectedValue: predicate.HasExpectedValue}
+		if predicate.HasExpectedValue {
+			obligation.ExpectHash = sha256.Sum256(predicate.ExpectedValue)
+		}
+		switch predicate.Kind {
+		case PredicateExists:
+			obligation.NeedValue = true
+		case PredicateNotExists:
+			obligation.NeedAbsent = true
+		case PredicateObservedValue:
+			obligation.NeedValue = true
+		}
+		predicates = append(predicates, obligation)
+	}
+	guards := make([]GuardObligation, 0, len(delta.RuntimeGuards))
+	for _, guard := range delta.RuntimeGuards {
+		guards = append(guards, GuardObligation{Guard: guard, Digest: GuardObligationDigest(guard)})
+	}
+	effects := make([]EffectPlan, 0, len(delta.WriteEffects))
+	for i, effect := range delta.WriteEffects {
+		plan := EffectPlan{ID: MutationID(i), Kind: effect.Kind, Key: effect.Key, Value: effect.Value, Concrete: effect.Kind == EffectPut || effect.Kind == EffectDelete}
+		if len(effect.Value) > 0 {
+			plan.ValueHash = sha256.Sum256(effect.Value)
+		}
+		if parts, ok := fsmeta.InspectKey(effect.Key); ok {
+			plan.MountKeyID = parts.MountKeyID
+			plan.Bucket = parts.Bucket
+			plan.RecordKind = parts.Kind
+		} else if len(effect.Key) > 0 {
+			plan.Opaque = true
+		}
+		switch effect.Kind {
+		case EffectDerivedPut, EffectDerivedDelete:
+			plan.Derivation = DerivationRuntimeValue
+		}
+		effects = append(effects, plan)
+	}
+	atomicity := AtomicityGroup{Members: make([]MutationID, 0, len(delta.WriteEffects)), Recovery: RecoveryReplayAllOrNothing, Digest: digest}
+	for i := range delta.WriteEffects {
+		atomicity.Members = append(atomicity.Members, MutationID(i))
+	}
+	atomicity.Splittable = len(atomicity.Members) <= 1
+	segment := SegmentPlan{MergeKey: placement.MergeKey, Install: placement.Install, CanAppend: placement.CanSegment, RequiresMaterialize: placement.RequiresMaterialize, EstimatedPayloadBytes: footprint.EstimatedBytes, OperationCount: 1, MutationCount: uint32(len(effects))}
+	switch {
+	case placement.Install == SegmentInstallSingleBucket:
+		segment.CanMaterialize = placement.CanSegment
+		segment.MaterializeInstall = SegmentInstallSingleBucket
+		segment.MaterializeMergeKey = placement.MergeKey
+	case placement.Install == SegmentInstallCatalog && placement.SingleBucket && len(placement.Buckets) == 1:
+		segment.CanMaterialize = placement.CanSegment
+		segment.MaterializeInstall = SegmentInstallSingleBucket
+		segment.MaterializeMergeKey = SegmentMergeKey{MountKeyID: placement.MountKeyID, HasPrimaryBucket: true, PrimaryBucket: placement.Buckets[0], Install: SegmentInstallSingleBucket, Durability: placement.MergeKey.Durability, FormatVersion: placement.MergeKey.FormatVersion}
+	case placement.Install == SegmentInstallCatalog && placement.CanSegment:
+		// Multi-bucket catalog op: materialize is still safe because the
+		// installer writes each entry as a direct MVCC mutation regardless
+		// of bucket. MergeKey carries no PrimaryBucket so all multi-bucket
+		// materialize ops batch together in one install. Local fsmeta runtimes
+		// consume this path when their installer materializes segments;
+		// distributed runtimes keep catalog install and never enter materialize
+		// in SegmentPlanForInstall.
+		segment.CanMaterialize = placement.CanSegment
+		segment.MaterializeInstall = SegmentInstallSingleBucket
+		segment.MaterializeMergeKey = SegmentMergeKey{MountKeyID: placement.MountKeyID, Install: SegmentInstallSingleBucket, Durability: placement.MergeKey.Durability, FormatVersion: placement.MergeKey.FormatVersion}
+	}
+	completion := CompletionPlan{}
+	if delta.Eligibility == EligibilityVisibleCommit && len(effects) != 0 {
+		kind := CompletionVisible
+		if durability != DurabilityVisibleOnly {
+			kind = CompletionDurable
+		}
+		completion = CompletionPlan{RetainCompletion: true, Kind: kind, MutationCount: uint32(len(effects)), DescriptorDigest: digest}
+	}
+	watch := []WatchProjection(nil)
+	if len(delta.WriteEffects) > 0 {
+		emitAt := WatchEmitVisible
+		if delta.WatchAtSeal || delta.DurabilityBarrier {
+			emitAt = WatchEmitSeal
+		}
+		watch = make([]WatchProjection, 0, len(delta.WriteEffects))
+		for _, effect := range delta.WriteEffects {
+			if len(effect.Key) == 0 {
+				continue
+			}
+			parts, ok := fsmeta.InspectKey(effect.Key)
+			if !ok || parts.Kind != fsmeta.KeyKindDentry {
+				continue
+			}
+			projection := WatchProjection{EventKind: watchEventKind(delta, effect), Key: effect.Key, Parent: parts.Parent, Name: dentryName(effect.Key), EmitAt: emitAt}
+			if len(effect.Value) > 0 {
+				if dentry, err := fsmeta.DecodeDentryValue(effect.Value); err == nil {
+					projection.Inode = dentry.Inode
+				}
+			}
+			watch = append(watch, projection)
+		}
+	}
+	return CompiledOp{
+		Delta:            delta,
+		DescriptorDigest: digest,
+		IntentDigest:     digest,
+		ReplayDigest:     digest,
+		Authority:        AuthorityPlan{Scope: delta.Authority, Required: delta.Eligibility == EligibilityVisibleCommit, Fence: fenceMode(delta)},
+		Placement:        placement,
+		Footprint:        footprint,
+		Predicates:       predicates,
+		Guards:           guards,
+		Effects:          effects,
+		Atomicity:        atomicity,
+		Durability:       durability,
+		Watch:            watch,
+		Completion:       completion,
+		Segment:          segment,
+	}, nil
+}
+
+func compileRenameReplaceCompiledOp(delta SemanticDelta) (CompiledOp, error) {
+	if delta.Kind != fsmeta.OperationRenameReplace || len(delta.WriteEffects) != 4 {
 		return CompiledOp{}, fsmeta.ErrInvalidRequest
 	}
 	digest := descriptorDigest(delta)

--- a/fsmeta/exec/compile/specs/operations.go
+++ b/fsmeta/exec/compile/specs/operations.go
@@ -159,6 +159,35 @@ var Rename = specdsl.OpSpec{
 	},
 }
 
+var RenameReplace = specdsl.OpSpec{
+	Name:           "RenameReplace",
+	FileName:       "rename.program.go",
+	ProgramType:    "RenameReplaceProgram",
+	RequestType:    "fsmeta.RenameReplaceRequest",
+	CompileName:    "CompileRenameReplaceProgram",
+	PlanName:       "fsmeta.PlanRenameReplace",
+	OperationKind:  "fsmeta.OperationRenameReplace",
+	Durability:     "DurabilityVisibleOnly",
+	Eligibility:    "EligibilitySlowPath",
+	SlowReason:     "SlowReasonDynamicWriteSet",
+	PredicateCount: -1,
+	EffectCount:    4,
+	Emitter:        "operation",
+	Authority:      specdsl.AuthoritySpec{Parents: []string{"from_parent", "to_parent"}},
+	Predicates: []specdsl.PredicateSpec{
+		{Name: "from_dentry_observed", Kind: "PredicateObservedValue", Key: "read[0]"},
+		{Name: "to_dentry_observed", Kind: "PredicateObservedValue", Key: "read[1]"},
+		{Name: "from_parent_inode_observed", Kind: "PredicateObservedValue", Key: "read[2]"},
+		{Name: "to_parent_inode_observed", Kind: "PredicateObservedValue", Key: "read[3]"},
+	},
+	Effects: []specdsl.EffectSpec{
+		{Name: "from_dentry", Kind: "EffectDelete", Key: "mutate[0]"},
+		{Name: "to_dentry", Kind: "EffectDerivedPut", Key: "mutate[1]", ValueSource: "runtime"},
+		{Name: "from_parent_inode", Kind: "EffectDerivedPut", Key: "mutate[2]", ValueSource: "runtime"},
+		{Name: "to_parent_inode", Kind: "EffectDerivedPut", Key: "mutate[3]", ValueSource: "runtime"},
+	},
+}
+
 var RenameSubtree = specdsl.OpSpec{
 	Name:              "RenameSubtree",
 	FileName:          "rename.program.go",
@@ -434,6 +463,7 @@ func All() []specdsl.OpSpec {
 		ReadDir,
 		SnapshotSubtree,
 		Rename,
+		RenameReplace,
 		RenameSubtree,
 		Link,
 		Unlink,

--- a/fsmeta/exec/executor_rename.go
+++ b/fsmeta/exec/executor_rename.go
@@ -118,6 +118,17 @@ func renameMoveFromRename(req fsmeta.RenameRequest, identity fsmeta.MountIdentit
 	}
 }
 
+func renameMoveFromRenameReplace(req fsmeta.RenameReplaceRequest, identity fsmeta.MountIdentity) renameMove {
+	return renameMove{
+		mount:      req.Mount,
+		identity:   identity,
+		fromParent: req.FromParent,
+		fromName:   req.FromName,
+		toParent:   req.ToParent,
+		toName:     req.ToName,
+	}
+}
+
 func renameMoveFromRenameSubtree(req fsmeta.RenameSubtreeRequest, identity fsmeta.MountIdentity) renameMove {
 	return renameMove{
 		mount:      req.Mount,
@@ -180,6 +191,50 @@ func (e *Executor) Rename(ctx context.Context, req fsmeta.RenameRequest) error {
 	e.invalidateNegative(plan.MutateKeys...)
 	e.invalidateDirPages(req.Mount, req.FromParent, req.ToParent)
 	return nil
+}
+
+// RenameReplace atomically publishes the source dentry at the destination name,
+// replacing an existing non-directory destination dentry when present. It is the
+// artifact publish primitive: no subtree handoff or durability barrier is
+// emitted, and all namespace/index mutations commit in one KV transaction.
+func (e *Executor) RenameReplace(ctx context.Context, req fsmeta.RenameReplaceRequest) (fsmeta.RenameReplaceResult, error) {
+	mountRecord, err := e.resolveActiveMount(ctx, req.Mount)
+	if err != nil {
+		return fsmeta.RenameReplaceResult{}, err
+	}
+	mount := mountRecord.Identity()
+	program, err := compile.CompileRenameReplaceProgram(req, mount)
+	if err != nil {
+		return fsmeta.RenameReplaceResult{}, err
+	}
+	delta := program.Compiled.Delta
+	if err := e.requireSameAuthority(ctx, req.Mount, req.FromParent, req.ToParent); err != nil {
+		return fsmeta.RenameReplaceResult{}, err
+	}
+	if err := e.admitVisibleAuthority(ctx, delta); err != nil {
+		return fsmeta.RenameReplaceResult{}, err
+	}
+	plan := delta.Plan
+	move := renameMoveFromRenameReplace(req, mount)
+	var result fsmeta.RenameReplaceResult
+	if err := e.withTxnRetry(ctx, func(startVersion, commitVersion uint64) error {
+		nextResult, mutations, err := e.prepareRenameReplaceMutations(ctx, plan, move, startVersion)
+		if err != nil {
+			return fmt.Errorf("prepare rename replace: %w", err)
+		}
+		if err := e.mutateWithoutAtomicOnePhase(ctx, plan.Kind, plan.PrimaryKey, mutations, startVersion, commitVersion); err != nil {
+			return fmt.Errorf("commit rename replace: %w", err)
+		}
+		result = nextResult
+		return nil
+	}, delta.Authority); err != nil {
+		return fsmeta.RenameReplaceResult{}, err
+	}
+	e.forgetVisibleEmptyDirectory(mount, req.ToParent)
+	e.invalidateNegative(plan.ReadKeys...)
+	e.invalidateNegative(plan.MutateKeys...)
+	e.invalidateDirPages(req.Mount, req.FromParent, req.ToParent)
+	return result, nil
 }
 
 // RenameSubtree moves the subtree root dentry from source to destination.
@@ -252,6 +307,187 @@ func (e *Executor) RenameSubtree(ctx context.Context, req fsmeta.RenameSubtreeRe
 	e.invalidateNegative(plan.ReadKeys...)
 	e.invalidateNegative(plan.MutateKeys...)
 	e.invalidateDirPages(req.Mount, req.FromParent, req.ToParent)
+	return nil
+}
+
+func (e *Executor) prepareRenameReplaceMutations(ctx context.Context, plan fsmeta.OperationPlan, move renameMove, startVersion uint64) (fsmeta.RenameReplaceResult, []*kvrpcpb.Mutation, error) {
+	sourceDentry, err := e.readDentry(ctx, plan.ReadKeys[0], startVersion)
+	if err != nil {
+		return fsmeta.RenameReplaceResult{}, nil, fmt.Errorf("source dentry: %w", err)
+	}
+	if sourceDentry.Type == fsmeta.InodeTypeDirectory {
+		return fsmeta.RenameReplaceResult{}, nil, fsmeta.ErrInvalidRequest
+	}
+	sourceInode, ok, err := e.readInode(ctx, move.identity, sourceDentry.Inode, startVersion)
+	if err != nil {
+		return fsmeta.RenameReplaceResult{}, nil, fmt.Errorf("source inode: %w", err)
+	}
+	if !ok {
+		return fsmeta.RenameReplaceResult{}, nil, fmt.Errorf("%w: inode %d", fsmeta.ErrNotFound, sourceDentry.Inode)
+	}
+	if err := validateRenameReplaceDentryInode(sourceDentry, sourceInode); err != nil {
+		return fsmeta.RenameReplaceResult{}, nil, err
+	}
+	if sourceInode.Type == fsmeta.InodeTypeDirectory {
+		return fsmeta.RenameReplaceResult{}, nil, fsmeta.ErrInvalidRequest
+	}
+	fromParent, err := e.readDirectoryInode(ctx, move.identity, move.fromParent, startVersion)
+	if err != nil {
+		return fsmeta.RenameReplaceResult{}, nil, fmt.Errorf("from parent inode: %w", err)
+	}
+
+	result := fsmeta.RenameReplaceResult{}
+	destinationExisted := false
+	destinationDentry, err := e.readDentry(ctx, plan.ReadKeys[1], startVersion)
+	if err == nil {
+		destinationExisted = true
+		result.Replaced = true
+		result.OldDentry = destinationDentry
+	} else if !errors.Is(err, fsmeta.ErrNotFound) {
+		return fsmeta.RenameReplaceResult{}, nil, err
+	} else {
+		err = nil
+	}
+
+	var destinationInode fsmeta.InodeRecord
+	if destinationExisted {
+		if destinationDentry.Type == fsmeta.InodeTypeDirectory {
+			return fsmeta.RenameReplaceResult{}, nil, fsmeta.ErrInvalidRequest
+		}
+		destinationInode, ok, err = e.readInode(ctx, move.identity, destinationDentry.Inode, startVersion)
+		if err != nil {
+			return fsmeta.RenameReplaceResult{}, nil, err
+		}
+		if !ok {
+			return fsmeta.RenameReplaceResult{}, nil, fmt.Errorf("%w: inode %d", fsmeta.ErrNotFound, destinationDentry.Inode)
+		}
+		if err := validateRenameReplaceDentryInode(destinationDentry, destinationInode); err != nil {
+			return fsmeta.RenameReplaceResult{}, nil, err
+		}
+		if destinationInode.Type == fsmeta.InodeTypeDirectory {
+			return fsmeta.RenameReplaceResult{}, nil, fsmeta.ErrInvalidRequest
+		}
+		result.OldInode = destinationInode
+	}
+	toParent := fromParent
+	if move.fromParent != move.toParent {
+		toParent, err = e.readDirectoryInode(ctx, move.identity, move.toParent, startVersion)
+		if err != nil {
+			return fsmeta.RenameReplaceResult{}, nil, fmt.Errorf("to parent inode: %w", err)
+		}
+	}
+	nextFromParent := fromParent.record
+	nextToParent := toParent.record
+	switch {
+	case move.fromParent == move.toParent && destinationExisted:
+		nextFromParent, err = decrementDirectoryChildCount(nextFromParent)
+	case move.fromParent != move.toParent:
+		nextFromParent, err = decrementDirectoryChildCount(nextFromParent)
+		if err == nil && !destinationExisted {
+			nextToParent, err = incrementDirectoryChildCount(nextToParent)
+		}
+	}
+	if err != nil {
+		return fsmeta.RenameReplaceResult{}, nil, err
+	}
+
+	replacementDentry := sourceDentry
+	replacementDentry.Parent = move.toParent
+	replacementDentry.Name = move.toName
+	replacementValue, err := fsmeta.EncodeDentryValue(replacementDentry)
+	if err != nil {
+		return fsmeta.RenameReplaceResult{}, nil, err
+	}
+	putDestination := &kvrpcpb.Mutation{
+		Op:    kvrpcpb.Mutation_Put,
+		Key:   cloneBytes(plan.MutateKeys[1]),
+		Value: replacementValue,
+	}
+	if !destinationExisted {
+		putDestination.AssertionNotExist = true
+	}
+	fromParentValue, err := fsmeta.EncodeInodeValue(nextFromParent)
+	if err != nil {
+		return fsmeta.RenameReplaceResult{}, nil, err
+	}
+	toParentValue, err := fsmeta.EncodeInodeValue(nextToParent)
+	if err != nil {
+		return fsmeta.RenameReplaceResult{}, nil, err
+	}
+	mutations := []*kvrpcpb.Mutation{
+		{
+			Op:  kvrpcpb.Mutation_Delete,
+			Key: cloneBytes(plan.MutateKeys[0]),
+		},
+		putDestination,
+	}
+	if move.fromParent == move.toParent {
+		mutations = append(mutations, &kvrpcpb.Mutation{Op: kvrpcpb.Mutation_Put, Key: cloneBytes(plan.MutateKeys[2]), Value: fromParentValue})
+	} else {
+		mutations = append(mutations,
+			&kvrpcpb.Mutation{Op: kvrpcpb.Mutation_Put, Key: cloneBytes(plan.MutateKeys[2]), Value: fromParentValue},
+			&kvrpcpb.Mutation{Op: kvrpcpb.Mutation_Put, Key: cloneBytes(plan.MutateKeys[3]), Value: toParentValue},
+		)
+	}
+
+	quotaChanges := make([]QuotaChange, 0, 3)
+	if move.fromParent != move.toParent {
+		quotaChanges = append(quotaChanges,
+			QuotaChange{Mount: move.mount, MountKeyID: move.identity.MountKeyID, Scope: move.fromParent, Bytes: -inodeSizeDelta(sourceInode.Size), Inodes: -1},
+			QuotaChange{Mount: move.mount, MountKeyID: move.identity.MountKeyID, Scope: move.toParent, Bytes: inodeSizeDelta(sourceInode.Size), Inodes: 1},
+		)
+	}
+	if destinationExisted {
+		destinationInodeKey, err := fsmeta.EncodeInodeKey(move.identity, destinationInode.Inode)
+		if err != nil {
+			return fsmeta.RenameReplaceResult{}, nil, err
+		}
+		if destinationInode.Inode == sourceInode.Inode && destinationInode.LinkCount <= 1 {
+			return fsmeta.RenameReplaceResult{}, nil, fsmeta.ErrInvalidValue
+		}
+		if destinationInode.LinkCount <= 1 {
+			result.OldInodeDeleted = true
+			mutations = append(mutations, &kvrpcpb.Mutation{
+				Op:  kvrpcpb.Mutation_Delete,
+				Key: cloneBytes(destinationInodeKey),
+			})
+		} else {
+			destinationInode.LinkCount--
+			destinationValue, err := fsmeta.EncodeInodeValue(destinationInode)
+			if err != nil {
+				return fsmeta.RenameReplaceResult{}, nil, err
+			}
+			mutations = append(mutations, &kvrpcpb.Mutation{
+				Op:    kvrpcpb.Mutation_Put,
+				Key:   cloneBytes(destinationInodeKey),
+				Value: destinationValue,
+			})
+		}
+		quotaChanges = append(quotaChanges, QuotaChange{
+			Mount:      move.mount,
+			MountKeyID: move.identity.MountKeyID,
+			Scope:      move.toParent,
+			Bytes:      -inodeSizeDelta(result.OldInode.Size),
+			Inodes:     -1,
+		})
+	}
+	if len(quotaChanges) > 0 {
+		quotaMutations, err := e.reserveQuota(ctx, quotaChanges, startVersion)
+		if err != nil {
+			return fsmeta.RenameReplaceResult{}, nil, err
+		}
+		mutations = append(mutations, quotaMutations...)
+	}
+	return result, mutations, nil
+}
+
+func validateRenameReplaceDentryInode(dentry fsmeta.DentryRecord, inode fsmeta.InodeRecord) error {
+	if dentry.Inode != inode.Inode {
+		return fmt.Errorf("%w: dentry inode=%d value inode=%d", fsmeta.ErrInvalidValue, dentry.Inode, inode.Inode)
+	}
+	if dentry.Type != inode.Type {
+		return fmt.Errorf("%w: dentry type=%s inode type=%s", fsmeta.ErrInvalidValue, dentry.Type, inode.Type)
+	}
 	return nil
 }
 

--- a/fsmeta/plan.go
+++ b/fsmeta/plan.go
@@ -24,6 +24,7 @@ const (
 	OperationReadSession      OperationKind = "read_session"
 	OperationSnapshotSubtree  OperationKind = "snapshot_subtree"
 	OperationRename           OperationKind = "rename"
+	OperationRenameReplace    OperationKind = "rename_replace"
 	OperationRenameSubtree    OperationKind = "rename_subtree"
 	OperationLink             OperationKind = "link"
 	OperationUnlink           OperationKind = "unlink"
@@ -111,6 +112,21 @@ type RenameRequest struct {
 	FromName   string
 	ToParent   InodeID
 	ToName     string
+}
+
+type RenameReplaceRequest struct {
+	Mount      MountID
+	FromParent InodeID
+	FromName   string
+	ToParent   InodeID
+	ToName     string
+}
+
+type RenameReplaceResult struct {
+	Replaced        bool
+	OldDentry       DentryRecord
+	OldInode        InodeRecord
+	OldInodeDeleted bool
 }
 
 type RenameSubtreeRequest struct {
@@ -215,6 +231,10 @@ func ValidateRenameRequest(req RenameRequest) error {
 		return ErrInvalidRequest
 	}
 	return nil
+}
+
+func ValidateRenameReplaceRequest(req RenameReplaceRequest) error {
+	return ValidateRenameRequest(RenameRequest(req))
 }
 
 func PlanCreate(req CreateRequest, mount MountIdentity, inodeID InodeID) (OperationPlan, error) {
@@ -373,6 +393,38 @@ func PlanRename(req RenameRequest, mount MountIdentity) (OperationPlan, error) {
 	}
 	return OperationPlan{
 		Kind:       OperationRename,
+		Mount:      req.Mount,
+		PrimaryKey: cloneBytes(source),
+		ReadKeys:   cloneKeySet(source, dest, fromParent, toParent),
+		MutateKeys: cloneKeySet(source, dest, fromParent, toParent),
+	}, nil
+}
+
+func PlanRenameReplace(req RenameReplaceRequest, mount MountIdentity) (OperationPlan, error) {
+	if err := validateMountIdentityForRequest(mount, req.Mount); err != nil {
+		return OperationPlan{}, err
+	}
+	if req.FromParent == req.ToParent && req.FromName == req.ToName {
+		return OperationPlan{}, ErrInvalidRequest
+	}
+	source, err := EncodeDentryKey(mount, req.FromParent, req.FromName)
+	if err != nil {
+		return OperationPlan{}, err
+	}
+	dest, err := EncodeDentryKey(mount, req.ToParent, req.ToName)
+	if err != nil {
+		return OperationPlan{}, err
+	}
+	fromParent, err := EncodeInodeKey(mount, req.FromParent)
+	if err != nil {
+		return OperationPlan{}, err
+	}
+	toParent, err := EncodeInodeKey(mount, req.ToParent)
+	if err != nil {
+		return OperationPlan{}, err
+	}
+	return OperationPlan{
+		Kind:       OperationRenameReplace,
 		Mount:      req.Mount,
 		PrimaryKey: cloneBytes(source),
 		ReadKeys:   cloneKeySet(source, dest, fromParent, toParent),

--- a/fsmeta/runtime/local/rename_replace_test.go
+++ b/fsmeta/runtime/local/rename_replace_test.go
@@ -1,0 +1,211 @@
+// Copyright 2024-2026 The NoKV Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package local
+
+import (
+	"context"
+	"testing"
+
+	"github.com/feichai0017/NoKV/fsmeta"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLocalRuntimeRenameReplaceOverwritesFileAtomically(t *testing.T) {
+	ctx := context.Background()
+	rt, err := Open(ctx, Options{WorkDir: t.TempDir(), Mount: testMount()})
+	require.NoError(t, err)
+	defer func() { require.NoError(t, rt.Close()) }()
+
+	oldFinal, err := rt.Executor.Create(ctx, fsmeta.CreateRequest{
+		Mount:  "vol",
+		Parent: fsmeta.RootInode,
+		Name:   "artifact",
+		Attrs: fsmeta.CreateAttrs{
+			Type:        fsmeta.InodeTypeFile,
+			Size:        3,
+			OpaqueAttrs: []byte("old-body"),
+		},
+	})
+	require.NoError(t, err)
+	staged, err := rt.Executor.Create(ctx, fsmeta.CreateRequest{
+		Mount:  "vol",
+		Parent: fsmeta.RootInode,
+		Name:   ".stage-artifact",
+		Attrs: fsmeta.CreateAttrs{
+			Type:        fsmeta.InodeTypeFile,
+			Size:        7,
+			OpaqueAttrs: []byte("new-body"),
+		},
+	})
+	require.NoError(t, err)
+
+	result, err := rt.Executor.RenameReplace(ctx, fsmeta.RenameReplaceRequest{
+		Mount:      "vol",
+		FromParent: fsmeta.RootInode,
+		FromName:   ".stage-artifact",
+		ToParent:   fsmeta.RootInode,
+		ToName:     "artifact",
+	})
+	require.NoError(t, err)
+	require.True(t, result.Replaced)
+	require.Equal(t, oldFinal.Dentry, result.OldDentry)
+	require.Equal(t, oldFinal.Inode, result.OldInode)
+	require.True(t, result.OldInodeDeleted)
+
+	_, err = rt.Executor.Lookup(ctx, fsmeta.LookupRequest{Mount: "vol", Parent: fsmeta.RootInode, Name: ".stage-artifact"})
+	require.ErrorIs(t, err, fsmeta.ErrNotFound)
+	final, err := rt.Executor.LookupPlus(ctx, fsmeta.LookupRequest{Mount: "vol", Parent: fsmeta.RootInode, Name: "artifact"})
+	require.NoError(t, err)
+	require.Equal(t, staged.Inode.Inode, final.Inode.Inode)
+	require.Equal(t, fsmeta.InodeRecord{
+		Inode:       staged.Inode.Inode,
+		Type:        fsmeta.InodeTypeFile,
+		Size:        7,
+		LinkCount:   1,
+		OpaqueAttrs: []byte("new-body"),
+	}, final.Inode)
+
+	oldInodeKey, err := fsmeta.EncodeInodeKey(testMount(), oldFinal.Inode.Inode)
+	require.NoError(t, err)
+	readVersion, err := rt.Runner.ReserveTimestamp(ctx, 1)
+	require.NoError(t, err)
+	_, ok, err := rt.Runner.Get(ctx, oldInodeKey, readVersion)
+	require.NoError(t, err)
+	require.False(t, ok, "old overwritten inode must be removed in the same namespace mutation")
+}
+
+func TestLocalRuntimeRenameReplacePreservesRemainingHardLinks(t *testing.T) {
+	ctx := context.Background()
+	rt, err := Open(ctx, Options{WorkDir: t.TempDir(), Mount: testMount()})
+	require.NoError(t, err)
+	defer func() { require.NoError(t, rt.Close()) }()
+
+	oldFinal, err := rt.Executor.Create(ctx, fsmeta.CreateRequest{
+		Mount:  "vol",
+		Parent: fsmeta.RootInode,
+		Name:   "artifact",
+		Attrs:  fsmeta.CreateAttrs{Type: fsmeta.InodeTypeFile, Size: 3},
+	})
+	require.NoError(t, err)
+	err = rt.Executor.Link(ctx, fsmeta.LinkRequest{
+		Mount:      "vol",
+		FromParent: fsmeta.RootInode,
+		FromName:   "artifact",
+		ToParent:   fsmeta.RootInode,
+		ToName:     "artifact-link",
+	})
+	require.NoError(t, err)
+	staged, err := rt.Executor.Create(ctx, fsmeta.CreateRequest{
+		Mount:  "vol",
+		Parent: fsmeta.RootInode,
+		Name:   ".stage-artifact",
+		Attrs:  fsmeta.CreateAttrs{Type: fsmeta.InodeTypeFile, Size: 7},
+	})
+	require.NoError(t, err)
+
+	result, err := rt.Executor.RenameReplace(ctx, fsmeta.RenameReplaceRequest{
+		Mount:      "vol",
+		FromParent: fsmeta.RootInode,
+		FromName:   ".stage-artifact",
+		ToParent:   fsmeta.RootInode,
+		ToName:     "artifact",
+	})
+	require.NoError(t, err)
+	require.True(t, result.Replaced)
+	require.Equal(t, oldFinal.Inode.Inode, result.OldInode.Inode)
+	require.Equal(t, uint32(2), result.OldInode.LinkCount)
+	require.False(t, result.OldInodeDeleted)
+
+	final, err := rt.Executor.LookupPlus(ctx, fsmeta.LookupRequest{Mount: "vol", Parent: fsmeta.RootInode, Name: "artifact"})
+	require.NoError(t, err)
+	require.Equal(t, staged.Inode.Inode, final.Inode.Inode)
+	remaining, err := rt.Executor.LookupPlus(ctx, fsmeta.LookupRequest{Mount: "vol", Parent: fsmeta.RootInode, Name: "artifact-link"})
+	require.NoError(t, err)
+	require.Equal(t, oldFinal.Inode.Inode, remaining.Inode.Inode)
+	require.Equal(t, uint32(1), remaining.Inode.LinkCount)
+}
+
+func TestLocalRuntimeRenameReplaceMissingTargetActsLikeRename(t *testing.T) {
+	ctx := context.Background()
+	rt, err := Open(ctx, Options{WorkDir: t.TempDir(), Mount: testMount()})
+	require.NoError(t, err)
+	defer func() { require.NoError(t, rt.Close()) }()
+
+	staged, err := rt.Executor.Create(ctx, fsmeta.CreateRequest{
+		Mount:  "vol",
+		Parent: fsmeta.RootInode,
+		Name:   ".stage-artifact",
+		Attrs:  fsmeta.CreateAttrs{Type: fsmeta.InodeTypeFile, Size: 11},
+	})
+	require.NoError(t, err)
+
+	result, err := rt.Executor.RenameReplace(ctx, fsmeta.RenameReplaceRequest{
+		Mount:      "vol",
+		FromParent: fsmeta.RootInode,
+		FromName:   ".stage-artifact",
+		ToParent:   fsmeta.RootInode,
+		ToName:     "artifact",
+	})
+	require.NoError(t, err)
+	require.False(t, result.Replaced)
+
+	final, err := rt.Executor.LookupPlus(ctx, fsmeta.LookupRequest{Mount: "vol", Parent: fsmeta.RootInode, Name: "artifact"})
+	require.NoError(t, err)
+	require.Equal(t, staged.Inode.Inode, final.Inode.Inode)
+}
+
+func TestLocalRuntimeRenameReplaceRejectsDirectorySources(t *testing.T) {
+	ctx := context.Background()
+	rt, err := Open(ctx, Options{WorkDir: t.TempDir(), Mount: testMount()})
+	require.NoError(t, err)
+	defer func() { require.NoError(t, rt.Close()) }()
+
+	_, err = rt.Executor.Create(ctx, fsmeta.CreateRequest{
+		Mount:  "vol",
+		Parent: fsmeta.RootInode,
+		Name:   ".stage-artifact",
+		Attrs:  fsmeta.CreateAttrs{Type: fsmeta.InodeTypeDirectory},
+	})
+	require.NoError(t, err)
+
+	_, err = rt.Executor.RenameReplace(ctx, fsmeta.RenameReplaceRequest{
+		Mount:      "vol",
+		FromParent: fsmeta.RootInode,
+		FromName:   ".stage-artifact",
+		ToParent:   fsmeta.RootInode,
+		ToName:     "artifact",
+	})
+	require.ErrorIs(t, err, fsmeta.ErrInvalidRequest)
+}
+
+func TestLocalRuntimeRenameReplaceRejectsDirectoryTargets(t *testing.T) {
+	ctx := context.Background()
+	rt, err := Open(ctx, Options{WorkDir: t.TempDir(), Mount: testMount()})
+	require.NoError(t, err)
+	defer func() { require.NoError(t, rt.Close()) }()
+
+	_, err = rt.Executor.Create(ctx, fsmeta.CreateRequest{
+		Mount:  "vol",
+		Parent: fsmeta.RootInode,
+		Name:   ".stage-artifact",
+		Attrs:  fsmeta.CreateAttrs{Type: fsmeta.InodeTypeFile},
+	})
+	require.NoError(t, err)
+	_, err = rt.Executor.Create(ctx, fsmeta.CreateRequest{
+		Mount:  "vol",
+		Parent: fsmeta.RootInode,
+		Name:   "artifact",
+		Attrs:  fsmeta.CreateAttrs{Type: fsmeta.InodeTypeDirectory},
+	})
+	require.NoError(t, err)
+
+	_, err = rt.Executor.RenameReplace(ctx, fsmeta.RenameReplaceRequest{
+		Mount:      "vol",
+		FromParent: fsmeta.RootInode,
+		FromName:   ".stage-artifact",
+		ToParent:   fsmeta.RootInode,
+		ToName:     "artifact",
+	})
+	require.ErrorIs(t, err, fsmeta.ErrInvalidRequest)
+}

--- a/fsmeta/server/service.go
+++ b/fsmeta/server/service.go
@@ -28,6 +28,7 @@ type Executor interface {
 	ResolveSnapshotSubtreeToken(ctx context.Context, token fsmeta.SnapshotSubtreeToken) (fsmeta.SnapshotSubtreeToken, error)
 	GetQuotaUsage(ctx context.Context, req fsmeta.QuotaUsageRequest) (fsmeta.UsageRecord, error)
 	Rename(ctx context.Context, req fsmeta.RenameRequest) error
+	RenameReplace(ctx context.Context, req fsmeta.RenameReplaceRequest) (fsmeta.RenameReplaceResult, error)
 	RenameSubtree(ctx context.Context, req fsmeta.RenameSubtreeRequest) error
 	Link(ctx context.Context, req fsmeta.LinkRequest) error
 	Unlink(ctx context.Context, req fsmeta.UnlinkRequest) error
@@ -332,6 +333,20 @@ func (s *Service) Rename(ctx context.Context, req *fsmetapb.RenameRequest) (*fsm
 		return nil, rpcError(err)
 	}
 	return &fsmetapb.RenameResponse{}, nil
+}
+
+func (s *Service) RenameReplace(ctx context.Context, req *fsmetapb.RenameReplaceRequest) (*fsmetapb.RenameReplaceResponse, error) {
+	if err := s.requireExecutor(); err != nil {
+		return nil, err
+	}
+	if req == nil {
+		return nil, rpcInvalidArgument("fsmeta rename replace request is required")
+	}
+	result, err := s.executor.RenameReplace(ctx, renameReplaceRequestFromProto(req))
+	if err != nil {
+		return nil, rpcError(err)
+	}
+	return renameReplaceResponseToProto(result), nil
 }
 
 func (s *Service) RenameSubtree(ctx context.Context, req *fsmetapb.RenameSubtreeRequest) (*fsmetapb.RenameSubtreeResponse, error) {

--- a/fsmeta/server/service_test.go
+++ b/fsmeta/server/service_test.go
@@ -31,6 +31,7 @@ type fakeExecutor struct {
 	snapshotReq      fsmeta.SnapshotSubtreeRequest
 	quotaReq         fsmeta.QuotaUsageRequest
 	renameReq        fsmeta.RenameRequest
+	renameReplaceReq fsmeta.RenameReplaceRequest
 	renameSubtreeReq fsmeta.RenameSubtreeRequest
 	linkReq          fsmeta.LinkRequest
 	unlinkReq        fsmeta.UnlinkRequest
@@ -178,6 +179,19 @@ func (e *fakeExecutor) GetQuotaUsage(_ context.Context, req fsmeta.QuotaUsageReq
 func (e *fakeExecutor) Rename(_ context.Context, req fsmeta.RenameRequest) error {
 	e.renameReq = req
 	return e.err
+}
+
+func (e *fakeExecutor) RenameReplace(_ context.Context, req fsmeta.RenameReplaceRequest) (fsmeta.RenameReplaceResult, error) {
+	e.renameReplaceReq = req
+	if e.err != nil {
+		return fsmeta.RenameReplaceResult{}, e.err
+	}
+	return fsmeta.RenameReplaceResult{
+		Replaced:        true,
+		OldDentry:       fsmeta.DentryRecord{Parent: req.ToParent, Name: req.ToName, Inode: 41, Type: fsmeta.InodeTypeFile},
+		OldInode:        fsmeta.InodeRecord{Inode: 41, Type: fsmeta.InodeTypeFile, LinkCount: 1},
+		OldInodeDeleted: true,
+	}, nil
 }
 
 func (e *fakeExecutor) RenameSubtree(_ context.Context, req fsmeta.RenameSubtreeRequest) error {
@@ -337,6 +351,25 @@ func TestGRPCServiceReadDirAndMutationRPCs(t *testing.T) {
 		ToParent:   2,
 		ToName:     "new",
 	}, executor.renameReq)
+
+	replaceResp, err := client.RenameReplace(context.Background(), &fsmetapb.RenameReplaceRequest{
+		Mount:      "vol",
+		FromParent: 1,
+		FromName:   ".stage-new",
+		ToParent:   2,
+		ToName:     "new",
+	})
+	require.NoError(t, err)
+	require.True(t, replaceResp.GetReplaced())
+	require.True(t, replaceResp.GetOldInodeDeleted())
+	require.Equal(t, uint64(41), replaceResp.GetOldDentry().GetInode())
+	require.Equal(t, fsmeta.RenameReplaceRequest{
+		Mount:      "vol",
+		FromParent: 1,
+		FromName:   ".stage-new",
+		ToParent:   2,
+		ToName:     "new",
+	}, executor.renameReplaceReq)
 
 	_, err = client.RenameSubtree(context.Background(), &fsmetapb.RenameSubtreeRequest{
 		Mount:      "vol",

--- a/fsmeta/server/wire.go
+++ b/fsmeta/server/wire.go
@@ -182,6 +182,25 @@ func renameRequestFromProto(req *fsmetapb.RenameRequest) fsmeta.RenameRequest {
 	}
 }
 
+func renameReplaceRequestFromProto(req *fsmetapb.RenameReplaceRequest) fsmeta.RenameReplaceRequest {
+	return fsmeta.RenameReplaceRequest{
+		Mount:      fsmeta.MountID(req.GetMount()),
+		FromParent: fsmeta.InodeID(req.GetFromParent()),
+		FromName:   req.GetFromName(),
+		ToParent:   fsmeta.InodeID(req.GetToParent()),
+		ToName:     req.GetToName(),
+	}
+}
+
+func renameReplaceResponseToProto(result fsmeta.RenameReplaceResult) *fsmetapb.RenameReplaceResponse {
+	return &fsmetapb.RenameReplaceResponse{
+		Replaced:        result.Replaced,
+		OldDentry:       dentryToProto(result.OldDentry),
+		OldInode:        inodeToProto(result.OldInode),
+		OldInodeDeleted: result.OldInodeDeleted,
+	}
+}
+
 func renameSubtreeRequestFromProto(req *fsmetapb.RenameSubtreeRequest) fsmeta.RenameSubtreeRequest {
 	return fsmeta.RenameSubtreeRequest{
 		Mount:      fsmeta.MountID(req.GetMount()),

--- a/pb/fsmeta/fsmeta.pb.go
+++ b/pb/fsmeta/fsmeta.pb.go
@@ -2297,6 +2297,150 @@ func (*RenameResponse) Descriptor() ([]byte, []int) {
 	return file_fsmeta_fsmeta_proto_rawDescGZIP(), []int{34}
 }
 
+type RenameReplaceRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Mount         string                 `protobuf:"bytes,1,opt,name=mount,proto3" json:"mount,omitempty"`
+	FromParent    uint64                 `protobuf:"varint,2,opt,name=from_parent,json=fromParent,proto3" json:"from_parent,omitempty"`
+	FromName      string                 `protobuf:"bytes,3,opt,name=from_name,json=fromName,proto3" json:"from_name,omitempty"`
+	ToParent      uint64                 `protobuf:"varint,4,opt,name=to_parent,json=toParent,proto3" json:"to_parent,omitempty"`
+	ToName        string                 `protobuf:"bytes,5,opt,name=to_name,json=toName,proto3" json:"to_name,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *RenameReplaceRequest) Reset() {
+	*x = RenameReplaceRequest{}
+	mi := &file_fsmeta_fsmeta_proto_msgTypes[35]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *RenameReplaceRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*RenameReplaceRequest) ProtoMessage() {}
+
+func (x *RenameReplaceRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_fsmeta_fsmeta_proto_msgTypes[35]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use RenameReplaceRequest.ProtoReflect.Descriptor instead.
+func (*RenameReplaceRequest) Descriptor() ([]byte, []int) {
+	return file_fsmeta_fsmeta_proto_rawDescGZIP(), []int{35}
+}
+
+func (x *RenameReplaceRequest) GetMount() string {
+	if x != nil {
+		return x.Mount
+	}
+	return ""
+}
+
+func (x *RenameReplaceRequest) GetFromParent() uint64 {
+	if x != nil {
+		return x.FromParent
+	}
+	return 0
+}
+
+func (x *RenameReplaceRequest) GetFromName() string {
+	if x != nil {
+		return x.FromName
+	}
+	return ""
+}
+
+func (x *RenameReplaceRequest) GetToParent() uint64 {
+	if x != nil {
+		return x.ToParent
+	}
+	return 0
+}
+
+func (x *RenameReplaceRequest) GetToName() string {
+	if x != nil {
+		return x.ToName
+	}
+	return ""
+}
+
+type RenameReplaceResponse struct {
+	state           protoimpl.MessageState `protogen:"open.v1"`
+	Replaced        bool                   `protobuf:"varint,1,opt,name=replaced,proto3" json:"replaced,omitempty"`
+	OldDentry       *DentryRecord          `protobuf:"bytes,2,opt,name=old_dentry,json=oldDentry,proto3" json:"old_dentry,omitempty"`
+	OldInode        *InodeRecord           `protobuf:"bytes,3,opt,name=old_inode,json=oldInode,proto3" json:"old_inode,omitempty"`
+	OldInodeDeleted bool                   `protobuf:"varint,4,opt,name=old_inode_deleted,json=oldInodeDeleted,proto3" json:"old_inode_deleted,omitempty"`
+	unknownFields   protoimpl.UnknownFields
+	sizeCache       protoimpl.SizeCache
+}
+
+func (x *RenameReplaceResponse) Reset() {
+	*x = RenameReplaceResponse{}
+	mi := &file_fsmeta_fsmeta_proto_msgTypes[36]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *RenameReplaceResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*RenameReplaceResponse) ProtoMessage() {}
+
+func (x *RenameReplaceResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_fsmeta_fsmeta_proto_msgTypes[36]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use RenameReplaceResponse.ProtoReflect.Descriptor instead.
+func (*RenameReplaceResponse) Descriptor() ([]byte, []int) {
+	return file_fsmeta_fsmeta_proto_rawDescGZIP(), []int{36}
+}
+
+func (x *RenameReplaceResponse) GetReplaced() bool {
+	if x != nil {
+		return x.Replaced
+	}
+	return false
+}
+
+func (x *RenameReplaceResponse) GetOldDentry() *DentryRecord {
+	if x != nil {
+		return x.OldDentry
+	}
+	return nil
+}
+
+func (x *RenameReplaceResponse) GetOldInode() *InodeRecord {
+	if x != nil {
+		return x.OldInode
+	}
+	return nil
+}
+
+func (x *RenameReplaceResponse) GetOldInodeDeleted() bool {
+	if x != nil {
+		return x.OldInodeDeleted
+	}
+	return false
+}
+
 type RenameSubtreeRequest struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	Mount         string                 `protobuf:"bytes,1,opt,name=mount,proto3" json:"mount,omitempty"`
@@ -2310,7 +2454,7 @@ type RenameSubtreeRequest struct {
 
 func (x *RenameSubtreeRequest) Reset() {
 	*x = RenameSubtreeRequest{}
-	mi := &file_fsmeta_fsmeta_proto_msgTypes[35]
+	mi := &file_fsmeta_fsmeta_proto_msgTypes[37]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2322,7 +2466,7 @@ func (x *RenameSubtreeRequest) String() string {
 func (*RenameSubtreeRequest) ProtoMessage() {}
 
 func (x *RenameSubtreeRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_fsmeta_fsmeta_proto_msgTypes[35]
+	mi := &file_fsmeta_fsmeta_proto_msgTypes[37]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2335,7 +2479,7 @@ func (x *RenameSubtreeRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RenameSubtreeRequest.ProtoReflect.Descriptor instead.
 func (*RenameSubtreeRequest) Descriptor() ([]byte, []int) {
-	return file_fsmeta_fsmeta_proto_rawDescGZIP(), []int{35}
+	return file_fsmeta_fsmeta_proto_rawDescGZIP(), []int{37}
 }
 
 func (x *RenameSubtreeRequest) GetMount() string {
@@ -2381,7 +2525,7 @@ type RenameSubtreeResponse struct {
 
 func (x *RenameSubtreeResponse) Reset() {
 	*x = RenameSubtreeResponse{}
-	mi := &file_fsmeta_fsmeta_proto_msgTypes[36]
+	mi := &file_fsmeta_fsmeta_proto_msgTypes[38]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2393,7 +2537,7 @@ func (x *RenameSubtreeResponse) String() string {
 func (*RenameSubtreeResponse) ProtoMessage() {}
 
 func (x *RenameSubtreeResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_fsmeta_fsmeta_proto_msgTypes[36]
+	mi := &file_fsmeta_fsmeta_proto_msgTypes[38]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2406,7 +2550,7 @@ func (x *RenameSubtreeResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RenameSubtreeResponse.ProtoReflect.Descriptor instead.
 func (*RenameSubtreeResponse) Descriptor() ([]byte, []int) {
-	return file_fsmeta_fsmeta_proto_rawDescGZIP(), []int{36}
+	return file_fsmeta_fsmeta_proto_rawDescGZIP(), []int{38}
 }
 
 type LinkRequest struct {
@@ -2422,7 +2566,7 @@ type LinkRequest struct {
 
 func (x *LinkRequest) Reset() {
 	*x = LinkRequest{}
-	mi := &file_fsmeta_fsmeta_proto_msgTypes[37]
+	mi := &file_fsmeta_fsmeta_proto_msgTypes[39]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2434,7 +2578,7 @@ func (x *LinkRequest) String() string {
 func (*LinkRequest) ProtoMessage() {}
 
 func (x *LinkRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_fsmeta_fsmeta_proto_msgTypes[37]
+	mi := &file_fsmeta_fsmeta_proto_msgTypes[39]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2447,7 +2591,7 @@ func (x *LinkRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use LinkRequest.ProtoReflect.Descriptor instead.
 func (*LinkRequest) Descriptor() ([]byte, []int) {
-	return file_fsmeta_fsmeta_proto_rawDescGZIP(), []int{37}
+	return file_fsmeta_fsmeta_proto_rawDescGZIP(), []int{39}
 }
 
 func (x *LinkRequest) GetMount() string {
@@ -2493,7 +2637,7 @@ type LinkResponse struct {
 
 func (x *LinkResponse) Reset() {
 	*x = LinkResponse{}
-	mi := &file_fsmeta_fsmeta_proto_msgTypes[38]
+	mi := &file_fsmeta_fsmeta_proto_msgTypes[40]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2505,7 +2649,7 @@ func (x *LinkResponse) String() string {
 func (*LinkResponse) ProtoMessage() {}
 
 func (x *LinkResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_fsmeta_fsmeta_proto_msgTypes[38]
+	mi := &file_fsmeta_fsmeta_proto_msgTypes[40]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2518,7 +2662,7 @@ func (x *LinkResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use LinkResponse.ProtoReflect.Descriptor instead.
 func (*LinkResponse) Descriptor() ([]byte, []int) {
-	return file_fsmeta_fsmeta_proto_rawDescGZIP(), []int{38}
+	return file_fsmeta_fsmeta_proto_rawDescGZIP(), []int{40}
 }
 
 type UnlinkRequest struct {
@@ -2532,7 +2676,7 @@ type UnlinkRequest struct {
 
 func (x *UnlinkRequest) Reset() {
 	*x = UnlinkRequest{}
-	mi := &file_fsmeta_fsmeta_proto_msgTypes[39]
+	mi := &file_fsmeta_fsmeta_proto_msgTypes[41]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2544,7 +2688,7 @@ func (x *UnlinkRequest) String() string {
 func (*UnlinkRequest) ProtoMessage() {}
 
 func (x *UnlinkRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_fsmeta_fsmeta_proto_msgTypes[39]
+	mi := &file_fsmeta_fsmeta_proto_msgTypes[41]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2557,7 +2701,7 @@ func (x *UnlinkRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UnlinkRequest.ProtoReflect.Descriptor instead.
 func (*UnlinkRequest) Descriptor() ([]byte, []int) {
-	return file_fsmeta_fsmeta_proto_rawDescGZIP(), []int{39}
+	return file_fsmeta_fsmeta_proto_rawDescGZIP(), []int{41}
 }
 
 func (x *UnlinkRequest) GetMount() string {
@@ -2589,7 +2733,7 @@ type UnlinkResponse struct {
 
 func (x *UnlinkResponse) Reset() {
 	*x = UnlinkResponse{}
-	mi := &file_fsmeta_fsmeta_proto_msgTypes[40]
+	mi := &file_fsmeta_fsmeta_proto_msgTypes[42]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2601,7 +2745,7 @@ func (x *UnlinkResponse) String() string {
 func (*UnlinkResponse) ProtoMessage() {}
 
 func (x *UnlinkResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_fsmeta_fsmeta_proto_msgTypes[40]
+	mi := &file_fsmeta_fsmeta_proto_msgTypes[42]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2614,7 +2758,7 @@ func (x *UnlinkResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UnlinkResponse.ProtoReflect.Descriptor instead.
 func (*UnlinkResponse) Descriptor() ([]byte, []int) {
-	return file_fsmeta_fsmeta_proto_rawDescGZIP(), []int{40}
+	return file_fsmeta_fsmeta_proto_rawDescGZIP(), []int{42}
 }
 
 type RemoveRequest struct {
@@ -2628,7 +2772,7 @@ type RemoveRequest struct {
 
 func (x *RemoveRequest) Reset() {
 	*x = RemoveRequest{}
-	mi := &file_fsmeta_fsmeta_proto_msgTypes[41]
+	mi := &file_fsmeta_fsmeta_proto_msgTypes[43]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2640,7 +2784,7 @@ func (x *RemoveRequest) String() string {
 func (*RemoveRequest) ProtoMessage() {}
 
 func (x *RemoveRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_fsmeta_fsmeta_proto_msgTypes[41]
+	mi := &file_fsmeta_fsmeta_proto_msgTypes[43]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2653,7 +2797,7 @@ func (x *RemoveRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RemoveRequest.ProtoReflect.Descriptor instead.
 func (*RemoveRequest) Descriptor() ([]byte, []int) {
-	return file_fsmeta_fsmeta_proto_rawDescGZIP(), []int{41}
+	return file_fsmeta_fsmeta_proto_rawDescGZIP(), []int{43}
 }
 
 func (x *RemoveRequest) GetMount() string {
@@ -2685,7 +2829,7 @@ type RemoveResponse struct {
 
 func (x *RemoveResponse) Reset() {
 	*x = RemoveResponse{}
-	mi := &file_fsmeta_fsmeta_proto_msgTypes[42]
+	mi := &file_fsmeta_fsmeta_proto_msgTypes[44]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2697,7 +2841,7 @@ func (x *RemoveResponse) String() string {
 func (*RemoveResponse) ProtoMessage() {}
 
 func (x *RemoveResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_fsmeta_fsmeta_proto_msgTypes[42]
+	mi := &file_fsmeta_fsmeta_proto_msgTypes[44]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2710,7 +2854,7 @@ func (x *RemoveResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RemoveResponse.ProtoReflect.Descriptor instead.
 func (*RemoveResponse) Descriptor() ([]byte, []int) {
-	return file_fsmeta_fsmeta_proto_rawDescGZIP(), []int{42}
+	return file_fsmeta_fsmeta_proto_rawDescGZIP(), []int{44}
 }
 
 type RemoveDirectoryRequest struct {
@@ -2724,7 +2868,7 @@ type RemoveDirectoryRequest struct {
 
 func (x *RemoveDirectoryRequest) Reset() {
 	*x = RemoveDirectoryRequest{}
-	mi := &file_fsmeta_fsmeta_proto_msgTypes[43]
+	mi := &file_fsmeta_fsmeta_proto_msgTypes[45]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2736,7 +2880,7 @@ func (x *RemoveDirectoryRequest) String() string {
 func (*RemoveDirectoryRequest) ProtoMessage() {}
 
 func (x *RemoveDirectoryRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_fsmeta_fsmeta_proto_msgTypes[43]
+	mi := &file_fsmeta_fsmeta_proto_msgTypes[45]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2749,7 +2893,7 @@ func (x *RemoveDirectoryRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RemoveDirectoryRequest.ProtoReflect.Descriptor instead.
 func (*RemoveDirectoryRequest) Descriptor() ([]byte, []int) {
-	return file_fsmeta_fsmeta_proto_rawDescGZIP(), []int{43}
+	return file_fsmeta_fsmeta_proto_rawDescGZIP(), []int{45}
 }
 
 func (x *RemoveDirectoryRequest) GetMount() string {
@@ -2781,7 +2925,7 @@ type RemoveDirectoryResponse struct {
 
 func (x *RemoveDirectoryResponse) Reset() {
 	*x = RemoveDirectoryResponse{}
-	mi := &file_fsmeta_fsmeta_proto_msgTypes[44]
+	mi := &file_fsmeta_fsmeta_proto_msgTypes[46]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2793,7 +2937,7 @@ func (x *RemoveDirectoryResponse) String() string {
 func (*RemoveDirectoryResponse) ProtoMessage() {}
 
 func (x *RemoveDirectoryResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_fsmeta_fsmeta_proto_msgTypes[44]
+	mi := &file_fsmeta_fsmeta_proto_msgTypes[46]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2806,7 +2950,7 @@ func (x *RemoveDirectoryResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RemoveDirectoryResponse.ProtoReflect.Descriptor instead.
 func (*RemoveDirectoryResponse) Descriptor() ([]byte, []int) {
-	return file_fsmeta_fsmeta_proto_rawDescGZIP(), []int{44}
+	return file_fsmeta_fsmeta_proto_rawDescGZIP(), []int{46}
 }
 
 type OpenWriteSessionRequest struct {
@@ -2823,7 +2967,7 @@ type OpenWriteSessionRequest struct {
 
 func (x *OpenWriteSessionRequest) Reset() {
 	*x = OpenWriteSessionRequest{}
-	mi := &file_fsmeta_fsmeta_proto_msgTypes[45]
+	mi := &file_fsmeta_fsmeta_proto_msgTypes[47]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2835,7 +2979,7 @@ func (x *OpenWriteSessionRequest) String() string {
 func (*OpenWriteSessionRequest) ProtoMessage() {}
 
 func (x *OpenWriteSessionRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_fsmeta_fsmeta_proto_msgTypes[45]
+	mi := &file_fsmeta_fsmeta_proto_msgTypes[47]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2848,7 +2992,7 @@ func (x *OpenWriteSessionRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use OpenWriteSessionRequest.ProtoReflect.Descriptor instead.
 func (*OpenWriteSessionRequest) Descriptor() ([]byte, []int) {
-	return file_fsmeta_fsmeta_proto_rawDescGZIP(), []int{45}
+	return file_fsmeta_fsmeta_proto_rawDescGZIP(), []int{47}
 }
 
 func (x *OpenWriteSessionRequest) GetMount() string {
@@ -2888,7 +3032,7 @@ type OpenWriteSessionResponse struct {
 
 func (x *OpenWriteSessionResponse) Reset() {
 	*x = OpenWriteSessionResponse{}
-	mi := &file_fsmeta_fsmeta_proto_msgTypes[46]
+	mi := &file_fsmeta_fsmeta_proto_msgTypes[48]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2900,7 +3044,7 @@ func (x *OpenWriteSessionResponse) String() string {
 func (*OpenWriteSessionResponse) ProtoMessage() {}
 
 func (x *OpenWriteSessionResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_fsmeta_fsmeta_proto_msgTypes[46]
+	mi := &file_fsmeta_fsmeta_proto_msgTypes[48]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2913,7 +3057,7 @@ func (x *OpenWriteSessionResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use OpenWriteSessionResponse.ProtoReflect.Descriptor instead.
 func (*OpenWriteSessionResponse) Descriptor() ([]byte, []int) {
-	return file_fsmeta_fsmeta_proto_rawDescGZIP(), []int{46}
+	return file_fsmeta_fsmeta_proto_rawDescGZIP(), []int{48}
 }
 
 func (x *OpenWriteSessionResponse) GetSession() *SessionRecord {
@@ -2937,7 +3081,7 @@ type HeartbeatWriteSessionRequest struct {
 
 func (x *HeartbeatWriteSessionRequest) Reset() {
 	*x = HeartbeatWriteSessionRequest{}
-	mi := &file_fsmeta_fsmeta_proto_msgTypes[47]
+	mi := &file_fsmeta_fsmeta_proto_msgTypes[49]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2949,7 +3093,7 @@ func (x *HeartbeatWriteSessionRequest) String() string {
 func (*HeartbeatWriteSessionRequest) ProtoMessage() {}
 
 func (x *HeartbeatWriteSessionRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_fsmeta_fsmeta_proto_msgTypes[47]
+	mi := &file_fsmeta_fsmeta_proto_msgTypes[49]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2962,7 +3106,7 @@ func (x *HeartbeatWriteSessionRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use HeartbeatWriteSessionRequest.ProtoReflect.Descriptor instead.
 func (*HeartbeatWriteSessionRequest) Descriptor() ([]byte, []int) {
-	return file_fsmeta_fsmeta_proto_rawDescGZIP(), []int{47}
+	return file_fsmeta_fsmeta_proto_rawDescGZIP(), []int{49}
 }
 
 func (x *HeartbeatWriteSessionRequest) GetMount() string {
@@ -3002,7 +3146,7 @@ type HeartbeatWriteSessionResponse struct {
 
 func (x *HeartbeatWriteSessionResponse) Reset() {
 	*x = HeartbeatWriteSessionResponse{}
-	mi := &file_fsmeta_fsmeta_proto_msgTypes[48]
+	mi := &file_fsmeta_fsmeta_proto_msgTypes[50]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3014,7 +3158,7 @@ func (x *HeartbeatWriteSessionResponse) String() string {
 func (*HeartbeatWriteSessionResponse) ProtoMessage() {}
 
 func (x *HeartbeatWriteSessionResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_fsmeta_fsmeta_proto_msgTypes[48]
+	mi := &file_fsmeta_fsmeta_proto_msgTypes[50]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3027,7 +3171,7 @@ func (x *HeartbeatWriteSessionResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use HeartbeatWriteSessionResponse.ProtoReflect.Descriptor instead.
 func (*HeartbeatWriteSessionResponse) Descriptor() ([]byte, []int) {
-	return file_fsmeta_fsmeta_proto_rawDescGZIP(), []int{48}
+	return file_fsmeta_fsmeta_proto_rawDescGZIP(), []int{50}
 }
 
 func (x *HeartbeatWriteSessionResponse) GetSession() *SessionRecord {
@@ -3048,7 +3192,7 @@ type CloseWriteSessionRequest struct {
 
 func (x *CloseWriteSessionRequest) Reset() {
 	*x = CloseWriteSessionRequest{}
-	mi := &file_fsmeta_fsmeta_proto_msgTypes[49]
+	mi := &file_fsmeta_fsmeta_proto_msgTypes[51]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3060,7 +3204,7 @@ func (x *CloseWriteSessionRequest) String() string {
 func (*CloseWriteSessionRequest) ProtoMessage() {}
 
 func (x *CloseWriteSessionRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_fsmeta_fsmeta_proto_msgTypes[49]
+	mi := &file_fsmeta_fsmeta_proto_msgTypes[51]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3073,7 +3217,7 @@ func (x *CloseWriteSessionRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CloseWriteSessionRequest.ProtoReflect.Descriptor instead.
 func (*CloseWriteSessionRequest) Descriptor() ([]byte, []int) {
-	return file_fsmeta_fsmeta_proto_rawDescGZIP(), []int{49}
+	return file_fsmeta_fsmeta_proto_rawDescGZIP(), []int{51}
 }
 
 func (x *CloseWriteSessionRequest) GetMount() string {
@@ -3105,7 +3249,7 @@ type CloseWriteSessionResponse struct {
 
 func (x *CloseWriteSessionResponse) Reset() {
 	*x = CloseWriteSessionResponse{}
-	mi := &file_fsmeta_fsmeta_proto_msgTypes[50]
+	mi := &file_fsmeta_fsmeta_proto_msgTypes[52]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3117,7 +3261,7 @@ func (x *CloseWriteSessionResponse) String() string {
 func (*CloseWriteSessionResponse) ProtoMessage() {}
 
 func (x *CloseWriteSessionResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_fsmeta_fsmeta_proto_msgTypes[50]
+	mi := &file_fsmeta_fsmeta_proto_msgTypes[52]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3130,7 +3274,7 @@ func (x *CloseWriteSessionResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CloseWriteSessionResponse.ProtoReflect.Descriptor instead.
 func (*CloseWriteSessionResponse) Descriptor() ([]byte, []int) {
-	return file_fsmeta_fsmeta_proto_rawDescGZIP(), []int{50}
+	return file_fsmeta_fsmeta_proto_rawDescGZIP(), []int{52}
 }
 
 type ExpireWriteSessionsRequest struct {
@@ -3143,7 +3287,7 @@ type ExpireWriteSessionsRequest struct {
 
 func (x *ExpireWriteSessionsRequest) Reset() {
 	*x = ExpireWriteSessionsRequest{}
-	mi := &file_fsmeta_fsmeta_proto_msgTypes[51]
+	mi := &file_fsmeta_fsmeta_proto_msgTypes[53]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3155,7 +3299,7 @@ func (x *ExpireWriteSessionsRequest) String() string {
 func (*ExpireWriteSessionsRequest) ProtoMessage() {}
 
 func (x *ExpireWriteSessionsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_fsmeta_fsmeta_proto_msgTypes[51]
+	mi := &file_fsmeta_fsmeta_proto_msgTypes[53]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3168,7 +3312,7 @@ func (x *ExpireWriteSessionsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ExpireWriteSessionsRequest.ProtoReflect.Descriptor instead.
 func (*ExpireWriteSessionsRequest) Descriptor() ([]byte, []int) {
-	return file_fsmeta_fsmeta_proto_rawDescGZIP(), []int{51}
+	return file_fsmeta_fsmeta_proto_rawDescGZIP(), []int{53}
 }
 
 func (x *ExpireWriteSessionsRequest) GetMount() string {
@@ -3194,7 +3338,7 @@ type ExpireWriteSessionsResponse struct {
 
 func (x *ExpireWriteSessionsResponse) Reset() {
 	*x = ExpireWriteSessionsResponse{}
-	mi := &file_fsmeta_fsmeta_proto_msgTypes[52]
+	mi := &file_fsmeta_fsmeta_proto_msgTypes[54]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3206,7 +3350,7 @@ func (x *ExpireWriteSessionsResponse) String() string {
 func (*ExpireWriteSessionsResponse) ProtoMessage() {}
 
 func (x *ExpireWriteSessionsResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_fsmeta_fsmeta_proto_msgTypes[52]
+	mi := &file_fsmeta_fsmeta_proto_msgTypes[54]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3219,7 +3363,7 @@ func (x *ExpireWriteSessionsResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ExpireWriteSessionsResponse.ProtoReflect.Descriptor instead.
 func (*ExpireWriteSessionsResponse) Descriptor() ([]byte, []int) {
-	return file_fsmeta_fsmeta_proto_rawDescGZIP(), []int{52}
+	return file_fsmeta_fsmeta_proto_rawDescGZIP(), []int{54}
 }
 
 func (x *ExpireWriteSessionsResponse) GetExpired() uint64 {
@@ -3388,6 +3532,19 @@ const file_fsmeta_fsmeta_proto_rawDesc = "" +
 	"\tto_parent\x18\x04 \x01(\x04R\btoParent\x12\x17\n" +
 	"\ato_name\x18\x05 \x01(\tR\x06toName\"\x10\n" +
 	"\x0eRenameResponse\"\xa0\x01\n" +
+	"\x14RenameReplaceRequest\x12\x14\n" +
+	"\x05mount\x18\x01 \x01(\tR\x05mount\x12\x1f\n" +
+	"\vfrom_parent\x18\x02 \x01(\x04R\n" +
+	"fromParent\x12\x1b\n" +
+	"\tfrom_name\x18\x03 \x01(\tR\bfromName\x12\x1b\n" +
+	"\tto_parent\x18\x04 \x01(\x04R\btoParent\x12\x17\n" +
+	"\ato_name\x18\x05 \x01(\tR\x06toName\"\xd6\x01\n" +
+	"\x15RenameReplaceResponse\x12\x1a\n" +
+	"\breplaced\x18\x01 \x01(\bR\breplaced\x12;\n" +
+	"\n" +
+	"old_dentry\x18\x02 \x01(\v2\x1c.nokv.fsmeta.v1.DentryRecordR\toldDentry\x128\n" +
+	"\told_inode\x18\x03 \x01(\v2\x1b.nokv.fsmeta.v1.InodeRecordR\boldInode\x12*\n" +
+	"\x11old_inode_deleted\x18\x04 \x01(\bR\x0foldInodeDeleted\"\xa0\x01\n" +
 	"\x14RenameSubtreeRequest\x12\x14\n" +
 	"\x05mount\x18\x01 \x01(\tR\x05mount\x12\x1f\n" +
 	"\vfrom_parent\x18\x02 \x01(\x04R\n" +
@@ -3451,7 +3608,7 @@ const file_fsmeta_fsmeta_proto_rawDesc = "" +
 	"\x1eWATCH_EVENT_SOURCE_UNSPECIFIED\x10\x00\x12\x1d\n" +
 	"\x19WATCH_EVENT_SOURCE_COMMIT\x10\x01\x12#\n" +
 	"\x1fWATCH_EVENT_SOURCE_RESOLVE_LOCK\x10\x02\x12&\n" +
-	"\"WATCH_EVENT_SOURCE_RUNTIME_VISIBLE\x10\x032\xf0\x0e\n" +
+	"\"WATCH_EVENT_SOURCE_RUNTIME_VISIBLE\x10\x032\xce\x0f\n" +
 	"\n" +
 	"FSMetadata\x12G\n" +
 	"\x06Create\x12\x1d.nokv.fsmeta.v1.CreateRequest\x1a\x1e.nokv.fsmeta.v1.CreateResponse\x12V\n" +
@@ -3467,6 +3624,7 @@ const file_fsmeta_fsmeta_proto_rawDesc = "" +
 	"\x15RetireSnapshotSubtree\x12,.nokv.fsmeta.v1.RetireSnapshotSubtreeRequest\x1a-.nokv.fsmeta.v1.RetireSnapshotSubtreeResponse\x12V\n" +
 	"\rGetQuotaUsage\x12!.nokv.fsmeta.v1.QuotaUsageRequest\x1a\".nokv.fsmeta.v1.QuotaUsageResponse\x12G\n" +
 	"\x06Rename\x12\x1d.nokv.fsmeta.v1.RenameRequest\x1a\x1e.nokv.fsmeta.v1.RenameResponse\x12\\\n" +
+	"\rRenameReplace\x12$.nokv.fsmeta.v1.RenameReplaceRequest\x1a%.nokv.fsmeta.v1.RenameReplaceResponse\x12\\\n" +
 	"\rRenameSubtree\x12$.nokv.fsmeta.v1.RenameSubtreeRequest\x1a%.nokv.fsmeta.v1.RenameSubtreeResponse\x12A\n" +
 	"\x04Link\x12\x1b.nokv.fsmeta.v1.LinkRequest\x1a\x1c.nokv.fsmeta.v1.LinkResponse\x12G\n" +
 	"\x06Unlink\x12\x1d.nokv.fsmeta.v1.UnlinkRequest\x1a\x1e.nokv.fsmeta.v1.UnlinkResponse\x12G\n" +
@@ -3490,7 +3648,7 @@ func file_fsmeta_fsmeta_proto_rawDescGZIP() []byte {
 }
 
 var file_fsmeta_fsmeta_proto_enumTypes = make([]protoimpl.EnumInfo, 2)
-var file_fsmeta_fsmeta_proto_msgTypes = make([]protoimpl.MessageInfo, 53)
+var file_fsmeta_fsmeta_proto_msgTypes = make([]protoimpl.MessageInfo, 55)
 var file_fsmeta_fsmeta_proto_goTypes = []any{
 	(InodeType)(0),                        // 0: nokv.fsmeta.v1.InodeType
 	(WatchEventSource)(0),                 // 1: nokv.fsmeta.v1.WatchEventSource
@@ -3529,24 +3687,26 @@ var file_fsmeta_fsmeta_proto_goTypes = []any{
 	(*QuotaUsageResponse)(nil),            // 34: nokv.fsmeta.v1.QuotaUsageResponse
 	(*RenameRequest)(nil),                 // 35: nokv.fsmeta.v1.RenameRequest
 	(*RenameResponse)(nil),                // 36: nokv.fsmeta.v1.RenameResponse
-	(*RenameSubtreeRequest)(nil),          // 37: nokv.fsmeta.v1.RenameSubtreeRequest
-	(*RenameSubtreeResponse)(nil),         // 38: nokv.fsmeta.v1.RenameSubtreeResponse
-	(*LinkRequest)(nil),                   // 39: nokv.fsmeta.v1.LinkRequest
-	(*LinkResponse)(nil),                  // 40: nokv.fsmeta.v1.LinkResponse
-	(*UnlinkRequest)(nil),                 // 41: nokv.fsmeta.v1.UnlinkRequest
-	(*UnlinkResponse)(nil),                // 42: nokv.fsmeta.v1.UnlinkResponse
-	(*RemoveRequest)(nil),                 // 43: nokv.fsmeta.v1.RemoveRequest
-	(*RemoveResponse)(nil),                // 44: nokv.fsmeta.v1.RemoveResponse
-	(*RemoveDirectoryRequest)(nil),        // 45: nokv.fsmeta.v1.RemoveDirectoryRequest
-	(*RemoveDirectoryResponse)(nil),       // 46: nokv.fsmeta.v1.RemoveDirectoryResponse
-	(*OpenWriteSessionRequest)(nil),       // 47: nokv.fsmeta.v1.OpenWriteSessionRequest
-	(*OpenWriteSessionResponse)(nil),      // 48: nokv.fsmeta.v1.OpenWriteSessionResponse
-	(*HeartbeatWriteSessionRequest)(nil),  // 49: nokv.fsmeta.v1.HeartbeatWriteSessionRequest
-	(*HeartbeatWriteSessionResponse)(nil), // 50: nokv.fsmeta.v1.HeartbeatWriteSessionResponse
-	(*CloseWriteSessionRequest)(nil),      // 51: nokv.fsmeta.v1.CloseWriteSessionRequest
-	(*CloseWriteSessionResponse)(nil),     // 52: nokv.fsmeta.v1.CloseWriteSessionResponse
-	(*ExpireWriteSessionsRequest)(nil),    // 53: nokv.fsmeta.v1.ExpireWriteSessionsRequest
-	(*ExpireWriteSessionsResponse)(nil),   // 54: nokv.fsmeta.v1.ExpireWriteSessionsResponse
+	(*RenameReplaceRequest)(nil),          // 37: nokv.fsmeta.v1.RenameReplaceRequest
+	(*RenameReplaceResponse)(nil),         // 38: nokv.fsmeta.v1.RenameReplaceResponse
+	(*RenameSubtreeRequest)(nil),          // 39: nokv.fsmeta.v1.RenameSubtreeRequest
+	(*RenameSubtreeResponse)(nil),         // 40: nokv.fsmeta.v1.RenameSubtreeResponse
+	(*LinkRequest)(nil),                   // 41: nokv.fsmeta.v1.LinkRequest
+	(*LinkResponse)(nil),                  // 42: nokv.fsmeta.v1.LinkResponse
+	(*UnlinkRequest)(nil),                 // 43: nokv.fsmeta.v1.UnlinkRequest
+	(*UnlinkResponse)(nil),                // 44: nokv.fsmeta.v1.UnlinkResponse
+	(*RemoveRequest)(nil),                 // 45: nokv.fsmeta.v1.RemoveRequest
+	(*RemoveResponse)(nil),                // 46: nokv.fsmeta.v1.RemoveResponse
+	(*RemoveDirectoryRequest)(nil),        // 47: nokv.fsmeta.v1.RemoveDirectoryRequest
+	(*RemoveDirectoryResponse)(nil),       // 48: nokv.fsmeta.v1.RemoveDirectoryResponse
+	(*OpenWriteSessionRequest)(nil),       // 49: nokv.fsmeta.v1.OpenWriteSessionRequest
+	(*OpenWriteSessionResponse)(nil),      // 50: nokv.fsmeta.v1.OpenWriteSessionResponse
+	(*HeartbeatWriteSessionRequest)(nil),  // 51: nokv.fsmeta.v1.HeartbeatWriteSessionRequest
+	(*HeartbeatWriteSessionResponse)(nil), // 52: nokv.fsmeta.v1.HeartbeatWriteSessionResponse
+	(*CloseWriteSessionRequest)(nil),      // 53: nokv.fsmeta.v1.CloseWriteSessionRequest
+	(*CloseWriteSessionResponse)(nil),     // 54: nokv.fsmeta.v1.CloseWriteSessionResponse
+	(*ExpireWriteSessionsRequest)(nil),    // 55: nokv.fsmeta.v1.ExpireWriteSessionsRequest
+	(*ExpireWriteSessionsResponse)(nil),   // 56: nokv.fsmeta.v1.ExpireWriteSessionsResponse
 }
 var file_fsmeta_fsmeta_proto_depIdxs = []int32{
 	0,  // 0: nokv.fsmeta.v1.InodeRecord.type:type_name -> nokv.fsmeta.v1.InodeType
@@ -3576,55 +3736,59 @@ var file_fsmeta_fsmeta_proto_depIdxs = []int32{
 	20, // 24: nokv.fsmeta.v1.WatchAckOrSubscribe.ack:type_name -> nokv.fsmeta.v1.WatchAck
 	29, // 25: nokv.fsmeta.v1.SnapshotSubtreeResponse.runtime_evidence:type_name -> nokv.fsmeta.v1.SnapshotEvidenceRef
 	29, // 26: nokv.fsmeta.v1.RetireSnapshotSubtreeRequest.runtime_evidence:type_name -> nokv.fsmeta.v1.SnapshotEvidenceRef
-	3,  // 27: nokv.fsmeta.v1.OpenWriteSessionResponse.session:type_name -> nokv.fsmeta.v1.SessionRecord
-	3,  // 28: nokv.fsmeta.v1.HeartbeatWriteSessionResponse.session:type_name -> nokv.fsmeta.v1.SessionRecord
-	7,  // 29: nokv.fsmeta.v1.FSMetadata.Create:input_type -> nokv.fsmeta.v1.CreateRequest
-	9,  // 30: nokv.fsmeta.v1.FSMetadata.UpdateInode:input_type -> nokv.fsmeta.v1.UpdateInodeRequest
-	11, // 31: nokv.fsmeta.v1.FSMetadata.Lookup:input_type -> nokv.fsmeta.v1.LookupRequest
-	11, // 32: nokv.fsmeta.v1.FSMetadata.LookupPlus:input_type -> nokv.fsmeta.v1.LookupRequest
-	14, // 33: nokv.fsmeta.v1.FSMetadata.ReadDir:input_type -> nokv.fsmeta.v1.ReadDirRequest
-	14, // 34: nokv.fsmeta.v1.FSMetadata.ReadDirPlus:input_type -> nokv.fsmeta.v1.ReadDirRequest
-	25, // 35: nokv.fsmeta.v1.FSMetadata.WatchSubtree:input_type -> nokv.fsmeta.v1.WatchAckOrSubscribe
-	26, // 36: nokv.fsmeta.v1.FSMetadata.GetReadVersion:input_type -> nokv.fsmeta.v1.GetReadVersionRequest
-	28, // 37: nokv.fsmeta.v1.FSMetadata.SnapshotSubtree:input_type -> nokv.fsmeta.v1.SnapshotSubtreeRequest
-	31, // 38: nokv.fsmeta.v1.FSMetadata.RetireSnapshotSubtree:input_type -> nokv.fsmeta.v1.RetireSnapshotSubtreeRequest
-	33, // 39: nokv.fsmeta.v1.FSMetadata.GetQuotaUsage:input_type -> nokv.fsmeta.v1.QuotaUsageRequest
-	35, // 40: nokv.fsmeta.v1.FSMetadata.Rename:input_type -> nokv.fsmeta.v1.RenameRequest
-	37, // 41: nokv.fsmeta.v1.FSMetadata.RenameSubtree:input_type -> nokv.fsmeta.v1.RenameSubtreeRequest
-	39, // 42: nokv.fsmeta.v1.FSMetadata.Link:input_type -> nokv.fsmeta.v1.LinkRequest
-	41, // 43: nokv.fsmeta.v1.FSMetadata.Unlink:input_type -> nokv.fsmeta.v1.UnlinkRequest
-	43, // 44: nokv.fsmeta.v1.FSMetadata.Remove:input_type -> nokv.fsmeta.v1.RemoveRequest
-	45, // 45: nokv.fsmeta.v1.FSMetadata.RemoveDirectory:input_type -> nokv.fsmeta.v1.RemoveDirectoryRequest
-	47, // 46: nokv.fsmeta.v1.FSMetadata.OpenWriteSession:input_type -> nokv.fsmeta.v1.OpenWriteSessionRequest
-	49, // 47: nokv.fsmeta.v1.FSMetadata.HeartbeatWriteSession:input_type -> nokv.fsmeta.v1.HeartbeatWriteSessionRequest
-	51, // 48: nokv.fsmeta.v1.FSMetadata.CloseWriteSession:input_type -> nokv.fsmeta.v1.CloseWriteSessionRequest
-	53, // 49: nokv.fsmeta.v1.FSMetadata.ExpireWriteSessions:input_type -> nokv.fsmeta.v1.ExpireWriteSessionsRequest
-	8,  // 50: nokv.fsmeta.v1.FSMetadata.Create:output_type -> nokv.fsmeta.v1.CreateResponse
-	10, // 51: nokv.fsmeta.v1.FSMetadata.UpdateInode:output_type -> nokv.fsmeta.v1.UpdateInodeResponse
-	12, // 52: nokv.fsmeta.v1.FSMetadata.Lookup:output_type -> nokv.fsmeta.v1.LookupResponse
-	13, // 53: nokv.fsmeta.v1.FSMetadata.LookupPlus:output_type -> nokv.fsmeta.v1.LookupPlusResponse
-	15, // 54: nokv.fsmeta.v1.FSMetadata.ReadDir:output_type -> nokv.fsmeta.v1.ReadDirResponse
-	16, // 55: nokv.fsmeta.v1.FSMetadata.ReadDirPlus:output_type -> nokv.fsmeta.v1.ReadDirPlusResponse
-	24, // 56: nokv.fsmeta.v1.FSMetadata.WatchSubtree:output_type -> nokv.fsmeta.v1.WatchSubtreeResponse
-	27, // 57: nokv.fsmeta.v1.FSMetadata.GetReadVersion:output_type -> nokv.fsmeta.v1.GetReadVersionResponse
-	30, // 58: nokv.fsmeta.v1.FSMetadata.SnapshotSubtree:output_type -> nokv.fsmeta.v1.SnapshotSubtreeResponse
-	32, // 59: nokv.fsmeta.v1.FSMetadata.RetireSnapshotSubtree:output_type -> nokv.fsmeta.v1.RetireSnapshotSubtreeResponse
-	34, // 60: nokv.fsmeta.v1.FSMetadata.GetQuotaUsage:output_type -> nokv.fsmeta.v1.QuotaUsageResponse
-	36, // 61: nokv.fsmeta.v1.FSMetadata.Rename:output_type -> nokv.fsmeta.v1.RenameResponse
-	38, // 62: nokv.fsmeta.v1.FSMetadata.RenameSubtree:output_type -> nokv.fsmeta.v1.RenameSubtreeResponse
-	40, // 63: nokv.fsmeta.v1.FSMetadata.Link:output_type -> nokv.fsmeta.v1.LinkResponse
-	42, // 64: nokv.fsmeta.v1.FSMetadata.Unlink:output_type -> nokv.fsmeta.v1.UnlinkResponse
-	44, // 65: nokv.fsmeta.v1.FSMetadata.Remove:output_type -> nokv.fsmeta.v1.RemoveResponse
-	46, // 66: nokv.fsmeta.v1.FSMetadata.RemoveDirectory:output_type -> nokv.fsmeta.v1.RemoveDirectoryResponse
-	48, // 67: nokv.fsmeta.v1.FSMetadata.OpenWriteSession:output_type -> nokv.fsmeta.v1.OpenWriteSessionResponse
-	50, // 68: nokv.fsmeta.v1.FSMetadata.HeartbeatWriteSession:output_type -> nokv.fsmeta.v1.HeartbeatWriteSessionResponse
-	52, // 69: nokv.fsmeta.v1.FSMetadata.CloseWriteSession:output_type -> nokv.fsmeta.v1.CloseWriteSessionResponse
-	54, // 70: nokv.fsmeta.v1.FSMetadata.ExpireWriteSessions:output_type -> nokv.fsmeta.v1.ExpireWriteSessionsResponse
-	50, // [50:71] is the sub-list for method output_type
-	29, // [29:50] is the sub-list for method input_type
-	29, // [29:29] is the sub-list for extension type_name
-	29, // [29:29] is the sub-list for extension extendee
-	0,  // [0:29] is the sub-list for field type_name
+	4,  // 27: nokv.fsmeta.v1.RenameReplaceResponse.old_dentry:type_name -> nokv.fsmeta.v1.DentryRecord
+	2,  // 28: nokv.fsmeta.v1.RenameReplaceResponse.old_inode:type_name -> nokv.fsmeta.v1.InodeRecord
+	3,  // 29: nokv.fsmeta.v1.OpenWriteSessionResponse.session:type_name -> nokv.fsmeta.v1.SessionRecord
+	3,  // 30: nokv.fsmeta.v1.HeartbeatWriteSessionResponse.session:type_name -> nokv.fsmeta.v1.SessionRecord
+	7,  // 31: nokv.fsmeta.v1.FSMetadata.Create:input_type -> nokv.fsmeta.v1.CreateRequest
+	9,  // 32: nokv.fsmeta.v1.FSMetadata.UpdateInode:input_type -> nokv.fsmeta.v1.UpdateInodeRequest
+	11, // 33: nokv.fsmeta.v1.FSMetadata.Lookup:input_type -> nokv.fsmeta.v1.LookupRequest
+	11, // 34: nokv.fsmeta.v1.FSMetadata.LookupPlus:input_type -> nokv.fsmeta.v1.LookupRequest
+	14, // 35: nokv.fsmeta.v1.FSMetadata.ReadDir:input_type -> nokv.fsmeta.v1.ReadDirRequest
+	14, // 36: nokv.fsmeta.v1.FSMetadata.ReadDirPlus:input_type -> nokv.fsmeta.v1.ReadDirRequest
+	25, // 37: nokv.fsmeta.v1.FSMetadata.WatchSubtree:input_type -> nokv.fsmeta.v1.WatchAckOrSubscribe
+	26, // 38: nokv.fsmeta.v1.FSMetadata.GetReadVersion:input_type -> nokv.fsmeta.v1.GetReadVersionRequest
+	28, // 39: nokv.fsmeta.v1.FSMetadata.SnapshotSubtree:input_type -> nokv.fsmeta.v1.SnapshotSubtreeRequest
+	31, // 40: nokv.fsmeta.v1.FSMetadata.RetireSnapshotSubtree:input_type -> nokv.fsmeta.v1.RetireSnapshotSubtreeRequest
+	33, // 41: nokv.fsmeta.v1.FSMetadata.GetQuotaUsage:input_type -> nokv.fsmeta.v1.QuotaUsageRequest
+	35, // 42: nokv.fsmeta.v1.FSMetadata.Rename:input_type -> nokv.fsmeta.v1.RenameRequest
+	37, // 43: nokv.fsmeta.v1.FSMetadata.RenameReplace:input_type -> nokv.fsmeta.v1.RenameReplaceRequest
+	39, // 44: nokv.fsmeta.v1.FSMetadata.RenameSubtree:input_type -> nokv.fsmeta.v1.RenameSubtreeRequest
+	41, // 45: nokv.fsmeta.v1.FSMetadata.Link:input_type -> nokv.fsmeta.v1.LinkRequest
+	43, // 46: nokv.fsmeta.v1.FSMetadata.Unlink:input_type -> nokv.fsmeta.v1.UnlinkRequest
+	45, // 47: nokv.fsmeta.v1.FSMetadata.Remove:input_type -> nokv.fsmeta.v1.RemoveRequest
+	47, // 48: nokv.fsmeta.v1.FSMetadata.RemoveDirectory:input_type -> nokv.fsmeta.v1.RemoveDirectoryRequest
+	49, // 49: nokv.fsmeta.v1.FSMetadata.OpenWriteSession:input_type -> nokv.fsmeta.v1.OpenWriteSessionRequest
+	51, // 50: nokv.fsmeta.v1.FSMetadata.HeartbeatWriteSession:input_type -> nokv.fsmeta.v1.HeartbeatWriteSessionRequest
+	53, // 51: nokv.fsmeta.v1.FSMetadata.CloseWriteSession:input_type -> nokv.fsmeta.v1.CloseWriteSessionRequest
+	55, // 52: nokv.fsmeta.v1.FSMetadata.ExpireWriteSessions:input_type -> nokv.fsmeta.v1.ExpireWriteSessionsRequest
+	8,  // 53: nokv.fsmeta.v1.FSMetadata.Create:output_type -> nokv.fsmeta.v1.CreateResponse
+	10, // 54: nokv.fsmeta.v1.FSMetadata.UpdateInode:output_type -> nokv.fsmeta.v1.UpdateInodeResponse
+	12, // 55: nokv.fsmeta.v1.FSMetadata.Lookup:output_type -> nokv.fsmeta.v1.LookupResponse
+	13, // 56: nokv.fsmeta.v1.FSMetadata.LookupPlus:output_type -> nokv.fsmeta.v1.LookupPlusResponse
+	15, // 57: nokv.fsmeta.v1.FSMetadata.ReadDir:output_type -> nokv.fsmeta.v1.ReadDirResponse
+	16, // 58: nokv.fsmeta.v1.FSMetadata.ReadDirPlus:output_type -> nokv.fsmeta.v1.ReadDirPlusResponse
+	24, // 59: nokv.fsmeta.v1.FSMetadata.WatchSubtree:output_type -> nokv.fsmeta.v1.WatchSubtreeResponse
+	27, // 60: nokv.fsmeta.v1.FSMetadata.GetReadVersion:output_type -> nokv.fsmeta.v1.GetReadVersionResponse
+	30, // 61: nokv.fsmeta.v1.FSMetadata.SnapshotSubtree:output_type -> nokv.fsmeta.v1.SnapshotSubtreeResponse
+	32, // 62: nokv.fsmeta.v1.FSMetadata.RetireSnapshotSubtree:output_type -> nokv.fsmeta.v1.RetireSnapshotSubtreeResponse
+	34, // 63: nokv.fsmeta.v1.FSMetadata.GetQuotaUsage:output_type -> nokv.fsmeta.v1.QuotaUsageResponse
+	36, // 64: nokv.fsmeta.v1.FSMetadata.Rename:output_type -> nokv.fsmeta.v1.RenameResponse
+	38, // 65: nokv.fsmeta.v1.FSMetadata.RenameReplace:output_type -> nokv.fsmeta.v1.RenameReplaceResponse
+	40, // 66: nokv.fsmeta.v1.FSMetadata.RenameSubtree:output_type -> nokv.fsmeta.v1.RenameSubtreeResponse
+	42, // 67: nokv.fsmeta.v1.FSMetadata.Link:output_type -> nokv.fsmeta.v1.LinkResponse
+	44, // 68: nokv.fsmeta.v1.FSMetadata.Unlink:output_type -> nokv.fsmeta.v1.UnlinkResponse
+	46, // 69: nokv.fsmeta.v1.FSMetadata.Remove:output_type -> nokv.fsmeta.v1.RemoveResponse
+	48, // 70: nokv.fsmeta.v1.FSMetadata.RemoveDirectory:output_type -> nokv.fsmeta.v1.RemoveDirectoryResponse
+	50, // 71: nokv.fsmeta.v1.FSMetadata.OpenWriteSession:output_type -> nokv.fsmeta.v1.OpenWriteSessionResponse
+	52, // 72: nokv.fsmeta.v1.FSMetadata.HeartbeatWriteSession:output_type -> nokv.fsmeta.v1.HeartbeatWriteSessionResponse
+	54, // 73: nokv.fsmeta.v1.FSMetadata.CloseWriteSession:output_type -> nokv.fsmeta.v1.CloseWriteSessionResponse
+	56, // 74: nokv.fsmeta.v1.FSMetadata.ExpireWriteSessions:output_type -> nokv.fsmeta.v1.ExpireWriteSessionsResponse
+	53, // [53:75] is the sub-list for method output_type
+	31, // [31:53] is the sub-list for method input_type
+	31, // [31:31] is the sub-list for extension type_name
+	31, // [31:31] is the sub-list for extension extendee
+	0,  // [0:31] is the sub-list for field type_name
 }
 
 func init() { file_fsmeta_fsmeta_proto_init() }
@@ -3648,7 +3812,7 @@ func file_fsmeta_fsmeta_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_fsmeta_fsmeta_proto_rawDesc), len(file_fsmeta_fsmeta_proto_rawDesc)),
 			NumEnums:      2,
-			NumMessages:   53,
+			NumMessages:   55,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/pb/fsmeta/fsmeta.proto
+++ b/pb/fsmeta/fsmeta.proto
@@ -234,6 +234,21 @@ message RenameRequest {
 
 message RenameResponse {}
 
+message RenameReplaceRequest {
+  string mount = 1;
+  uint64 from_parent = 2;
+  string from_name = 3;
+  uint64 to_parent = 4;
+  string to_name = 5;
+}
+
+message RenameReplaceResponse {
+  bool replaced = 1;
+  DentryRecord old_dentry = 2;
+  InodeRecord old_inode = 3;
+  bool old_inode_deleted = 4;
+}
+
 message RenameSubtreeRequest {
   string mount = 1;
   uint64 from_parent = 2;
@@ -334,6 +349,7 @@ service FSMetadata {
   rpc RetireSnapshotSubtree(RetireSnapshotSubtreeRequest) returns (RetireSnapshotSubtreeResponse);
   rpc GetQuotaUsage(QuotaUsageRequest) returns (QuotaUsageResponse);
   rpc Rename(RenameRequest) returns (RenameResponse);
+  rpc RenameReplace(RenameReplaceRequest) returns (RenameReplaceResponse);
   rpc RenameSubtree(RenameSubtreeRequest) returns (RenameSubtreeResponse);
   rpc Link(LinkRequest) returns (LinkResponse);
   rpc Unlink(UnlinkRequest) returns (UnlinkResponse);

--- a/pb/fsmeta/fsmeta_grpc.pb.go
+++ b/pb/fsmeta/fsmeta_grpc.pb.go
@@ -36,6 +36,7 @@ const (
 	FSMetadata_RetireSnapshotSubtree_FullMethodName = "/nokv.fsmeta.v1.FSMetadata/RetireSnapshotSubtree"
 	FSMetadata_GetQuotaUsage_FullMethodName         = "/nokv.fsmeta.v1.FSMetadata/GetQuotaUsage"
 	FSMetadata_Rename_FullMethodName                = "/nokv.fsmeta.v1.FSMetadata/Rename"
+	FSMetadata_RenameReplace_FullMethodName         = "/nokv.fsmeta.v1.FSMetadata/RenameReplace"
 	FSMetadata_RenameSubtree_FullMethodName         = "/nokv.fsmeta.v1.FSMetadata/RenameSubtree"
 	FSMetadata_Link_FullMethodName                  = "/nokv.fsmeta.v1.FSMetadata/Link"
 	FSMetadata_Unlink_FullMethodName                = "/nokv.fsmeta.v1.FSMetadata/Unlink"
@@ -63,6 +64,7 @@ type FSMetadataClient interface {
 	RetireSnapshotSubtree(ctx context.Context, in *RetireSnapshotSubtreeRequest, opts ...grpc.CallOption) (*RetireSnapshotSubtreeResponse, error)
 	GetQuotaUsage(ctx context.Context, in *QuotaUsageRequest, opts ...grpc.CallOption) (*QuotaUsageResponse, error)
 	Rename(ctx context.Context, in *RenameRequest, opts ...grpc.CallOption) (*RenameResponse, error)
+	RenameReplace(ctx context.Context, in *RenameReplaceRequest, opts ...grpc.CallOption) (*RenameReplaceResponse, error)
 	RenameSubtree(ctx context.Context, in *RenameSubtreeRequest, opts ...grpc.CallOption) (*RenameSubtreeResponse, error)
 	Link(ctx context.Context, in *LinkRequest, opts ...grpc.CallOption) (*LinkResponse, error)
 	Unlink(ctx context.Context, in *UnlinkRequest, opts ...grpc.CallOption) (*UnlinkResponse, error)
@@ -205,6 +207,16 @@ func (c *fSMetadataClient) Rename(ctx context.Context, in *RenameRequest, opts .
 	return out, nil
 }
 
+func (c *fSMetadataClient) RenameReplace(ctx context.Context, in *RenameReplaceRequest, opts ...grpc.CallOption) (*RenameReplaceResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(RenameReplaceResponse)
+	err := c.cc.Invoke(ctx, FSMetadata_RenameReplace_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 func (c *fSMetadataClient) RenameSubtree(ctx context.Context, in *RenameSubtreeRequest, opts ...grpc.CallOption) (*RenameSubtreeResponse, error) {
 	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
 	out := new(RenameSubtreeResponse)
@@ -311,6 +323,7 @@ type FSMetadataServer interface {
 	RetireSnapshotSubtree(context.Context, *RetireSnapshotSubtreeRequest) (*RetireSnapshotSubtreeResponse, error)
 	GetQuotaUsage(context.Context, *QuotaUsageRequest) (*QuotaUsageResponse, error)
 	Rename(context.Context, *RenameRequest) (*RenameResponse, error)
+	RenameReplace(context.Context, *RenameReplaceRequest) (*RenameReplaceResponse, error)
 	RenameSubtree(context.Context, *RenameSubtreeRequest) (*RenameSubtreeResponse, error)
 	Link(context.Context, *LinkRequest) (*LinkResponse, error)
 	Unlink(context.Context, *UnlinkRequest) (*UnlinkResponse, error)
@@ -364,6 +377,9 @@ func (UnimplementedFSMetadataServer) GetQuotaUsage(context.Context, *QuotaUsageR
 }
 func (UnimplementedFSMetadataServer) Rename(context.Context, *RenameRequest) (*RenameResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method Rename not implemented")
+}
+func (UnimplementedFSMetadataServer) RenameReplace(context.Context, *RenameReplaceRequest) (*RenameReplaceResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method RenameReplace not implemented")
 }
 func (UnimplementedFSMetadataServer) RenameSubtree(context.Context, *RenameSubtreeRequest) (*RenameSubtreeResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method RenameSubtree not implemented")
@@ -617,6 +633,24 @@ func _FSMetadata_Rename_Handler(srv interface{}, ctx context.Context, dec func(i
 	return interceptor(ctx, in, info, handler)
 }
 
+func _FSMetadata_RenameReplace_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(RenameReplaceRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(FSMetadataServer).RenameReplace(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: FSMetadata_RenameReplace_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(FSMetadataServer).RenameReplace(ctx, req.(*RenameReplaceRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
 func _FSMetadata_RenameSubtree_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
 	in := new(RenameSubtreeRequest)
 	if err := dec(in); err != nil {
@@ -829,6 +863,10 @@ var FSMetadata_ServiceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "Rename",
 			Handler:    _FSMetadata_Rename_Handler,
+		},
+		{
+			MethodName: "RenameReplace",
+			Handler:    _FSMetadata_RenameReplace_Handler,
 		},
 		{
 			MethodName: "RenameSubtree",


### PR DESCRIPTION
## Summary
- add an fsmeta rename-replace primitive across the public, wire, and execution paths
- include contract, generated-program, and local runtime coverage

## Validation
- `PATH="$(go env GOPATH)/bin:$PATH" make fmt`
- `PATH="$(go env GOPATH)/bin:$PATH" go test ./fsmeta/... -count=1`
- `PATH="$(go env GOPATH)/bin:$PATH" go generate ./fsmeta/exec/compile`
- `git diff --exit-code -- fsmeta/exec/compile`
- `PATH="$(go env GOPATH)/bin:$PATH" make proto-check`
- `PATH="$(go env GOPATH)/bin:$PATH" make test-lint`
- `PATH="$(go env GOPATH)/bin:$PATH" make lint`
- `PATH="$(go env GOPATH)/bin:$PATH" make test`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added atomic "rename replace" operation to replace files at a destination path with files from another location, providing details about the replaced file and whether it was deleted.

* **Enhancements**
  * Implemented directory replacement validation to prevent overwriting directories with this operation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/feichai0017/NoKV/pull/320?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->