### PR TITLE
feat(fsmeta): return deleted metadata from remove

### DIFF
--- a/fsmeta/client/client.go
+++ b/fsmeta/client/client.go
@@ -57,7 +57,7 @@ type Client interface {
 	RenameSubtree(ctx context.Context, req fsmeta.RenameSubtreeRequest) error
 	Link(ctx context.Context, req fsmeta.LinkRequest) error
 	Unlink(ctx context.Context, req fsmeta.UnlinkRequest) error
-	Remove(ctx context.Context, req fsmeta.RemoveRequest) error
+	Remove(ctx context.Context, req fsmeta.RemoveRequest) (fsmeta.RemoveResult, error)
 	RemoveDirectory(ctx context.Context, req fsmeta.RemoveDirectoryRequest) error
 	OpenWriteSession(ctx context.Context, req fsmeta.OpenWriteSessionRequest) (fsmeta.SessionRecord, error)
 	HeartbeatWriteSession(ctx context.Context, req fsmeta.HeartbeatWriteSessionRequest) (fsmeta.SessionRecord, error)
@@ -389,16 +389,16 @@ func (c *GRPCClient) Unlink(ctx context.Context, req fsmeta.UnlinkRequest) error
 	return nil
 }
 
-func (c *GRPCClient) Remove(ctx context.Context, req fsmeta.RemoveRequest) error {
+func (c *GRPCClient) Remove(ctx context.Context, req fsmeta.RemoveRequest) (fsmeta.RemoveResult, error) {
 	if err := c.requireRPC(); err != nil {
-		return err
+		return fsmeta.RemoveResult{}, err
 	}
-	_, err := c.rpc.Remove(ctx, removeRequestToProto(req))
+	resp, err := c.rpc.Remove(ctx, removeRequestToProto(req))
 	if err != nil {
-		return translateRPCError(err)
+		return fsmeta.RemoveResult{}, translateRPCError(err)
 	}
 	c.lookup.Invalidate(req.Mount, req.Parent, req.Name)
-	return nil
+	return removeResultFromProto(resp), nil
 }
 
 func (c *GRPCClient) RemoveDirectory(ctx context.Context, req fsmeta.RemoveDirectoryRequest) error {

--- a/fsmeta/client/client_test.go
+++ b/fsmeta/client/client_test.go
@@ -237,8 +237,15 @@ func (e *fakeExecutor) Unlink(context.Context, fsmeta.UnlinkRequest) error {
 	return e.err
 }
 
-func (e *fakeExecutor) Remove(context.Context, fsmeta.RemoveRequest) error {
-	return e.err
+func (e *fakeExecutor) Remove(_ context.Context, req fsmeta.RemoveRequest) (fsmeta.RemoveResult, error) {
+	if e.err != nil {
+		return fsmeta.RemoveResult{}, e.err
+	}
+	return fsmeta.RemoveResult{
+		RemovedDentry: fsmeta.DentryRecord{Parent: req.Parent, Name: req.Name, Inode: 61, Type: fsmeta.InodeTypeFile},
+		OldInode:      fsmeta.InodeRecord{Inode: 61, Type: fsmeta.InodeTypeFile, LinkCount: 1},
+		InodeDeleted:  true,
+	}, nil
 }
 
 func (e *fakeExecutor) RemoveDirectory(context.Context, fsmeta.RemoveDirectoryRequest) error {
@@ -386,11 +393,15 @@ func TestTypedClientMutationRPCs(t *testing.T) {
 		Parent: 2,
 		Name:   "alias",
 	}))
-	require.NoError(t, cli.Remove(context.Background(), fsmeta.RemoveRequest{
+	removed, err := cli.Remove(context.Background(), fsmeta.RemoveRequest{
 		Mount:  "vol",
 		Parent: 2,
 		Name:   "old-file",
-	}))
+	})
+	require.NoError(t, err)
+	require.Equal(t, fsmeta.InodeID(61), removed.RemovedDentry.Inode)
+	require.Equal(t, fsmeta.InodeID(61), removed.OldInode.Inode)
+	require.True(t, removed.InodeDeleted)
 	require.NoError(t, cli.RemoveDirectory(context.Background(), fsmeta.RemoveDirectoryRequest{
 		Mount:  "vol",
 		Parent: 2,

--- a/fsmeta/client/wire.go
+++ b/fsmeta/client/wire.go
@@ -213,6 +213,17 @@ func removeRequestToProto(req fsmeta.RemoveRequest) *fsmetapb.RemoveRequest {
 	}
 }
 
+func removeResultFromProto(resp *fsmetapb.RemoveResponse) fsmeta.RemoveResult {
+	if resp == nil {
+		return fsmeta.RemoveResult{}
+	}
+	return fsmeta.RemoveResult{
+		RemovedDentry: dentryFromProto(resp.GetRemovedDentry()),
+		OldInode:      inodeFromProto(resp.GetOldInode()),
+		InodeDeleted:  resp.GetInodeDeleted(),
+	}
+}
+
 func removeDirectoryRequestToProto(req fsmeta.RemoveDirectoryRequest) *fsmetapb.RemoveDirectoryRequest {
 	return &fsmetapb.RemoveDirectoryRequest{
 		Mount:  string(req.Mount),

--- a/fsmeta/contract/harness.go
+++ b/fsmeta/contract/harness.go
@@ -25,7 +25,7 @@ type Executor interface {
 	RenameSubtree(context.Context, fsmeta.RenameSubtreeRequest) error
 	Link(context.Context, fsmeta.LinkRequest) error
 	Unlink(context.Context, fsmeta.UnlinkRequest) error
-	Remove(context.Context, fsmeta.RemoveRequest) error
+	Remove(context.Context, fsmeta.RemoveRequest) (fsmeta.RemoveResult, error)
 	OpenWriteSession(context.Context, fsmeta.OpenWriteSessionRequest) (fsmeta.SessionRecord, error)
 	HeartbeatWriteSession(context.Context, fsmeta.HeartbeatWriteSessionRequest) (fsmeta.SessionRecord, error)
 	CloseWriteSession(context.Context, fsmeta.CloseWriteSessionRequest) error
@@ -178,12 +178,12 @@ func execute(ctx context.Context, exec Executor, model *Model, op Operation) Res
 		})
 		return Result{Err: err}
 	case OpRemove:
-		err := exec.Remove(ctx, fsmeta.RemoveRequest{
+		result, err := exec.Remove(ctx, fsmeta.RemoveRequest{
 			Mount:  op.Mount,
 			Parent: op.Parent,
 			Name:   op.Name,
 		})
-		return Result{Err: err}
+		return Result{Err: err, Remove: result}
 	case OpOpenWriteSession:
 		session, err := exec.OpenWriteSession(ctx, fsmeta.OpenWriteSessionRequest{
 			Mount:   op.Mount,
@@ -242,6 +242,9 @@ func compareResult(got, want Result) error {
 	if !reflect.DeepEqual(got.RenameReplace, want.RenameReplace) {
 		return fmt.Errorf("rename replace mismatch: got %+v want %+v", got.RenameReplace, want.RenameReplace)
 	}
+	if !reflect.DeepEqual(got.Remove, want.Remove) {
+		return fmt.Errorf("remove mismatch: got %+v want %+v", got.Remove, want.Remove)
+	}
 	if got.Session != want.Session {
 		return fmt.Errorf("session mismatch: got %+v want %+v", got.Session, want.Session)
 	}
@@ -273,6 +276,9 @@ func summarize(result Result) string {
 	}
 	if result.RenameReplace.Replaced {
 		return fmt.Sprintf("rename_replace old=%s:%d deleted=%t", result.RenameReplace.OldDentry.Name, result.RenameReplace.OldDentry.Inode, result.RenameReplace.OldInodeDeleted)
+	}
+	if result.Remove.RemovedDentry.Name != "" {
+		return fmt.Sprintf("remove old=%s:%d deleted=%t", result.Remove.RemovedDentry.Name, result.Remove.RemovedDentry.Inode, result.Remove.InodeDeleted)
 	}
 	if result.Session.Session != "" {
 		return fmt.Sprintf("session=%s inode=%d expires=%d", result.Session.Session, result.Session.Inode, result.Session.ExpiresUnixNs)

--- a/fsmeta/contract/history_test.go
+++ b/fsmeta/contract/history_test.go
@@ -129,8 +129,8 @@ func (unavailableCreateExecutor) Unlink(context.Context, fsmeta.UnlinkRequest) e
 	return fsmeta.ErrInvalidRequest
 }
 
-func (unavailableCreateExecutor) Remove(context.Context, fsmeta.RemoveRequest) error {
-	return fsmeta.ErrInvalidRequest
+func (unavailableCreateExecutor) Remove(context.Context, fsmeta.RemoveRequest) (fsmeta.RemoveResult, error) {
+	return fsmeta.RemoveResult{}, fsmeta.ErrInvalidRequest
 }
 
 func (unavailableCreateExecutor) OpenWriteSession(context.Context, fsmeta.OpenWriteSessionRequest) (fsmeta.SessionRecord, error) {

--- a/fsmeta/contract/mapping.go
+++ b/fsmeta/contract/mapping.go
@@ -171,9 +171,15 @@ func (m *inodeMappingExecutor) Unlink(ctx context.Context, req fsmeta.UnlinkRequ
 	return m.base.Unlink(ctx, req)
 }
 
-func (m *inodeMappingExecutor) Remove(ctx context.Context, req fsmeta.RemoveRequest) error {
+func (m *inodeMappingExecutor) Remove(ctx context.Context, req fsmeta.RemoveRequest) (fsmeta.RemoveResult, error) {
 	req.Parent = m.actualInode(req.Parent)
-	return m.base.Remove(ctx, req)
+	result, err := m.base.Remove(ctx, req)
+	if err != nil {
+		return fsmeta.RemoveResult{}, err
+	}
+	result.RemovedDentry = m.translateDentryRecord(result.RemovedDentry)
+	result.OldInode = m.translateInodeRecord(result.OldInode)
+	return result, nil
 }
 
 func (m *inodeMappingExecutor) OpenWriteSession(ctx context.Context, req fsmeta.OpenWriteSessionRequest) (fsmeta.SessionRecord, error) {

--- a/fsmeta/contract/mapping_test.go
+++ b/fsmeta/contract/mapping_test.go
@@ -53,6 +53,33 @@ func TestInodeMappingExecutorRecoversCommittedCreate(t *testing.T) {
 	}
 }
 
+func TestInodeMappingExecutorTranslatesRemoveResult(t *testing.T) {
+	base := newFakeExternalExecutor()
+	exec, err := NewInodeMappingExecutor(base)
+	if err != nil {
+		t.Fatalf("NewInodeMappingExecutor: %v", err)
+	}
+	_, err = exec.Create(withPlannedCreateInode(context.Background(), 10), fsmeta.CreateRequest{
+		Mount:  "vol",
+		Parent: fsmeta.RootInode,
+		Name:   "alpha",
+		Attrs:  fsmeta.CreateAttrs{Type: fsmeta.InodeTypeFile, Mode: 0o644},
+	})
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	result, err := exec.Remove(context.Background(), fsmeta.RemoveRequest{Mount: "vol", Parent: fsmeta.RootInode, Name: "alpha"})
+	if err != nil {
+		t.Fatalf("Remove: %v", err)
+	}
+	if result.RemovedDentry.Inode != 10 || result.OldInode.Inode != 10 {
+		t.Fatalf("remove result was not translated to planned inode: %+v", result)
+	}
+	if !result.InodeDeleted {
+		t.Fatalf("Remove result did not report deleted inode: %+v", result)
+	}
+}
+
 func TestInodeMappingExecutorDoesNotRecoverSemanticCreateError(t *testing.T) {
 	base := newFakeExternalExecutor()
 	_, err := base.Create(context.Background(), fsmeta.CreateRequest{
@@ -340,8 +367,36 @@ func (f *fakeExternalExecutor) Unlink(context.Context, fsmeta.UnlinkRequest) err
 	return nil
 }
 
-func (f *fakeExternalExecutor) Remove(context.Context, fsmeta.RemoveRequest) error {
-	return nil
+func (f *fakeExternalExecutor) Remove(_ context.Context, req fsmeta.RemoveRequest) (fsmeta.RemoveResult, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	key := [2]any{req.Parent, req.Name}
+	dentry, ok := f.dentries[key]
+	if !ok {
+		return fsmeta.RemoveResult{}, fsmeta.ErrNotFound
+	}
+	if dentry.Type == fsmeta.InodeTypeDirectory {
+		return fsmeta.RemoveResult{}, fsmeta.ErrInvalidRequest
+	}
+	result := fsmeta.RemoveResult{RemovedDentry: dentry}
+	inode, ok := f.inodes[dentry.Inode]
+	if !ok {
+		delete(f.dentries, key)
+		return result, nil
+	}
+	if inode.Type == fsmeta.InodeTypeDirectory {
+		return fsmeta.RemoveResult{}, fsmeta.ErrInvalidRequest
+	}
+	result.OldInode = inode
+	delete(f.dentries, key)
+	if inode.LinkCount <= 1 {
+		result.InodeDeleted = true
+		delete(f.inodes, inode.Inode)
+	} else {
+		inode.LinkCount--
+		f.inodes[inode.Inode] = inode
+	}
+	return result, nil
 }
 
 func (f *fakeExternalExecutor) OpenWriteSession(context.Context, fsmeta.OpenWriteSessionRequest) (fsmeta.SessionRecord, error) {

--- a/fsmeta/contract/model.go
+++ b/fsmeta/contract/model.go
@@ -76,6 +76,7 @@ type Result struct {
 	Token         fsmeta.SnapshotSubtreeToken
 	Inode         fsmeta.InodeRecord
 	RenameReplace fsmeta.RenameReplaceResult
+	Remove        fsmeta.RemoveResult
 	Session       fsmeta.SessionRecord
 	Expired       uint64
 }
@@ -159,7 +160,7 @@ func (m *Model) Apply(op Operation) Result {
 	case OpUnlink:
 		return m.unlink(op)
 	case OpRemove:
-		return m.unlink(op)
+		return m.remove(op)
 	case OpOpenWriteSession:
 		return m.openWriteSession(op)
 	case OpHeartbeatSession:
@@ -446,20 +447,33 @@ func (m *Model) link(op Operation) Result {
 }
 
 func (m *Model) unlink(op Operation) Result {
+	_, err := m.removeDentry(op)
+	return Result{Err: err}
+}
+
+func (m *Model) remove(op Operation) Result {
+	result, err := m.removeDentry(op)
+	return Result{Err: err, Remove: result}
+}
+
+func (m *Model) removeDentry(op Operation) (fsmeta.RemoveResult, error) {
 	key := dentryKey{parent: op.Parent, name: op.Name}
 	record, ok := m.dentries[key]
 	if !ok {
-		return Result{Err: fsmeta.ErrNotFound}
+		return fsmeta.RemoveResult{}, fsmeta.ErrNotFound
 	}
 	if record.Type == fsmeta.InodeTypeDirectory {
-		return Result{Err: fsmeta.ErrInvalidRequest}
+		return fsmeta.RemoveResult{}, fsmeta.ErrInvalidRequest
 	}
+	result := fsmeta.RemoveResult{RemovedDentry: record}
 	if inode, ok := m.inodes[record.Inode]; ok {
 		if inode.Type == fsmeta.InodeTypeDirectory {
-			return Result{Err: fsmeta.ErrInvalidRequest}
+			return fsmeta.RemoveResult{}, fsmeta.ErrInvalidRequest
 		}
+		result.OldInode = inode
 		delete(m.dentries, key)
 		if inode.LinkCount <= 1 {
+			result.InodeDeleted = true
 			delete(m.inodes, inode.Inode)
 		} else {
 			inode.LinkCount--
@@ -468,7 +482,7 @@ func (m *Model) unlink(op Operation) Result {
 	} else {
 		delete(m.dentries, key)
 	}
-	return Result{}
+	return result, nil
 }
 
 func (m *Model) openWriteSession(op Operation) Result {

--- a/fsmeta/contract/model_test.go
+++ b/fsmeta/contract/model_test.go
@@ -233,6 +233,33 @@ func TestModelLinkRenameUnlinkMaintainsLinkCounts(t *testing.T) {
 	require.NoError(t, model.CheckInvariants())
 }
 
+func TestModelRemoveReturnsDeletedEntryAndInode(t *testing.T) {
+	model := NewModel("vol")
+	require.NoError(t, model.Apply(Operation{
+		Kind:   OpCreate,
+		Mount:  "vol",
+		Parent: model.Root,
+		Name:   "file",
+		Inode:  10,
+		Type:   fsmeta.InodeTypeFile,
+		Mode:   0o600,
+	}).Err)
+
+	result := model.Apply(Operation{
+		Kind:   OpRemove,
+		Mount:  "vol",
+		Parent: model.Root,
+		Name:   "file",
+	})
+
+	require.NoError(t, result.Err)
+	require.Equal(t, fsmeta.DentryRecord{Parent: model.Root, Name: "file", Inode: 10, Type: fsmeta.InodeTypeFile}, result.Remove.RemovedDentry)
+	require.Equal(t, fsmeta.InodeID(10), result.Remove.OldInode.Inode)
+	require.True(t, result.Remove.InodeDeleted)
+	require.NotContains(t, model.inodes, fsmeta.InodeID(10))
+	require.NoError(t, model.CheckInvariants())
+}
+
 func TestModelRenameReplaceMaintainsReplacedLinkCounts(t *testing.T) {
 	model := NewModel("vol")
 	require.NoError(t, model.Apply(Operation{

--- a/fsmeta/exec/executor_unlink.go
+++ b/fsmeta/exec/executor_unlink.go
@@ -16,34 +16,34 @@ type removeDentryRequest struct {
 	Name   string
 }
 
-func (e *Executor) tryVisibleRemoveDentry(ctx context.Context, compiled compile.CompiledOp, mount fsmeta.MountIdentity, req removeDentryRequest) (bool, error) {
+func (e *Executor) tryVisibleRemoveDentry(ctx context.Context, compiled compile.CompiledOp, mount fsmeta.MountIdentity, req removeDentryRequest) (fsmeta.RemoveResult, bool, error) {
 	delta := compiled.Delta
 	plan := delta.Plan
 	if e == nil || e.visibleCommitter == nil || e.visibleAuthority == nil || delta.Eligibility != compile.EligibilityVisibleCommit {
-		return false, nil
+		return fsmeta.RemoveResult{}, false, nil
 	}
 	view := e.newVisibleReadView(ctx)
 	record, err := view.readDentry(plan.PrimaryKey)
 	if err != nil {
-		return false, err
+		return fsmeta.RemoveResult{}, false, err
 	}
 	inode, ok, err := view.readInode(mount, record.Inode)
 	if err != nil {
-		return false, err
+		return fsmeta.RemoveResult{}, false, err
 	}
 	if !ok {
-		return false, nil
+		return fsmeta.RemoveResult{}, false, nil
 	}
 	if inode.Type == fsmeta.InodeTypeDirectory {
-		return false, fsmeta.ErrInvalidRequest
+		return fsmeta.RemoveResult{}, false, fsmeta.ErrInvalidRequest
 	}
 	parent, err := readVisibleDirectoryInode(view, mount, req.Parent)
 	if err != nil {
-		return false, err
+		return fsmeta.RemoveResult{}, false, err
 	}
 	parent, err = decrementDirectoryChildCount(parent)
 	if err != nil {
-		return false, err
+		return fsmeta.RemoveResult{}, false, err
 	}
 	quotaOK, err := e.visibleQuotaAllowsCommit(ctx, []QuotaChange{{
 		Mount:      req.Mount,
@@ -53,52 +53,62 @@ func (e *Executor) tryVisibleRemoveDentry(ctx context.Context, compiled compile.
 		Inodes:     -1,
 	}})
 	if err != nil {
-		return false, err
+		return fsmeta.RemoveResult{}, false, err
 	}
 	if !quotaOK {
-		return false, nil
+		return fsmeta.RemoveResult{}, false, nil
 	}
 	inodeKey, err := fsmeta.EncodeInodeKey(mount, inode.Inode)
 	if err != nil {
-		return false, err
+		return fsmeta.RemoveResult{}, false, err
+	}
+	result := fsmeta.RemoveResult{
+		RemovedDentry: record,
+		OldInode:      inode,
+		InodeDeleted:  inode.LinkCount <= 1,
 	}
 	effects := []compile.WriteEffect{visibleDeleteEffect(plan.MutateKeys[0])}
-	if inode.LinkCount <= 1 {
+	if result.InodeDeleted {
 		effects = append(effects, visibleDeleteEffect(inodeKey))
 	} else {
 		inode.LinkCount--
 		inodeValue, err := fsmeta.EncodeInodeValue(inode)
 		if err != nil {
-			return false, err
+			return fsmeta.RemoveResult{}, false, err
 		}
 		effects = append(effects, visiblePutEffect(inodeKey, inodeValue))
 	}
 	parentValue, err := fsmeta.EncodeInodeValue(parent)
 	if err != nil {
-		return false, err
+		return fsmeta.RemoveResult{}, false, err
 	}
 	effects = append(effects, visiblePutEffect(plan.MutateKeys[1], parentValue))
 	concrete, err := view.materializeVisibleCompiledOp(compiled, effects)
 	if err != nil {
-		return false, err
+		return fsmeta.RemoveResult{}, false, err
 	}
-	return e.tryVisibleCommitAfterRead(ctx, view, concrete)
+	committed, err := e.tryVisibleCommitAfterRead(ctx, view, concrete)
+	if err != nil || !committed {
+		return fsmeta.RemoveResult{}, committed, err
+	}
+	return result, true, nil
 }
 
-func (e *Executor) removeDentry(ctx context.Context, mount fsmeta.MountIdentity, compiled compile.CompiledOp, req removeDentryRequest) error {
+func (e *Executor) removeDentry(ctx context.Context, mount fsmeta.MountIdentity, compiled compile.CompiledOp, req removeDentryRequest) (fsmeta.RemoveResult, error) {
 	delta := compiled.Delta
 	plan := delta.Plan
 	if err := e.admitVisibleAuthority(ctx, delta); err != nil {
-		return err
+		return fsmeta.RemoveResult{}, err
 	}
-	if committed, err := e.tryVisibleRemoveDentry(ctx, compiled, mount, req); committed || err != nil {
+	if result, committed, err := e.tryVisibleRemoveDentry(ctx, compiled, mount, req); committed || err != nil {
 		if err != nil {
-			return err
+			return fsmeta.RemoveResult{}, err
 		}
 		e.invalidateNegative(plan.MutateKeys[0])
 		e.invalidateDirPages(req.Mount, req.Parent)
-		return nil
+		return result, nil
 	}
+	var result fsmeta.RemoveResult
 	if err := e.withTxnRetry(ctx, func(startVersion, commitVersion uint64) error {
 		record, err := e.readDentry(ctx, plan.PrimaryKey, startVersion)
 		if err != nil {
@@ -112,6 +122,7 @@ func (e *Executor) removeDentry(ctx context.Context, mount fsmeta.MountIdentity,
 			Op:  kvrpcpb.Mutation_Delete,
 			Key: cloneBytes(plan.MutateKeys[0]),
 		}}
+		attemptResult := fsmeta.RemoveResult{RemovedDentry: record}
 		predicates := []*kvrpcpb.AtomicPredicate{atomicValueEquals(plan.PrimaryKey, dentryValue)}
 		parent, err := e.readDirectoryInode(ctx, mount, req.Parent, startVersion)
 		if err != nil {
@@ -129,6 +140,7 @@ func (e *Executor) removeDentry(ctx context.Context, mount fsmeta.MountIdentity,
 		if inode, ok, err := e.readInode(ctx, mount, record.Inode, startVersion); err != nil {
 			return err
 		} else if ok {
+			attemptResult.OldInode = inode
 			inodeKey, err := fsmeta.EncodeInodeKey(mount, inode.Inode)
 			if err != nil {
 				return err
@@ -142,6 +154,7 @@ func (e *Executor) removeDentry(ctx context.Context, mount fsmeta.MountIdentity,
 			}
 			predicates = append(predicates, atomicValueEquals(inodeKey, oldInodeValue))
 			if inode.LinkCount <= 1 {
+				attemptResult.InodeDeleted = true
 				mutations = append(mutations, &kvrpcpb.Mutation{Op: kvrpcpb.Mutation_Delete, Key: inodeKey})
 			} else {
 				inode.LinkCount--
@@ -163,19 +176,20 @@ func (e *Executor) removeDentry(ctx context.Context, mount fsmeta.MountIdentity,
 			}
 			mutations = append(mutations, quotaMutations...)
 		}
+		result = attemptResult
 		mutations = append(mutations, &kvrpcpb.Mutation{Op: kvrpcpb.Mutation_Put, Key: cloneBytes(plan.MutateKeys[1]), Value: parentValue})
 		if len(mutations) == len(predicates) {
 			return e.mutateWithAtomicOnePhase(ctx, plan.Kind, plan.PrimaryKey, predicates, mutations, startVersion, commitVersion)
 		}
 		return e.mutateWithoutAtomicOnePhase(ctx, plan.Kind, plan.PrimaryKey, mutations, startVersion, commitVersion)
 	}, delta.Authority); err != nil {
-		return err
+		return fsmeta.RemoveResult{}, err
 	}
 	// Removing the dentry must invalidate both point misses and any
 	// materialized directory page under its parent.
 	e.invalidateNegative(plan.MutateKeys[0])
 	e.invalidateDirPages(req.Mount, req.Parent)
-	return nil
+	return result, nil
 }
 
 // Unlink removes one non-directory dentry, decrements its inode link count,
@@ -190,7 +204,8 @@ func (e *Executor) Unlink(ctx context.Context, req fsmeta.UnlinkRequest) error {
 	if err != nil {
 		return err
 	}
-	return e.removeDentry(ctx, mount, program.Compiled, removeDentryRequest(req))
+	_, err = e.removeDentry(ctx, mount, program.Compiled, removeDentryRequest(req))
+	return err
 }
 
 // RemoveDirectory removes one empty directory dentry and its directory inode.
@@ -361,15 +376,15 @@ func (e *Executor) tryVisibleRemoveDirectory(ctx context.Context, compiled compi
 // Remove is the product-facing primitive for removing one non-directory
 // namespace entry. Directory removal needs a separate directory-emptiness
 // contract, so v1 keeps directory targets invalid instead of orphaning children.
-func (e *Executor) Remove(ctx context.Context, req fsmeta.RemoveRequest) error {
+func (e *Executor) Remove(ctx context.Context, req fsmeta.RemoveRequest) (fsmeta.RemoveResult, error) {
 	mountRecord, err := e.resolveActiveMount(ctx, req.Mount)
 	if err != nil {
-		return err
+		return fsmeta.RemoveResult{}, err
 	}
 	mount := mountRecord.Identity()
 	program, err := compile.CompileRemoveProgram(req, mount, compile.WithQuotaMode(e.visibleQuotaMode()))
 	if err != nil {
-		return err
+		return fsmeta.RemoveResult{}, err
 	}
 	return e.removeDentry(ctx, mount, program.Compiled, removeDentryRequest(req))
 }

--- a/fsmeta/exec/executor_unlink_test.go
+++ b/fsmeta/exec/executor_unlink_test.go
@@ -61,12 +61,15 @@ func TestExecutorRemoveRemovesDentry(t *testing.T) {
 	executor, err := newTestExecutor(runner)
 	require.NoError(t, err)
 
-	err = executor.Remove(context.Background(), fsmeta.RemoveRequest{
+	result, err := executor.Remove(context.Background(), fsmeta.RemoveRequest{
 		Mount:  "vol",
 		Parent: 7,
 		Name:   "file",
 	})
 	require.NoError(t, err)
+	require.Equal(t, fsmeta.DentryRecord{Parent: 7, Name: "file", Inode: 22, Type: fsmeta.InodeTypeFile}, result.RemovedDentry)
+	require.Equal(t, fsmeta.InodeID(22), result.OldInode.Inode)
+	require.True(t, result.InodeDeleted)
 
 	_, err = executor.Lookup(context.Background(), fsmeta.LookupRequest{
 		Mount:  "vol",
@@ -212,7 +215,7 @@ func TestExecutorRemoveRejectsDirectoryOnTxnPath(t *testing.T) {
 	executor, err := newTestExecutor(runner)
 	require.NoError(t, err)
 
-	err = executor.Remove(context.Background(), fsmeta.RemoveRequest{Mount: "vol", Parent: 7, Name: "dir"})
+	_, err = executor.Remove(context.Background(), fsmeta.RemoveRequest{Mount: "vol", Parent: 7, Name: "dir"})
 	require.ErrorIs(t, err, fsmeta.ErrInvalidRequest)
 
 	require.Empty(t, runner.mutations)

--- a/fsmeta/plan.go
+++ b/fsmeta/plan.go
@@ -157,6 +157,15 @@ type RemoveRequest struct {
 	Name   string
 }
 
+// RemoveResult reports the namespace entry detached by Remove. OldInode is the
+// inode record observed before link-count decrement or deletion; InodeDeleted
+// tells callers whether the inode record itself was removed.
+type RemoveResult struct {
+	RemovedDentry DentryRecord
+	OldInode      InodeRecord
+	InodeDeleted  bool
+}
+
 type RemoveDirectoryRequest struct {
 	Mount  MountID
 	Parent InodeID

--- a/fsmeta/server/service.go
+++ b/fsmeta/server/service.go
@@ -32,7 +32,7 @@ type Executor interface {
 	RenameSubtree(ctx context.Context, req fsmeta.RenameSubtreeRequest) error
 	Link(ctx context.Context, req fsmeta.LinkRequest) error
 	Unlink(ctx context.Context, req fsmeta.UnlinkRequest) error
-	Remove(ctx context.Context, req fsmeta.RemoveRequest) error
+	Remove(ctx context.Context, req fsmeta.RemoveRequest) (fsmeta.RemoveResult, error)
 	RemoveDirectory(ctx context.Context, req fsmeta.RemoveDirectoryRequest) error
 	OpenWriteSession(ctx context.Context, req fsmeta.OpenWriteSessionRequest) (fsmeta.SessionRecord, error)
 	HeartbeatWriteSession(ctx context.Context, req fsmeta.HeartbeatWriteSessionRequest) (fsmeta.SessionRecord, error)
@@ -395,10 +395,11 @@ func (s *Service) Remove(ctx context.Context, req *fsmetapb.RemoveRequest) (*fsm
 	if req == nil {
 		return nil, rpcInvalidArgument("fsmeta remove request is required")
 	}
-	if err := s.executor.Remove(ctx, removeRequestFromProto(req)); err != nil {
+	result, err := s.executor.Remove(ctx, removeRequestFromProto(req))
+	if err != nil {
 		return nil, rpcError(err)
 	}
-	return &fsmetapb.RemoveResponse{}, nil
+	return removeResponseToProto(result), nil
 }
 
 func (s *Service) RemoveDirectory(ctx context.Context, req *fsmetapb.RemoveDirectoryRequest) (*fsmetapb.RemoveDirectoryResponse, error) {

--- a/fsmeta/server/service_test.go
+++ b/fsmeta/server/service_test.go
@@ -209,9 +209,16 @@ func (e *fakeExecutor) Unlink(_ context.Context, req fsmeta.UnlinkRequest) error
 	return e.err
 }
 
-func (e *fakeExecutor) Remove(_ context.Context, req fsmeta.RemoveRequest) error {
+func (e *fakeExecutor) Remove(_ context.Context, req fsmeta.RemoveRequest) (fsmeta.RemoveResult, error) {
 	e.removeReq = req
-	return e.err
+	if e.err != nil {
+		return fsmeta.RemoveResult{}, e.err
+	}
+	return fsmeta.RemoveResult{
+		RemovedDentry: fsmeta.DentryRecord{Parent: req.Parent, Name: req.Name, Inode: 61, Type: fsmeta.InodeTypeFile},
+		OldInode:      fsmeta.InodeRecord{Inode: 61, Type: fsmeta.InodeTypeFile, LinkCount: 1},
+		InodeDeleted:  true,
+	}, nil
 }
 
 func (e *fakeExecutor) RemoveDirectory(_ context.Context, req fsmeta.RemoveDirectoryRequest) error {
@@ -415,7 +422,7 @@ func TestGRPCServiceReadDirAndMutationRPCs(t *testing.T) {
 		Name:   "alias",
 	}, executor.unlinkReq)
 
-	_, err = client.Remove(context.Background(), &fsmetapb.RemoveRequest{
+	removed, err := client.Remove(context.Background(), &fsmetapb.RemoveRequest{
 		Mount:  "vol",
 		Parent: 2,
 		Name:   "alias",
@@ -426,6 +433,9 @@ func TestGRPCServiceReadDirAndMutationRPCs(t *testing.T) {
 		Parent: 2,
 		Name:   "alias",
 	}, executor.removeReq)
+	require.Equal(t, uint64(61), removed.GetRemovedDentry().GetInode())
+	require.Equal(t, uint64(61), removed.GetOldInode().GetInode())
+	require.True(t, removed.GetInodeDeleted())
 
 	_, err = client.RemoveDirectory(context.Background(), &fsmetapb.RemoveDirectoryRequest{
 		Mount:  "vol",

--- a/fsmeta/server/wire.go
+++ b/fsmeta/server/wire.go
@@ -237,6 +237,14 @@ func removeRequestFromProto(req *fsmetapb.RemoveRequest) fsmeta.RemoveRequest {
 	}
 }
 
+func removeResponseToProto(result fsmeta.RemoveResult) *fsmetapb.RemoveResponse {
+	return &fsmetapb.RemoveResponse{
+		RemovedDentry: dentryToProto(result.RemovedDentry),
+		OldInode:      inodeToProto(result.OldInode),
+		InodeDeleted:  result.InodeDeleted,
+	}
+}
+
 func removeDirectoryRequestFromProto(req *fsmetapb.RemoveDirectoryRequest) fsmeta.RemoveDirectoryRequest {
 	return fsmeta.RemoveDirectoryRequest{
 		Mount:  fsmeta.MountID(req.GetMount()),

--- a/pb/fsmeta/fsmeta.pb.go
+++ b/pb/fsmeta/fsmeta.pb.go
@@ -2823,6 +2823,9 @@ func (x *RemoveRequest) GetName() string {
 
 type RemoveResponse struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
+	RemovedDentry *DentryRecord          `protobuf:"bytes,1,opt,name=removed_dentry,json=removedDentry,proto3" json:"removed_dentry,omitempty"`
+	OldInode      *InodeRecord           `protobuf:"bytes,2,opt,name=old_inode,json=oldInode,proto3" json:"old_inode,omitempty"`
+	InodeDeleted  bool                   `protobuf:"varint,3,opt,name=inode_deleted,json=inodeDeleted,proto3" json:"inode_deleted,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -2855,6 +2858,27 @@ func (x *RemoveResponse) ProtoReflect() protoreflect.Message {
 // Deprecated: Use RemoveResponse.ProtoReflect.Descriptor instead.
 func (*RemoveResponse) Descriptor() ([]byte, []int) {
 	return file_fsmeta_fsmeta_proto_rawDescGZIP(), []int{44}
+}
+
+func (x *RemoveResponse) GetRemovedDentry() *DentryRecord {
+	if x != nil {
+		return x.RemovedDentry
+	}
+	return nil
+}
+
+func (x *RemoveResponse) GetOldInode() *InodeRecord {
+	if x != nil {
+		return x.OldInode
+	}
+	return nil
+}
+
+func (x *RemoveResponse) GetInodeDeleted() bool {
+	if x != nil {
+		return x.InodeDeleted
+	}
+	return false
 }
 
 type RemoveDirectoryRequest struct {
@@ -3569,8 +3593,11 @@ const file_fsmeta_fsmeta_proto_rawDesc = "" +
 	"\rRemoveRequest\x12\x14\n" +
 	"\x05mount\x18\x01 \x01(\tR\x05mount\x12\x16\n" +
 	"\x06parent\x18\x02 \x01(\x04R\x06parent\x12\x12\n" +
-	"\x04name\x18\x03 \x01(\tR\x04name\"\x10\n" +
-	"\x0eRemoveResponse\"Z\n" +
+	"\x04name\x18\x03 \x01(\tR\x04name\"\xb4\x01\n" +
+	"\x0eRemoveResponse\x12C\n" +
+	"\x0eremoved_dentry\x18\x01 \x01(\v2\x1c.nokv.fsmeta.v1.DentryRecordR\rremovedDentry\x128\n" +
+	"\told_inode\x18\x02 \x01(\v2\x1b.nokv.fsmeta.v1.InodeRecordR\boldInode\x12#\n" +
+	"\rinode_deleted\x18\x03 \x01(\bR\finodeDeleted\"Z\n" +
 	"\x16RemoveDirectoryRequest\x12\x14\n" +
 	"\x05mount\x18\x01 \x01(\tR\x05mount\x12\x16\n" +
 	"\x06parent\x18\x02 \x01(\x04R\x06parent\x12\x12\n" +
@@ -3738,57 +3765,59 @@ var file_fsmeta_fsmeta_proto_depIdxs = []int32{
 	29, // 26: nokv.fsmeta.v1.RetireSnapshotSubtreeRequest.runtime_evidence:type_name -> nokv.fsmeta.v1.SnapshotEvidenceRef
 	4,  // 27: nokv.fsmeta.v1.RenameReplaceResponse.old_dentry:type_name -> nokv.fsmeta.v1.DentryRecord
 	2,  // 28: nokv.fsmeta.v1.RenameReplaceResponse.old_inode:type_name -> nokv.fsmeta.v1.InodeRecord
-	3,  // 29: nokv.fsmeta.v1.OpenWriteSessionResponse.session:type_name -> nokv.fsmeta.v1.SessionRecord
-	3,  // 30: nokv.fsmeta.v1.HeartbeatWriteSessionResponse.session:type_name -> nokv.fsmeta.v1.SessionRecord
-	7,  // 31: nokv.fsmeta.v1.FSMetadata.Create:input_type -> nokv.fsmeta.v1.CreateRequest
-	9,  // 32: nokv.fsmeta.v1.FSMetadata.UpdateInode:input_type -> nokv.fsmeta.v1.UpdateInodeRequest
-	11, // 33: nokv.fsmeta.v1.FSMetadata.Lookup:input_type -> nokv.fsmeta.v1.LookupRequest
-	11, // 34: nokv.fsmeta.v1.FSMetadata.LookupPlus:input_type -> nokv.fsmeta.v1.LookupRequest
-	14, // 35: nokv.fsmeta.v1.FSMetadata.ReadDir:input_type -> nokv.fsmeta.v1.ReadDirRequest
-	14, // 36: nokv.fsmeta.v1.FSMetadata.ReadDirPlus:input_type -> nokv.fsmeta.v1.ReadDirRequest
-	25, // 37: nokv.fsmeta.v1.FSMetadata.WatchSubtree:input_type -> nokv.fsmeta.v1.WatchAckOrSubscribe
-	26, // 38: nokv.fsmeta.v1.FSMetadata.GetReadVersion:input_type -> nokv.fsmeta.v1.GetReadVersionRequest
-	28, // 39: nokv.fsmeta.v1.FSMetadata.SnapshotSubtree:input_type -> nokv.fsmeta.v1.SnapshotSubtreeRequest
-	31, // 40: nokv.fsmeta.v1.FSMetadata.RetireSnapshotSubtree:input_type -> nokv.fsmeta.v1.RetireSnapshotSubtreeRequest
-	33, // 41: nokv.fsmeta.v1.FSMetadata.GetQuotaUsage:input_type -> nokv.fsmeta.v1.QuotaUsageRequest
-	35, // 42: nokv.fsmeta.v1.FSMetadata.Rename:input_type -> nokv.fsmeta.v1.RenameRequest
-	37, // 43: nokv.fsmeta.v1.FSMetadata.RenameReplace:input_type -> nokv.fsmeta.v1.RenameReplaceRequest
-	39, // 44: nokv.fsmeta.v1.FSMetadata.RenameSubtree:input_type -> nokv.fsmeta.v1.RenameSubtreeRequest
-	41, // 45: nokv.fsmeta.v1.FSMetadata.Link:input_type -> nokv.fsmeta.v1.LinkRequest
-	43, // 46: nokv.fsmeta.v1.FSMetadata.Unlink:input_type -> nokv.fsmeta.v1.UnlinkRequest
-	45, // 47: nokv.fsmeta.v1.FSMetadata.Remove:input_type -> nokv.fsmeta.v1.RemoveRequest
-	47, // 48: nokv.fsmeta.v1.FSMetadata.RemoveDirectory:input_type -> nokv.fsmeta.v1.RemoveDirectoryRequest
-	49, // 49: nokv.fsmeta.v1.FSMetadata.OpenWriteSession:input_type -> nokv.fsmeta.v1.OpenWriteSessionRequest
-	51, // 50: nokv.fsmeta.v1.FSMetadata.HeartbeatWriteSession:input_type -> nokv.fsmeta.v1.HeartbeatWriteSessionRequest
-	53, // 51: nokv.fsmeta.v1.FSMetadata.CloseWriteSession:input_type -> nokv.fsmeta.v1.CloseWriteSessionRequest
-	55, // 52: nokv.fsmeta.v1.FSMetadata.ExpireWriteSessions:input_type -> nokv.fsmeta.v1.ExpireWriteSessionsRequest
-	8,  // 53: nokv.fsmeta.v1.FSMetadata.Create:output_type -> nokv.fsmeta.v1.CreateResponse
-	10, // 54: nokv.fsmeta.v1.FSMetadata.UpdateInode:output_type -> nokv.fsmeta.v1.UpdateInodeResponse
-	12, // 55: nokv.fsmeta.v1.FSMetadata.Lookup:output_type -> nokv.fsmeta.v1.LookupResponse
-	13, // 56: nokv.fsmeta.v1.FSMetadata.LookupPlus:output_type -> nokv.fsmeta.v1.LookupPlusResponse
-	15, // 57: nokv.fsmeta.v1.FSMetadata.ReadDir:output_type -> nokv.fsmeta.v1.ReadDirResponse
-	16, // 58: nokv.fsmeta.v1.FSMetadata.ReadDirPlus:output_type -> nokv.fsmeta.v1.ReadDirPlusResponse
-	24, // 59: nokv.fsmeta.v1.FSMetadata.WatchSubtree:output_type -> nokv.fsmeta.v1.WatchSubtreeResponse
-	27, // 60: nokv.fsmeta.v1.FSMetadata.GetReadVersion:output_type -> nokv.fsmeta.v1.GetReadVersionResponse
-	30, // 61: nokv.fsmeta.v1.FSMetadata.SnapshotSubtree:output_type -> nokv.fsmeta.v1.SnapshotSubtreeResponse
-	32, // 62: nokv.fsmeta.v1.FSMetadata.RetireSnapshotSubtree:output_type -> nokv.fsmeta.v1.RetireSnapshotSubtreeResponse
-	34, // 63: nokv.fsmeta.v1.FSMetadata.GetQuotaUsage:output_type -> nokv.fsmeta.v1.QuotaUsageResponse
-	36, // 64: nokv.fsmeta.v1.FSMetadata.Rename:output_type -> nokv.fsmeta.v1.RenameResponse
-	38, // 65: nokv.fsmeta.v1.FSMetadata.RenameReplace:output_type -> nokv.fsmeta.v1.RenameReplaceResponse
-	40, // 66: nokv.fsmeta.v1.FSMetadata.RenameSubtree:output_type -> nokv.fsmeta.v1.RenameSubtreeResponse
-	42, // 67: nokv.fsmeta.v1.FSMetadata.Link:output_type -> nokv.fsmeta.v1.LinkResponse
-	44, // 68: nokv.fsmeta.v1.FSMetadata.Unlink:output_type -> nokv.fsmeta.v1.UnlinkResponse
-	46, // 69: nokv.fsmeta.v1.FSMetadata.Remove:output_type -> nokv.fsmeta.v1.RemoveResponse
-	48, // 70: nokv.fsmeta.v1.FSMetadata.RemoveDirectory:output_type -> nokv.fsmeta.v1.RemoveDirectoryResponse
-	50, // 71: nokv.fsmeta.v1.FSMetadata.OpenWriteSession:output_type -> nokv.fsmeta.v1.OpenWriteSessionResponse
-	52, // 72: nokv.fsmeta.v1.FSMetadata.HeartbeatWriteSession:output_type -> nokv.fsmeta.v1.HeartbeatWriteSessionResponse
-	54, // 73: nokv.fsmeta.v1.FSMetadata.CloseWriteSession:output_type -> nokv.fsmeta.v1.CloseWriteSessionResponse
-	56, // 74: nokv.fsmeta.v1.FSMetadata.ExpireWriteSessions:output_type -> nokv.fsmeta.v1.ExpireWriteSessionsResponse
-	53, // [53:75] is the sub-list for method output_type
-	31, // [31:53] is the sub-list for method input_type
-	31, // [31:31] is the sub-list for extension type_name
-	31, // [31:31] is the sub-list for extension extendee
-	0,  // [0:31] is the sub-list for field type_name
+	4,  // 29: nokv.fsmeta.v1.RemoveResponse.removed_dentry:type_name -> nokv.fsmeta.v1.DentryRecord
+	2,  // 30: nokv.fsmeta.v1.RemoveResponse.old_inode:type_name -> nokv.fsmeta.v1.InodeRecord
+	3,  // 31: nokv.fsmeta.v1.OpenWriteSessionResponse.session:type_name -> nokv.fsmeta.v1.SessionRecord
+	3,  // 32: nokv.fsmeta.v1.HeartbeatWriteSessionResponse.session:type_name -> nokv.fsmeta.v1.SessionRecord
+	7,  // 33: nokv.fsmeta.v1.FSMetadata.Create:input_type -> nokv.fsmeta.v1.CreateRequest
+	9,  // 34: nokv.fsmeta.v1.FSMetadata.UpdateInode:input_type -> nokv.fsmeta.v1.UpdateInodeRequest
+	11, // 35: nokv.fsmeta.v1.FSMetadata.Lookup:input_type -> nokv.fsmeta.v1.LookupRequest
+	11, // 36: nokv.fsmeta.v1.FSMetadata.LookupPlus:input_type -> nokv.fsmeta.v1.LookupRequest
+	14, // 37: nokv.fsmeta.v1.FSMetadata.ReadDir:input_type -> nokv.fsmeta.v1.ReadDirRequest
+	14, // 38: nokv.fsmeta.v1.FSMetadata.ReadDirPlus:input_type -> nokv.fsmeta.v1.ReadDirRequest
+	25, // 39: nokv.fsmeta.v1.FSMetadata.WatchSubtree:input_type -> nokv.fsmeta.v1.WatchAckOrSubscribe
+	26, // 40: nokv.fsmeta.v1.FSMetadata.GetReadVersion:input_type -> nokv.fsmeta.v1.GetReadVersionRequest
+	28, // 41: nokv.fsmeta.v1.FSMetadata.SnapshotSubtree:input_type -> nokv.fsmeta.v1.SnapshotSubtreeRequest
+	31, // 42: nokv.fsmeta.v1.FSMetadata.RetireSnapshotSubtree:input_type -> nokv.fsmeta.v1.RetireSnapshotSubtreeRequest
+	33, // 43: nokv.fsmeta.v1.FSMetadata.GetQuotaUsage:input_type -> nokv.fsmeta.v1.QuotaUsageRequest
+	35, // 44: nokv.fsmeta.v1.FSMetadata.Rename:input_type -> nokv.fsmeta.v1.RenameRequest
+	37, // 45: nokv.fsmeta.v1.FSMetadata.RenameReplace:input_type -> nokv.fsmeta.v1.RenameReplaceRequest
+	39, // 46: nokv.fsmeta.v1.FSMetadata.RenameSubtree:input_type -> nokv.fsmeta.v1.RenameSubtreeRequest
+	41, // 47: nokv.fsmeta.v1.FSMetadata.Link:input_type -> nokv.fsmeta.v1.LinkRequest
+	43, // 48: nokv.fsmeta.v1.FSMetadata.Unlink:input_type -> nokv.fsmeta.v1.UnlinkRequest
+	45, // 49: nokv.fsmeta.v1.FSMetadata.Remove:input_type -> nokv.fsmeta.v1.RemoveRequest
+	47, // 50: nokv.fsmeta.v1.FSMetadata.RemoveDirectory:input_type -> nokv.fsmeta.v1.RemoveDirectoryRequest
+	49, // 51: nokv.fsmeta.v1.FSMetadata.OpenWriteSession:input_type -> nokv.fsmeta.v1.OpenWriteSessionRequest
+	51, // 52: nokv.fsmeta.v1.FSMetadata.HeartbeatWriteSession:input_type -> nokv.fsmeta.v1.HeartbeatWriteSessionRequest
+	53, // 53: nokv.fsmeta.v1.FSMetadata.CloseWriteSession:input_type -> nokv.fsmeta.v1.CloseWriteSessionRequest
+	55, // 54: nokv.fsmeta.v1.FSMetadata.ExpireWriteSessions:input_type -> nokv.fsmeta.v1.ExpireWriteSessionsRequest
+	8,  // 55: nokv.fsmeta.v1.FSMetadata.Create:output_type -> nokv.fsmeta.v1.CreateResponse
+	10, // 56: nokv.fsmeta.v1.FSMetadata.UpdateInode:output_type -> nokv.fsmeta.v1.UpdateInodeResponse
+	12, // 57: nokv.fsmeta.v1.FSMetadata.Lookup:output_type -> nokv.fsmeta.v1.LookupResponse
+	13, // 58: nokv.fsmeta.v1.FSMetadata.LookupPlus:output_type -> nokv.fsmeta.v1.LookupPlusResponse
+	15, // 59: nokv.fsmeta.v1.FSMetadata.ReadDir:output_type -> nokv.fsmeta.v1.ReadDirResponse
+	16, // 60: nokv.fsmeta.v1.FSMetadata.ReadDirPlus:output_type -> nokv.fsmeta.v1.ReadDirPlusResponse
+	24, // 61: nokv.fsmeta.v1.FSMetadata.WatchSubtree:output_type -> nokv.fsmeta.v1.WatchSubtreeResponse
+	27, // 62: nokv.fsmeta.v1.FSMetadata.GetReadVersion:output_type -> nokv.fsmeta.v1.GetReadVersionResponse
+	30, // 63: nokv.fsmeta.v1.FSMetadata.SnapshotSubtree:output_type -> nokv.fsmeta.v1.SnapshotSubtreeResponse
+	32, // 64: nokv.fsmeta.v1.FSMetadata.RetireSnapshotSubtree:output_type -> nokv.fsmeta.v1.RetireSnapshotSubtreeResponse
+	34, // 65: nokv.fsmeta.v1.FSMetadata.GetQuotaUsage:output_type -> nokv.fsmeta.v1.QuotaUsageResponse
+	36, // 66: nokv.fsmeta.v1.FSMetadata.Rename:output_type -> nokv.fsmeta.v1.RenameResponse
+	38, // 67: nokv.fsmeta.v1.FSMetadata.RenameReplace:output_type -> nokv.fsmeta.v1.RenameReplaceResponse
+	40, // 68: nokv.fsmeta.v1.FSMetadata.RenameSubtree:output_type -> nokv.fsmeta.v1.RenameSubtreeResponse
+	42, // 69: nokv.fsmeta.v1.FSMetadata.Link:output_type -> nokv.fsmeta.v1.LinkResponse
+	44, // 70: nokv.fsmeta.v1.FSMetadata.Unlink:output_type -> nokv.fsmeta.v1.UnlinkResponse
+	46, // 71: nokv.fsmeta.v1.FSMetadata.Remove:output_type -> nokv.fsmeta.v1.RemoveResponse
+	48, // 72: nokv.fsmeta.v1.FSMetadata.RemoveDirectory:output_type -> nokv.fsmeta.v1.RemoveDirectoryResponse
+	50, // 73: nokv.fsmeta.v1.FSMetadata.OpenWriteSession:output_type -> nokv.fsmeta.v1.OpenWriteSessionResponse
+	52, // 74: nokv.fsmeta.v1.FSMetadata.HeartbeatWriteSession:output_type -> nokv.fsmeta.v1.HeartbeatWriteSessionResponse
+	54, // 75: nokv.fsmeta.v1.FSMetadata.CloseWriteSession:output_type -> nokv.fsmeta.v1.CloseWriteSessionResponse
+	56, // 76: nokv.fsmeta.v1.FSMetadata.ExpireWriteSessions:output_type -> nokv.fsmeta.v1.ExpireWriteSessionsResponse
+	55, // [55:77] is the sub-list for method output_type
+	33, // [33:55] is the sub-list for method input_type
+	33, // [33:33] is the sub-list for extension type_name
+	33, // [33:33] is the sub-list for extension extendee
+	0,  // [0:33] is the sub-list for field type_name
 }
 
 func init() { file_fsmeta_fsmeta_proto_init() }

--- a/pb/fsmeta/fsmeta.proto
+++ b/pb/fsmeta/fsmeta.proto
@@ -283,7 +283,11 @@ message RemoveRequest {
   string name = 3;
 }
 
-message RemoveResponse {}
+message RemoveResponse {
+  DentryRecord removed_dentry = 1;
+  InodeRecord old_inode = 2;
+  bool inode_deleted = 3;
+}
 
 message RemoveDirectoryRequest {
   string mount = 1;


### PR DESCRIPTION
## Summary
- change fsmeta Remove to return a RemoveResult containing the removed dentry, removed inode, and whether the inode was deleted
- propagate the result through proto, client/server wire code, executor, and contract harness/model
- keep Unlink as the fire-and-forget error-only POSIX-style API while Remove becomes the metadata-returning primitive

## Notes
- This is an intentional API break instead of a compatibility shim; the deleted metadata is needed by artifact/body GC callers.
- RemoveDirectory is unchanged.

## Validation
- make proto
- gofmt
- go test -count=1 ./fsmeta/contract ./fsmeta/exec/compile ./fsmeta/exec ./fsmeta/runtime/local ./fsmeta/client ./fsmeta/server
- git diff --check
- make proto-check
- go test -count=1 ./fsmeta/...
- make lint
- make test

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Remove now returns structured removal details: removed dentry, previous inode state, and a flag indicating whether the inode was deleted. The RPC surface now returns this information so callers get full removal outcomes.

* **Tests**
  * Tests updated to validate and assert the new removal result semantics and returned fields.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/feichai0017/NoKV/pull/322?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->