### PR TITLE
fix: harden fsmeta history chaos readiness

### DIFF
--- a/cmd/nokv-fsmeta-history/main.go
+++ b/cmd/nokv-fsmeta-history/main.go
@@ -114,11 +114,7 @@ func createScopeWithRetry(ctx context.Context, cli fsmetaclient.Client, op fsmet
 				return fsmeta.CreateResult{Dentry: dentry, Inode: req.Attrs.InodeRecord(dentry.Inode)}, nil
 			}
 		}
-		// Compose startup can return NotFound until the fsmeta gateway observes
-		// rooted mount/root admission. The scope create is an admission barrier,
-		// so retrying here keeps startup synchronization out of the generated
-		// correctness history.
-		if !nokverrors.Retryable(err) && !nokverrors.IsKind(err, nokverrors.KindNotFound) {
+		if !retryScopeCreateError(err) {
 			return fsmeta.CreateResult{}, err
 		}
 		timer := time.NewTimer(delay)
@@ -131,6 +127,25 @@ func createScopeWithRetry(ctx context.Context, cli fsmetaclient.Client, op fsmet
 		if delay < time.Second {
 			delay *= 2
 		}
+	}
+}
+
+func retryScopeCreateError(err error) bool {
+	if err == nil {
+		return false
+	}
+	// The scope create is a startup/admission barrier, not part of the
+	// generated correctness history. Let the outer command timeout absorb
+	// transient root, coordinator, and store recovery windows.
+	if errors.Is(err, fsmeta.ErrMountNotRegistered) {
+		return true
+	}
+	switch nokverrors.KindOf(err) {
+	case nokverrors.KindNotFound,
+		nokverrors.KindRetryExhausted:
+		return true
+	default:
+		return nokverrors.Retryable(err)
 	}
 }
 

--- a/cmd/nokv-fsmeta-history/main_test.go
+++ b/cmd/nokv-fsmeta-history/main_test.go
@@ -6,6 +6,7 @@ package main
 import (
 	"testing"
 
+	nokverrors "github.com/feichai0017/NoKV/errors"
 	"github.com/feichai0017/NoKV/fsmeta"
 	fsmetacontract "github.com/feichai0017/NoKV/fsmeta/contract"
 )
@@ -37,6 +38,28 @@ func TestExternalHistoryOpsScopesRootOperationsAndFiltersInternalSessions(t *tes
 	requireOp(t, ops[2], fsmetacontract.OpLink, mount, scopeInode, "link", scopeInode+11)
 	if got := scopeGeneratedInode(scopeInode, 0); got != 0 {
 		t.Fatalf("zero inode remapped to %d", got)
+	}
+}
+
+func TestRetryScopeCreateErrorIncludesStartupAvailabilityWindows(t *testing.T) {
+	cases := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{name: "nil", err: nil, want: false},
+		{name: "mount not registered", err: fsmeta.ErrMountNotRegistered, want: true},
+		{name: "not found", err: nokverrors.New(nokverrors.KindNotFound, "root not admitted"), want: true},
+		{name: "inner retry exhausted", err: nokverrors.New(nokverrors.KindRetryExhausted, "client: kv get retries exhausted"), want: true},
+		{name: "unavailable", err: nokverrors.New(nokverrors.KindUnavailable, "store restarting"), want: true},
+		{name: "invalid", err: nokverrors.New(nokverrors.KindInvalidArgument, "bad request"), want: false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := retryScopeCreateError(tc.err); got != tc.want {
+				t.Fatalf("retryScopeCreateError(%v)=%v, want %v", tc.err, got, tc.want)
+			}
+		})
 	}
 }
 

--- a/scripts/chaos/docker_fsmeta_history.sh
+++ b/scripts/chaos/docker_fsmeta_history.sh
@@ -35,7 +35,12 @@ stop_chaos() {
   fi
   chaos_pid=""
   docker compose unpause coordinator-1 coordinator-2 coordinator-3 store-1 store-2 store-3 meta-root-1 meta-root-2 meta-root-3 fsmeta >/dev/null 2>&1 || true
-  docker compose up -d coordinator-1 coordinator-2 coordinator-3 store-1 store-2 store-3 meta-root-1 meta-root-2 meta-root-3 fsmeta >/dev/null 2>&1 || true
+  docker compose up -d --no-deps coordinator-1 coordinator-2 coordinator-3 store-1 store-2 store-3 meta-root-1 meta-root-2 meta-root-3 fsmeta >/dev/null 2>&1 || true
+}
+
+recover_service() {
+  local service="$1"
+  docker compose up -d --no-deps "$service"
 }
 
 cleanup() {
@@ -76,14 +81,14 @@ inject_fault() {
       ;;
     2)
       docker compose kill -s SIGKILL store-2
-      docker compose up -d store-2
+      recover_service store-2
       ;;
     3)
       docker compose restart meta-root-3
       ;;
     4)
       docker compose kill -s SIGKILL coordinator-2
-      docker compose up -d coordinator-2
+      recover_service coordinator-2
       ;;
     5)
       docker compose restart store-3
@@ -104,7 +109,7 @@ inject_fault() {
       ;;
     9)
       docker compose kill -s SIGKILL store-1
-      docker compose up -d store-1
+      recover_service store-1
       ;;
     10)
       isolate_service store-2 2
@@ -144,7 +149,7 @@ inject_recovery_fault() {
   case $((seed % 4)) in
     0)
       docker compose kill -s SIGKILL store-1
-      docker compose up -d store-1
+      recover_service store-1
       ;;
     1)
       docker compose restart store-2


### PR DESCRIPTION
## Summary
- recover killed compose services with --no-deps in fsmeta history chaos so fault recovery does not recreate root/coordinator dependencies
- retry scope setup through transient retry-exhausted availability windows before generated history validation starts
- add coverage for startup availability retry classification

## Validation
- bash -n scripts/chaos/docker_fsmeta_history.sh
- go test ./cmd/nokv-fsmeta-history ./fsmeta/contract -count=1
- git diff --check
- make lint

Note: local Docker chaos could not run here because the local Docker daemon is not running.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved startup retry logic with clearer classification of which errors should trigger retries, enhancing reliability during initialization.

* **Tests**
  * Added unit tests that exercise retry-decision behavior across multiple error scenarios to prevent regressions.

* **Chores**
  * Updated chaos test scripts to use a consistent no-dependencies recovery approach when restarting services.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/feichai0017/NoKV/pull/324?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->