### PR TITLE
fix: bump holt to 0.5.5 for the exclusive store-directory open lock

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -693,9 +693,9 @@ dependencies = [
 
 [[package]]
 name = "holt"
-version = "0.5.4"
+version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "576f0d0563f9bbf7f00c99d07ce45ac92496462cddf9a29f12ec5286b7f5f69f"
+checksum = "de022a73ba4286944ebba64a25397f06107545a29899d3c9064658bc408c42b4"
 dependencies = [
  "crc32fast",
  "crossbeam-channel",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ nokv-server = { path = "crates/nokv-server", version = "0.1.0" }
 nokv = { path = "crates/nokv", version = "0.1.0" }
 nokv-bench = { path = "bench", version = "0.1.0" }
 fuser = { version = "0.17.0", default-features = false }
-holt = { version = "0.5.4", default-features = false }
+holt = { version = "0.5.5", default-features = false }
 libc = "0.2"
 opendal = { version = "0.57.0", default-features = false, features = ["blocking", "executors-tokio", "reqwest-rustls-tls", "services-s3"] }
 rmp-serde = "1.3"


### PR DESCRIPTION
## Problem

holt 0.5.4's `FileBlobStore` takes no exclusivity lock on its data directory. Two live store instances on one directory — which the agent benchmark produces routinely, because each run opens the store from a detached `ToolWorker` thread and the next run's open can overlap the previous instance's drop — each replay `manifest.log` into the same `next_slot` and append conflicting set deltas. The store is then permanently poisoned: every later open fails with

```
nokv error: metadata backend error: node corrupt at FileBlobStore::Manifest::duplicate slot
```

and every nokv-arm task from that point returns empty results (observed as "all tasks except T1 empty" in the 2026-06-12 consistency run). Anyone cloning NoKV and preparing their own data root hits the same corruption within a few bench repeats.

## Fix

Bump to holt 0.5.5 ([release](https://github.com/feichai0017/holt/releases/tag/v0.5.5), [changelog](https://github.com/feichai0017/holt/blob/0.5.x/CHANGELOG.md)): `FileBlobStore::open` now holds an exclusive `flock(2)` on `<data_dir>/store.lock` for the lifetime of the instance. Handover reopen serializes behind the previous instance's drop (up to 5 s wait); a genuinely concurrent second opener fails cleanly with `WouldBlock` instead of corrupting the manifest. Same-process double-opens are caught too, and the kernel releases the lock if the holder crashes.

## Verification

- `prepare --reset` + `verify`: zero mismatches on both arms (875 runs).
- Full nokv arm (gpt-5.4-mini, 1 repeat): 5/5 tasks PASS, zero backend tool errors.
- Per-task metrics (prompt/total/cost-weighted tokens, tool calls, turns) fall within the published 10-repeat telemetry ranges from `bench/agent-interface/results/`; T1 re-checked at 3 repeats (6.6k–8.0k prompt, 3 turns, matching the published 7.9k mean).
- Negative control: the same harness on unpatched 0.5.4 corrupted a freshly prepared data root within 3 repeats; with the lock the same workload stays clean across repeated open/close cycles.
- Repeated `verify`/`nokv-stat` open/close cycles on the same data root stay clean; the store directory now contains a zero-byte `store.lock`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated a dependency to the latest patch version for improved stability and performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->