### PR TITLE
docs: restore CNCF and DBDB.io recognition logos in README and landing page

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,31 @@ SPDX-License-Identifier: Apache-2.0
     <a href="#-headline-evidence">Benchmarks</a> ·
     <a href="https://github.com/feichai0017/NoKV/discussions">Discussions</a>
   </p>
+
+  <h3>Recognized In The AI-Native Storage Ecosystem</h3>
+
+  <table>
+    <tr>
+      <td align="center" width="360">
+        <a href="https://landscape.cncf.io/?group=projects-and-products&item=runtime--cloud-native-storage--nokv">
+          <img src="./docs/public/img/recognition/cncf.svg" width="128" alt="Cloud Native Computing Foundation" />
+        </a>
+        <br />
+        <strong>Linux Foundation CNCF Landscape</strong>
+        <br />
+        <sub>Listed in AI Native Infra / Storage and Cloud Native Storage.</sub>
+      </td>
+      <td align="center" width="360">
+        <a href="https://dbdb.io/db/nokv">
+          <img src="./docs/public/img/recognition/dbdb.svg" width="128" alt="DBDB.io Database of Databases" />
+        </a>
+        <br />
+        <strong>DBDB.io Database of Databases</strong>
+        <br />
+        <sub>Historical database profile; current NoKV is the Rust filesystem product line.</sub>
+      </td>
+    </tr>
+  </table>
 </div>
 
 <br/>

--- a/docs/index.md
+++ b/docs/index.md
@@ -33,3 +33,15 @@ features:
 Copyright 2024-2026 The NoKV Authors.
 SPDX-License-Identifier: Apache-2.0
 -->
+
+<div style="text-align: center; margin: 4rem auto 2rem; max-width: 820px;">
+  <p style="color: var(--vp-c-text-2); font-size: 0.8rem; letter-spacing: 0.12em; text-transform: uppercase; margin-bottom: 1.75rem;">Recognized in the AI-Native Storage Ecosystem</p>
+  <p>
+    <a href="https://landscape.cncf.io/?group=projects-and-products&item=runtime--cloud-native-storage--nokv" target="_blank" rel="noreferrer" style="display: inline-block; margin: 0 2rem 1rem;">
+      <img src="/img/recognition/cncf.svg" alt="CNCF Landscape" width="190" />
+    </a>
+    <a href="https://dbdb.io/db/nokv" target="_blank" rel="noreferrer" style="display: inline-block; margin: 0 2rem 1rem;">
+      <img src="/img/recognition/dbdb.svg" alt="DBDB.io Database of Databases" width="190" />
+    </a>
+  </p>
+</div>


### PR DESCRIPTION
Follow-up to #341. The README content redesign dropped the "Recognized In The AI-Native Storage Ecosystem" table; this restores the **CNCF Landscape** and **DBDB.io** logo cards (their SVGs were already in `docs/public/img/recognition/`). README content only — no logo, name, or branding changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added "Recognized in the AI-Native Storage Ecosystem" section showcasing external platform certifications and partnerships
  * Featured CNCF Landscape and DBDB.io recognitions with corresponding badges and links

<!-- end of auto-generated comment: release notes by coderabbit.ai -->