### PR TITLE
docs: add contributor onboarding guide and README Contributing section

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,9 +7,33 @@ SPDX-License-Identifier: Apache-2.0
 
 Thanks for contributing. This file is the authoritative contribution guide for this repository.
 
+## Start Here
+
+Welcome, and thanks for your interest in NoKV. Whether this is your first open-source PR or your hundredth, we're glad you're here.
+
+NoKV gives AI agents a filesystem (directories, paths, listing, reading) instead of a database to query. File bodies live as immutable blocks in S3-compatible object storage; NoKV manages the metadata layer on top. The bet: agents burn far fewer tokens walking a directory tree than reasoning over a SQL schema. The agent surface is seven verbs over the namespace: `ls`, `stat`, `find` (navigate), `read`, `grep` (read content), and `catalog`, `aggregate` (summarize). They are exposed to MCP (Model Context Protocol) clients via the `nokv-agent` crate. See the Agent Interface section of the [README](README.md) for the full description of this surface.
+
+### New here? Read these three first (in order)
+
+1. **Why:** [Agents Want Filesystems: Agent-Friendly Interfaces Are a Token-Efficiency Strategy](https://nokv.io/blog/agents-want-filesystems): the product argument for why a filesystem-shaped interface cuts agent token use (~45% fewer tokens, ~39% lower cost) versus a SQL schema.
+2. **How:** [List a directory in 131 nanoseconds: holt, the metadata engine inside nokv](https://nokv.io/blog/holt-in-nokv): the metadata engine, an adaptive radix tree built for path-shaped keys.
+3. **Evidence:** [Agent Interface Benchmark — NoKV](https://nokv.io/benchmark): 875 Yanex runs, the NoKV namespace vs. raw SQLite, showing 1.83x fewer prompt tokens, 1.63x lower cost, and 4.5/5 vs. 4.4/5 tasks solved.
+
+### Make your first contribution
+
+- Browse [good first issues](https://github.com/NoKV-Lab/NoKV/issues?q=is%3Aissue%20state%3Aopen%20label%3A%22good%20first%20issue%22) for a scoped starting point.
+- Recommended newcomer track: [#354: MCP server for the agent namespace surface](https://github.com/NoKV-Lab/NoKV/issues/354), which exposes the seven-verb agent surface to MCP clients over stdio.
+- For a new bug or feature, open an issue via the [template chooser](https://github.com/NoKV-Lab/NoKV/issues/new/choose). For broad design, onboarding, or meta topics, open a [Discussion](https://github.com/NoKV-Lab/NoKV/discussions) first.
+
+Before you open a PR, read **[Issues and Proposals](#issues-and-proposals)**, **Branch and Commit Conventions** (including DCO sign-off), and **Pull Request Rules** below. Those sections are the source of truth for branch names, commit format, the local make-gate, and review expectations.
+
+### Reporting security issues
+
+Do not open a public issue with exploit details. Follow the private reporting process in [SECURITY.md](SECURITY.md). If private reporting is unavailable, open a minimal public issue asking for a private follow-up channel, with no exploit details, secrets, or proof-of-concept.
+
 ## Scope
 
-- Repository: `github.com/feichai0017/NoKV`
+- Repository: `github.com/NoKV-Lab/NoKV`
 - Main branch: `main`
 - Main product line: Rust NoKV under `crates/`
 - Rust toolchain: stable
@@ -21,7 +45,7 @@ Thanks for contributing. This file is the authoritative contribution guide for t
 3. Install Rust stable and Node.js for documentation builds.
 
 ```bash
-git clone https://github.com/feichai0017/NoKV.git
+git clone https://github.com/NoKV-Lab/NoKV.git
 cd NoKV
 git remote rename origin upstream
 cargo fetch

--- a/README.md
+++ b/README.md
@@ -27,7 +27,8 @@ SPDX-License-Identifier: Apache-2.0
     <a href="https://nokv.io/blog/agents-want-filesystems">Why Filesystems</a> ·
     <a href="#-quick-start">Quick Start</a> ·
     <a href="#-measured-evidence">Benchmarks</a> ·
-    <a href="https://github.com/feichai0017/NoKV/discussions">Discussions</a>
+    <a href="https://github.com/feichai0017/NoKV/discussions">Discussions</a> ·
+    <a href="#-contributing">Contributing</a>
   </p>
 
   <h3>Listed In The AI-Native Storage Ecosystem</h3>
@@ -423,6 +424,12 @@ mode uses `NOKV_HA_OWNER_B_BIND` for the replacement owner.
 - [Checkpointing](docs/checkpointing.md)
 - [RustFS Backend](docs/rustfs.md)
 - [Benchmarks](docs/benchmarks.md)
+
+## 🤝 Contributing
+
+Contributions are welcome, from first-timers to seasoned Rustaceans. Read [CONTRIBUTING.md](CONTRIBUTING.md) to get started: it covers setup, conventions, and the review gate. Pick up a [good first issue](https://github.com/NoKV-Lab/NoKV/issues?q=is%3Aissue%20state%3Aopen%20label%3A%22good%20first%20issue%22), or follow the recommended newcomer track in [#354](https://github.com/NoKV-Lab/NoKV/issues/354) (MCP server for the agent namespace surface).
+
+To understand the project first, read [Why filesystems](https://nokv.io/blog/agents-want-filesystems), [the metadata engine](https://nokv.io/blog/holt-in-nokv), and [the benchmark](https://nokv.io/benchmark).
 
 ## 📄 License
 


### PR DESCRIPTION
## Summary

- Add a **Start Here** onboarding entry at the top of `CONTRIBUTING.md` as the single source of truth for new contributors: the three best reads (why → how → evidence), the first-contribution path (good first issues, the `#354` MCP-server track, the issue policy), and a security-reporting pointer. It **defers** branch/commit/DCO/PR mechanics to the existing sections rather than restating them.
- Add a **Contributing** section to `README.md` (a short pointer routing to `CONTRIBUTING.md` and good first issues) plus a `Contributing` entry in the top nav.
- Fix the stale repo identity in `CONTRIBUTING.md` (`## Scope` repository line + the clone command) from the personal fork to the canonical `NoKV-Lab/NoKV`, so the file no longer contradicts the new onboarding links within the same file.

**Why:** the repo had no contributor onboarding entry point. README had no Contributing section; CONTRIBUTING had the rules but no "start here". This gives newcomers one discoverable, version-controlled path in, with README/Discussion as thin pointers into CONTRIBUTING (single source of truth).

**How validated:** docs-only change at repo root (`README.md`, `CONTRIBUTING.md`); it touches no `crates/`, `docs/`, or build inputs, so the Rust/clippy/test and docs-site build are not exercised by it. Verified manually: all new links resolve to `NoKV-Lab/NoKV`; the four nav/section anchors are correct (`#-contributing`, `#start-here`, `#issues-and-proposals`); relative links (`README.md`, `CONTRIBUTING.md`, `SECURITY.md`) resolve; the three blog/benchmark links and the `#354` track are the verified-live targets.

## Scope

- [x] This PR changes one logical boundary only (contributor onboarding entry + the repo-identity fix it depends on).
- [x] No unrelated refactor, benchmark, metadata model, Holt layout, object-store, or docs change is mixed in.
- [x] Any breaking change is intentional and documented. (None — additive docs.)
- [x] No compatibility shim, deprecated alias, or forwarding wrapper was added without a removal condition. (N/A)

## Validation

- Markdown structure, link targets, and heading anchors checked by hand (see "How validated" above).
- No code paths affected; Rust gate (`make fmt/lint/test`) and `make docs-build` are not exercised by root-level markdown changes.

## Follow-up (intentionally out of scope, recommended next)

A separate cleanup PR should migrate the remaining `feichai0017/NoKV` references to `NoKV-Lab/NoKV` for repo-wide consistency. Notably, `README.md` already contains **two `#354` links pointing at `feichai0017/NoKV/issues/354`, which 404** (issues are disabled on the fork) — lines ~132 and ~345 — plus the CI badge, DeepWiki, and Discussions nav links, and `SECURITY.md` / `CODE_OF_CONDUCT.md` references.

## Contributor Sign-off

- [x] Every commit in this PR includes a DCO `Signed-off-by` trailer.
