### PR TITLE
Fix CI package names and FUSE lock conversions

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -50,8 +50,8 @@ jobs:
           build-args: |
             RUST_VERSION=${{ env.RUST_VERSION }}
             DEBIAN_VERSION=${{ env.DEBIAN_VERSION }}
-            NOKV_PACKAGE=nokvfs-cli
-            NOKV_BINARY=nokv-fs
+            NOKV_PACKAGE=nokv
+            NOKV_BINARY=nokv
           push: ${{ github.repository == 'feichai0017/NoKV' && github.ref == 'refs/heads/main' }}
           tags: |
             ${{ env.IMAGE_NAME }}:latest

--- a/.github/workflows/release-crates.yml
+++ b/.github/workflows/release-crates.yml
@@ -39,14 +39,15 @@ jobs:
         run: |
           set -euo pipefail
           crates=(
-            nokvfs-types
-            nokvfs-object
-            nokvfs-protocol
-            nokvfs-meta
-            nokvfs-client
-            nokvfs-fuse
-            nokvfs-server
-            nokvfs-cli
+            nokv-types
+            nokv-protocol
+            nokv-object
+            nokv-meta
+            nokv-cluster
+            nokv-server
+            nokv-client
+            nokv-fuse
+            nokv
           )
           {
             echo "list<<EOF"

--- a/.github/workflows/release-images.yml
+++ b/.github/workflows/release-images.yml
@@ -95,8 +95,8 @@ jobs:
           build-args: |
             RUST_VERSION=${{ inputs.rust_version }}
             DEBIAN_VERSION=${{ inputs.debian_version }}
-            NOKV_PACKAGE=nokvfs-cli
-            NOKV_BINARY=nokv-fs
+            NOKV_PACKAGE=nokv
+            NOKV_BINARY=nokv
           push: true
           tags: ${{ steps.tags.outputs.ghcr }}
 
@@ -118,7 +118,7 @@ jobs:
           build-args: |
             RUST_VERSION=${{ inputs.rust_version }}
             DEBIAN_VERSION=${{ inputs.debian_version }}
-            NOKV_PACKAGE=nokvfs-cli
-            NOKV_BINARY=nokv-fs
+            NOKV_PACKAGE=nokv
+            NOKV_BINARY=nokv
           push: true
           tags: ${{ steps.tags.outputs.dockerhub }}

--- a/crates/nokv-cluster/src/store.rs
+++ b/crates/nokv-cluster/src/store.rs
@@ -1831,6 +1831,7 @@ mod tests {
 
     #[test]
     fn three_node_openraft_group_replicates_client_write() {
+        let _guard = openraft_cluster_test_lock();
         let cluster = TestMetadataRaftCluster::start(&[1, 2, 3]);
         let leader = cluster.wait_for_leader(None);
 
@@ -1844,6 +1845,7 @@ mod tests {
 
     #[test]
     fn three_node_openraft_group_elects_new_leader_after_leader_shutdown() {
+        let _guard = openraft_cluster_test_lock();
         let cluster = TestMetadataRaftCluster::start(&[1, 2, 3]);
         let leader = cluster.wait_for_leader(None);
 
@@ -1861,6 +1863,7 @@ mod tests {
 
     #[test]
     fn openraft_membership_adds_promotes_and_removes_nodes() {
+        let _guard = openraft_cluster_test_lock();
         let mut cluster = TestMetadataRaftCluster::start_with_voters(&[1, 2, 3, 4], &[1, 2, 3]);
         let leader = cluster.wait_for_leader(None);
         cluster.wait_for_membership_counts(3, 0);
@@ -1974,6 +1977,11 @@ mod tests {
         ids.iter()
             .map(|id| NodeId::new(*id).unwrap())
             .collect::<BTreeSet<_>>()
+    }
+
+    fn openraft_cluster_test_lock() -> std::sync::MutexGuard<'static, ()> {
+        static LOCK: Mutex<()> = Mutex::new(());
+        LOCK.lock().unwrap_or_else(|poisoned| poisoned.into_inner())
     }
 
     struct TestMetadataRaftCluster {
@@ -2111,28 +2119,54 @@ mod tests {
         fn wait_for_key_on_nodes(&self, key: &[u8], version: u64, ids: &[u64]) {
             let deadline = std::time::Instant::now() + Duration::from_secs(10);
             loop {
-                let all_visible = ids.iter().all(|id| {
-                    self.nodes
-                        .get(id)
-                        .unwrap()
-                        .get(
-                            RecordFamily::Dentry,
-                            key,
-                            Version::new(version).unwrap(),
-                            ReadPurpose::UserStrong,
-                        )
-                        .unwrap()
-                        .is_some()
-                });
+                let all_visible = ids
+                    .iter()
+                    .all(|id| self.key_visible_on_node(*id, key, version).unwrap_or(false));
                 if all_visible {
                     return;
                 }
                 assert!(
                     std::time::Instant::now() < deadline,
-                    "metadata raft key did not replicate to requested nodes"
+                    "metadata raft key did not replicate to requested nodes: {}",
+                    self.key_states(key, version, ids)
                 );
                 thread::sleep(Duration::from_millis(20));
             }
+        }
+
+        fn key_visible_on_node(
+            &self,
+            id: u64,
+            key: &[u8],
+            version: u64,
+        ) -> Result<bool, MetadataError> {
+            self.nodes
+                .get(&id)
+                .unwrap()
+                .get(
+                    RecordFamily::Dentry,
+                    key,
+                    Version::new(version).unwrap(),
+                    ReadPurpose::UserStrong,
+                )
+                .map(|value| value.is_some())
+        }
+
+        fn key_states(&self, key: &[u8], version: u64, ids: &[u64]) -> String {
+            ids.iter()
+                .map(|id| {
+                    let visible = match self.key_visible_on_node(*id, key, version) {
+                        Ok(visible) => visible.to_string(),
+                        Err(err) => format!("error={err}"),
+                    };
+                    let stats = self.nodes.get(id).unwrap().stats_handle().stats();
+                    format!(
+                        "node={id} leader={:?} state={} applied={:?} visible={visible}",
+                        stats.current_leader, stats.state, stats.last_applied_index
+                    )
+                })
+                .collect::<Vec<_>>()
+                .join("; ")
         }
 
         fn shutdown_all(&self, excluded: Option<u64>) {

--- a/crates/nokv-fuse/src/filesystem.rs
+++ b/crates/nokv-fuse/src/filesystem.rs
@@ -48,8 +48,8 @@ use directory::{
 };
 use errors::errno;
 use locks::{
-    advisory_lock_kind_from_fuse, advisory_lock_kind_to_fuse, fuse_rename_mode, FuseLockRequest,
-    FuseRenameMode,
+    advisory_lock_kind_from_fuse, advisory_lock_kind_to_fuse, fuse_lock_type, fuse_rename_mode,
+    FuseLockRequest, FuseRenameMode,
 };
 use options::{
     mount_options, FuseStatfs, STATFS_BLOCK_SIZE, STATFS_NAME_MAX, STATFS_TOTAL_BYTES,
@@ -2253,7 +2253,7 @@ where
                 Ok(typ) => reply.locked(lock.start, lock.end, typ, lock.pid),
                 Err(err) => reply.error(err),
             },
-            Ok(None) => reply.locked(start, end, i32::from(libc::F_UNLCK), 0),
+            Ok(None) => reply.locked(start, end, fuse_lock_type(libc::F_UNLCK), 0),
             Err(err) => reply.error(errno(err)),
         }
     }

--- a/crates/nokv-fuse/src/filesystem/locks.rs
+++ b/crates/nokv-fuse/src/filesystem/locks.rs
@@ -19,12 +19,16 @@ pub(super) enum FuseRenameMode {
     NoReplace,
 }
 
+pub(super) fn fuse_lock_type(lock_type: impl Into<i32>) -> i32 {
+    lock_type.into()
+}
+
 pub(super) fn advisory_lock_kind_from_fuse(typ: i32) -> Result<AdvisoryLockKind, Errno> {
-    if typ == i32::from(libc::F_RDLCK) {
+    if typ == fuse_lock_type(libc::F_RDLCK) {
         Ok(AdvisoryLockKind::Read)
-    } else if typ == i32::from(libc::F_WRLCK) {
+    } else if typ == fuse_lock_type(libc::F_WRLCK) {
         Ok(AdvisoryLockKind::Write)
-    } else if typ == i32::from(libc::F_UNLCK) {
+    } else if typ == fuse_lock_type(libc::F_UNLCK) {
         Ok(AdvisoryLockKind::Unlock)
     } else {
         Err(Errno::EINVAL)
@@ -33,9 +37,9 @@ pub(super) fn advisory_lock_kind_from_fuse(typ: i32) -> Result<AdvisoryLockKind,
 
 pub(super) fn advisory_lock_kind_to_fuse(kind: AdvisoryLockKind) -> Result<i32, Errno> {
     match kind {
-        AdvisoryLockKind::Read => Ok(i32::from(libc::F_RDLCK)),
-        AdvisoryLockKind::Write => Ok(i32::from(libc::F_WRLCK)),
-        AdvisoryLockKind::Unlock => Ok(i32::from(libc::F_UNLCK)),
+        AdvisoryLockKind::Read => Ok(fuse_lock_type(libc::F_RDLCK)),
+        AdvisoryLockKind::Write => Ok(fuse_lock_type(libc::F_WRLCK)),
+        AdvisoryLockKind::Unlock => Ok(fuse_lock_type(libc::F_UNLCK)),
     }
 }
 

--- a/crates/nokv-server/src/server.rs
+++ b/crates/nokv-server/src/server.rs
@@ -978,13 +978,7 @@ pub(crate) mod tests {
                     .iter()
                     .filter(|(id, _)| excluded != Some(**id))
                     .all(|(_, running)| {
-                        running.server.refresh_metadata_view().unwrap();
-                        running
-                            .server
-                            .service()
-                            .lookup_path(path)
-                            .unwrap()
-                            .is_some()
+                        path_visible_on_openraft_server(running, path).unwrap_or(false)
                     });
             if all_visible {
                 return;
@@ -996,6 +990,22 @@ pub(crate) mod tests {
             );
             thread::sleep(Duration::from_millis(20));
         }
+    }
+
+    fn path_visible_on_openraft_server(
+        running: &RunningTestServer,
+        path: &str,
+    ) -> Result<bool, String> {
+        running
+            .server
+            .refresh_metadata_view()
+            .map_err(|err| format!("refresh failed: {err}"))?;
+        running
+            .server
+            .service()
+            .lookup_path(path)
+            .map(|entry| entry.is_some())
+            .map_err(|err| format!("lookup failed: {err}"))
     }
 
     fn openraft_server_path_states(
@@ -1013,13 +1023,10 @@ pub(crate) mod tests {
                     .as_ref()
                     .expect("OpenRaft test server has metadata raft")
                     .stats();
-                running.server.refresh_metadata_view().unwrap();
-                let visible = running
-                    .server
-                    .service()
-                    .lookup_path(path)
-                    .unwrap()
-                    .is_some();
+                let visible = match path_visible_on_openraft_server(running, path) {
+                    Ok(visible) => visible.to_string(),
+                    Err(err) => format!("error={err}"),
+                };
                 format!(
                     "node={id} leader={:?} state={} applied={:?} visible={visible}",
                     stats.current_leader, stats.state, stats.last_applied_index


### PR DESCRIPTION
## Summary
- normalize FUSE lock constants through a small helper so Clippy passes on Linux while macOS constants still compile
- update Docker image workflows to build the current nokv package and binary
- refresh the release crate list to match the current workspace packages
- harden OpenRaft integration tests by serializing multi-node cluster cases and retrying transient read/refresh errors during replication waits

## Validation
- cargo fmt --all -- --check
- git diff --check
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test --workspace
- cargo build --release --locked -p nokv --bin nokv
- cargo package --locked --allow-dirty --no-verify -p nokv-types -p nokv-protocol -p nokv-object -p nokv-meta -p nokv-cluster -p nokv-server -p nokv-client -p nokv-fuse -p nokv

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved file lock handling consistency in FUSE operations.

* **Chores**
  * Updated Docker image build configuration to use updated package naming.
  * Updated release workflows to publish updated crate names to the registry.
  * Enhanced test infrastructure with parallel execution support and improved diagnostics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->