### PR TITLE
docs: add issue policy to PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -3,27 +3,47 @@ Copyright 2024-2026 The NoKV Authors.
 SPDX-License-Identifier: Apache-2.0
 -->
 
+## Related Issue
+
+<!--
+Every non-trivial PR should be tied to an existing issue so maintainers can
+review the agreed problem, scope, and design history before reading the diff.
+
+Use one of:
+- Closes #issue_number
+- Fixes #issue_number
+- Relates to #issue_number
+
+Small exceptions are allowed for typo-only docs edits, CI/dependency chores,
+release chores, and maintainer-approved emergency fixes. If this PR has no
+issue, explain the exception here.
+-->
+
+Closes | Fixes | Relates to #
+
 ## Summary
 
-- 
+-
 
 ## Scope
 
 - [ ] This PR changes one logical boundary only.
 - [ ] No unrelated refactor, benchmark, metadata model, Holt layout,
       object-store, or docs change is mixed in.
+- [ ] The linked issue describes the user-visible problem, design decision, or
+      maintenance task this PR resolves.
 - [ ] Any breaking change is intentional and documented.
 - [ ] No compatibility shim, deprecated alias, or forwarding wrapper was added without a removal condition.
 
 ## Code Contract
 
-- [ ] Package boundaries follow `docs/guide/development/code_contract.md`.
+- [ ] Package boundaries follow `docs/development/code_contract.md`.
 - [ ] Shared helpers reuse the standard library or existing repository helpers.
       New generic helper modules are domain-neutral and tested.
 - [ ] File names and file placement follow the code contract.
 - [ ] New types, interfaces, structs, fields, and functions use domain-specific names.
-- [ ] New errors are in the owning package's `errors.go` and carry stable error kinds when crossing package boundaries.
-- [ ] New metrics/stats are owned by `metrics.go`, `stats.go`, `/metrics`, or a `*/stats` package.
+- [ ] New errors are in the owning package's `errors.rs` and carry stable error kinds when crossing package boundaries.
+- [ ] New metrics/stats are owned by the package that reports or serves them.
 - [ ] Metadata changes state durability, object-reference lifetime,
       watch/snapshot retention, GC, and fallback boundaries.
 


### PR DESCRIPTION
## Related Issue\n\nMaintainer policy update; no existing issue.\n\n## Summary\n\n- require non-trivial PRs to link an existing issue with Closes/Fixes/Relates\n- document small exceptions for typo-only docs, CI/dependency chores, release chores, and maintainer-approved emergency fixes\n- update stale Rust template paths and file names in the checklist\n\n## Validation\n\n- git diff --check\n\n## Contributor Sign-off\n\n- [x] Commit includes DCO Signed-off-by trailer