### PR TITLE
fix: start fsmeta history chaos after scope setup

### DIFF
--- a/cmd/nokv-fsmeta-history/main.go
+++ b/cmd/nokv-fsmeta-history/main.go
@@ -18,6 +18,17 @@ import (
 	"github.com/feichai0017/NoKV/fsmeta/model"
 )
 
+type historyRun struct {
+	seed  int64
+	state *fsmetacontract.Model
+	ops   []fsmetacontract.Operation
+}
+
+type historyScopeClient interface {
+	Create(context.Context, model.CreateRequest) (model.CreateResult, error)
+	Lookup(context.Context, model.LookupRequest) (model.DentryRecord, error)
+}
+
 func main() {
 	var (
 		addr               = flag.String("addr", "127.0.0.1:8090", "FSMetadata gRPC address")
@@ -28,6 +39,7 @@ func main() {
 		batch              = flag.Int("batch", 3, "concurrent history batch size")
 		timeout            = flag.Duration("timeout", 60*time.Second, "overall command timeout")
 		scope              = flag.String("scope-prefix", "history", "unique root directory prefix for isolating each generated history")
+		readyFile          = flag.String("ready-file", "", "optional file written after all history scopes are prepared")
 		allowIndeterminate = flag.Bool("allow-indeterminate-errors", false, "treat retryable availability errors as operations with unknown commit outcome")
 	)
 	flag.Parse()
@@ -48,36 +60,73 @@ func main() {
 	defer func() { _ = cli.Close() }()
 
 	mountID := model.MountID(*mount)
-	for seed := *start; seed < *start+int64(*seeds); seed++ {
+	runs, err := prepareAndSignalHistoryRuns(ctx, cli, mountID, *start, *seeds, *steps, *scope, *readyFile)
+	if err != nil {
+		log.Fatal(err)
+	}
+	opts := fsmetacontract.HistoryOptions{AllowIndeterminateErrors: *allowIndeterminate}
+	if err := runHistoryRuns(ctx, cli, runs, *batch, opts); err != nil {
+		log.Fatal(err)
+	}
+}
+
+func prepareAndSignalHistoryRuns(ctx context.Context, cli historyScopeClient, mountID model.MountID, start int64, seeds, steps int, scopePrefix, readyFile string) ([]historyRun, error) {
+	runs, err := prepareHistoryRuns(ctx, cli, mountID, start, seeds, steps, scopePrefix)
+	if err != nil {
+		return nil, err
+	}
+	if err := writeReadyFile(readyFile); err != nil {
+		return nil, fmt.Errorf("write history ready file: %w", err)
+	}
+	return runs, nil
+}
+
+func prepareHistoryRuns(ctx context.Context, cli historyScopeClient, mountID model.MountID, start int64, seeds, steps int, scopePrefix string) ([]historyRun, error) {
+	runs := make([]historyRun, 0, seeds)
+	for seed := start; seed < start+int64(seeds); seed++ {
 		state := fsmetacontract.NewModel(mountID)
 		unique := time.Now().UnixNano()
-		scopeName := fmt.Sprintf("%s-%06d-%d", *scope, seed, unique)
+		scopeName := fmt.Sprintf("%s-%06d-%d", scopePrefix, seed, unique)
 		scopeInode := model.InodeID(9_000_000_000 + seed*1_000_000 + unique%1_000_000)
 		scopeOp := scopeCreateOperation(mountID, scopeName, scopeInode)
 		scopeResult, err := createScopeWithRetry(ctx, cli, scopeOp)
 		if err != nil {
-			log.Fatalf("create history scope seed=%d: %v", seed, err)
+			return nil, fmt.Errorf("create history scope seed=%d: %w", seed, err)
 		}
 		scopeOp.Inode = scopeResult.Inode.Inode
 		scopeInode = scopeResult.Inode.Inode
 		if got := state.Apply(scopeOp); got.Err != nil {
-			log.Fatalf("apply history scope seed=%d: %v", seed, got.Err)
+			return nil, fmt.Errorf("apply history scope seed=%d: %w", seed, got.Err)
 		}
-		ops := externalHistoryOps(fsmetacontract.GenerateScript(seed, *steps), mountID, scopeInode, scopeInode)
+		ops := externalHistoryOps(fsmetacontract.GenerateScript(seed, steps), mountID, scopeInode, scopeInode)
 		if len(ops) == 0 {
-			log.Fatalf("seed %d generated no external-safe operations", seed)
+			return nil, fmt.Errorf("seed %d generated no external-safe operations", seed)
 		}
-		historyExec, err := fsmetacontract.NewInodeMappingExecutor(cli)
-		if err != nil {
-			log.Fatalf("open history inode mapper: %v", err)
-		}
-		opts := fsmetacontract.HistoryOptions{AllowIndeterminateErrors: *allowIndeterminate}
-		if err := fsmetacontract.RunConcurrentBatches(ctx, historyExec, state, ops, *batch, opts); err != nil {
-			fmt.Fprintf(os.Stderr, "fsmeta history failed seed=%d steps=%d filtered_ops=%d\n", seed, *steps, len(ops))
-			log.Fatal(err)
-		}
-		log.Printf("fsmeta history passed seed=%d filtered_ops=%d", seed, len(ops))
+		runs = append(runs, historyRun{seed: seed, state: state, ops: ops})
 	}
+	return runs, nil
+}
+
+func runHistoryRuns(ctx context.Context, exec fsmetacontract.Executor, runs []historyRun, batch int, opts fsmetacontract.HistoryOptions) error {
+	for _, run := range runs {
+		historyExec, err := fsmetacontract.NewInodeMappingExecutor(exec)
+		if err != nil {
+			return fmt.Errorf("open history inode mapper: %w", err)
+		}
+		if err := fsmetacontract.RunConcurrentBatches(ctx, historyExec, run.state, run.ops, batch, opts); err != nil {
+			fmt.Fprintf(os.Stderr, "fsmeta history failed seed=%d filtered_ops=%d\n", run.seed, len(run.ops))
+			return err
+		}
+		log.Printf("fsmeta history passed seed=%d filtered_ops=%d", run.seed, len(run.ops))
+	}
+	return nil
+}
+
+func writeReadyFile(path string) error {
+	if path == "" {
+		return nil
+	}
+	return os.WriteFile(path, []byte(time.Now().Format(time.RFC3339Nano)+"\n"), 0o644)
 }
 
 func scopeCreateOperation(mount model.MountID, scopeName string, scopeInode model.InodeID) fsmetacontract.Operation {
@@ -92,7 +141,7 @@ func scopeCreateOperation(mount model.MountID, scopeName string, scopeInode mode
 	}
 }
 
-func createScopeWithRetry(ctx context.Context, cli fsmetaclient.Client, op fsmetacontract.Operation) (model.CreateResult, error) {
+func createScopeWithRetry(ctx context.Context, cli historyScopeClient, op fsmetacontract.Operation) (model.CreateResult, error) {
 	delay := 100 * time.Millisecond
 	for {
 		req := model.CreateRequest{

--- a/cmd/nokv-fsmeta-history/main_test.go
+++ b/cmd/nokv-fsmeta-history/main_test.go
@@ -4,6 +4,10 @@
 package main
 
 import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
 	"testing"
 
 	nokverrors "github.com/feichai0017/NoKV/errors"
@@ -61,6 +65,62 @@ func TestRetryScopeCreateErrorIncludesStartupAvailabilityWindows(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestPrepareAndSignalHistoryRunsWritesReadyAfterAllScopes(t *testing.T) {
+	readyFile := filepath.Join(t.TempDir(), "history.ready")
+	cli := &readyAwareScopeClient{
+		t:         t,
+		readyFile: readyFile,
+		nextInode: 1000,
+	}
+	runs, err := prepareAndSignalHistoryRuns(context.Background(), cli, "vol", 1, 2, 4, "history", readyFile)
+	if err != nil {
+		t.Fatalf("prepareAndSignalHistoryRuns() error=%v", err)
+	}
+	if len(runs) != 2 {
+		t.Fatalf("prepared runs=%d, want 2", len(runs))
+	}
+	if cli.creates != 2 {
+		t.Fatalf("scope creates=%d, want 2", cli.creates)
+	}
+	if _, err := os.Stat(readyFile); err != nil {
+		t.Fatalf("ready file was not written after scope preparation: %v", err)
+	}
+}
+
+type readyAwareScopeClient struct {
+	t         *testing.T
+	readyFile string
+	creates   int
+	nextInode model.InodeID
+}
+
+func (c *readyAwareScopeClient) Create(_ context.Context, req model.CreateRequest) (model.CreateResult, error) {
+	c.t.Helper()
+	if _, err := os.Stat(c.readyFile); err == nil {
+		c.t.Fatalf("ready file was written before all scope creates completed")
+	} else if !errors.Is(err, os.ErrNotExist) {
+		c.t.Fatalf("stat ready file: %v", err)
+	}
+	c.creates++
+	inode := c.nextInode
+	c.nextInode++
+	return model.CreateResult{
+		Dentry: model.DentryRecord{
+			Parent: req.Parent,
+			Name:   req.Name,
+			Inode:  inode,
+			Type:   req.Attrs.Type,
+		},
+		Inode: req.Attrs.InodeRecord(inode),
+	}, nil
+}
+
+func (c *readyAwareScopeClient) Lookup(context.Context, model.LookupRequest) (model.DentryRecord, error) {
+	c.t.Helper()
+	c.t.Fatalf("Lookup should not be needed after successful scope create")
+	return model.DentryRecord{}, nil
 }
 
 func requireOp(t *testing.T, op fsmetacontract.Operation, kind fsmetacontract.OperationKind, mount model.MountID, parent model.InodeID, name string, inode model.InodeID) {

--- a/scripts/chaos/docker_fsmeta_history.sh
+++ b/scripts/chaos/docker_fsmeta_history.sh
@@ -19,6 +19,7 @@ CHAOS_INTERVAL="${NOKV_DOCKER_CHAOS_INTERVAL:-5}"
 ALLOW_INDETERMINATE="${NOKV_DOCKER_CHAOS_ALLOW_INDETERMINATE:-1}"
 TOOLS_DIR="$(mktemp -d "${TMPDIR:-/tmp}/nokv-fsmeta-chaos.XXXXXX")"
 chaos_pid=""
+history_pid=""
 
 dump_cluster_state() {
   if [[ "${NOKV_DOCKER_CHAOS_DUMP_LOGS:-1}" != "1" ]]; then
@@ -38,6 +39,14 @@ stop_chaos() {
   docker compose up -d --no-deps coordinator-1 coordinator-2 coordinator-3 store-1 store-2 store-3 meta-root-1 meta-root-2 meta-root-3 fsmeta >/dev/null 2>&1 || true
 }
 
+stop_history() {
+  if [[ -n "$history_pid" ]] && kill -0 "$history_pid" 2>/dev/null; then
+    kill "$history_pid" 2>/dev/null || true
+    wait "$history_pid" 2>/dev/null || true
+  fi
+  history_pid=""
+}
+
 recover_service() {
   local service="$1"
   docker compose up -d --no-deps "$service"
@@ -48,6 +57,7 @@ cleanup() {
   if [[ "$status" != "0" ]]; then
     dump_cluster_state
   fi
+  stop_history
   stop_chaos
   rm -rf "$TOOLS_DIR"
   if [[ "${NOKV_DOCKER_CHAOS_DOWN:-0}" == "1" ]]; then
@@ -173,13 +183,25 @@ chaos_loop() {
   done
 }
 
+wait_history_ready() {
+  local pid="$1"
+  local ready_file="$2"
+  local deadline=$((SECONDS + READY_TIMEOUT))
+  while [[ ! -f "$ready_file" ]]; do
+    if ! kill -0 "$pid" 2>/dev/null; then
+      wait "$pid"
+      return $?
+    fi
+    if (( SECONDS >= deadline )); then
+      echo "timed out waiting for fsmeta history scope preparation" >&2
+      stop_history
+      return 1
+    fi
+    sleep 1
+  done
+}
+
 wait_fsmeta
-if [[ "${NOKV_DOCKER_CHAOS_NEMESIS:-1}" == "1" ]]; then
-  inject_recovery_fault 1
-  wait_fsmeta
-  chaos_loop &
-  chaos_pid="$!"
-fi
 
 history_args=(
   --addr "$ADDR"
@@ -197,7 +219,20 @@ if [[ "$ALLOW_INDETERMINATE" == "1" ]]; then
   history_args+=(--allow-indeterminate-errors)
 fi
 
-"$TOOLS_DIR/nokv-fsmeta-history" "${history_args[@]}"
+if [[ "${NOKV_DOCKER_CHAOS_NEMESIS:-1}" == "1" ]]; then
+  history_ready_file="$TOOLS_DIR/history.ready"
+  inject_recovery_fault 1
+  wait_fsmeta
+  "$TOOLS_DIR/nokv-fsmeta-history" "${history_args[@]}" --ready-file "$history_ready_file" &
+  history_pid="$!"
+  wait_history_ready "$history_pid" "$history_ready_file"
+  chaos_loop &
+  chaos_pid="$!"
+  wait "$history_pid"
+  history_pid=""
+else
+  "$TOOLS_DIR/nokv-fsmeta-history" "${history_args[@]}"
+fi
 
 stop_chaos
 wait_fsmeta


### PR DESCRIPTION
## Summary
- split fsmeta history chaos into a setup phase and an execution phase
- add a ready-file barrier so the nemesis starts only after all per-seed root scopes exist
- add a regression test that the ready file is written after scope preparation

## Validation
- bash -n scripts/chaos/docker_fsmeta_history.sh
- go test -count=1 ./cmd/nokv-fsmeta-history ./fsmeta/contract
- git diff --check

Not run locally: Docker chaos, because the local Docker daemon is not running on this machine.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * FS metadata history operations now support a readiness signal after the preparation phase completes.

* **Refactor**
  * Refactored metadata history execution into distinct preparation and execution phases for improved operational control.

* **Bug Fixes**
  * Improved error handling: errors in per-operation tasks are now aggregated instead of terminating immediately.

* **Tests**
  * Added test coverage for readiness marker sequencing.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/feichai0017/NoKV/pull/328?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->