### PR TITLE
docs: redesign landing page — light, content-rich, rustfs-style

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -16,7 +16,7 @@ export default withMermaid(
       'Rust filesystem for AI training and agent workspaces, backed by Holt metadata and S3-compatible object storage.',
     cleanUrls: true,
     lastUpdated: true,
-    appearance: 'dark',
+    appearance: true,
 
     // Source-code links in docs are absolute GitHub URLs. Keep this as a
     // narrow safety net for any future fragment-only links.

--- a/docs/.vitepress/theme/style.css
+++ b/docs/.vitepress/theme/style.css
@@ -93,11 +93,13 @@
   --nokv-code-text: #e6edf3;
 }
 
-/* Buttons */
+/* Buttons — VitePress applies these via `background-color`, which silently
+   rejects a gradient value (→ transparent button, invisible on a light page).
+   Keep them SOLID. */
 :root {
-  --vp-button-brand-bg: linear-gradient(135deg, #2563eb 0%, #1d4ed8 100%);
-  --vp-button-brand-hover-bg: linear-gradient(135deg, #1d4ed8 0%, #1e40af 100%);
-  --vp-button-brand-active-bg: linear-gradient(135deg, #1e40af 0%, #1e3a8a 100%);
+  --vp-button-brand-bg: #2563eb;
+  --vp-button-brand-hover-bg: #1d4ed8;
+  --vp-button-brand-active-bg: #1e40af;
   --vp-button-brand-border: transparent;
   --vp-button-brand-hover-border: transparent;
   --vp-button-brand-active-border: transparent;
@@ -105,9 +107,9 @@
 }
 
 .dark {
-  --vp-button-brand-bg: linear-gradient(135deg, #3b82f6 0%, #2563eb 100%);
-  --vp-button-brand-hover-bg: linear-gradient(135deg, #60a5fa 0%, #3b82f6 100%);
-  --vp-button-brand-active-bg: linear-gradient(135deg, #2563eb 0%, #1d4ed8 100%);
+  --vp-button-brand-bg: #3b82f6;
+  --vp-button-brand-hover-bg: #2563eb;
+  --vp-button-brand-active-bg: #1d4ed8;
 }
 
 /* --------------------------------- Globals -------------------------------- */
@@ -450,4 +452,456 @@ body {
 ::selection {
   background: color-mix(in srgb, var(--nokv-accent) 35%, transparent);
   color: var(--vp-c-text-1);
+}
+
+/* ========================================================================= */
+/*  Home landing — clean, airy, light-first (rustfs-flavored)                */
+/* ========================================================================= */
+
+:root {
+  /* Hero brand name → subtle blue→cyan gradient (echoes the mark) */
+  --vp-home-hero-name-color: transparent;
+  --vp-home-hero-name-background: linear-gradient(118deg, #2563eb 12%, #0891b2 92%);
+}
+
+.dark {
+  --vp-home-hero-name-background: linear-gradient(118deg, #60a5fa 12%, #22d3ee 92%);
+}
+
+/* Faint dot-grid texture fading out below the hero (very subtle) */
+.VPHome {
+  position: relative;
+  overflow: hidden;
+  padding-bottom: 8px;
+}
+
+.VPHome::before {
+  content: '';
+  position: absolute;
+  inset: 0 0 auto 0;
+  height: 680px;
+  background-image: radial-gradient(
+    color-mix(in srgb, var(--nokv-accent) 22%, transparent) 1px,
+    transparent 1px
+  );
+  background-size: 28px 28px;
+  -webkit-mask-image: radial-gradient(
+    ellipse 64% 58% at 50% 0%,
+    #000 28%,
+    transparent 76%
+  );
+  mask-image: radial-gradient(ellipse 64% 58% at 50% 0%, #000 28%, transparent 76%);
+  opacity: 0.5;
+  pointer-events: none;
+  z-index: 0;
+}
+
+.VPHome .VPHero,
+.VPHome .VPFeatures,
+.VPHome .vp-doc {
+  position: relative;
+  z-index: 1;
+}
+
+/* Hero — more breathing room, refined type scale */
+.VPHero.has-image {
+  padding: 80px 24px 56px;
+}
+
+@media (min-width: 960px) {
+  .VPHero.has-image {
+    padding: 104px 0 80px;
+  }
+}
+
+.VPHero .name {
+  font-size: clamp(3rem, 6.4vw, 4.75rem);
+  line-height: 1.02;
+  letter-spacing: -0.04em;
+  font-weight: 800;
+}
+
+.VPHero .text {
+  font-size: clamp(1.35rem, 2.6vw, 2.05rem);
+  line-height: 1.24;
+  letter-spacing: -0.022em;
+  font-weight: 700;
+  color: var(--vp-c-text-1);
+  max-width: 26ch;
+}
+
+.VPHero .tagline {
+  font-size: 1.08rem;
+  line-height: 1.66;
+  color: var(--vp-c-text-2);
+  max-width: 54ch;
+  padding-top: 10px;
+}
+
+/* Gopher mark — gentle float, soft brand-tinted shadow, no heavy frame */
+.VPHero .image-bg {
+  opacity: 0;
+}
+
+.VPHero .VPImage {
+  max-width: 340px;
+  filter: drop-shadow(0 20px 44px color-mix(in srgb, var(--nokv-accent) 22%, transparent));
+}
+
+/* Hero buttons — rounded, clean */
+.VPHero .actions {
+  padding-top: 6px;
+}
+
+.VPHero .action .VPButton.medium {
+  border-radius: 11px;
+  padding: 0 22px;
+  line-height: 46px;
+  font-size: 0.98rem;
+  font-weight: 650;
+}
+
+.VPButton.medium.brand {
+  box-shadow: 0 12px 30px -12px var(--nokv-accent-glow);
+}
+
+/* Features — airy, clean, light cards */
+.VPFeatures {
+  padding: 8px 24px 40px;
+}
+
+@media (min-width: 960px) {
+  .VPFeatures {
+    padding: 8px 0 56px;
+  }
+}
+
+.VPFeatures .container {
+  max-width: 1200px;
+}
+
+.VPFeatures .VPFeature {
+  border: 1px solid var(--vp-c-border);
+  border-radius: 16px;
+  background: var(--vp-c-bg);
+  padding: 0;
+  box-shadow: 0 1px 2px rgba(15, 23, 42, 0.05);
+  transition: transform 0.22s ease, border-color 0.22s ease, box-shadow 0.22s ease;
+}
+
+.VPFeatures .VPFeature .box {
+  padding: 28px 26px;
+}
+
+.dark .VPFeatures .VPFeature {
+  background: var(--nokv-card-bg);
+  box-shadow: none;
+}
+
+.VPFeatures .VPFeature:hover {
+  transform: translateY(-3px);
+  border-color: color-mix(in srgb, var(--nokv-accent) 50%, transparent);
+  box-shadow: 0 18px 40px -20px var(--nokv-accent-glow);
+}
+
+.VPFeature .title {
+  font-size: 1.16rem;
+  font-weight: 750;
+  letter-spacing: -0.012em;
+  line-height: 1.3;
+}
+
+.VPFeature .details {
+  color: var(--vp-c-text-2);
+  line-height: 1.62;
+  font-size: 0.96rem;
+  margin-top: 8px;
+}
+
+/* ---- Recognition strip ---- */
+.recognition {
+  max-width: 880px;
+  margin: 8px auto 80px;
+  padding-top: 56px;
+  border-top: 1px solid var(--vp-c-divider);
+  text-align: center;
+}
+
+.recognition-label {
+  font-size: 0.74rem;
+  font-weight: 600;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--vp-c-text-3);
+  margin: 0 0 30px;
+}
+
+.recognition-logos {
+  display: flex;
+  gap: 28px;
+  align-items: stretch;
+  justify-content: center;
+  flex-wrap: wrap;
+}
+
+.recognition-logos a {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 220px;
+  height: 104px;
+  padding: 0 40px;
+  border: 1px solid var(--vp-c-divider);
+  border-radius: 16px;
+  background: var(--vp-c-bg-soft);
+  transition: transform 0.2s ease, border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.recognition-logos a:hover {
+  transform: translateY(-2px);
+  border-color: color-mix(in srgb, var(--nokv-accent) 42%, transparent);
+  box-shadow: 0 14px 30px -18px var(--nokv-accent-glow);
+}
+
+.recognition-logos img {
+  height: 56px;
+  width: auto;
+}
+
+/* ========================================================================= */
+/*  Home landing — content sections (rich body below the hero)               */
+/* ========================================================================= */
+
+/* The home body renders inside `.vp-doc`; neutralize article prose so our
+   section components render cleanly. `.VPHome .vp-doc el` (0,2,1) beats
+   VitePress's `.vp-doc el` (0,1,1). */
+.VPHome .vp-doc h2 {
+  border-top: 0;
+  padding-top: 0;
+}
+.VPHome .vp-doc table {
+  display: table;
+  width: auto;
+  margin: 0;
+  border-collapse: separate;
+}
+.VPHome .vp-doc tr {
+  border: 0;
+  background: transparent;
+}
+.VPHome .vp-doc th,
+.VPHome .vp-doc td {
+  border: 0;
+}
+.VPHome .vp-doc ul {
+  margin: 0;
+  padding: 0;
+}
+
+/* Section rhythm tuned for a flowing landing */
+.VPHome .vp-doc .nokv-section {
+  max-width: 1152px;
+  padding: 64px 32px;
+}
+.VPHome .vp-doc .nokv-section--tight {
+  padding: 52px 32px;
+}
+.VPHome .vp-doc .nokv-section-head {
+  margin-bottom: 40px;
+}
+.VPHome .vp-doc .nokv-h2 {
+  margin: 0 0 14px;
+  border-top: 0;
+  padding-top: 0;
+}
+.VPHome .vp-doc .nokv-lead {
+  margin: 0 auto;
+}
+.VPHome .vp-doc .nokv-eyebrow {
+  margin-bottom: 16px;
+}
+
+/* 3-up architecture cards */
+.VPHome .vp-doc .nokv-grid-3 {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 20px;
+}
+@media (max-width: 860px) {
+  .VPHome .vp-doc .nokv-grid-3 {
+    grid-template-columns: 1fr;
+  }
+}
+.VPHome .vp-doc .nokv-card-kicker {
+  font-family: var(--vp-font-family-mono);
+  font-size: 0.72rem;
+  font-weight: 600;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--nokv-accent);
+  margin-bottom: 12px;
+}
+.VPHome .vp-doc .nokv-card h3 {
+  font-size: 1.18rem;
+  font-weight: 700;
+  letter-spacing: -0.01em;
+  margin: 0 0 10px;
+}
+.VPHome .vp-doc .nokv-card p {
+  color: var(--vp-c-text-2);
+  font-size: 0.97rem;
+  line-height: 1.62;
+  margin: 0;
+}
+.VPHome .vp-doc .nokv-card code {
+  font-size: 0.85em;
+  color: var(--nokv-accent);
+  background: var(--vp-c-brand-soft);
+  padding: 2px 6px;
+  border-radius: 6px;
+}
+
+/* Atomic-publish callout */
+.VPHome .vp-doc .nokv-callout {
+  margin: 24px auto 0;
+  max-width: 920px;
+  padding: 18px 26px;
+  border: 1px solid color-mix(in srgb, var(--nokv-accent) 24%, transparent);
+  border-radius: 14px;
+  background: var(--vp-c-brand-soft);
+  color: var(--vp-c-text-2);
+  line-height: 1.62;
+  font-size: 0.97rem;
+  text-align: center;
+}
+.VPHome .vp-doc .nokv-callout strong {
+  color: var(--vp-c-text-1);
+}
+
+/* Benchmark stat cards */
+.VPHome .vp-doc .nokv-stats {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 20px;
+}
+@media (max-width: 860px) {
+  .VPHome .vp-doc .nokv-stats {
+    grid-template-columns: repeat(2, 1fr);
+  }
+}
+.VPHome .vp-doc .nokv-stat {
+  border: 1px solid var(--vp-c-border);
+  border-radius: 16px;
+  background: var(--vp-c-bg-soft);
+  padding: 26px 20px;
+  text-align: center;
+}
+.VPHome .vp-doc .nokv-stat-num {
+  display: block;
+  font-weight: 800;
+  line-height: 1;
+  font-size: clamp(1.8rem, 3vw, 2.5rem);
+  letter-spacing: -0.03em;
+  background: linear-gradient(120deg, var(--nokv-accent), var(--nokv-accent-2));
+  -webkit-background-clip: text;
+  background-clip: text;
+  color: transparent;
+}
+.VPHome .vp-doc .nokv-stat-label {
+  display: block;
+  margin-top: 12px;
+  font-size: 0.86rem;
+  line-height: 1.5;
+  color: var(--vp-c-text-3);
+}
+
+/* Comparison table */
+.VPHome .vp-doc .nokv-table {
+  width: 100%;
+  max-width: 940px;
+  margin: 0 auto;
+  border-collapse: separate;
+  border-spacing: 0;
+  border: 1px solid var(--vp-c-border);
+  border-radius: 16px;
+  overflow: hidden;
+  font-size: 0.95rem;
+}
+.VPHome .vp-doc .nokv-table th,
+.VPHome .vp-doc .nokv-table td {
+  padding: 14px 20px;
+  text-align: left;
+  border-bottom: 1px solid var(--vp-c-divider);
+}
+.VPHome .vp-doc .nokv-table thead th {
+  font-weight: 700;
+  font-size: 0.9rem;
+  color: var(--vp-c-text-1);
+  background: var(--vp-c-bg-soft);
+}
+.VPHome .vp-doc .nokv-table thead th:last-child {
+  color: var(--nokv-accent);
+}
+.VPHome .vp-doc .nokv-table tbody tr:last-child td {
+  border-bottom: 0;
+}
+.VPHome .vp-doc .nokv-table td:first-child {
+  color: var(--vp-c-text-2);
+  font-weight: 600;
+}
+.VPHome .vp-doc .nokv-table td:last-child {
+  color: var(--vp-c-text-1);
+}
+.VPHome .vp-doc .nokv-table strong {
+  color: var(--nokv-accent);
+}
+
+/* Quick-start code panel (dark on light — like VitePress code blocks) */
+.VPHome .vp-doc .nokv-code {
+  max-width: 760px;
+  margin: 0 auto;
+  background: var(--nokv-code-bg);
+  border: 1px solid var(--vp-c-border);
+  border-radius: 16px;
+  padding: 22px 26px;
+  overflow-x: auto;
+  text-align: left;
+}
+.VPHome .vp-doc .nokv-code code {
+  display: block;
+  font-family: var(--vp-font-family-mono);
+  font-size: 0.85rem;
+  line-height: 1.85;
+  color: #c9d4e3;
+  white-space: pre;
+}
+.VPHome .vp-doc .nokv-code .c {
+  color: #5f6b7c;
+}
+
+/* Final CTA */
+.VPHome .vp-doc .nokv-cta {
+  text-align: center;
+}
+.VPHome .vp-doc .nokv-actions {
+  display: flex;
+  gap: 14px;
+  justify-content: center;
+  flex-wrap: wrap;
+  margin-top: 30px;
+}
+
+/* Buttons are <a> inside .vp-doc — keep their own colors, not link colors */
+.VPHome .vp-doc .nokv-btn {
+  text-decoration: none;
+  font-weight: 600;
+}
+.VPHome .vp-doc .nokv-btn--primary {
+  color: #fff;
+}
+.VPHome .vp-doc .nokv-btn--ghost {
+  color: var(--vp-c-text-1);
+}
+.VPHome .vp-doc .nokv-btn--ghost:hover {
+  color: var(--nokv-accent);
 }

--- a/docs/index.md
+++ b/docs/index.md
@@ -34,14 +34,103 @@ Copyright 2024-2026 The NoKV Authors.
 SPDX-License-Identifier: Apache-2.0
 -->
 
-<div style="text-align: center; margin: 4rem auto 2rem; max-width: 820px;">
-  <p style="color: var(--vp-c-text-2); font-size: 0.8rem; letter-spacing: 0.12em; text-transform: uppercase; margin-bottom: 1.75rem;">Recognized in the AI-Native Storage Ecosystem</p>
-  <p>
-    <a href="https://landscape.cncf.io/?group=projects-and-products&item=runtime--cloud-native-storage--nokv" target="_blank" rel="noreferrer" style="display: inline-block; margin: 0 2rem 1rem;">
-      <img src="/img/recognition/cncf.svg" alt="CNCF Landscape" width="190" />
+<div class="nokv-section">
+  <div class="nokv-section-head nokv-section-head--center">
+    <p class="nokv-eyebrow">How it works</p>
+    <h2 class="nokv-h2">A filesystem — not a filesystem plus a database</h2>
+    <p class="nokv-lead">NoKV owns namespace truth, metadata transactions, snapshots, watches, and object-reference GC. The object store owns byte durability. The metadata engine is built in — no separate Redis, MySQL, or TiKV cluster to run.</p>
+  </div>
+  <div class="nokv-grid-3">
+    <div class="nokv-card">
+      <div class="nokv-card-kicker">Application surface</div>
+      <h3>FUSE · SDK · CLI</h3>
+      <p>Mount it, call the Rust SDK, or drive it from <code>nokv-fs</code>. One namespace, three front doors.</p>
+    </div>
+    <div class="nokv-card">
+      <div class="nokv-card-kicker">Metadata layer</div>
+      <h3>Holt engine</h3>
+      <p>Path-native inode &amp; dentry metadata in a built-in ART engine — <code>MetadataCommand</code> transactions, snapshots, and typed watches.</p>
+    </div>
+    <div class="nokv-card">
+      <div class="nokv-card-kicker">Body storage</div>
+      <h3>S3-compatible objects</h3>
+      <p>File bytes are immutable blocks in RustFS, MinIO, Ceph RGW, or AWS S3 — elastic, cheap, zero-ops durability.</p>
+    </div>
+  </div>
+  <div class="nokv-callout"><strong>Atomic checkpoint publish.</strong> Object bytes upload first, then one metadata commit publishes the dentry, inode, and body manifest as a new generation. A crash in between leaves orphan objects for GC — never a corrupt namespace.</div>
+</div>
+
+<div class="nokv-section nokv-section--tight">
+  <div class="nokv-section-head nokv-section-head--center">
+    <p class="nokv-eyebrow">Benchmarks</p>
+    <h2 class="nokv-h2">Single-node, measured end to end</h2>
+    <p class="nokv-lead">Release build, full server + RPC + Holt path, local RustFS backend. Distributed numbers need separate runs.</p>
+  </div>
+  <div class="nokv-stats">
+    <div class="nokv-stat"><span class="nokv-stat-num">~127K</span><span class="nokv-stat-label">metadata ops/s — create, batched</span></div>
+    <div class="nokv-stat"><span class="nokv-stat-num">~1.1 GB/s</span><span class="nokv-stat-label">checkpoint publish — 1 MiB blocks, conc 16</span></div>
+    <div class="nokv-stat"><span class="nokv-stat-num">~3,000</span><span class="nokv-stat-label">dataset samples/s — 16 KiB, conc 16</span></div>
+    <div class="nokv-stat"><span class="nokv-stat-num">~1.5 KB</span><span class="nokv-stat-label">resident metadata per file</span></div>
+  </div>
+  <p class="nokv-fine" style="text-align: center; margin-top: 20px;">A single directory of 65k entries holds the same throughput — the path-native ART doesn't degrade on big directories.</p>
+</div>
+
+<div class="nokv-section nokv-section--tight">
+  <div class="nokv-section-head nokv-section-head--center">
+    <p class="nokv-eyebrow">Comparison</p>
+    <h2 class="nokv-h2">Same skeleton as JuiceFS — different metadata</h2>
+    <p class="nokv-lead">Object-backed, metadata/data split, FUSE and SDK paths. The difference is the metadata layer and the semantics.</p>
+  </div>
+  <table class="nokv-table">
+    <thead><tr><th>&nbsp;</th><th>JuiceFS</th><th>NoKV</th></tr></thead>
+    <tbody>
+      <tr><td>Metadata engine</td><td>rents a general DB (Redis / MySQL / TiKV)</td><td><strong>built-in, path-native</strong> (Holt)</td></tr>
+      <tr><td>Checkpoint publish</td><td>general POSIX</td><td><strong>first-class atomic primitive</strong></td></tr>
+      <tr><td>Block model</td><td>slice + compaction</td><td>immutable + new-generation</td></tr>
+      <tr><td>AI-native primitives</td><td>bolted on</td><td>snapshots, typed watch, GC floor</td></tr>
+      <tr><td>POSIX completeness</td><td>full</td><td>partial (single-node)</td></tr>
+      <tr><td>Maturity</td><td>production, billions of files</td><td>young — single-node, no HA yet</td></tr>
+    </tbody>
+  </table>
+</div>
+
+<div class="nokv-section nokv-section--tight">
+  <div class="nokv-section-head nokv-section-head--center">
+    <p class="nokv-eyebrow">Quick start</p>
+    <h2 class="nokv-h2">Running in a handful of commands</h2>
+  </div>
+  <pre class="nokv-code"><code><span class="c"># Build the CLI</span>
+cargo build --release -p nokvfs-cli --bin nokv-fs
+<span class="c"># A local S3 endpoint (RustFS) — bucket `nokv`, dev creds rustfsadmin</span>
+rustfs server --address 127.0.0.1:9000 \
+  --access-key rustfsadmin --secret-key rustfsadmin ./rustfs-data &amp;
+<span class="c"># Initialize, publish an artifact, read it back</span>
+nokv-fs --object-backend rustfs init
+nokv-fs --object-backend rustfs put-artifact /runs/1/ckpt.bin ./ckpt.bin
+nokv-fs --object-backend rustfs cat /runs/1/ckpt.bin &gt; restored.bin
+<span class="c"># Mount with FUSE (macOS needs macFUSE)</span>
+nokv-fs --object-backend rustfs mount /tmp/nokv-mount</code></pre>
+</div>
+
+<div class="recognition">
+  <p class="recognition-label">Recognized in the AI-native storage ecosystem</p>
+  <div class="recognition-logos">
+    <a href="https://landscape.cncf.io/?group=projects-and-products&amp;item=runtime--cloud-native-storage--nokv" target="_blank" rel="noreferrer">
+      <img src="/img/recognition/cncf.svg" alt="CNCF Landscape" />
     </a>
-    <a href="https://dbdb.io/db/nokv" target="_blank" rel="noreferrer" style="display: inline-block; margin: 0 2rem 1rem;">
-      <img src="/img/recognition/dbdb.svg" alt="DBDB.io Database of Databases" width="190" />
+    <a href="https://dbdb.io/db/nokv" target="_blank" rel="noreferrer">
+      <img src="/img/recognition/dbdb.svg" alt="DBDB.io Database of Databases" />
     </a>
-  </p>
+  </div>
+</div>
+
+<div class="nokv-section nokv-section--tight nokv-cta">
+  <div class="nokv-section-head nokv-section-head--center">
+    <h2 class="nokv-h2">Build on a self-contained filesystem</h2>
+    <p class="nokv-lead">Apache-2.0. A usable single-node object-backed filesystem today — a distributed metadata layer with Holt as the shard-local state machine next.</p>
+  </div>
+  <div class="nokv-actions">
+    <a class="nokv-btn nokv-btn--primary" href="/architecture">Read the architecture <span class="arrow">→</span></a>
+    <a class="nokv-btn nokv-btn--ghost" href="https://github.com/feichai0017/NoKV">View on GitHub</a>
+  </div>
 </div>


### PR DESCRIPTION
## Redesign the docs landing — light, content-rich, rustfs-style

The landing was a forced-dark hero + four feature cards, then a lot of empty
space. This reworks it into a light-first, content-rich page in the spirit of
rustfs.com — while keeping the **NoKV** name, the gopher logo, and the
**CNCF / DBDB.io** recognition logos.

### Changed
- **Light-first** (`appearance: true`) with a clean light/dark toggle — both verified.
- **Hero**: gradient wordmark, bold value prop, airy spacing.
- **Fixed an invisible primary button** — `--vp-button-brand-bg` held a gradient, but VitePress applies it via `background-color`, which silently drops gradient values, leaving a transparent (invisible-on-light) button. Now solid brand colors; fixes light and dark.
- **New content sections** from real data:
  - *How it works* — three architecture layers + atomic-publish callout
  - *Benchmarks* — ~127K meta ops/s, ~1.1 GB/s checkpoint, ~3,000 samples/s, ~1.5 KB/file
  - *NoKV vs JuiceFS* — comparison table
  - *Quick start* — build → RustFS → init / put / cat → mount
  - closing CTA
- **Recognition** logos unified into clean tiles.
- Quick-start code uses `<pre>` so Vue's template whitespace condensing preserves line breaks.

### Unchanged
NoKV name; gopher logo (`docs/public/img/logo.svg`).

Files: `docs/index.md`, `docs/.vitepress/theme/style.css`, `docs/.vitepress/config.ts`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated website theme and appearance settings for improved dark mode handling
  * Redesigned home page with restructured landing content including new "How it Works" section, Benchmarks, and Comparison table
  * Enhanced visual styling for hero section, features layout, and call-to-action elements

<!-- end of auto-generated comment: release notes by coderabbit.ai -->