### PR TITLE
feat: add LingTai workbench integration

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,6 +9,14 @@ This repository uses `docs/development/code_contract.md` as the source of truth
 for Rust package boundaries, naming, errors, metrics, tests, DCO, and storage
 safety review.
 
+## Local Collaboration Direction
+
+Treat LingTai as the active partner and integration target for this repository.
+Do not preserve, debug, document, or route around Yanex-specific workflows unless
+the user explicitly asks for Yanex work. Yanex artifacts are historical
+benchmark/demo material only; they must not drive new NoKV behavior, scripts,
+docs, naming, preflight decisions, or compatibility paths.
+
 Before reviewing or editing a PR:
 
 1. Read `docs/development/code_contract.md`.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1376,6 +1376,7 @@ dependencies = [
 name = "nokv"
 version = "0.1.0"
 dependencies = [
+ "base64",
  "nokv-agent",
  "nokv-client",
  "nokv-control",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ repository = "https://github.com/feichai0017/NoKV"
 homepage = "https://nokv.io"
 
 [workspace.dependencies]
+base64 = "0.22.1"
 nokv-types = { path = "crates/nokv-types", version = "0.1.0" }
 nokv-protocol = { path = "crates/nokv-protocol", version = "0.1.0" }
 nokv-meta = { path = "crates/nokv-meta", version = "0.1.0" }

--- a/crates/nokv/Cargo.toml
+++ b/crates/nokv/Cargo.toml
@@ -14,6 +14,7 @@ default = []
 etcd = ["nokv-control/etcd", "nokv-server/etcd"]
 
 [dependencies]
+base64.workspace = true
 nokv-client.workspace = true
 nokv-control.workspace = true
 nokv-fuse.workspace = true

--- a/crates/nokv/src/bin/nokv.rs
+++ b/crates/nokv/src/bin/nokv.rs
@@ -3145,7 +3145,7 @@ mod tests {
     }
 
     #[test]
-    fn workbench_mcp_tools_are_prefixed_and_isolated() {
+    fn workbench_mcp_tools_use_workbench_prefix_and_are_isolated() {
         let responses = run_workbench_mcp_requests(vec![serde_json::json!({
             "jsonrpc": "2.0",
             "id": 1,
@@ -3156,18 +3156,19 @@ mod tests {
         assert_eq!(
             names,
             vec![
-                "nokv_workbench_create",
-                "nokv_workbench_put_file",
-                "nokv_workbench_list",
-                "nokv_workbench_stat",
-                "nokv_workbench_read",
-                "nokv_workbench_grep",
-                "nokv_workbench_find",
-                "nokv_workbench_commit",
-                "nokv_workbench_snapshot",
+                "workbench_create",
+                "workbench_put_file",
+                "workbench_list",
+                "workbench_stat",
+                "workbench_read",
+                "workbench_grep",
+                "workbench_find",
+                "workbench_commit",
+                "workbench_snapshot",
             ]
         );
-        assert!(names.iter().all(|name| name.starts_with("nokv_workbench_")));
+        assert!(names.iter().all(|name| name.starts_with("workbench_")));
+        assert!(names.iter().all(|name| !name.starts_with("nokv_")));
         assert!(!names.contains(&"read"));
         assert!(!names.contains(&"grep"));
     }
@@ -3195,7 +3196,7 @@ mod tests {
                 "id": 1,
                 "method": "tools/call",
                 "params": {
-                    "name": "nokv_workbench_create",
+                    "name": "workbench_create",
                     "arguments": {"id": "spedas-task-001"}
                 }
             }),
@@ -3204,7 +3205,7 @@ mod tests {
                 "id": 2,
                 "method": "tools/call",
                 "params": {
-                    "name": "nokv_workbench_put_file",
+                    "name": "workbench_put_file",
                     "arguments": {
                         "id": "spedas-task-001",
                         "section": "input",
@@ -3219,7 +3220,7 @@ mod tests {
                 "id": 3,
                 "method": "tools/call",
                 "params": {
-                    "name": "nokv_workbench_put_file",
+                    "name": "workbench_put_file",
                     "arguments": {
                         "id": "spedas-task-001",
                         "section": "outputs",
@@ -3234,7 +3235,7 @@ mod tests {
                 "id": 4,
                 "method": "tools/call",
                 "params": {
-                    "name": "nokv_workbench_put_file",
+                    "name": "workbench_put_file",
                     "arguments": {
                         "id": "spedas-task-001",
                         "section": "scripts",
@@ -3249,7 +3250,7 @@ mod tests {
                 "id": 5,
                 "method": "tools/call",
                 "params": {
-                    "name": "nokv_workbench_list",
+                    "name": "workbench_list",
                     "arguments": {
                         "id": "spedas-task-001",
                         "section": "outputs"
@@ -3261,7 +3262,7 @@ mod tests {
                 "id": 6,
                 "method": "tools/call",
                 "params": {
-                    "name": "nokv_workbench_stat",
+                    "name": "workbench_stat",
                     "arguments": {
                         "id": "spedas-task-001",
                         "section": "outputs",
@@ -3274,7 +3275,7 @@ mod tests {
                 "id": 7,
                 "method": "tools/call",
                 "params": {
-                    "name": "nokv_workbench_read",
+                    "name": "workbench_read",
                     "arguments": {
                         "id": "spedas-task-001",
                         "section": "outputs",
@@ -3288,7 +3289,7 @@ mod tests {
                 "id": 8,
                 "method": "tools/call",
                 "params": {
-                    "name": "nokv_workbench_grep",
+                    "name": "workbench_grep",
                     "arguments": {
                         "id": "spedas-task-001",
                         "section": "outputs",
@@ -3302,7 +3303,7 @@ mod tests {
                 "id": 9,
                 "method": "tools/call",
                 "params": {
-                    "name": "nokv_workbench_commit",
+                    "name": "workbench_commit",
                     "arguments": {
                         "id": "spedas-task-001",
                         "manifest": {
@@ -3317,7 +3318,7 @@ mod tests {
                 "id": 10,
                 "method": "tools/call",
                 "params": {
-                    "name": "nokv_workbench_read",
+                    "name": "workbench_read",
                     "arguments": {
                         "id": "spedas-task-001",
                         "section": "metadata",
@@ -3331,7 +3332,7 @@ mod tests {
                 "id": 11,
                 "method": "tools/call",
                 "params": {
-                    "name": "nokv_workbench_snapshot",
+                    "name": "workbench_snapshot",
                     "arguments": {"id": "spedas-task-001"}
                 }
             }),
@@ -3420,7 +3421,7 @@ mod tests {
                 "id": 1,
                 "method": "tools/call",
                 "params": {
-                    "name": "nokv_workbench_create",
+                    "name": "workbench_create",
                     "arguments": {"id": "spedas-task-010"}
                 }
             }),
@@ -3429,7 +3430,7 @@ mod tests {
                 "id": 2,
                 "method": "tools/call",
                 "params": {
-                    "name": "nokv_workbench_create",
+                    "name": "workbench_create",
                     "arguments": {"id": "spedas-task-011"}
                 }
             }),
@@ -3438,7 +3439,7 @@ mod tests {
                 "id": 3,
                 "method": "tools/call",
                 "params": {
-                    "name": "nokv_workbench_commit",
+                    "name": "workbench_commit",
                     "arguments": {
                         "id": "spedas-task-010",
                         "manifest": {
@@ -3454,7 +3455,7 @@ mod tests {
                 "id": 4,
                 "method": "tools/call",
                 "params": {
-                    "name": "nokv_workbench_find",
+                    "name": "workbench_find",
                     "arguments": {
                         "committed": true,
                         "manifest_pattern": "spedas",
@@ -3467,7 +3468,7 @@ mod tests {
                 "id": 5,
                 "method": "tools/call",
                 "params": {
-                    "name": "nokv_workbench_find",
+                    "name": "workbench_find",
                     "arguments": {
                         "committed": false,
                         "limit": 10
@@ -3479,7 +3480,7 @@ mod tests {
                 "id": 6,
                 "method": "tools/call",
                 "params": {
-                    "name": "nokv_workbench_find",
+                    "name": "workbench_find",
                     "arguments": {
                         "committed": true,
                         "include_manifest": true,
@@ -3531,7 +3532,7 @@ mod tests {
                 "id": 1,
                 "method": "tools/call",
                 "params": {
-                    "name": "nokv_workbench_create",
+                    "name": "workbench_create",
                     "arguments": {"id": "spedas-task-002"}
                 }
             }),
@@ -3540,7 +3541,7 @@ mod tests {
                 "id": 2,
                 "method": "tools/call",
                 "params": {
-                    "name": "nokv_workbench_put_file",
+                    "name": "workbench_put_file",
                     "arguments": {
                         "id": "spedas-task-002",
                         "section": "outputs",
@@ -3554,7 +3555,7 @@ mod tests {
                 "id": 3,
                 "method": "tools/call",
                 "params": {
-                    "name": "nokv_workbench_put_file",
+                    "name": "workbench_put_file",
                     "arguments": {
                         "id": "spedas-task-002",
                         "section": "outputs",
@@ -3568,7 +3569,7 @@ mod tests {
                 "id": 4,
                 "method": "tools/call",
                 "params": {
-                    "name": "nokv_workbench_put_file",
+                    "name": "workbench_put_file",
                     "arguments": {
                         "id": "spedas-task-002",
                         "section": "outputs",
@@ -3583,6 +3584,95 @@ mod tests {
     }
 
     #[test]
+    fn workbench_mcp_put_file_ignores_empty_unused_payload_variant() {
+        let responses = run_workbench_mcp_requests(vec![
+            serde_json::json!({
+                "jsonrpc": "2.0",
+                "id": 1,
+                "method": "tools/call",
+                "params": {
+                    "name": "workbench_create",
+                    "arguments": {"id": "spedas-task-012"}
+                }
+            }),
+            serde_json::json!({
+                "jsonrpc": "2.0",
+                "id": 2,
+                "method": "tools/call",
+                "params": {
+                    "name": "workbench_put_file",
+                    "arguments": {
+                        "id": "spedas-task-012",
+                        "section": "input",
+                        "path": "from-text.txt",
+                        "text": "hello from text",
+                        "base64": "",
+                        "content_type": "text/plain; charset=utf-8"
+                    }
+                }
+            }),
+            serde_json::json!({
+                "jsonrpc": "2.0",
+                "id": 3,
+                "method": "tools/call",
+                "params": {
+                    "name": "workbench_put_file",
+                    "arguments": {
+                        "id": "spedas-task-012",
+                        "section": "input",
+                        "path": "from-base64.txt",
+                        "text": "",
+                        "base64": "aGVsbG8gZnJvbSBiYXNlNjQ=",
+                        "content_type": "text/plain; charset=utf-8"
+                    }
+                }
+            }),
+            serde_json::json!({
+                "jsonrpc": "2.0",
+                "id": 4,
+                "method": "tools/call",
+                "params": {
+                    "name": "workbench_read",
+                    "arguments": {
+                        "id": "spedas-task-012",
+                        "section": "input",
+                        "path": "from-text.txt",
+                        "format": "structured"
+                    }
+                }
+            }),
+            serde_json::json!({
+                "jsonrpc": "2.0",
+                "id": 5,
+                "method": "tools/call",
+                "params": {
+                    "name": "workbench_read",
+                    "arguments": {
+                        "id": "spedas-task-012",
+                        "section": "input",
+                        "path": "from-base64.txt",
+                        "format": "structured"
+                    }
+                }
+            }),
+        ]);
+        for (index, response) in responses.iter().enumerate() {
+            assert_ne!(
+                response["result"]["isError"], true,
+                "response {index}: {response}"
+            );
+        }
+        assert_eq!(
+            responses[3]["result"]["structuredContent"]["items"][0]["value"]["text"],
+            "hello from text"
+        );
+        assert_eq!(
+            responses[4]["result"]["structuredContent"]["items"][0]["value"]["text"],
+            "hello from base64"
+        );
+    }
+
+    #[test]
     fn workbench_mcp_rejects_section_prefixed_paths() {
         let responses = run_workbench_mcp_requests(vec![
             serde_json::json!({
@@ -3590,7 +3680,7 @@ mod tests {
                 "id": 1,
                 "method": "tools/call",
                 "params": {
-                    "name": "nokv_workbench_put_file",
+                    "name": "workbench_put_file",
                     "arguments": {
                         "id": "spedas-task-006",
                         "section": "outputs",
@@ -3604,7 +3694,7 @@ mod tests {
                 "id": 2,
                 "method": "tools/call",
                 "params": {
-                    "name": "nokv_workbench_read",
+                    "name": "workbench_read",
                     "arguments": {
                         "id": "spedas-task-006",
                         "section": "outputs",
@@ -3617,7 +3707,7 @@ mod tests {
                 "id": 3,
                 "method": "tools/call",
                 "params": {
-                    "name": "nokv_workbench_list",
+                    "name": "workbench_list",
                     "arguments": {
                         "id": "spedas-task-006",
                         "section": "outputs",
@@ -3644,7 +3734,7 @@ mod tests {
                 "id": 1,
                 "method": "tools/call",
                 "params": {
-                    "name": "nokv_workbench_create",
+                    "name": "workbench_create",
                     "arguments": {"id": "_bad"}
                 }
             }),
@@ -3653,7 +3743,7 @@ mod tests {
                 "id": 2,
                 "method": "tools/call",
                 "params": {
-                    "name": "nokv_workbench_put_file",
+                    "name": "workbench_put_file",
                     "arguments": {
                         "id": "spedas-task-004",
                         "section": "tmp",
@@ -3667,7 +3757,7 @@ mod tests {
                 "id": 3,
                 "method": "tools/call",
                 "params": {
-                    "name": "nokv_workbench_put_file",
+                    "name": "workbench_put_file",
                     "arguments": {
                         "id": "spedas-task-004",
                         "section": "outputs",
@@ -3682,7 +3772,7 @@ mod tests {
                 "id": 4,
                 "method": "tools/call",
                 "params": {
-                    "name": "nokv_workbench_put_file",
+                    "name": "workbench_put_file",
                     "arguments": {
                         "id": "spedas-task-004",
                         "section": "outputs",
@@ -3695,7 +3785,7 @@ mod tests {
                 "id": 5,
                 "method": "tools/call",
                 "params": {
-                    "name": "nokv_workbench_put_file",
+                    "name": "workbench_put_file",
                     "arguments": {
                         "id": "spedas-task-004",
                         "section": "outputs",
@@ -3709,7 +3799,7 @@ mod tests {
                 "id": 6,
                 "method": "tools/call",
                 "params": {
-                    "name": "nokv_workbench_commit",
+                    "name": "workbench_commit",
                     "arguments": {
                         "id": "spedas-task-004",
                         "manifest": "done"
@@ -3734,7 +3824,7 @@ mod tests {
                     "id": 1,
                     "method": "tools/call",
                     "params": {
-                        "name": "nokv_workbench_put_file",
+                        "name": "workbench_put_file",
                         "arguments": {
                             "id": "spedas-task-005",
                             "section": "outputs",
@@ -3748,7 +3838,7 @@ mod tests {
                     "id": 2,
                     "method": "tools/call",
                     "params": {
-                        "name": "nokv_workbench_put_file",
+                        "name": "workbench_put_file",
                         "arguments": {
                             "id": "spedas-task-005",
                             "section": "outputs",
@@ -3762,7 +3852,7 @@ mod tests {
                     "id": 3,
                     "method": "tools/call",
                     "params": {
-                        "name": "nokv_workbench_put_file",
+                        "name": "workbench_put_file",
                         "arguments": {
                             "id": "spedas-task-005",
                             "section": "outputs",
@@ -3788,7 +3878,7 @@ mod tests {
                 "id": 1,
                 "method": "tools/call",
                 "params": {
-                    "name": "nokv_workbench_create",
+                    "name": "workbench_create",
                     "arguments": {"id": "spedas-task-003"}
                 }
             }),
@@ -3797,7 +3887,7 @@ mod tests {
                 "id": 2,
                 "method": "tools/call",
                 "params": {
-                    "name": "nokv_workbench_snapshot",
+                    "name": "workbench_snapshot",
                     "arguments": {"id": "spedas-task-003"}
                 }
             }),

--- a/crates/nokv/src/bin/nokv.rs
+++ b/crates/nokv/src/bin/nokv.rs
@@ -1,5 +1,8 @@
 //! Minimal NoKV command line interface.
 
+#[path = "nokv/workbench_mcp.rs"]
+mod workbench_mcp;
+
 use std::env;
 use std::error::Error;
 use std::fmt;
@@ -121,7 +124,7 @@ enum Command {
         options: MountCliOptions,
     },
     Serve,
-    Mcp,
+    Mcp(McpCliOptions),
     Gc {
         limit: usize,
     },
@@ -172,6 +175,19 @@ struct MountCliOptions {
     writeback: nokv_fuse::FuseWritebackOptions,
 }
 
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct McpCliOptions {
+    profile: McpProfile,
+    workbench_root: Option<String>,
+    workbench_max_bytes: usize,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum McpProfile {
+    Agent,
+    Workbench,
+}
+
 #[derive(Debug)]
 enum CliError {
     MissingValue(&'static str),
@@ -202,6 +218,16 @@ impl Default for MountCliOptions {
             prefetch: defaults.prefetch,
             read_pipeline: defaults.read_pipeline,
             writeback: defaults.writeback,
+        }
+    }
+}
+
+impl Default for McpCliOptions {
+    fn default() -> Self {
+        Self {
+            profile: McpProfile::Agent,
+            workbench_root: None,
+            workbench_max_bytes: workbench_mcp::DEFAULT_WORKBENCH_MAX_BYTES,
         }
     }
 }
@@ -488,9 +514,9 @@ fn run(args: Vec<String>) -> Result<(), CliError> {
         Command::Serve => {
             nokv_server::run(server_options_from_config(config)).map_err(from_io)?;
         }
-        Command::Mcp => {
+        Command::Mcp(options) => {
             let client = open_client(&config)?;
-            run_mcp(client).map_err(from_io)?;
+            run_mcp(client, options, config.uid, config.gid).map_err(from_io)?;
         }
         Command::Gc { limit } => {
             let body = control_get(&config, &format!("/gc?limit={limit}"))?;
@@ -1137,6 +1163,65 @@ fn parse_archive_prefix(raw: &str, option: &str) -> Result<String, CliError> {
     Ok(prefix.to_owned())
 }
 
+fn parse_mcp_args(args: &[String]) -> Result<McpCliOptions, CliError> {
+    let mut options = McpCliOptions::default();
+    let mut index = 1;
+    while index < args.len() {
+        match args[index].as_str() {
+            "--profile" => {
+                index += 1;
+                options.profile = parse_mcp_profile(value(args, index, "--profile")?)?;
+            }
+            "--workbench-root" => {
+                index += 1;
+                let root = workbench_mcp::normalize_workbench_root(value(
+                    args,
+                    index,
+                    "--workbench-root",
+                )?)
+                .map_err(|err| CliError::InvalidOption {
+                    field: "workbench-root",
+                    value: err,
+                })?;
+                options.workbench_root = Some(root);
+            }
+            "--workbench-max-bytes" => {
+                index += 1;
+                options.workbench_max_bytes = parse_usize(
+                    value(args, index, "--workbench-max-bytes")?,
+                    "workbench-max-bytes",
+                )?;
+            }
+            other => return Err(CliError::UnknownOption(other.to_owned())),
+        }
+        index += 1;
+    }
+    if options.profile == McpProfile::Workbench && options.workbench_root.is_none() {
+        return Err(CliError::MissingArgument("workbench root"));
+    }
+    if options.profile == McpProfile::Agent
+        && (options.workbench_root.is_some()
+            || options.workbench_max_bytes != workbench_mcp::DEFAULT_WORKBENCH_MAX_BYTES)
+    {
+        return Err(CliError::InvalidOption {
+            field: "mcp profile",
+            value: "workbench options require --profile workbench".to_owned(),
+        });
+    }
+    Ok(options)
+}
+
+fn parse_mcp_profile(raw: &str) -> Result<McpProfile, CliError> {
+    match raw {
+        "agent" => Ok(McpProfile::Agent),
+        "workbench" => Ok(McpProfile::Workbench),
+        _ => Err(CliError::InvalidOption {
+            field: "profile",
+            value: raw.to_owned(),
+        }),
+    }
+}
+
 fn object_config(
     backend: ObjectBackendKind,
     mut s3: S3ObjectStoreOptions,
@@ -1247,7 +1332,7 @@ fn parse_command(args: &[String]) -> Result<Command, CliError> {
             })
         }
         "serve" => exact_args(args, 1).map(|()| Command::Serve),
-        "mcp" => exact_args(args, 1).map(|()| Command::Mcp),
+        "mcp" => parse_mcp_args(args).map(Command::Mcp),
         "backup" => exact_args(args, 1).map(|()| Command::Backup),
         "restore" => exact_args(args, 1).map(|()| Command::Restore),
         "fsck" => exact_args(args, 1).map(|()| Command::Fsck),
@@ -1712,14 +1797,36 @@ fn from_client(err: impl Error) -> CliError {
 fn from_object(err: impl Error) -> CliError {
     CliError::Client(err.to_string())
 }
-fn run_mcp(client: Client) -> std::io::Result<()> {
+fn run_mcp(client: Client, options: McpCliOptions, uid: u32, gid: u32) -> std::io::Result<()> {
     let stdin = std::io::stdin();
     let stdout = std::io::stdout();
-    run_mcp_stream(client, stdin.lock(), stdout.lock())
+    run_mcp_stream_with_options(client, options, uid, gid, stdin.lock(), stdout.lock())
 }
 
+#[cfg(test)]
 fn run_mcp_stream<O>(
     client: nokv_client::NoKvFsClient<O>,
+    mut reader: impl std::io::BufRead,
+    mut writer: impl std::io::Write,
+) -> std::io::Result<()>
+where
+    O: nokv_object::ObjectStore + Send + Sync + 'static,
+{
+    run_mcp_stream_with_options(
+        client,
+        McpCliOptions::default(),
+        DEFAULT_UID,
+        DEFAULT_GID,
+        &mut reader,
+        &mut writer,
+    )
+}
+
+fn run_mcp_stream_with_options<O>(
+    client: nokv_client::NoKvFsClient<O>,
+    options: McpCliOptions,
+    uid: u32,
+    gid: u32,
     mut reader: impl std::io::BufRead,
     mut writer: impl std::io::Write,
 ) -> std::io::Result<()>
@@ -1759,6 +1866,19 @@ where
     fn err_response(id: Option<serde_json::Value>, code: i64, message: &str) -> serde_json::Value {
         json!({ "jsonrpc": "2.0", "id": id, "error": { "code": code, "message": message } })
     }
+
+    let workbench_options = match options.profile {
+        McpProfile::Agent => None,
+        McpProfile::Workbench => Some(workbench_mcp::WorkbenchMcpOptions {
+            root: options
+                .workbench_root
+                .clone()
+                .expect("workbench profile requires a root"),
+            max_bytes: options.workbench_max_bytes,
+            uid,
+            gid,
+        }),
+    };
 
     let mut line = String::new();
     while reader.read_line(&mut line)? > 0 {
@@ -1832,17 +1952,24 @@ where
                                         }
                                         "initialized" | "ping" => Ok(json!({})),
                                         "tools/list" => {
-                                            let tools: Vec<serde_json::Value> =
-                                                nokv_agent::agent_tool_definitions()
-                                                    .into_iter()
-                                                    .map(|t| {
-                                                        json!({
-                                                            "name": t.name,
-                                                            "description": t.description,
-                                                            "inputSchema": t.parameters,
-                                                        })
+                                            let definitions = match options.profile {
+                                                McpProfile::Agent => {
+                                                    nokv_agent::agent_tool_definitions()
+                                                }
+                                                McpProfile::Workbench => {
+                                                    workbench_mcp::tool_definitions()
+                                                }
+                                            };
+                                            let tools: Vec<serde_json::Value> = definitions
+                                                .into_iter()
+                                                .map(|t| {
+                                                    json!({
+                                                        "name": t.name,
+                                                        "description": t.description,
+                                                        "inputSchema": t.parameters,
                                                     })
-                                                    .collect();
+                                                })
+                                                .collect();
                                             Ok(json!({ "tools": tools }))
                                         }
                                         "tools/call" => {
@@ -1854,9 +1981,26 @@ where
                                                 )),
                                                 Ok(call) => {
                                                     let args = call.arguments.unwrap_or(json!({}));
-                                                    match nokv_agent::execute_agent_tool(
-                                                        &client, &call.name, &args,
-                                                    ) {
+                                                    let tool_result = match options.profile {
+                                                        McpProfile::Agent => {
+                                                            nokv_agent::execute_agent_tool(
+                                                                &client, &call.name, &args,
+                                                            )
+                                                            .map_err(|err| err.to_string())
+                                                        }
+                                                        McpProfile::Workbench => {
+                                                            workbench_mcp::execute_tool(
+                                                                &client,
+                                                                workbench_options
+                                                                    .as_ref()
+                                                                    .expect("workbench options"),
+                                                                &call.name,
+                                                                &args,
+                                                            )
+                                                            .map_err(|err| err.to_string())
+                                                        }
+                                                    };
+                                                    match tool_result {
                                                         Ok(val) => Ok(json!({
                                                             "content": [{ "type": "text", "text": serde_json::to_string_pretty(&val).unwrap_or_default() }],
                                                             "structuredContent": val,
@@ -1919,7 +2063,7 @@ Usage:\n\
   nokv [--server-bind ADDR] [--object-backend s3|rustfs] [--mount ID] mount [--read-only] [--no-kernel-cache] [--direct-io] [--entry-ttl-ms MS] [--attr-ttl-ms MS] [--writeback-cache] MOUNTPOINT\n\
   nokv [--server-bind ADDR] [--object-backend s3|rustfs] [--mount ID] mount-snapshot SNAPSHOT_ID [--no-kernel-cache] [--direct-io] [--entry-ttl-ms MS] [--attr-ttl-ms MS] [--writeback-cache] MOUNTPOINT\n\
   nokv [--meta PATH] [--object-backend s3|rustfs] [--mount ID] [--control-backend etcd] serve\n\
-  nokv [--server-bind ADDR] [--object-backend s3|rustfs] [--mount ID] mcp\n\
+  nokv [--server-bind ADDR] [--object-backend s3|rustfs] [--mount ID] mcp [--profile agent|workbench] [--workbench-root PATH] [--workbench-max-bytes BYTES]\n\
   nokv [--server-bind ADDR] [--object-backend s3|rustfs] [--mount ID] backup\n\
   nokv [--meta PATH] [--object-backend s3|rustfs] [--mount ID] restore\n\
   nokv [--server-bind ADDR] [--object-backend s3|rustfs] [--mount ID] fsck\n\
@@ -2039,15 +2183,15 @@ mod tests {
     use std::thread;
 
     use nokv_client::NoKvFsClient;
-    use nokv_object::{MemoryObjectStore, ObjectKey, ObjectStore};
+    use nokv_object::{LocalObjectStore, MemoryObjectStore, ObjectKey, ObjectStore};
     use tempfile::tempdir;
 
     fn s(value: &str) -> String {
         value.to_owned()
     }
 
-    fn fake_server_object_config() -> ObjectStoreConfig {
-        ObjectStoreConfig::s3(S3ObjectStoreOptions {
+    fn fake_s3_options() -> S3ObjectStoreOptions {
+        S3ObjectStoreOptions {
             bucket: "test".to_owned(),
             root: "/".to_owned(),
             region: "auto".to_owned(),
@@ -2057,10 +2201,18 @@ mod tests {
             session_token: None,
             virtual_host_style: false,
             skip_signature: true,
-        })
+        }
+    }
+
+    fn fake_server_object_config() -> ObjectStoreConfig {
+        ObjectStoreConfig::s3(fake_s3_options())
     }
 
     fn spawn_test_server() -> SocketAddr {
+        spawn_test_server_with_object_config(fake_server_object_config())
+    }
+
+    fn spawn_test_server_with_object_config(object: ObjectStoreConfig) -> SocketAddr {
         let dir = tempdir().unwrap();
         let listener = TcpListener::bind("127.0.0.1:0").unwrap();
         let bind = listener.local_addr().unwrap();
@@ -2069,7 +2221,7 @@ mod tests {
             mount: MountId::new(1).unwrap(),
             meta_path: dir.path().join("meta"),
             metadata_checkpoint_archive_prefix: None,
-            object: fake_server_object_config(),
+            object,
             uid: 1000,
             gid: 1000,
             object_gc: ObjectGcOptions {
@@ -2824,11 +2976,127 @@ mod tests {
     #[test]
     fn parse_mcp_command() {
         let command = parse(vec![s("mcp")]).unwrap().1;
-        assert_eq!(command, Command::Mcp);
+        assert_eq!(command, Command::Mcp(McpCliOptions::default()));
+        assert_eq!(
+            parse(vec![
+                s("mcp"),
+                s("--profile"),
+                s("workbench"),
+                s("--workbench-root"),
+                s("/workbenches")
+            ])
+            .unwrap()
+            .1,
+            Command::Mcp(McpCliOptions {
+                profile: McpProfile::Workbench,
+                workbench_root: Some(s("/workbenches")),
+                workbench_max_bytes: workbench_mcp::DEFAULT_WORKBENCH_MAX_BYTES,
+            })
+        );
+        assert_eq!(
+            parse(vec![
+                s("mcp"),
+                s("--profile"),
+                s("workbench"),
+                s("--workbench-root"),
+                s("/workbenches/"),
+                s("--workbench-max-bytes"),
+                s("1024")
+            ])
+            .unwrap()
+            .1,
+            Command::Mcp(McpCliOptions {
+                profile: McpProfile::Workbench,
+                workbench_root: Some(s("/workbenches")),
+                workbench_max_bytes: 1024,
+            })
+        );
         assert!(matches!(
             parse(vec![s("mcp"), s("extra")]),
-            Err(CliError::TooManyArguments)
+            Err(CliError::UnknownOption(_))
         ));
+        assert!(matches!(
+            parse(vec![s("mcp"), s("--profile"), s("workbench")]),
+            Err(CliError::MissingArgument("workbench root"))
+        ));
+        assert!(matches!(
+            parse(vec![s("mcp"), s("--workbench-root"), s("/workbenches")]),
+            Err(CliError::InvalidOption {
+                field: "mcp profile",
+                ..
+            })
+        ));
+        assert!(matches!(
+            parse(vec![s("mcp"), s("--profile"), s("unknown")]),
+            Err(CliError::InvalidOption {
+                field: "profile",
+                ..
+            })
+        ));
+        assert!(matches!(
+            parse(vec![
+                s("mcp"),
+                s("--profile"),
+                s("workbench"),
+                s("--workbench-root"),
+                s("/")
+            ]),
+            Err(CliError::InvalidOption {
+                field: "workbench-root",
+                ..
+            })
+        ));
+    }
+
+    fn workbench_mcp_options() -> McpCliOptions {
+        McpCliOptions {
+            profile: McpProfile::Workbench,
+            workbench_root: Some(s("/workbenches")),
+            workbench_max_bytes: workbench_mcp::DEFAULT_WORKBENCH_MAX_BYTES,
+        }
+    }
+
+    fn run_workbench_mcp_requests(requests: Vec<serde_json::Value>) -> Vec<serde_json::Value> {
+        run_workbench_mcp_requests_with_options(workbench_mcp_options(), requests)
+    }
+
+    fn run_workbench_mcp_requests_with_options(
+        options: McpCliOptions,
+        requests: Vec<serde_json::Value>,
+    ) -> Vec<serde_json::Value> {
+        let object_dir = tempdir().unwrap();
+        let object_root = object_dir.path().join("objects");
+        let client_store =
+            LocalObjectStore::new(LocalObjectStoreOptions::new(object_root.clone())).unwrap();
+        let client = NoKvFsClient::connect(
+            spawn_test_server_with_object_config(ObjectStoreConfig::tiered_local(
+                object_root,
+                fake_s3_options(),
+            )),
+            client_store,
+        );
+        let reqs = requests
+            .into_iter()
+            .map(|request| serde_json::to_string(&request).unwrap())
+            .collect::<Vec<_>>()
+            .join("\n")
+            + "\n";
+        let reader = std::io::Cursor::new(reqs);
+        let mut writer = Vec::new();
+        run_mcp_stream_with_options(
+            client,
+            options,
+            DEFAULT_UID,
+            DEFAULT_GID,
+            reader,
+            &mut writer,
+        )
+        .unwrap();
+        String::from_utf8(writer)
+            .unwrap()
+            .lines()
+            .map(|line| serde_json::from_str(line).unwrap())
+            .collect()
     }
 
     #[test]
@@ -2874,6 +3142,484 @@ mod tests {
             names,
             vec!["ls", "stat", "catalog", "read", "aggregate", "find", "grep"]
         );
+    }
+
+    #[test]
+    fn workbench_mcp_tools_are_prefixed_and_isolated() {
+        let responses = run_workbench_mcp_requests(vec![serde_json::json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "tools/list"
+        })]);
+        let tools = responses[0]["result"]["tools"].as_array().unwrap();
+        let names: Vec<&str> = tools.iter().map(|t| t["name"].as_str().unwrap()).collect();
+        assert_eq!(
+            names,
+            vec![
+                "nokv_workbench_create",
+                "nokv_workbench_put_file",
+                "nokv_workbench_list",
+                "nokv_workbench_stat",
+                "nokv_workbench_read",
+                "nokv_workbench_grep",
+                "nokv_workbench_commit",
+                "nokv_workbench_snapshot",
+            ]
+        );
+        assert!(names.iter().all(|name| name.starts_with("nokv_workbench_")));
+        assert!(!names.contains(&"read"));
+        assert!(!names.contains(&"grep"));
+    }
+
+    #[test]
+    fn workbench_mcp_tool_schemas_are_closed() {
+        let responses = run_workbench_mcp_requests(vec![serde_json::json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "tools/list"
+        })]);
+        let tools = responses[0]["result"]["tools"].as_array().unwrap();
+        for tool in tools {
+            assert_eq!(tool["inputSchema"]["type"], "object");
+            assert_eq!(tool["inputSchema"]["additionalProperties"], false);
+            assert!(tool["inputSchema"]["properties"].is_object());
+        }
+    }
+
+    #[test]
+    fn workbench_mcp_create_put_read_list_stat_grep_commit_snapshot_flow() {
+        let responses = run_workbench_mcp_requests(vec![
+            serde_json::json!({
+                "jsonrpc": "2.0",
+                "id": 1,
+                "method": "tools/call",
+                "params": {
+                    "name": "nokv_workbench_create",
+                    "arguments": {"id": "spedas-task-001"}
+                }
+            }),
+            serde_json::json!({
+                "jsonrpc": "2.0",
+                "id": 2,
+                "method": "tools/call",
+                "params": {
+                    "name": "nokv_workbench_put_file",
+                    "arguments": {
+                        "id": "spedas-task-001",
+                        "section": "input",
+                        "path": "event.json",
+                        "text": "{\"event\":\"storm\"}",
+                        "content_type": "application/json"
+                    }
+                }
+            }),
+            serde_json::json!({
+                "jsonrpc": "2.0",
+                "id": 3,
+                "method": "tools/call",
+                "params": {
+                    "name": "nokv_workbench_put_file",
+                    "arguments": {
+                        "id": "spedas-task-001",
+                        "section": "outputs",
+                        "path": "spectrum.csv",
+                        "text": "freq,power\n1,2\n",
+                        "content_type": "text/csv"
+                    }
+                }
+            }),
+            serde_json::json!({
+                "jsonrpc": "2.0",
+                "id": 4,
+                "method": "tools/call",
+                "params": {
+                    "name": "nokv_workbench_put_file",
+                    "arguments": {
+                        "id": "spedas-task-001",
+                        "section": "scripts",
+                        "path": "analysis.py",
+                        "text": "print('spedas')\n",
+                        "content_type": "text/x-python"
+                    }
+                }
+            }),
+            serde_json::json!({
+                "jsonrpc": "2.0",
+                "id": 5,
+                "method": "tools/call",
+                "params": {
+                    "name": "nokv_workbench_list",
+                    "arguments": {
+                        "id": "spedas-task-001",
+                        "section": "outputs"
+                    }
+                }
+            }),
+            serde_json::json!({
+                "jsonrpc": "2.0",
+                "id": 6,
+                "method": "tools/call",
+                "params": {
+                    "name": "nokv_workbench_stat",
+                    "arguments": {
+                        "id": "spedas-task-001",
+                        "section": "outputs",
+                        "path": "spectrum.csv"
+                    }
+                }
+            }),
+            serde_json::json!({
+                "jsonrpc": "2.0",
+                "id": 7,
+                "method": "tools/call",
+                "params": {
+                    "name": "nokv_workbench_read",
+                    "arguments": {
+                        "id": "spedas-task-001",
+                        "section": "outputs",
+                        "path": "spectrum.csv",
+                        "format": "structured"
+                    }
+                }
+            }),
+            serde_json::json!({
+                "jsonrpc": "2.0",
+                "id": 8,
+                "method": "tools/call",
+                "params": {
+                    "name": "nokv_workbench_grep",
+                    "arguments": {
+                        "id": "spedas-task-001",
+                        "section": "outputs",
+                        "pattern": "freq",
+                        "recursive": true
+                    }
+                }
+            }),
+            serde_json::json!({
+                "jsonrpc": "2.0",
+                "id": 9,
+                "method": "tools/call",
+                "params": {
+                    "name": "nokv_workbench_commit",
+                    "arguments": {
+                        "id": "spedas-task-001",
+                        "manifest": {
+                            "task": "spedas-task-001",
+                            "outputs": ["outputs/spectrum.csv"]
+                        }
+                    }
+                }
+            }),
+            serde_json::json!({
+                "jsonrpc": "2.0",
+                "id": 10,
+                "method": "tools/call",
+                "params": {
+                    "name": "nokv_workbench_read",
+                    "arguments": {
+                        "id": "spedas-task-001",
+                        "section": "metadata",
+                        "path": "run_manifest.json",
+                        "format": "structured"
+                    }
+                }
+            }),
+            serde_json::json!({
+                "jsonrpc": "2.0",
+                "id": 11,
+                "method": "tools/call",
+                "params": {
+                    "name": "nokv_workbench_snapshot",
+                    "arguments": {"id": "spedas-task-001"}
+                }
+            }),
+        ]);
+        for (index, response) in responses.iter().enumerate() {
+            assert_ne!(
+                response["result"]["isError"], true,
+                "response {index}: {response}"
+            );
+        }
+        assert_eq!(
+            responses[1]["result"]["structuredContent"]["path"],
+            "/workbenches/spedas-task-001/input/event.json"
+        );
+        assert_eq!(
+            responses[4]["result"]["structuredContent"]["result"]["entries"][0]["name"],
+            "spectrum.csv"
+        );
+        assert_eq!(
+            responses[5]["result"]["structuredContent"]["result"]["card"]["path"],
+            "/workbenches/spedas-task-001/outputs/spectrum.csv"
+        );
+        assert_eq!(
+            responses[6]["result"]["structuredContent"]["result"]["record_type"], "text_lines",
+            "read response: {}",
+            responses[6]
+        );
+        assert_eq!(
+            responses[6]["result"]["structuredContent"]["result"]["items"][0]["value"]["text"],
+            "freq,power"
+        );
+        assert_eq!(
+            responses[7]["result"]["structuredContent"]["result"]["matches"][0]["path"],
+            "/workbenches/spedas-task-001/outputs/spectrum.csv"
+        );
+        assert_eq!(
+            responses[8]["result"]["structuredContent"]["path"],
+            "/workbenches/spedas-task-001/metadata/run_manifest.json"
+        );
+        let manifest_items = responses[9]["result"]["structuredContent"]["result"]["items"]
+            .as_array()
+            .unwrap();
+        assert!(
+            manifest_items.iter().any(|item| {
+                item["value"]["key"] == "schema"
+                    && item["value"]["value"] == "nokv.workbench.run_manifest.v0"
+            }),
+            "manifest read response: {}",
+            responses[9]
+        );
+        assert!(
+            responses[10]["result"]["structuredContent"]["snapshot_id"]
+                .as_u64()
+                .unwrap()
+                > 0
+        );
+    }
+
+    #[test]
+    fn workbench_mcp_rejects_path_escape_and_default_overwrite() {
+        let responses = run_workbench_mcp_requests(vec![
+            serde_json::json!({
+                "jsonrpc": "2.0",
+                "id": 1,
+                "method": "tools/call",
+                "params": {
+                    "name": "nokv_workbench_create",
+                    "arguments": {"id": "spedas-task-002"}
+                }
+            }),
+            serde_json::json!({
+                "jsonrpc": "2.0",
+                "id": 2,
+                "method": "tools/call",
+                "params": {
+                    "name": "nokv_workbench_put_file",
+                    "arguments": {
+                        "id": "spedas-task-002",
+                        "section": "outputs",
+                        "path": "../escape.csv",
+                        "text": "bad"
+                    }
+                }
+            }),
+            serde_json::json!({
+                "jsonrpc": "2.0",
+                "id": 3,
+                "method": "tools/call",
+                "params": {
+                    "name": "nokv_workbench_put_file",
+                    "arguments": {
+                        "id": "spedas-task-002",
+                        "section": "outputs",
+                        "path": "spectrum.csv",
+                        "text": "freq,power\n1,2\n"
+                    }
+                }
+            }),
+            serde_json::json!({
+                "jsonrpc": "2.0",
+                "id": 4,
+                "method": "tools/call",
+                "params": {
+                    "name": "nokv_workbench_put_file",
+                    "arguments": {
+                        "id": "spedas-task-002",
+                        "section": "outputs",
+                        "path": "spectrum.csv",
+                        "text": "freq,power\n1,3\n"
+                    }
+                }
+            }),
+        ]);
+        assert_eq!(responses[1]["result"]["isError"], true);
+        assert_eq!(responses[3]["result"]["isError"], true);
+    }
+
+    #[test]
+    fn workbench_mcp_rejects_invalid_ids_sections_payloads_and_manifest() {
+        let responses = run_workbench_mcp_requests(vec![
+            serde_json::json!({
+                "jsonrpc": "2.0",
+                "id": 1,
+                "method": "tools/call",
+                "params": {
+                    "name": "nokv_workbench_create",
+                    "arguments": {"id": "_bad"}
+                }
+            }),
+            serde_json::json!({
+                "jsonrpc": "2.0",
+                "id": 2,
+                "method": "tools/call",
+                "params": {
+                    "name": "nokv_workbench_put_file",
+                    "arguments": {
+                        "id": "spedas-task-004",
+                        "section": "tmp",
+                        "path": "x.txt",
+                        "text": "x"
+                    }
+                }
+            }),
+            serde_json::json!({
+                "jsonrpc": "2.0",
+                "id": 3,
+                "method": "tools/call",
+                "params": {
+                    "name": "nokv_workbench_put_file",
+                    "arguments": {
+                        "id": "spedas-task-004",
+                        "section": "outputs",
+                        "path": "x.txt",
+                        "text": "x",
+                        "base64": "eA=="
+                    }
+                }
+            }),
+            serde_json::json!({
+                "jsonrpc": "2.0",
+                "id": 4,
+                "method": "tools/call",
+                "params": {
+                    "name": "nokv_workbench_put_file",
+                    "arguments": {
+                        "id": "spedas-task-004",
+                        "section": "outputs",
+                        "path": "x.txt"
+                    }
+                }
+            }),
+            serde_json::json!({
+                "jsonrpc": "2.0",
+                "id": 5,
+                "method": "tools/call",
+                "params": {
+                    "name": "nokv_workbench_put_file",
+                    "arguments": {
+                        "id": "spedas-task-004",
+                        "section": "outputs",
+                        "path": "x.txt",
+                        "base64": "not base64"
+                    }
+                }
+            }),
+            serde_json::json!({
+                "jsonrpc": "2.0",
+                "id": 6,
+                "method": "tools/call",
+                "params": {
+                    "name": "nokv_workbench_commit",
+                    "arguments": {
+                        "id": "spedas-task-004",
+                        "manifest": "done"
+                    }
+                }
+            }),
+        ]);
+        for response in responses {
+            assert_eq!(response["result"]["isError"], true);
+        }
+    }
+
+    #[test]
+    fn workbench_mcp_respects_max_bytes_and_replace_true() {
+        let mut options = workbench_mcp_options();
+        options.workbench_max_bytes = 4;
+        let responses = run_workbench_mcp_requests_with_options(
+            options,
+            vec![
+                serde_json::json!({
+                    "jsonrpc": "2.0",
+                    "id": 1,
+                    "method": "tools/call",
+                    "params": {
+                        "name": "nokv_workbench_put_file",
+                        "arguments": {
+                            "id": "spedas-task-005",
+                            "section": "outputs",
+                            "path": "small.txt",
+                            "text": "12345"
+                        }
+                    }
+                }),
+                serde_json::json!({
+                    "jsonrpc": "2.0",
+                    "id": 2,
+                    "method": "tools/call",
+                    "params": {
+                        "name": "nokv_workbench_put_file",
+                        "arguments": {
+                            "id": "spedas-task-005",
+                            "section": "outputs",
+                            "path": "small.txt",
+                            "text": "1234"
+                        }
+                    }
+                }),
+                serde_json::json!({
+                    "jsonrpc": "2.0",
+                    "id": 3,
+                    "method": "tools/call",
+                    "params": {
+                        "name": "nokv_workbench_put_file",
+                        "arguments": {
+                            "id": "spedas-task-005",
+                            "section": "outputs",
+                            "path": "small.txt",
+                            "text": "abcd",
+                            "replace": true
+                        }
+                    }
+                }),
+            ],
+        );
+        assert_eq!(responses[0]["result"]["isError"], true);
+        assert_ne!(responses[1]["result"]["isError"], true);
+        assert_ne!(responses[2]["result"]["isError"], true);
+        assert_eq!(responses[2]["result"]["structuredContent"]["replace"], true);
+    }
+
+    #[test]
+    fn workbench_mcp_snapshot_requires_commit_manifest() {
+        let responses = run_workbench_mcp_requests(vec![
+            serde_json::json!({
+                "jsonrpc": "2.0",
+                "id": 1,
+                "method": "tools/call",
+                "params": {
+                    "name": "nokv_workbench_create",
+                    "arguments": {"id": "spedas-task-003"}
+                }
+            }),
+            serde_json::json!({
+                "jsonrpc": "2.0",
+                "id": 2,
+                "method": "tools/call",
+                "params": {
+                    "name": "nokv_workbench_snapshot",
+                    "arguments": {"id": "spedas-task-003"}
+                }
+            }),
+        ]);
+        assert_ne!(responses[0]["result"]["isError"], true);
+        assert_eq!(responses[1]["result"]["isError"], true);
+        assert!(responses[1]["result"]["content"][0]["text"]
+            .as_str()
+            .unwrap()
+            .contains("not committed"));
     }
 
     #[test]

--- a/crates/nokv/src/bin/nokv.rs
+++ b/crates/nokv/src/bin/nokv.rs
@@ -3583,6 +3583,60 @@ mod tests {
     }
 
     #[test]
+    fn workbench_mcp_rejects_section_prefixed_paths() {
+        let responses = run_workbench_mcp_requests(vec![
+            serde_json::json!({
+                "jsonrpc": "2.0",
+                "id": 1,
+                "method": "tools/call",
+                "params": {
+                    "name": "nokv_workbench_put_file",
+                    "arguments": {
+                        "id": "spedas-task-006",
+                        "section": "outputs",
+                        "path": "outputs/spectrum.csv",
+                        "text": "freq,power\n1,2\n"
+                    }
+                }
+            }),
+            serde_json::json!({
+                "jsonrpc": "2.0",
+                "id": 2,
+                "method": "tools/call",
+                "params": {
+                    "name": "nokv_workbench_read",
+                    "arguments": {
+                        "id": "spedas-task-006",
+                        "section": "outputs",
+                        "path": "outputs/spectrum.csv"
+                    }
+                }
+            }),
+            serde_json::json!({
+                "jsonrpc": "2.0",
+                "id": 3,
+                "method": "tools/call",
+                "params": {
+                    "name": "nokv_workbench_list",
+                    "arguments": {
+                        "id": "spedas-task-006",
+                        "section": "outputs",
+                        "path": "outputs"
+                    }
+                }
+            }),
+        ]);
+
+        for response in responses {
+            assert_eq!(response["result"]["isError"], true);
+            assert!(response["result"]["content"][0]["text"]
+                .as_str()
+                .unwrap()
+                .contains("relative to section outputs"));
+        }
+    }
+
+    #[test]
     fn workbench_mcp_rejects_invalid_ids_sections_payloads_and_manifest() {
         let responses = run_workbench_mcp_requests(vec![
             serde_json::json!({

--- a/crates/nokv/src/bin/nokv.rs
+++ b/crates/nokv/src/bin/nokv.rs
@@ -3162,6 +3162,7 @@ mod tests {
                 "nokv_workbench_stat",
                 "nokv_workbench_read",
                 "nokv_workbench_grep",
+                "nokv_workbench_find",
                 "nokv_workbench_commit",
                 "nokv_workbench_snapshot",
             ]
@@ -3346,31 +3347,53 @@ mod tests {
             "/workbenches/spedas-task-001/input/event.json"
         );
         assert_eq!(
-            responses[4]["result"]["structuredContent"]["result"]["entries"][0]["name"],
+            responses[4]["result"]["structuredContent"]["entries"][0]["name"],
             "spectrum.csv"
         );
         assert_eq!(
-            responses[5]["result"]["structuredContent"]["result"]["card"]["path"],
+            responses[4]["result"]["structuredContent"]["entries"][0]["relative_path"],
+            "spectrum.csv"
+        );
+        assert_eq!(
+            responses[4]["result"]["structuredContent"]["entries"][0]["section"],
+            "outputs"
+        );
+        assert_eq!(
+            responses[5]["result"]["structuredContent"]["card"]["path"],
             "/workbenches/spedas-task-001/outputs/spectrum.csv"
         );
         assert_eq!(
-            responses[6]["result"]["structuredContent"]["result"]["record_type"], "text_lines",
+            responses[5]["result"]["structuredContent"]["card"]["relative_path"],
+            "spectrum.csv"
+        );
+        assert_eq!(
+            responses[5]["result"]["structuredContent"]["card"]["content_type"],
+            "text/csv"
+        );
+        assert!(
+            responses[5]["result"]["structuredContent"]["card"]["digest_uri"]
+                .as_str()
+                .unwrap()
+                .starts_with("sha256:")
+        );
+        assert_eq!(
+            responses[6]["result"]["structuredContent"]["record_type"], "text_lines",
             "read response: {}",
             responses[6]
         );
         assert_eq!(
-            responses[6]["result"]["structuredContent"]["result"]["items"][0]["value"]["text"],
+            responses[6]["result"]["structuredContent"]["items"][0]["value"]["text"],
             "freq,power"
         );
         assert_eq!(
-            responses[7]["result"]["structuredContent"]["result"]["matches"][0]["path"],
-            "/workbenches/spedas-task-001/outputs/spectrum.csv"
+            responses[7]["result"]["structuredContent"]["matches"][0]["relative_path"],
+            "spectrum.csv"
         );
         assert_eq!(
             responses[8]["result"]["structuredContent"]["path"],
             "/workbenches/spedas-task-001/metadata/run_manifest.json"
         );
-        let manifest_items = responses[9]["result"]["structuredContent"]["result"]["items"]
+        let manifest_items = responses[9]["result"]["structuredContent"]["items"]
             .as_array()
             .unwrap();
         assert!(
@@ -3386,6 +3409,117 @@ mod tests {
                 .as_u64()
                 .unwrap()
                 > 0
+        );
+    }
+
+    #[test]
+    fn workbench_mcp_find_lists_committed_workbenches_with_manifest_summary() {
+        let responses = run_workbench_mcp_requests(vec![
+            serde_json::json!({
+                "jsonrpc": "2.0",
+                "id": 1,
+                "method": "tools/call",
+                "params": {
+                    "name": "nokv_workbench_create",
+                    "arguments": {"id": "spedas-task-010"}
+                }
+            }),
+            serde_json::json!({
+                "jsonrpc": "2.0",
+                "id": 2,
+                "method": "tools/call",
+                "params": {
+                    "name": "nokv_workbench_create",
+                    "arguments": {"id": "spedas-task-011"}
+                }
+            }),
+            serde_json::json!({
+                "jsonrpc": "2.0",
+                "id": 3,
+                "method": "tools/call",
+                "params": {
+                    "name": "nokv_workbench_commit",
+                    "arguments": {
+                        "id": "spedas-task-010",
+                        "manifest": {
+                            "task": "spedas-task-010",
+                            "dataset": "spedas",
+                            "outputs": ["outputs/spectrum.csv"]
+                        }
+                    }
+                }
+            }),
+            serde_json::json!({
+                "jsonrpc": "2.0",
+                "id": 4,
+                "method": "tools/call",
+                "params": {
+                    "name": "nokv_workbench_find",
+                    "arguments": {
+                        "committed": true,
+                        "manifest_pattern": "spedas",
+                        "limit": 10
+                    }
+                }
+            }),
+            serde_json::json!({
+                "jsonrpc": "2.0",
+                "id": 5,
+                "method": "tools/call",
+                "params": {
+                    "name": "nokv_workbench_find",
+                    "arguments": {
+                        "committed": false,
+                        "limit": 10
+                    }
+                }
+            }),
+            serde_json::json!({
+                "jsonrpc": "2.0",
+                "id": 6,
+                "method": "tools/call",
+                "params": {
+                    "name": "nokv_workbench_find",
+                    "arguments": {
+                        "committed": true,
+                        "include_manifest": true,
+                        "limit": 10
+                    }
+                }
+            }),
+        ]);
+        for (index, response) in responses.iter().enumerate() {
+            assert_ne!(
+                response["result"]["isError"], true,
+                "response {index}: {response}"
+            );
+        }
+        assert_eq!(
+            responses[3]["result"]["structuredContent"]["matches"][0]["workbench_id"],
+            "spedas-task-010"
+        );
+        assert_eq!(
+            responses[3]["result"]["structuredContent"]["matches"][0]["committed"],
+            true
+        );
+        assert!(responses[3]["result"]["structuredContent"]["matches"][0]["manifest"].is_null());
+        assert_eq!(
+            responses[3]["result"]["structuredContent"]["matches"][0]["manifest_summary"]
+                ["manifest_task"],
+            "spedas-task-010"
+        );
+        assert_eq!(
+            responses[4]["result"]["structuredContent"]["matches"][0]["workbench_id"],
+            "spedas-task-011"
+        );
+        assert_eq!(
+            responses[4]["result"]["structuredContent"]["matches"][0]["committed"],
+            false
+        );
+        assert_eq!(
+            responses[5]["result"]["structuredContent"]["matches"][0]["manifest"]["manifest"]
+                ["dataset"],
+            "spedas"
         );
     }
 

--- a/crates/nokv/src/bin/nokv/workbench_mcp.rs
+++ b/crates/nokv/src/bin/nokv/workbench_mcp.rs
@@ -5,13 +5,15 @@ use base64::Engine;
 use nokv_agent::AgentToolDefinition;
 use nokv_client::{ArtifactMetadata, NoKvFsClient};
 use nokv_object::ObjectStore;
-use nokv_types::FileType;
+use nokv_types::{FileType, PathMetadata};
 use serde_json::{json, Value};
 use sha2::{Digest, Sha256};
 
 use crate::{DEFAULT_MODE_DIR, DEFAULT_MODE_FILE};
 
 pub const DEFAULT_WORKBENCH_MAX_BYTES: usize = 16 * 1024 * 1024;
+const DEFAULT_WORKBENCH_FIND_LIMIT: usize = 50;
+const MAX_WORKBENCH_FIND_LIMIT: usize = 100;
 
 const SECTIONS: &[&str] = &["input", "scripts", "outputs", "logs", "metadata"];
 
@@ -157,6 +159,22 @@ pub fn tool_definitions() -> Vec<AgentToolDefinition> {
             }),
         },
         AgentToolDefinition {
+            name: "nokv_workbench_find",
+            description:
+                "List workbenches across the workbench root with optional committed-state and manifest substring filters. Returns compact manifest summaries by default.",
+            parameters: json!({
+                "type": "object",
+                "properties": {
+                    "committed": {"type": ["boolean", "null"], "description": "Filter by completion marker. Null or omitted returns all workbenches."},
+                    "manifest_pattern": {"type": ["string", "null"], "description": "Case-insensitive literal substring filter over metadata/run_manifest.json."},
+                    "include_manifest": {"type": "boolean", "description": "Include full run_manifest.json envelopes. Defaults false."},
+                    "cursor": {"type": ["string", "null"]},
+                    "limit": {"type": "integer", "minimum": 1, "maximum": MAX_WORKBENCH_FIND_LIMIT}
+                },
+                "additionalProperties": false
+            }),
+        },
+        AgentToolDefinition {
             name: "nokv_workbench_commit",
             description:
                 "Mark a workbench complete by publishing metadata/run_manifest.json. This is the v0 commit point.",
@@ -203,6 +221,7 @@ where
         "nokv_workbench_stat" => execute_read_tool(client, options, "stat", args),
         "nokv_workbench_read" => execute_read_tool(client, options, "read", args),
         "nokv_workbench_grep" => execute_read_tool(client, options, "grep", args),
+        "nokv_workbench_find" => find_workbenches(client, options, args),
         "nokv_workbench_commit" => commit_workbench(client, options, args),
         "nokv_workbench_snapshot" => snapshot_workbench(client, options, args),
         other => Err(WorkbenchToolError::new(format!(
@@ -321,10 +340,220 @@ where
     }
     let result = nokv_agent::execute_agent_tool(client, read_tool, &Value::Object(forwarded))
         .map_err(|err| WorkbenchToolError::new(err.to_string()))?;
+    shape_read_tool_result(client, options, &id, &target, read_tool, result)
+}
+
+fn shape_read_tool_result<O>(
+    client: &NoKvFsClient<O>,
+    options: &WorkbenchMcpOptions,
+    id: &str,
+    target: &str,
+    read_tool: &str,
+    result: Value,
+) -> Result<Value, WorkbenchToolError>
+where
+    O: ObjectStore + Send + Sync + 'static,
+{
+    let scope = path_scope(options, id, target)?;
+    match read_tool {
+        "ls" => shape_list_result(options, id, &scope, result),
+        "stat" => shape_stat_result(client, options, id, &scope, result),
+        "read" => shape_file_read_result(options, id, &scope, result),
+        "grep" => shape_grep_result(options, id, &scope, result),
+        other => Err(WorkbenchToolError::new(format!(
+            "unsupported read tool {other}"
+        ))),
+    }
+}
+
+fn shape_list_result(
+    options: &WorkbenchMcpOptions,
+    id: &str,
+    scope: &WorkbenchPathScope,
+    result: Value,
+) -> Result<Value, WorkbenchToolError> {
+    let entries = result
+        .get("entries")
+        .and_then(Value::as_array)
+        .ok_or_else(|| WorkbenchToolError::new("ls result missing entries"))?
+        .iter()
+        .map(|entry| compact_list_entry(options, id, entry))
+        .collect::<Result<Vec<_>, _>>()?;
     Ok(json!({
+        "status": "success",
         "workbench_id": id,
-        "path": target,
-        "result": result,
+        "workbench_path": workbench_path(options, id),
+        "section": scope.section.clone(),
+        "relative_path": scope.relative_path.clone(),
+        "path": scope.path.clone(),
+        "entry_count": result.get("entry_count").cloned().unwrap_or(Value::Null),
+        "entries": entries,
+        "next_cursor": result.get("next_cursor").cloned().unwrap_or(Value::Null),
+        "truncated": result.get("truncated").cloned().unwrap_or(Value::Bool(false)),
+    }))
+}
+
+fn shape_stat_result<O>(
+    client: &NoKvFsClient<O>,
+    options: &WorkbenchMcpOptions,
+    id: &str,
+    scope: &WorkbenchPathScope,
+    result: Value,
+) -> Result<Value, WorkbenchToolError>
+where
+    O: ObjectStore + Send + Sync + 'static,
+{
+    let card = result
+        .get("card")
+        .ok_or_else(|| WorkbenchToolError::new("stat result missing card"))?;
+    let metadata = client
+        .metadata()
+        .stat_path(&scope.path)
+        .map_err(client_error)?
+        .ok_or_else(|| WorkbenchToolError::new(format!("path not found: {}", scope.path)))?;
+    Ok(json!({
+        "status": "success",
+        "workbench_id": id,
+        "workbench_path": workbench_path(options, id),
+        "section": scope.section.clone(),
+        "relative_path": scope.relative_path.clone(),
+        "path": scope.path.clone(),
+        "card": compact_stat_card(scope, card, &metadata),
+    }))
+}
+
+fn shape_file_read_result(
+    options: &WorkbenchMcpOptions,
+    id: &str,
+    scope: &WorkbenchPathScope,
+    result: Value,
+) -> Result<Value, WorkbenchToolError> {
+    Ok(json!({
+        "status": "success",
+        "workbench_id": id,
+        "workbench_path": workbench_path(options, id),
+        "section": scope.section.clone(),
+        "relative_path": scope.relative_path.clone(),
+        "path": scope.path.clone(),
+        "total_size_bytes": result.get("total_size_bytes").cloned().unwrap_or(Value::Null),
+        "format": result.get("format").cloned().unwrap_or(Value::Null),
+        "record_type": result.get("record_type").cloned().unwrap_or(Value::Null),
+        "record_count": result.get("record_count").cloned().unwrap_or(Value::Null),
+        "cursor": result.get("cursor").cloned().unwrap_or(Value::Null),
+        "next_cursor": result.get("next_cursor").cloned().unwrap_or(Value::Null),
+        "truncated": result.get("truncated").cloned().unwrap_or(Value::Bool(false)),
+        "items": result.get("items").cloned().unwrap_or_else(|| json!([])),
+        "bytes": result.get("bytes").cloned().unwrap_or(Value::Null),
+    }))
+}
+
+fn shape_grep_result(
+    options: &WorkbenchMcpOptions,
+    id: &str,
+    scope: &WorkbenchPathScope,
+    result: Value,
+) -> Result<Value, WorkbenchToolError> {
+    let matches = result
+        .get("matches")
+        .and_then(Value::as_array)
+        .ok_or_else(|| WorkbenchToolError::new("grep result missing matches"))?
+        .iter()
+        .map(|match_| compact_grep_match(options, id, match_))
+        .collect::<Result<Vec<_>, _>>()?;
+    Ok(json!({
+        "status": "success",
+        "workbench_id": id,
+        "workbench_path": workbench_path(options, id),
+        "section": scope.section.clone(),
+        "relative_path": scope.relative_path.clone(),
+        "path": scope.path.clone(),
+        "pattern": result.get("pattern").cloned().unwrap_or(Value::Null),
+        "recursive": result.get("recursive").cloned().unwrap_or(Value::Bool(false)),
+        "matches": matches,
+        "files_scanned": result.get("files_scanned").cloned().unwrap_or(Value::Null),
+        "next_cursor": result.get("next_cursor").cloned().unwrap_or(Value::Null),
+        "truncated": result.get("truncated").cloned().unwrap_or(Value::Bool(false)),
+    }))
+}
+
+fn find_workbenches<O>(
+    client: &NoKvFsClient<O>,
+    options: &WorkbenchMcpOptions,
+    args: &Value,
+) -> Result<Value, WorkbenchToolError>
+where
+    O: ObjectStore + Send + Sync + 'static,
+{
+    let committed_filter = optional_bool(args, "committed")?;
+    let manifest_pattern = optional_string(args, "manifest_pattern")?;
+    let include_manifest = optional_bool(args, "include_manifest")?.unwrap_or(false);
+    let cursor = optional_string(args, "cursor")?;
+    let limit = optional_usize(args, "limit")?.unwrap_or(DEFAULT_WORKBENCH_FIND_LIMIT);
+    if limit == 0 || limit > MAX_WORKBENCH_FIND_LIMIT {
+        return Err(WorkbenchToolError::new(format!(
+            "limit must be between 1 and {MAX_WORKBENCH_FIND_LIMIT}"
+        )));
+    }
+
+    if client
+        .metadata()
+        .stat_path(&options.root)
+        .map_err(client_error)?
+        .is_none()
+    {
+        return Ok(json!({
+            "status": "success",
+            "path": options.root.clone(),
+            "matches": [],
+            "match_count": 0,
+            "entry_count": 0,
+            "next_cursor": Value::Null,
+            "truncated": false,
+        }));
+    }
+
+    let list_args = json!({
+        "path": options.root,
+        "cursor": cursor,
+        "limit": limit,
+    });
+    let page = nokv_agent::execute_agent_tool(client, "ls", &list_args)
+        .map_err(|err| WorkbenchToolError::new(err.to_string()))?;
+    let entries = page
+        .get("entries")
+        .and_then(Value::as_array)
+        .ok_or_else(|| WorkbenchToolError::new("workbench root listing missing entries"))?;
+    let mut matches = Vec::new();
+    for entry in entries {
+        if entry.get("kind").and_then(Value::as_str) != Some("directory") {
+            continue;
+        }
+        let Some(id) = entry.get("name").and_then(Value::as_str) else {
+            continue;
+        };
+        let summary = workbench_manifest_summary(client, options, id, include_manifest)?;
+        if let Some(committed) = committed_filter {
+            if summary.committed != committed {
+                continue;
+            }
+        }
+        if let Some(pattern) = manifest_pattern {
+            if !summary.matches_manifest_pattern(pattern) {
+                continue;
+            }
+        }
+        matches.push(summary.into_json(options, id));
+    }
+
+    let match_count = matches.len();
+    Ok(json!({
+        "status": "success",
+        "path": options.root.clone(),
+        "matches": matches,
+        "match_count": match_count,
+        "entry_count": page.get("entry_count").cloned().unwrap_or(Value::Null),
+        "next_cursor": page.get("next_cursor").cloned().unwrap_or(Value::Null),
+        "truncated": page.get("truncated").cloned().unwrap_or(Value::Bool(false)),
     }))
 }
 
@@ -412,6 +641,220 @@ where
         "snapshot_id": snapshot.snapshot_id,
         "read_version": snapshot.read_version,
     }))
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct WorkbenchPathScope {
+    path: String,
+    section: Option<String>,
+    relative_path: Option<String>,
+}
+
+#[derive(Debug)]
+struct WorkbenchManifestSummary {
+    committed: bool,
+    manifest_path: Option<String>,
+    manifest_metadata: Option<PathMetadata>,
+    manifest_text: Option<String>,
+    envelope: Option<Value>,
+    include_manifest: bool,
+}
+
+impl WorkbenchManifestSummary {
+    fn matches_manifest_pattern(&self, pattern: &str) -> bool {
+        let Some(text) = &self.manifest_text else {
+            return false;
+        };
+        text.to_ascii_lowercase()
+            .contains(&pattern.to_ascii_lowercase())
+    }
+
+    fn into_json(self, options: &WorkbenchMcpOptions, id: &str) -> Value {
+        let body = self
+            .manifest_metadata
+            .as_ref()
+            .and_then(|metadata| metadata.body.as_ref());
+        let envelope = self.envelope.unwrap_or(Value::Null);
+        let manifest = if self.include_manifest {
+            envelope.clone()
+        } else {
+            Value::Null
+        };
+        json!({
+            "workbench_id": id,
+            "path": workbench_path(options, id),
+            "committed": self.committed,
+            "manifest_path": self.manifest_path,
+            "manifest_size_bytes": self.manifest_metadata.as_ref().map(|metadata| metadata.attr.size),
+            "manifest_generation": self.manifest_metadata.as_ref().map(|metadata| metadata.attr.generation),
+            "manifest_digest_uri": body.map(|body| body.digest_uri.clone()),
+            "manifest_summary": manifest_summary_json(&envelope),
+            "manifest": manifest,
+        })
+    }
+}
+
+fn path_scope(
+    options: &WorkbenchMcpOptions,
+    id: &str,
+    path: &str,
+) -> Result<WorkbenchPathScope, WorkbenchToolError> {
+    let base = workbench_path(options, id);
+    if path == base {
+        return Ok(WorkbenchPathScope {
+            path: path.to_owned(),
+            section: None,
+            relative_path: None,
+        });
+    }
+    let prefix = format!("{base}/");
+    let rest = path.strip_prefix(&prefix).ok_or_else(|| {
+        WorkbenchToolError::new(format!("path {path} is outside workbench {base}"))
+    })?;
+    let (section, relative_path) = match rest.split_once('/') {
+        Some((section, relative_path)) => {
+            validate_section(section)?;
+            (section.to_owned(), Some(relative_path.to_owned()))
+        }
+        None => {
+            validate_section(rest)?;
+            (rest.to_owned(), None)
+        }
+    };
+    Ok(WorkbenchPathScope {
+        path: path.to_owned(),
+        section: Some(section),
+        relative_path,
+    })
+}
+
+fn compact_list_entry(
+    options: &WorkbenchMcpOptions,
+    id: &str,
+    entry: &Value,
+) -> Result<Value, WorkbenchToolError> {
+    let path = entry
+        .get("path")
+        .and_then(Value::as_str)
+        .ok_or_else(|| WorkbenchToolError::new("list entry missing path"))?;
+    let scope = path_scope(options, id, path)?;
+    Ok(json!({
+        "name": entry.get("name").cloned().unwrap_or(Value::Null),
+        "path": scope.path,
+        "section": scope.section,
+        "relative_path": scope.relative_path,
+        "kind": entry.get("kind").cloned().unwrap_or(Value::Null),
+        "size_bytes": entry.get("size_bytes").cloned().unwrap_or(Value::Null),
+        "entry_count": entry.get("entry_count").cloned().unwrap_or(Value::Null),
+    }))
+}
+
+fn compact_stat_card(scope: &WorkbenchPathScope, card: &Value, metadata: &PathMetadata) -> Value {
+    let body = metadata.body.as_ref();
+    json!({
+        "name": card.get("name").cloned().unwrap_or(Value::Null),
+        "path": scope.path.clone(),
+        "section": scope.section.clone(),
+        "relative_path": scope.relative_path.clone(),
+        "kind": card.get("kind").cloned().unwrap_or(Value::Null),
+        "size_bytes": card.get("size_bytes").cloned().unwrap_or(Value::Null),
+        "entry_count": card.get("entry_count").cloned().unwrap_or(Value::Null),
+        "record_count": card.get("record_count").cloned().unwrap_or(Value::Null),
+        "inode": metadata.attr.inode.get(),
+        "generation": metadata.attr.generation,
+        "content_type": body.map(|body| body.content_type.clone()),
+        "digest_uri": body.map(|body| body.digest_uri.clone()),
+        "producer": body.map(|body| body.producer.clone()),
+        "manifest_id": body.map(|body| body.manifest_id.clone()),
+    })
+}
+
+fn compact_grep_match(
+    options: &WorkbenchMcpOptions,
+    id: &str,
+    match_: &Value,
+) -> Result<Value, WorkbenchToolError> {
+    let path = match_
+        .get("path")
+        .and_then(Value::as_str)
+        .ok_or_else(|| WorkbenchToolError::new("grep match missing path"))?;
+    let scope = path_scope(options, id, path)?;
+    Ok(json!({
+        "path": scope.path,
+        "section": scope.section,
+        "relative_path": scope.relative_path,
+        "line_number": match_.get("line_number").cloned().unwrap_or(Value::Null),
+        "snippet": match_.get("snippet").cloned().unwrap_or(Value::Null),
+    }))
+}
+
+fn workbench_manifest_summary<O>(
+    client: &NoKvFsClient<O>,
+    options: &WorkbenchMcpOptions,
+    id: &str,
+    include_manifest: bool,
+) -> Result<WorkbenchManifestSummary, WorkbenchToolError>
+where
+    O: ObjectStore + Send + Sync + 'static,
+{
+    let manifest_path = section_path(options, id, "metadata", Some("run_manifest.json"));
+    let Some(metadata) = client
+        .metadata()
+        .stat_path(&manifest_path)
+        .map_err(client_error)?
+    else {
+        return Ok(WorkbenchManifestSummary {
+            committed: false,
+            manifest_path: None,
+            manifest_metadata: None,
+            manifest_text: None,
+            envelope: None,
+            include_manifest,
+        });
+    };
+    let bytes = client.cat(&manifest_path).map_err(client_error)?;
+    let text = String::from_utf8(bytes).map_err(|err| {
+        WorkbenchToolError::new(format!("run manifest is not valid UTF-8: {err}"))
+    })?;
+    let envelope = serde_json::from_str::<Value>(&text)
+        .map_err(|err| WorkbenchToolError::new(format!("run manifest is not valid JSON: {err}")))?;
+    Ok(WorkbenchManifestSummary {
+        committed: true,
+        manifest_path: Some(manifest_path),
+        manifest_metadata: Some(metadata),
+        manifest_text: Some(text),
+        envelope: Some(envelope),
+        include_manifest,
+    })
+}
+
+fn manifest_summary_json(envelope: &Value) -> Value {
+    if envelope.is_null() {
+        return Value::Null;
+    }
+    let manifest_keys = envelope
+        .get("manifest")
+        .and_then(Value::as_object)
+        .map(|object| {
+            let mut keys = object.keys().cloned().collect::<Vec<_>>();
+            keys.sort();
+            keys
+        })
+        .unwrap_or_default();
+    json!({
+        "schema": envelope.get("schema").cloned().unwrap_or(Value::Null),
+        "workbench_id": envelope.get("workbench_id").cloned().unwrap_or(Value::Null),
+        "committed_at_unix_seconds": envelope
+            .get("committed_at_unix_seconds")
+            .cloned()
+            .unwrap_or(Value::Null),
+        "manifest_keys": manifest_keys,
+        "manifest_task": envelope
+            .get("manifest")
+            .and_then(|manifest| manifest.get("task"))
+            .cloned()
+            .unwrap_or(Value::Null),
+    })
 }
 
 fn ensure_standard_dirs<O>(
@@ -740,6 +1183,20 @@ fn optional_bool(args: &Value, name: &'static str) -> Result<Option<bool>, Workb
         Some(value) => value.as_bool().map(Some).ok_or_else(|| {
             WorkbenchToolError::new(format!("{name} must be a boolean when provided"))
         }),
+    }
+}
+
+fn optional_usize(args: &Value, name: &'static str) -> Result<Option<usize>, WorkbenchToolError> {
+    match args.get(name) {
+        None | Some(Value::Null) => Ok(None),
+        Some(value) => {
+            let raw = value.as_u64().ok_or_else(|| {
+                WorkbenchToolError::new(format!("{name} must be an integer when provided"))
+            })?;
+            usize::try_from(raw).map(Some).map_err(|_| {
+                WorkbenchToolError::new(format!("{name} is too large for this platform"))
+            })
+        }
     }
 }
 

--- a/crates/nokv/src/bin/nokv/workbench_mcp.rs
+++ b/crates/nokv/src/bin/nokv/workbench_mcp.rs
@@ -57,7 +57,7 @@ pub fn normalize_workbench_root(raw: &str) -> Result<String, String> {
 pub fn tool_definitions() -> Vec<AgentToolDefinition> {
     vec![
         AgentToolDefinition {
-            name: "nokv_workbench_create",
+            name: "workbench_create",
             description:
                 "Create a NoKV-controlled workbench directory with input, scripts, outputs, logs, and metadata sections.",
             parameters: json!({
@@ -70,7 +70,7 @@ pub fn tool_definitions() -> Vec<AgentToolDefinition> {
             }),
         },
         AgentToolDefinition {
-            name: "nokv_workbench_put_file",
+            name: "workbench_put_file",
             description:
                 "Publish one file into a jailed workbench section. Paths are relative to the section; overwrite requires replace=true.",
             parameters: json!({
@@ -89,7 +89,7 @@ pub fn tool_definitions() -> Vec<AgentToolDefinition> {
             }),
         },
         AgentToolDefinition {
-            name: "nokv_workbench_list",
+            name: "workbench_list",
             description:
                 "List a workbench, section, or subdirectory through the NoKV namespace. Not recursive.",
             parameters: json!({
@@ -106,7 +106,7 @@ pub fn tool_definitions() -> Vec<AgentToolDefinition> {
             }),
         },
         AgentToolDefinition {
-            name: "nokv_workbench_stat",
+            name: "workbench_stat",
             description:
                 "Inspect a workbench, section, subdirectory, or file compact card through the NoKV namespace.",
             parameters: json!({
@@ -121,7 +121,7 @@ pub fn tool_definitions() -> Vec<AgentToolDefinition> {
             }),
         },
         AgentToolDefinition {
-            name: "nokv_workbench_read",
+            name: "workbench_read",
             description:
                 "Read one workbench file through the NoKV namespace. Structured mode returns JSON, YAML, or text records; bytes mode returns byte ranges.",
             parameters: json!({
@@ -140,7 +140,7 @@ pub fn tool_definitions() -> Vec<AgentToolDefinition> {
             }),
         },
         AgentToolDefinition {
-            name: "nokv_workbench_grep",
+            name: "workbench_grep",
             description:
                 "Search workbench file bodies for a case-insensitive literal substring. This is not regex grep.",
             parameters: json!({
@@ -159,7 +159,7 @@ pub fn tool_definitions() -> Vec<AgentToolDefinition> {
             }),
         },
         AgentToolDefinition {
-            name: "nokv_workbench_find",
+            name: "workbench_find",
             description:
                 "List workbenches across the workbench root with optional committed-state and manifest substring filters. Returns compact manifest summaries by default.",
             parameters: json!({
@@ -175,7 +175,7 @@ pub fn tool_definitions() -> Vec<AgentToolDefinition> {
             }),
         },
         AgentToolDefinition {
-            name: "nokv_workbench_commit",
+            name: "workbench_commit",
             description:
                 "Mark a workbench complete by publishing metadata/run_manifest.json. This is the v0 commit point.",
             parameters: json!({
@@ -190,7 +190,7 @@ pub fn tool_definitions() -> Vec<AgentToolDefinition> {
             }),
         },
         AgentToolDefinition {
-            name: "nokv_workbench_snapshot",
+            name: "workbench_snapshot",
             description:
                 "Snapshot a committed workbench subtree and return the NoKV snapshot id and read version.",
             parameters: json!({
@@ -215,15 +215,15 @@ where
     O: ObjectStore + Send + Sync + 'static,
 {
     match name {
-        "nokv_workbench_create" => create_workbench(client, options, args),
-        "nokv_workbench_put_file" => put_file(client, options, args),
-        "nokv_workbench_list" => execute_read_tool(client, options, "ls", args),
-        "nokv_workbench_stat" => execute_read_tool(client, options, "stat", args),
-        "nokv_workbench_read" => execute_read_tool(client, options, "read", args),
-        "nokv_workbench_grep" => execute_read_tool(client, options, "grep", args),
-        "nokv_workbench_find" => find_workbenches(client, options, args),
-        "nokv_workbench_commit" => commit_workbench(client, options, args),
-        "nokv_workbench_snapshot" => snapshot_workbench(client, options, args),
+        "workbench_create" => create_workbench(client, options, args),
+        "workbench_put_file" => put_file(client, options, args),
+        "workbench_list" => execute_read_tool(client, options, "ls", args),
+        "workbench_stat" => execute_read_tool(client, options, "stat", args),
+        "workbench_read" => execute_read_tool(client, options, "read", args),
+        "workbench_grep" => execute_read_tool(client, options, "grep", args),
+        "workbench_find" => find_workbenches(client, options, args),
+        "workbench_commit" => commit_workbench(client, options, args),
+        "workbench_snapshot" => snapshot_workbench(client, options, args),
         other => Err(WorkbenchToolError::new(format!(
             "unknown workbench tool {other}"
         ))),
@@ -905,7 +905,36 @@ where
     Ok(())
 }
 
+/// Ensure `path` exists as a directory, creating any missing ancestors
+/// (mkdir -p). `mkdir` is non-recursive, so a multi-level workbench root such
+/// as `/agents/<agent_id>/wb` (per-agent tenant isolation) requires each
+/// ancestor to be created in turn — otherwise the first create fails with
+/// "metadata entry not found".
 fn ensure_dir_path<O>(
+    client: &NoKvFsClient<O>,
+    options: &WorkbenchMcpOptions,
+    path: &str,
+) -> Result<(), WorkbenchToolError>
+where
+    O: ObjectStore + Send + Sync + 'static,
+{
+    let mut current = String::new();
+    for component in path.trim_start_matches('/').split('/') {
+        if component.is_empty() {
+            continue;
+        }
+        current.push('/');
+        current.push_str(component);
+        ensure_single_dir(client, options, &current)?;
+    }
+    Ok(())
+}
+
+/// Ensure one path component exists as a directory. Idempotent: if a concurrent
+/// creator wins the race (e.g. two agents/daemons materializing the shared
+/// ancestors of their roots at once), a re-stat confirming the directory now
+/// exists is treated as success rather than surfacing the CAS conflict.
+fn ensure_single_dir<O>(
     client: &NoKvFsClient<O>,
     options: &WorkbenchMcpOptions,
     path: &str,
@@ -921,11 +950,20 @@ where
             "path exists but is not a directory: {path}"
         )));
     }
-    client
+    match client
         .metadata()
         .mkdir(path, DEFAULT_MODE_DIR, options.uid, options.gid)
-        .map_err(client_error)?;
-    Ok(())
+    {
+        Ok(_) => Ok(()),
+        Err(err) => {
+            if let Some(metadata) = client.metadata().stat_path(path).map_err(client_error)? {
+                if metadata.attr.file_type == FileType::Directory {
+                    return Ok(());
+                }
+            }
+            Err(client_error(err))
+        }
+    }
 }
 
 fn required_workbench_id(args: &Value) -> Result<String, WorkbenchToolError> {
@@ -1130,6 +1168,15 @@ fn payload_bytes(
     let text = optional_string(args, "text")?;
     let encoded = optional_string(args, "base64")?;
     let (bytes, content_type) = match (text, encoded) {
+        (Some(text), Some("")) if !text.is_empty() => {
+            (text.as_bytes().to_vec(), "text/plain; charset=utf-8")
+        }
+        (Some(""), Some(encoded)) if !encoded.is_empty() => (
+            base64::engine::general_purpose::STANDARD
+                .decode(encoded)
+                .map_err(|err| WorkbenchToolError::new(format!("invalid base64 payload: {err}")))?,
+            "application/octet-stream",
+        ),
         (Some(_), Some(_)) => {
             return Err(WorkbenchToolError::new(
                 "provide exactly one of text or base64",

--- a/crates/nokv/src/bin/nokv/workbench_mcp.rs
+++ b/crates/nokv/src/bin/nokv/workbench_mcp.rs
@@ -1,0 +1,788 @@
+use std::fmt;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use base64::Engine;
+use nokv_agent::AgentToolDefinition;
+use nokv_client::{ArtifactMetadata, NoKvFsClient};
+use nokv_object::ObjectStore;
+use nokv_types::FileType;
+use serde_json::{json, Value};
+use sha2::{Digest, Sha256};
+
+use crate::{DEFAULT_MODE_DIR, DEFAULT_MODE_FILE};
+
+pub const DEFAULT_WORKBENCH_MAX_BYTES: usize = 16 * 1024 * 1024;
+
+const SECTIONS: &[&str] = &["input", "scripts", "outputs", "logs", "metadata"];
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct WorkbenchMcpOptions {
+    pub root: String,
+    pub max_bytes: usize,
+    pub uid: u32,
+    pub gid: u32,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct WorkbenchToolError {
+    message: String,
+}
+
+impl WorkbenchToolError {
+    fn new(message: impl Into<String>) -> Self {
+        Self {
+            message: message.into(),
+        }
+    }
+}
+
+impl fmt::Display for WorkbenchToolError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.message)
+    }
+}
+
+impl std::error::Error for WorkbenchToolError {}
+
+pub fn normalize_workbench_root(raw: &str) -> Result<String, String> {
+    let normalized = normalize_absolute_path(raw, "workbench_root")?;
+    if normalized == "/" {
+        return Err("workbench_root must not be /".to_owned());
+    }
+    Ok(normalized)
+}
+
+pub fn tool_definitions() -> Vec<AgentToolDefinition> {
+    vec![
+        AgentToolDefinition {
+            name: "nokv_workbench_create",
+            description:
+                "Create a NoKV-controlled workbench directory with input, scripts, outputs, logs, and metadata sections.",
+            parameters: json!({
+                "type": "object",
+                "required": ["id"],
+                "properties": {
+                    "id": {"type": "string", "description": "Workbench id, e.g. spedas-task-001."}
+                },
+                "additionalProperties": false
+            }),
+        },
+        AgentToolDefinition {
+            name: "nokv_workbench_put_file",
+            description:
+                "Publish one file into a jailed workbench section. Paths are relative to the section; overwrite requires replace=true.",
+            parameters: json!({
+                "type": "object",
+                "required": ["id", "section", "path"],
+                "properties": {
+                    "id": {"type": "string"},
+                    "section": {"type": "string", "enum": SECTIONS},
+                    "path": {"type": "string"},
+                    "text": {"type": "string"},
+                    "base64": {"type": "string"},
+                    "content_type": {"type": "string"},
+                    "replace": {"type": "boolean"}
+                },
+                "additionalProperties": false
+            }),
+        },
+        AgentToolDefinition {
+            name: "nokv_workbench_list",
+            description:
+                "List a workbench, section, or subdirectory through the NoKV namespace. Not recursive.",
+            parameters: json!({
+                "type": "object",
+                "required": ["id"],
+                "properties": {
+                    "id": {"type": "string"},
+                    "section": {"type": ["string", "null"], "enum": ["input", "scripts", "outputs", "logs", "metadata", null]},
+                    "path": {"type": ["string", "null"]},
+                    "cursor": {"type": ["string", "null"]},
+                    "limit": {"type": "integer", "minimum": 1}
+                },
+                "additionalProperties": false
+            }),
+        },
+        AgentToolDefinition {
+            name: "nokv_workbench_stat",
+            description:
+                "Inspect a workbench, section, subdirectory, or file compact card through the NoKV namespace.",
+            parameters: json!({
+                "type": "object",
+                "required": ["id"],
+                "properties": {
+                    "id": {"type": "string"},
+                    "section": {"type": ["string", "null"], "enum": ["input", "scripts", "outputs", "logs", "metadata", null]},
+                    "path": {"type": ["string", "null"]}
+                },
+                "additionalProperties": false
+            }),
+        },
+        AgentToolDefinition {
+            name: "nokv_workbench_read",
+            description:
+                "Read one workbench file through the NoKV namespace. Structured mode returns JSON, YAML, or text records; bytes mode returns byte ranges.",
+            parameters: json!({
+                "type": "object",
+                "required": ["id", "section", "path"],
+                "properties": {
+                    "id": {"type": "string"},
+                    "section": {"type": "string", "enum": SECTIONS},
+                    "path": {"type": "string"},
+                    "format": {"type": "string", "enum": ["structured", "bytes"]},
+                    "cursor": {"type": ["string", "null"]},
+                    "offset": {"type": "integer", "minimum": 0},
+                    "limit": {"type": "integer", "minimum": 1}
+                },
+                "additionalProperties": false
+            }),
+        },
+        AgentToolDefinition {
+            name: "nokv_workbench_grep",
+            description:
+                "Search workbench file bodies for a case-insensitive literal substring. This is not regex grep.",
+            parameters: json!({
+                "type": "object",
+                "required": ["id", "pattern", "recursive"],
+                "properties": {
+                    "id": {"type": "string"},
+                    "section": {"type": ["string", "null"], "enum": ["input", "scripts", "outputs", "logs", "metadata", null]},
+                    "path": {"type": ["string", "null"]},
+                    "pattern": {"type": "string"},
+                    "recursive": {"type": "boolean"},
+                    "cursor": {"type": ["string", "null"]},
+                    "limit": {"type": "integer", "minimum": 1}
+                },
+                "additionalProperties": false
+            }),
+        },
+        AgentToolDefinition {
+            name: "nokv_workbench_commit",
+            description:
+                "Mark a workbench complete by publishing metadata/run_manifest.json. This is the v0 commit point.",
+            parameters: json!({
+                "type": "object",
+                "required": ["id", "manifest"],
+                "properties": {
+                    "id": {"type": "string"},
+                    "manifest": {"type": "object"},
+                    "replace": {"type": "boolean"}
+                },
+                "additionalProperties": false
+            }),
+        },
+        AgentToolDefinition {
+            name: "nokv_workbench_snapshot",
+            description:
+                "Snapshot a committed workbench subtree and return the NoKV snapshot id and read version.",
+            parameters: json!({
+                "type": "object",
+                "required": ["id"],
+                "properties": {
+                    "id": {"type": "string"}
+                },
+                "additionalProperties": false
+            }),
+        },
+    ]
+}
+
+pub fn execute_tool<O>(
+    client: &NoKvFsClient<O>,
+    options: &WorkbenchMcpOptions,
+    name: &str,
+    args: &Value,
+) -> Result<Value, WorkbenchToolError>
+where
+    O: ObjectStore + Send + Sync + 'static,
+{
+    match name {
+        "nokv_workbench_create" => create_workbench(client, options, args),
+        "nokv_workbench_put_file" => put_file(client, options, args),
+        "nokv_workbench_list" => execute_read_tool(client, options, "ls", args),
+        "nokv_workbench_stat" => execute_read_tool(client, options, "stat", args),
+        "nokv_workbench_read" => execute_read_tool(client, options, "read", args),
+        "nokv_workbench_grep" => execute_read_tool(client, options, "grep", args),
+        "nokv_workbench_commit" => commit_workbench(client, options, args),
+        "nokv_workbench_snapshot" => snapshot_workbench(client, options, args),
+        other => Err(WorkbenchToolError::new(format!(
+            "unknown workbench tool {other}"
+        ))),
+    }
+}
+
+fn create_workbench<O>(
+    client: &NoKvFsClient<O>,
+    options: &WorkbenchMcpOptions,
+    args: &Value,
+) -> Result<Value, WorkbenchToolError>
+where
+    O: ObjectStore + Send + Sync + 'static,
+{
+    let id = required_workbench_id(args)?;
+    ensure_standard_dirs(client, options, &id)?;
+    Ok(json!({
+        "status": "success",
+        "workbench_id": id,
+        "path": workbench_path(options, &id),
+        "sections": SECTIONS,
+    }))
+}
+
+fn put_file<O>(
+    client: &NoKvFsClient<O>,
+    options: &WorkbenchMcpOptions,
+    args: &Value,
+) -> Result<Value, WorkbenchToolError>
+where
+    O: ObjectStore + Send + Sync + 'static,
+{
+    let id = required_workbench_id(args)?;
+    let section = required_section(args)?;
+    let rel_path = required_relative_path(args, "path")?;
+    let replace = optional_bool(args, "replace")?.unwrap_or(false);
+    let (bytes, default_content_type) = payload_bytes(args, options.max_bytes)?;
+    let content_type = optional_string(args, "content_type")?
+        .unwrap_or(default_content_type)
+        .to_owned();
+
+    ensure_standard_dirs(client, options, &id)?;
+    ensure_parent_dirs(client, options, &id, section, &rel_path)?;
+    let path = section_path(options, &id, section, Some(&rel_path));
+    let digest_uri = digest_uri(&bytes);
+    let metadata = artifact_metadata(options, &path, &digest_uri, &content_type);
+    let entry = if replace {
+        client
+            .put_artifact_replace(&path, bytes, metadata)
+            .map_err(client_error)?
+            .entry
+    } else {
+        client
+            .put_artifact(&path, bytes, metadata)
+            .map_err(client_error)?
+    };
+
+    Ok(json!({
+        "status": "success",
+        "workbench_id": id,
+        "section": section,
+        "relative_path": rel_path,
+        "path": path,
+        "size_bytes": entry.attr.size,
+        "inode": entry.attr.inode.get(),
+        "generation": entry.attr.generation,
+        "digest_uri": digest_uri,
+        "content_type": content_type,
+        "replace": replace,
+    }))
+}
+
+fn execute_read_tool<O>(
+    client: &NoKvFsClient<O>,
+    options: &WorkbenchMcpOptions,
+    read_tool: &str,
+    args: &Value,
+) -> Result<Value, WorkbenchToolError>
+where
+    O: ObjectStore + Send + Sync + 'static,
+{
+    let id = required_workbench_id(args)?;
+    let target = match read_tool {
+        "read" => {
+            let section = required_section(args)?;
+            let rel_path = required_relative_path(args, "path")?;
+            section_path(options, &id, section, Some(&rel_path))
+        }
+        _ => scoped_path_from_optional_args(options, &id, args)?,
+    };
+    let mut forwarded = args
+        .as_object()
+        .cloned()
+        .ok_or_else(|| WorkbenchToolError::new("tool arguments must be a JSON object"))?;
+    forwarded.insert("path".to_owned(), Value::String(target.clone()));
+    forwarded.remove("id");
+    forwarded.remove("section");
+    match read_tool {
+        "ls" | "stat" => {
+            forwarded.remove("format");
+            forwarded.remove("offset");
+            forwarded.remove("pattern");
+            forwarded.remove("recursive");
+        }
+        "read" => {
+            forwarded.remove("pattern");
+            forwarded.remove("recursive");
+        }
+        "grep" => {
+            forwarded.remove("format");
+            forwarded.remove("offset");
+        }
+        _ => {}
+    }
+    let result = nokv_agent::execute_agent_tool(client, read_tool, &Value::Object(forwarded))
+        .map_err(|err| WorkbenchToolError::new(err.to_string()))?;
+    Ok(json!({
+        "workbench_id": id,
+        "path": target,
+        "result": result,
+    }))
+}
+
+fn commit_workbench<O>(
+    client: &NoKvFsClient<O>,
+    options: &WorkbenchMcpOptions,
+    args: &Value,
+) -> Result<Value, WorkbenchToolError>
+where
+    O: ObjectStore + Send + Sync + 'static,
+{
+    let id = required_workbench_id(args)?;
+    let manifest = args
+        .get("manifest")
+        .cloned()
+        .ok_or_else(|| WorkbenchToolError::new("missing required argument manifest"))?;
+    if !manifest.is_object() {
+        return Err(WorkbenchToolError::new("manifest must be a JSON object"));
+    }
+    let replace = optional_bool(args, "replace")?.unwrap_or(false);
+    ensure_standard_dirs(client, options, &id)?;
+    let path = section_path(options, &id, "metadata", Some("run_manifest.json"));
+    let envelope = json!({
+        "schema": "nokv.workbench.run_manifest.v0",
+        "workbench_id": id,
+        "workbench_path": workbench_path(options, &id),
+        "committed_at_unix_seconds": unix_seconds(),
+        "manifest": manifest,
+    });
+    let bytes = serde_json::to_vec_pretty(&envelope)
+        .map_err(|err| WorkbenchToolError::new(format!("failed to encode manifest: {err}")))?;
+    let digest_uri = digest_uri(&bytes);
+    let metadata = artifact_metadata(options, &path, &digest_uri, "application/json");
+    let entry = if replace {
+        client
+            .put_artifact_replace(&path, bytes, metadata)
+            .map_err(client_error)?
+            .entry
+    } else {
+        client
+            .put_artifact(&path, bytes, metadata)
+            .map_err(client_error)?
+    };
+    Ok(json!({
+        "status": "success",
+        "workbench_id": id,
+        "path": path,
+        "size_bytes": entry.attr.size,
+        "inode": entry.attr.inode.get(),
+        "generation": entry.attr.generation,
+        "digest_uri": digest_uri,
+        "replace": replace,
+    }))
+}
+
+fn snapshot_workbench<O>(
+    client: &NoKvFsClient<O>,
+    options: &WorkbenchMcpOptions,
+    args: &Value,
+) -> Result<Value, WorkbenchToolError>
+where
+    O: ObjectStore + Send + Sync + 'static,
+{
+    let id = required_workbench_id(args)?;
+    let manifest_path = section_path(options, &id, "metadata", Some("run_manifest.json"));
+    if client
+        .metadata()
+        .stat_path(&manifest_path)
+        .map_err(client_error)?
+        .is_none()
+    {
+        return Err(WorkbenchToolError::new(format!(
+            "workbench {id} is not committed; missing {manifest_path}"
+        )));
+    }
+    let path = workbench_path(options, &id);
+    let snapshot = client
+        .metadata()
+        .snapshot_subtree_path(&path)
+        .map_err(client_error)?;
+    Ok(json!({
+        "status": "success",
+        "workbench_id": id,
+        "path": path,
+        "snapshot_id": snapshot.snapshot_id,
+        "read_version": snapshot.read_version,
+    }))
+}
+
+fn ensure_standard_dirs<O>(
+    client: &NoKvFsClient<O>,
+    options: &WorkbenchMcpOptions,
+    id: &str,
+) -> Result<(), WorkbenchToolError>
+where
+    O: ObjectStore + Send + Sync + 'static,
+{
+    client
+        .metadata()
+        .bootstrap_root(DEFAULT_MODE_DIR, options.uid, options.gid)
+        .map_err(client_error)?;
+    ensure_dir_path(client, options, &options.root)?;
+    let base = workbench_path(options, id);
+    ensure_dir_path(client, options, &base)?;
+    for section in SECTIONS {
+        ensure_dir_path(client, options, &section_path(options, id, section, None))?;
+    }
+    Ok(())
+}
+
+fn ensure_parent_dirs<O>(
+    client: &NoKvFsClient<O>,
+    options: &WorkbenchMcpOptions,
+    id: &str,
+    section: &str,
+    rel_path: &str,
+) -> Result<(), WorkbenchToolError>
+where
+    O: ObjectStore + Send + Sync + 'static,
+{
+    let mut components: Vec<&str> = rel_path.split('/').collect();
+    components.pop();
+    if components.is_empty() {
+        return Ok(());
+    }
+    let mut current = String::new();
+    for component in components {
+        if !current.is_empty() {
+            current.push('/');
+        }
+        current.push_str(component);
+        let path = section_path(options, id, section, Some(&current));
+        ensure_dir_path(client, options, &path)?;
+    }
+    Ok(())
+}
+
+fn ensure_dir_path<O>(
+    client: &NoKvFsClient<O>,
+    options: &WorkbenchMcpOptions,
+    path: &str,
+) -> Result<(), WorkbenchToolError>
+where
+    O: ObjectStore + Send + Sync + 'static,
+{
+    if let Some(metadata) = client.metadata().stat_path(path).map_err(client_error)? {
+        if metadata.attr.file_type == FileType::Directory {
+            return Ok(());
+        }
+        return Err(WorkbenchToolError::new(format!(
+            "path exists but is not a directory: {path}"
+        )));
+    }
+    client
+        .metadata()
+        .mkdir(path, DEFAULT_MODE_DIR, options.uid, options.gid)
+        .map_err(client_error)?;
+    Ok(())
+}
+
+fn required_workbench_id(args: &Value) -> Result<String, WorkbenchToolError> {
+    let id = required_string(args, "id")?;
+    validate_workbench_id(id)?;
+    Ok(id.to_owned())
+}
+
+fn validate_workbench_id(id: &str) -> Result<(), WorkbenchToolError> {
+    let mut chars = id.chars();
+    let Some(first) = chars.next() else {
+        return Err(WorkbenchToolError::new("id must not be empty"));
+    };
+    if !first.is_ascii_alphanumeric() {
+        return Err(WorkbenchToolError::new(
+            "id must start with an ASCII letter or digit",
+        ));
+    }
+    if id.len() > 128 {
+        return Err(WorkbenchToolError::new("id must be at most 128 bytes"));
+    }
+    if !chars.all(|c| c.is_ascii_alphanumeric() || c == '_' || c == '-') {
+        return Err(WorkbenchToolError::new(
+            "id may contain only ASCII letters, digits, '_' and '-'",
+        ));
+    }
+    Ok(())
+}
+
+fn required_section(args: &Value) -> Result<&str, WorkbenchToolError> {
+    let section = required_string(args, "section")?;
+    validate_section(section)?;
+    Ok(section)
+}
+
+fn validate_section(section: &str) -> Result<(), WorkbenchToolError> {
+    if SECTIONS.contains(&section) {
+        Ok(())
+    } else {
+        Err(WorkbenchToolError::new(format!(
+            "invalid section {section}; expected one of {}",
+            SECTIONS.join(", ")
+        )))
+    }
+}
+
+fn scoped_path_from_optional_args(
+    options: &WorkbenchMcpOptions,
+    id: &str,
+    args: &Value,
+) -> Result<String, WorkbenchToolError> {
+    let section = optional_string(args, "section")?;
+    let rel_path = optional_string(args, "path")?;
+    match (section, rel_path) {
+        (None, None) => Ok(workbench_path(options, id)),
+        (None, Some("")) => Ok(workbench_path(options, id)),
+        (None, Some(_)) => Err(WorkbenchToolError::new(
+            "path requires section when scoped below a workbench",
+        )),
+        (Some(section), path) => {
+            validate_section(section)?;
+            let rel = match path {
+                Some(raw) => Some(normalize_relative_path(raw, "path", true)?),
+                None => None,
+            };
+            Ok(section_path(options, id, section, rel.as_deref()))
+        }
+    }
+}
+
+fn required_relative_path(args: &Value, field: &'static str) -> Result<String, WorkbenchToolError> {
+    normalize_relative_path(required_string(args, field)?, field, false)
+}
+
+fn normalize_relative_path(
+    raw: &str,
+    field: &'static str,
+    allow_empty: bool,
+) -> Result<String, WorkbenchToolError> {
+    if raw.is_empty() {
+        if allow_empty {
+            return Ok(String::new());
+        }
+        return Err(WorkbenchToolError::new(format!(
+            "{field} must not be empty"
+        )));
+    }
+    if raw.starts_with('/') {
+        return Err(WorkbenchToolError::new(format!("{field} must be relative")));
+    }
+    if raw.ends_with('/') {
+        return Err(WorkbenchToolError::new(format!(
+            "{field} must not end with '/'"
+        )));
+    }
+    if raw.contains("//") {
+        return Err(WorkbenchToolError::new(format!(
+            "{field} must not contain empty components"
+        )));
+    }
+    if raw.contains('\\') {
+        return Err(WorkbenchToolError::new(format!(
+            "{field} must use POSIX separators"
+        )));
+    }
+    if raw.contains('\0') {
+        return Err(WorkbenchToolError::new(format!(
+            "{field} contains a NUL byte"
+        )));
+    }
+    for component in raw.split('/') {
+        if component == "." || component == ".." {
+            return Err(WorkbenchToolError::new(format!(
+                "{field} must not contain '.' or '..' components"
+            )));
+        }
+    }
+    Ok(raw.to_owned())
+}
+
+fn normalize_absolute_path(raw: &str, field: &'static str) -> Result<String, String> {
+    if raw.is_empty() {
+        return Err(format!("{field} must not be empty"));
+    }
+    if !raw.starts_with('/') {
+        return Err(format!("{field} must be an absolute NoKV path"));
+    }
+    if raw.contains('\\') {
+        return Err(format!("{field} must use POSIX separators"));
+    }
+    if raw.contains('\0') {
+        return Err(format!("{field} contains a NUL byte"));
+    }
+    let trimmed = raw.trim_end_matches('/');
+    let path = if trimmed.is_empty() { "/" } else { trimmed };
+    let mut components = Vec::new();
+    for component in path.trim_start_matches('/').split('/') {
+        if component.is_empty() {
+            continue;
+        }
+        if component == "." || component == ".." {
+            return Err(format!("{field} must not contain '.' or '..' components"));
+        }
+        components.push(component);
+    }
+    if components.is_empty() {
+        Ok("/".to_owned())
+    } else {
+        Ok(format!("/{}", components.join("/")))
+    }
+}
+
+fn workbench_path(options: &WorkbenchMcpOptions, id: &str) -> String {
+    format!("{}/{}", options.root, id)
+}
+
+fn section_path(
+    options: &WorkbenchMcpOptions,
+    id: &str,
+    section: &str,
+    rel_path: Option<&str>,
+) -> String {
+    let base = format!("{}/{section}", workbench_path(options, id));
+    match rel_path {
+        Some(path) if !path.is_empty() => format!("{base}/{path}"),
+        _ => base,
+    }
+}
+
+fn payload_bytes(
+    args: &Value,
+    max_bytes: usize,
+) -> Result<(Vec<u8>, &'static str), WorkbenchToolError> {
+    let text = optional_string(args, "text")?;
+    let encoded = optional_string(args, "base64")?;
+    let (bytes, content_type) = match (text, encoded) {
+        (Some(_), Some(_)) => {
+            return Err(WorkbenchToolError::new(
+                "provide exactly one of text or base64",
+            ))
+        }
+        (Some(text), None) => (text.as_bytes().to_vec(), "text/plain; charset=utf-8"),
+        (None, Some(encoded)) => (
+            base64::engine::general_purpose::STANDARD
+                .decode(encoded)
+                .map_err(|err| WorkbenchToolError::new(format!("invalid base64 payload: {err}")))?,
+            "application/octet-stream",
+        ),
+        (None, None) => {
+            return Err(WorkbenchToolError::new(
+                "provide exactly one of text or base64",
+            ))
+        }
+    };
+    if bytes.len() > max_bytes {
+        return Err(WorkbenchToolError::new(format!(
+            "payload exceeds max_bytes: {} > {max_bytes}",
+            bytes.len()
+        )));
+    }
+    Ok((bytes, content_type))
+}
+
+fn artifact_metadata(
+    options: &WorkbenchMcpOptions,
+    path: &str,
+    digest_uri: &str,
+    content_type: &str,
+) -> ArtifactMetadata {
+    ArtifactMetadata {
+        producer: "nokv-workbench-mcp".to_owned(),
+        digest_uri: digest_uri.to_owned(),
+        content_type: content_type.to_owned(),
+        manifest_id: path.trim_start_matches('/').to_owned(),
+        mode: DEFAULT_MODE_FILE,
+        uid: options.uid,
+        gid: options.gid,
+    }
+}
+
+fn digest_uri(bytes: &[u8]) -> String {
+    let mut digest = Sha256::new();
+    digest.update(bytes);
+    format!("sha256:{:x}", digest.finalize())
+}
+
+fn unix_seconds() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|duration| duration.as_secs())
+        .unwrap_or(0)
+}
+
+fn required_string<'a>(args: &'a Value, name: &'static str) -> Result<&'a str, WorkbenchToolError> {
+    args.get(name)
+        .and_then(Value::as_str)
+        .ok_or_else(|| WorkbenchToolError::new(format!("missing required string argument {name}")))
+}
+
+fn optional_string<'a>(
+    args: &'a Value,
+    name: &'static str,
+) -> Result<Option<&'a str>, WorkbenchToolError> {
+    match args.get(name) {
+        None | Some(Value::Null) => Ok(None),
+        Some(value) => value.as_str().map(Some).ok_or_else(|| {
+            WorkbenchToolError::new(format!("{name} must be a string when provided"))
+        }),
+    }
+}
+
+fn optional_bool(args: &Value, name: &'static str) -> Result<Option<bool>, WorkbenchToolError> {
+    match args.get(name) {
+        None | Some(Value::Null) => Ok(None),
+        Some(value) => value.as_bool().map(Some).ok_or_else(|| {
+            WorkbenchToolError::new(format!("{name} must be a boolean when provided"))
+        }),
+    }
+}
+
+fn client_error(err: impl fmt::Display) -> WorkbenchToolError {
+    WorkbenchToolError::new(err.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn normalizes_workbench_root() {
+        assert_eq!(
+            normalize_workbench_root("/workbenches/").unwrap(),
+            "/workbenches"
+        );
+        assert!(normalize_workbench_root("relative").is_err());
+        assert!(normalize_workbench_root("/").is_err());
+        assert!(normalize_workbench_root("/work/../benches").is_err());
+    }
+
+    #[test]
+    fn validates_relative_paths() {
+        assert_eq!(
+            normalize_relative_path("plots/plot_001.png", "path", false).unwrap(),
+            "plots/plot_001.png"
+        );
+        assert_eq!(normalize_relative_path("", "path", true).unwrap(), "");
+        assert!(normalize_relative_path("", "path", false).is_err());
+        assert!(normalize_relative_path("../escape", "path", false).is_err());
+        assert!(normalize_relative_path("/escape", "path", false).is_err());
+        assert!(normalize_relative_path("bad//path", "path", false).is_err());
+        assert!(normalize_relative_path(".", "path", false).is_err());
+        assert!(normalize_relative_path("bad\\path", "path", false).is_err());
+        assert!(normalize_relative_path("dir/", "path", false).is_err());
+        assert!(normalize_relative_path("bad\0path", "path", false).is_err());
+    }
+
+    #[test]
+    fn validates_workbench_ids() {
+        assert!(validate_workbench_id("spedas-task-001").is_ok());
+        assert!(validate_workbench_id("_bad").is_err());
+        assert!(validate_workbench_id("bad/path").is_err());
+    }
+}

--- a/crates/nokv/src/bin/nokv/workbench_mcp.rs
+++ b/crates/nokv/src/bin/nokv/workbench_mcp.rs
@@ -79,7 +79,7 @@ pub fn tool_definitions() -> Vec<AgentToolDefinition> {
                 "properties": {
                     "id": {"type": "string"},
                     "section": {"type": "string", "enum": SECTIONS},
-                    "path": {"type": "string"},
+                    "path": {"type": "string", "description": "Path relative to section. Do not prefix it with the section name."},
                     "text": {"type": "string"},
                     "base64": {"type": "string"},
                     "content_type": {"type": "string"},
@@ -98,7 +98,7 @@ pub fn tool_definitions() -> Vec<AgentToolDefinition> {
                 "properties": {
                     "id": {"type": "string"},
                     "section": {"type": ["string", "null"], "enum": ["input", "scripts", "outputs", "logs", "metadata", null]},
-                    "path": {"type": ["string", "null"]},
+                    "path": {"type": ["string", "null"], "description": "Optional path relative to section. Do not prefix it with the section name."},
                     "cursor": {"type": ["string", "null"]},
                     "limit": {"type": "integer", "minimum": 1}
                 },
@@ -115,7 +115,7 @@ pub fn tool_definitions() -> Vec<AgentToolDefinition> {
                 "properties": {
                     "id": {"type": "string"},
                     "section": {"type": ["string", "null"], "enum": ["input", "scripts", "outputs", "logs", "metadata", null]},
-                    "path": {"type": ["string", "null"]}
+                    "path": {"type": ["string", "null"], "description": "Optional path relative to section. Do not prefix it with the section name."}
                 },
                 "additionalProperties": false
             }),
@@ -130,7 +130,7 @@ pub fn tool_definitions() -> Vec<AgentToolDefinition> {
                 "properties": {
                     "id": {"type": "string"},
                     "section": {"type": "string", "enum": SECTIONS},
-                    "path": {"type": "string"},
+                    "path": {"type": "string", "description": "Path relative to section. Do not prefix it with the section name."},
                     "format": {"type": "string", "enum": ["structured", "bytes"]},
                     "cursor": {"type": ["string", "null"]},
                     "offset": {"type": "integer", "minimum": 0},
@@ -149,7 +149,7 @@ pub fn tool_definitions() -> Vec<AgentToolDefinition> {
                 "properties": {
                     "id": {"type": "string"},
                     "section": {"type": ["string", "null"], "enum": ["input", "scripts", "outputs", "logs", "metadata", null]},
-                    "path": {"type": ["string", "null"]},
+                    "path": {"type": ["string", "null"], "description": "Optional path relative to section. Do not prefix it with the section name."},
                     "pattern": {"type": "string"},
                     "recursive": {"type": "boolean"},
                     "cursor": {"type": ["string", "null"]},
@@ -258,7 +258,7 @@ where
 {
     let id = required_workbench_id(args)?;
     let section = required_section(args)?;
-    let rel_path = required_relative_path(args, "path")?;
+    let rel_path = required_section_relative_path(args, section, "path")?;
     let replace = optional_bool(args, "replace")?.unwrap_or(false);
     let (bytes, default_content_type) = payload_bytes(args, options.max_bytes)?;
     let content_type = optional_string(args, "content_type")?
@@ -309,7 +309,7 @@ where
     let target = match read_tool {
         "read" => {
             let section = required_section(args)?;
-            let rel_path = required_relative_path(args, "path")?;
+            let rel_path = required_section_relative_path(args, section, "path")?;
             section_path(options, &id, section, Some(&rel_path))
         }
         _ => scoped_path_from_optional_args(options, &id, args)?,
@@ -988,7 +988,11 @@ fn scoped_path_from_optional_args(
         (Some(section), path) => {
             validate_section(section)?;
             let rel = match path {
-                Some(raw) => Some(normalize_relative_path(raw, "path", true)?),
+                Some(raw) => {
+                    let rel_path = normalize_relative_path(raw, "path", true)?;
+                    reject_section_prefixed_path(section, &rel_path, "path")?;
+                    Some(rel_path)
+                }
                 None => None,
             };
             Ok(section_path(options, id, section, rel.as_deref()))
@@ -996,8 +1000,32 @@ fn scoped_path_from_optional_args(
     }
 }
 
+fn required_section_relative_path(
+    args: &Value,
+    section: &str,
+    field: &'static str,
+) -> Result<String, WorkbenchToolError> {
+    let rel_path = required_relative_path(args, field)?;
+    reject_section_prefixed_path(section, &rel_path, field)?;
+    Ok(rel_path)
+}
+
 fn required_relative_path(args: &Value, field: &'static str) -> Result<String, WorkbenchToolError> {
     normalize_relative_path(required_string(args, field)?, field, false)
+}
+
+fn reject_section_prefixed_path(
+    section: &str,
+    rel_path: &str,
+    field: &'static str,
+) -> Result<(), WorkbenchToolError> {
+    let section_prefix = format!("{section}/");
+    if rel_path == section || rel_path.starts_with(&section_prefix) {
+        return Err(WorkbenchToolError::new(format!(
+            "{field} must be relative to section {section}; do not prefix it with {section}/"
+        )));
+    }
+    Ok(())
 }
 
 fn normalize_relative_path(

--- a/scripts/lingtai-workbench/README.md
+++ b/scripts/lingtai-workbench/README.md
@@ -1,0 +1,203 @@
+<!--
+Copyright 2024-2026 The NoKV Authors.
+SPDX-License-Identifier: Apache-2.0
+-->
+
+# LingTai Workbench Scripts
+
+This directory contains local preflight helpers for the LingTai workbench MCP
+demo path. These scripts are not benchmark harnesses and do not depend on
+benchmark data directories.
+
+## One-command Setup
+
+Run the full local preflight and MCP install path with:
+
+```bash
+./scripts/lingtai-workbench/up.sh
+```
+
+`up.sh` does the following with the defaults below:
+
+- builds `target/debug/nokv`
+- starts or verifies RustFS and the `nokv-lingtai-workbench` bucket
+- verifies or starts the NoKV server at `127.0.0.1:7799`
+- checks that the LingTai TUI runtime can see the `nokv-workbench` skill
+- checks that the workbench MCP exposes `workbench_*` tools
+- idempotently installs the MCP registration into the selected LingTai agent
+
+Defaults:
+
+```text
+RustFS endpoint:  http://127.0.0.1:9000
+NoKV server bind: 127.0.0.1:7799
+bucket:           nokv-lingtai-workbench
+workbench root:   /workbenches
+state dir:        target/lingtai-workbench
+```
+
+Project selection:
+
+1. `LINGTAI_WORKBENCH_PROJECT`
+2. the current directory when it contains `.lingtai/`
+3. `~/lingtai-demo`
+
+Agent selection is automatic: explicit `--agent-dir` or `--agent` in the lower
+level installer wins, otherwise the installer chooses one running coordinator,
+then one coordinator, then the only agent. Ambiguous multi-agent projects fail
+with a list of candidates.
+
+After `up.sh` finishes, refresh the selected agent inside LingTai:
+
+```text
+/refresh
+```
+
+`/refresh` restarts the MCP stdio child process. The NoKV server does not need
+to be restarted for MCP-only changes because request argument parsing and tool
+definitions live in `nokv mcp --profile workbench`.
+
+## Start RustFS
+
+Start or reuse the dedicated LingTai workbench RustFS endpoint:
+
+```bash
+./scripts/lingtai-workbench/start_rustfs.sh
+```
+
+Defaults:
+
+```text
+endpoint: http://127.0.0.1:9000
+bucket:   nokv-lingtai-workbench
+data:     target/lingtai-workbench/rustfs
+```
+
+Override the endpoint only when the default ports are already occupied:
+
+```bash
+LINGTAI_WORKBENCH_RUSTFS_PORT=9010 \
+LINGTAI_WORKBENCH_RUSTFS_CONSOLE_PORT=9011 \
+LINGTAI_WORKBENCH_S3_ENDPOINT=http://127.0.0.1:9010 \
+./scripts/lingtai-workbench/start_rustfs.sh
+```
+
+Use the same endpoint and bucket in the NoKV server, CLI checks, and MCP
+registration.
+
+## Start NoKV
+
+Build the CLI binary:
+
+```bash
+cargo build -p nokv --bin nokv
+```
+
+Start the metadata server in a separate terminal:
+
+```bash
+mkdir -p ~/nokv-workbench-meta
+
+./target/debug/nokv \
+  --server-bind 127.0.0.1:7799 \
+  --object-backend rustfs \
+  --s3-endpoint http://127.0.0.1:9000 \
+  --s3-bucket nokv-lingtai-workbench \
+  --meta ~/nokv-workbench-meta \
+  serve
+```
+
+Check that the client path can reach the server and object store:
+
+```bash
+./target/debug/nokv \
+  --server-bind 127.0.0.1:7799 \
+  --object-backend rustfs \
+  --s3-endpoint http://127.0.0.1:9000 \
+  --s3-bucket nokv-lingtai-workbench \
+  ls /
+```
+
+An empty root with exit status 0 is a successful preflight check.
+
+## Install MCP Into One LingTai Agent
+
+`install_workbench_mcp.py` idempotently writes the target agent's two LingTai
+MCP files:
+
+- `<agent>/mcp_registry.jsonl`
+- `<agent>/init.json`
+
+Example:
+
+```bash
+python3 ./scripts/lingtai-workbench/install_workbench_mcp.py \
+  --project /Users/wangchanghao/lingtai-demo \
+  --agent 'coordinator(codex-gpt-5.4)' \
+  --nokv-bin /Users/wangchanghao/NoKV/target/debug/nokv \
+  --server-bind 127.0.0.1:7799 \
+  --object-backend rustfs \
+  --s3-endpoint http://127.0.0.1:9000 \
+  --s3-bucket nokv-lingtai-workbench \
+  --workbench-root /workbenches
+```
+
+The installer upserts the `nokv-workbench` MCP server registration. Re-running
+the same command does not duplicate registry lines or rewrite files when the
+desired state is already present.
+
+If you already know the agent directory, pass it directly:
+
+```bash
+python3 ./scripts/lingtai-workbench/install_workbench_mcp.py \
+  --agent-dir '/Users/wangchanghao/lingtai-demo/.lingtai/coordinator(codex-gpt-5.4)' \
+  --nokv-bin /Users/wangchanghao/NoKV/target/debug/nokv
+```
+
+## Runtime Skill Check
+
+The TUI runtime must be able to see the `nokv-workbench` skill:
+
+```bash
+~/.lingtai-tui/runtime/venv/bin/python - <<'PY'
+from pathlib import Path
+import importlib.metadata as md
+import lingtai.intrinsic_skills as skills
+
+print("lingtai:", md.version("lingtai"))
+root = Path(skills.__file__).parent
+print("nokv-workbench skill:", (root / "nokv-workbench" / "SKILL.md").exists())
+PY
+```
+
+The installer does not replace or patch the TUI runtime. Install a
+workbench-enabled LingTai runtime separately, then run this installer for each
+agent that should receive the MCP tools.
+
+## Tool Names
+
+The MCP server exposes workbench tools with the `workbench_` prefix:
+
+```text
+workbench_create
+workbench_put_file
+workbench_list
+workbench_stat
+workbench_read
+workbench_grep
+workbench_find
+workbench_commit
+workbench_snapshot
+```
+
+The server registration name remains `nokv-workbench`; that is the MCP server
+id used by LingTai, not the public tool-name prefix.
+
+## Tests
+
+Run the installer tests with:
+
+```bash
+python3 ./scripts/lingtai-workbench/install_workbench_mcp_test.py
+bash -n ./scripts/lingtai-workbench/up.sh
+```

--- a/scripts/lingtai-workbench/install_workbench_mcp.py
+++ b/scripts/lingtai-workbench/install_workbench_mcp.py
@@ -1,0 +1,287 @@
+#!/usr/bin/env python3
+import argparse
+import json
+import os
+import sys
+import tempfile
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+
+DEFAULT_MCP_NAME = "nokv-workbench"
+DEFAULT_BUCKET = "nokv-lingtai-workbench"
+DEFAULT_ENDPOINT = "http://127.0.0.1:9000"
+DEFAULT_SERVER_BIND = "127.0.0.1:7799"
+DEFAULT_WORKBENCH_ROOT = "/workbenches"
+
+
+@dataclass(frozen=True)
+class InstallConfig:
+    nokv_bin: str
+    server_bind: str
+    object_backend: str
+    s3_endpoint: str | None
+    s3_bucket: str
+    workbench_root: str
+    mcp_name: str = DEFAULT_MCP_NAME
+
+
+@dataclass(frozen=True)
+class InstallResult:
+    agent_dir: Path
+    registry_changed: bool
+    init_changed: bool
+
+
+def repo_root() -> Path:
+    return Path(__file__).resolve().parents[2]
+
+
+def default_nokv_bin() -> str:
+    return str(repo_root() / "target" / "debug" / "nokv")
+
+
+def mcp_args(config: InstallConfig) -> list[str]:
+    args = [
+        "--server-bind",
+        config.server_bind,
+        "--object-backend",
+        config.object_backend,
+    ]
+    if config.s3_endpoint:
+        args.extend(["--s3-endpoint", config.s3_endpoint])
+    args.extend(
+        [
+            "--s3-bucket",
+            config.s3_bucket,
+            "mcp",
+            "--profile",
+            "workbench",
+            "--workbench-root",
+            config.workbench_root,
+        ]
+    )
+    return args
+
+
+def registry_record(config: InstallConfig) -> dict[str, Any]:
+    return {
+        "name": config.mcp_name,
+        "summary": "NoKV LingTai workbench.",
+        "transport": "stdio",
+        "command": config.nokv_bin,
+        "args": mcp_args(config),
+        "source": "local-nokv",
+    }
+
+
+def init_spec(config: InstallConfig) -> dict[str, Any]:
+    return {
+        "type": "stdio",
+        "command": config.nokv_bin,
+        "args": mcp_args(config),
+    }
+
+
+def read_registry(path: Path) -> list[dict[str, Any]]:
+    if not path.exists():
+        return []
+    records = []
+    for line_number, line in enumerate(path.read_text(encoding="utf-8").splitlines(), 1):
+        stripped = line.strip()
+        if not stripped:
+            continue
+        try:
+            record = json.loads(stripped)
+        except json.JSONDecodeError as err:
+            raise ValueError(f"{path}:{line_number}: invalid JSONL entry: {err}") from err
+        if not isinstance(record, dict):
+            raise ValueError(f"{path}:{line_number}: registry entry must be a JSON object")
+        name = record.get("name")
+        if not isinstance(name, str) or not name:
+            raise ValueError(f"{path}:{line_number}: registry entry must have a string name")
+        records.append(record)
+    return records
+
+
+def write_text_if_changed(path: Path, text: str) -> bool:
+    if path.exists() and path.read_text(encoding="utf-8") == text:
+        return False
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp_name = tempfile.mkstemp(prefix=f".{path.name}.", dir=str(path.parent))
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as handle:
+            handle.write(text)
+        os.replace(tmp_name, path)
+    finally:
+        if os.path.exists(tmp_name):
+            os.unlink(tmp_name)
+    return True
+
+
+def upsert_registry(agent_dir: Path, config: InstallConfig) -> bool:
+    path = agent_dir / "mcp_registry.jsonl"
+    desired = registry_record(config)
+    records = read_registry(path)
+    output = [desired]
+    output.extend(record for record in records if record.get("name") != config.mcp_name)
+    text = "".join(
+        json.dumps(record, ensure_ascii=False, separators=(",", ":")) + "\n"
+        for record in output
+    )
+    return write_text_if_changed(path, text)
+
+
+def read_init(path: Path) -> dict[str, Any]:
+    if not path.exists():
+        raise FileNotFoundError(f"{path} does not exist")
+    data = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(data, dict):
+        raise ValueError(f"{path} must contain a JSON object")
+    return data
+
+
+def upsert_init(agent_dir: Path, config: InstallConfig) -> bool:
+    path = agent_dir / "init.json"
+    data = read_init(path)
+    mcp = data.setdefault("mcp", {})
+    if not isinstance(mcp, dict):
+        raise ValueError(f"{path}: mcp must be a JSON object when present")
+    mcp[config.mcp_name] = init_spec(config)
+    text = json.dumps(data, ensure_ascii=False, indent=2) + "\n"
+    return write_text_if_changed(path, text)
+
+
+def configure_agent(agent_dir: Path | str, config: InstallConfig) -> InstallResult:
+    resolved = Path(agent_dir).expanduser().resolve()
+    if not resolved.is_dir():
+        raise FileNotFoundError(f"agent directory does not exist: {resolved}")
+    registry_changed = upsert_registry(resolved, config)
+    init_changed = upsert_init(resolved, config)
+    return InstallResult(
+        agent_dir=resolved,
+        registry_changed=registry_changed,
+        init_changed=init_changed,
+    )
+
+
+def agent_candidates(project: Path) -> list[Path]:
+    agents_root = project.expanduser() / ".lingtai"
+    if not agents_root.is_dir():
+        raise FileNotFoundError(f"LingTai project has no .lingtai directory: {project}")
+    return sorted(
+        path
+        for path in agents_root.iterdir()
+        if path.is_dir() and not path.name.startswith(".") and (path / "init.json").is_file()
+    )
+
+
+def agent_is_running(agent_dir: Path) -> bool:
+    status_path = agent_dir / ".status.json"
+    if not status_path.exists():
+        return False
+    try:
+        status = json.loads(status_path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError:
+        return False
+    runtime = status.get("runtime")
+    return isinstance(runtime, dict) and runtime.get("running") is True
+
+
+def is_coordinator(agent_dir: Path) -> bool:
+    return agent_dir.name.startswith("coordinator")
+
+
+def choose_default_agent(project: Path) -> Path:
+    candidates = agent_candidates(project)
+    if not candidates:
+        raise ValueError(f"no LingTai agents with init.json found under {project / '.lingtai'}")
+
+    running_coordinators = [
+        agent_dir for agent_dir in candidates if is_coordinator(agent_dir) and agent_is_running(agent_dir)
+    ]
+    if len(running_coordinators) == 1:
+        return running_coordinators[0]
+    if len(running_coordinators) > 1:
+        names = ", ".join(agent.name for agent in running_coordinators)
+        raise ValueError(f"multiple running coordinator agents found: {names}")
+
+    coordinators = [agent_dir for agent_dir in candidates if is_coordinator(agent_dir)]
+    if len(coordinators) == 1:
+        return coordinators[0]
+    if len(coordinators) > 1:
+        names = ", ".join(agent.name for agent in coordinators)
+        raise ValueError(f"multiple coordinator agents found: {names}")
+
+    if len(candidates) == 1:
+        return candidates[0]
+
+    names = ", ".join(agent.name for agent in candidates)
+    raise ValueError(f"multiple LingTai agents found; pass --agent explicitly: {names}")
+
+
+def resolve_agent_dir(project: Path, agent: str | None, agent_dir: str | None) -> Path:
+    if agent_dir:
+        return Path(agent_dir).expanduser()
+    if agent:
+        return project.expanduser() / ".lingtai" / agent
+    return choose_default_agent(project)
+
+
+def describe_agent_selection(agent: str | None, agent_dir: str | None, resolved: Path) -> str:
+    if agent_dir:
+        return "explicit --agent-dir"
+    if agent:
+        return f"explicit --agent {agent}"
+    return f"default {resolved.name}"
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Idempotently register the NoKV workbench MCP for one LingTai agent.",
+    )
+    parser.add_argument("--project", default=".", help="LingTai project directory.")
+    parser.add_argument("--agent", help="Agent directory name under PROJECT/.lingtai.")
+    parser.add_argument("--agent-dir", help="Explicit LingTai agent directory.")
+    parser.add_argument("--nokv-bin", default=default_nokv_bin(), help="Path to nokv binary.")
+    parser.add_argument("--server-bind", default=DEFAULT_SERVER_BIND)
+    parser.add_argument("--object-backend", default="rustfs")
+    parser.add_argument("--s3-endpoint", default=DEFAULT_ENDPOINT)
+    parser.add_argument("--s3-bucket", default=DEFAULT_BUCKET)
+    parser.add_argument("--workbench-root", default=DEFAULT_WORKBENCH_ROOT)
+    parser.add_argument("--mcp-name", default=DEFAULT_MCP_NAME)
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str]) -> int:
+    args = parse_args(argv)
+    try:
+        agent_dir = resolve_agent_dir(Path(args.project), args.agent, args.agent_dir)
+        config = InstallConfig(
+            nokv_bin=str(Path(args.nokv_bin).expanduser()),
+            server_bind=args.server_bind,
+            object_backend=args.object_backend,
+            s3_endpoint=args.s3_endpoint or None,
+            s3_bucket=args.s3_bucket,
+            workbench_root=args.workbench_root,
+            mcp_name=args.mcp_name,
+        )
+        result = configure_agent(agent_dir, config)
+    except Exception as err:
+        print(f"error: {err}", file=sys.stderr)
+        return 1
+
+    print(f"agent_dir: {result.agent_dir}")
+    print(f"agent_selection: {describe_agent_selection(args.agent, args.agent_dir, result.agent_dir)}")
+    print(f"registry_changed: {str(result.registry_changed).lower()}")
+    print(f"init_changed: {str(result.init_changed).lower()}")
+    if result.registry_changed or result.init_changed:
+        print("next: run /refresh in the target LingTai agent")
+    else:
+        print("already configured")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/scripts/lingtai-workbench/install_workbench_mcp_test.py
+++ b/scripts/lingtai-workbench/install_workbench_mcp_test.py
@@ -1,0 +1,197 @@
+#!/usr/bin/env python3
+import importlib.util
+import json
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+sys.dont_write_bytecode = True
+MODULE_PATH = Path(__file__).with_name("install_workbench_mcp.py")
+
+
+def load_module():
+    spec = importlib.util.spec_from_file_location("install_workbench_mcp", MODULE_PATH)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+class InstallWorkbenchMcpTest(unittest.TestCase):
+    def setUp(self):
+        self.module = load_module()
+
+    def make_agent(
+        self,
+        root: Path,
+        name: str = "coordinator",
+        init: dict | None = None,
+        registry: list[dict] | None = None,
+        running: bool | None = None,
+    ):
+        agent_dir = root / ".lingtai" / name
+        agent_dir.mkdir(parents=True)
+        (agent_dir / "init.json").write_text(
+            json.dumps(init or {"mcp": {}}, indent=2) + "\n",
+            encoding="utf-8",
+        )
+        if running is not None:
+            (agent_dir / ".status.json").write_text(
+                json.dumps(
+                    {
+                        "identity": {"agent_name": name},
+                        "runtime": {"running": running},
+                    },
+                    indent=2,
+                )
+                + "\n",
+                encoding="utf-8",
+            )
+        if registry is not None:
+            (agent_dir / "mcp_registry.jsonl").write_text(
+                "".join(json.dumps(record) + "\n" for record in registry),
+                encoding="utf-8",
+            )
+        return agent_dir
+
+    def config(self):
+        return self.module.InstallConfig(
+            nokv_bin="/repo/target/debug/nokv",
+            server_bind="127.0.0.1:7799",
+            object_backend="rustfs",
+            s3_endpoint="http://127.0.0.1:9000",
+            s3_bucket="nokv-lingtai-workbench",
+            workbench_root="/workbenches",
+        )
+
+    def test_install_adds_registry_and_init_entries(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            agent_dir = self.make_agent(Path(tmp))
+
+            result = self.module.configure_agent(agent_dir, self.config())
+
+            self.assertTrue(result.registry_changed)
+            self.assertTrue(result.init_changed)
+            registry = [
+                json.loads(line)
+                for line in (agent_dir / "mcp_registry.jsonl").read_text().splitlines()
+            ]
+            self.assertEqual([record["name"] for record in registry], ["nokv-workbench"])
+            self.assertEqual(registry[0]["transport"], "stdio")
+            self.assertEqual(
+                registry[0]["args"],
+                [
+                    "--server-bind",
+                    "127.0.0.1:7799",
+                    "--object-backend",
+                    "rustfs",
+                    "--s3-endpoint",
+                    "http://127.0.0.1:9000",
+                    "--s3-bucket",
+                    "nokv-lingtai-workbench",
+                    "mcp",
+                    "--profile",
+                    "workbench",
+                    "--workbench-root",
+                    "/workbenches",
+                ],
+            )
+            init = json.loads((agent_dir / "init.json").read_text())
+            self.assertEqual(init["mcp"]["nokv-workbench"]["command"], "/repo/target/debug/nokv")
+            self.assertEqual(init["mcp"]["nokv-workbench"]["args"], registry[0]["args"])
+
+    def test_install_is_idempotent(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            agent_dir = self.make_agent(Path(tmp))
+
+            first = self.module.configure_agent(agent_dir, self.config())
+            registry_before = (agent_dir / "mcp_registry.jsonl").read_text()
+            init_before = (agent_dir / "init.json").read_text()
+            second = self.module.configure_agent(agent_dir, self.config())
+
+            self.assertTrue(first.registry_changed)
+            self.assertTrue(first.init_changed)
+            self.assertFalse(second.registry_changed)
+            self.assertFalse(second.init_changed)
+            self.assertEqual((agent_dir / "mcp_registry.jsonl").read_text(), registry_before)
+            self.assertEqual((agent_dir / "init.json").read_text(), init_before)
+
+    def test_install_replaces_existing_nokv_workbench_entries(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            old_record = {
+                "name": "nokv-workbench",
+                "summary": "old",
+                "transport": "stdio",
+                "command": "/old/nokv",
+                "args": ["mcp"],
+                "source": "old",
+            }
+            other_record = {
+                "name": "imap",
+                "summary": "mail",
+                "transport": "stdio",
+                "command": "python",
+                "args": ["-m", "imap"],
+                "source": "local",
+            }
+            agent_dir = self.make_agent(
+                Path(tmp),
+                init={
+                    "mcp": {
+                        "nokv-workbench": {
+                            "type": "stdio",
+                            "command": "/old/nokv",
+                            "args": ["mcp"],
+                        },
+                        "imap": {"type": "stdio", "command": "python", "args": ["-m", "imap"]},
+                    }
+                },
+                registry=[old_record, other_record, old_record],
+            )
+
+            result = self.module.configure_agent(agent_dir, self.config())
+
+            self.assertTrue(result.registry_changed)
+            self.assertTrue(result.init_changed)
+            registry = [
+                json.loads(line)
+                for line in (agent_dir / "mcp_registry.jsonl").read_text().splitlines()
+            ]
+            self.assertEqual([record["name"] for record in registry], ["nokv-workbench", "imap"])
+            self.assertEqual(registry[0]["command"], "/repo/target/debug/nokv")
+            init = json.loads((agent_dir / "init.json").read_text())
+            self.assertEqual(init["mcp"]["nokv-workbench"]["command"], "/repo/target/debug/nokv")
+            self.assertEqual(init["mcp"]["imap"]["command"], "python")
+
+    def test_resolve_agent_dir_selects_running_coordinator_by_default(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            coordinator = self.make_agent(root, "coordinator(codex-gpt-5.4)", running=True)
+            self.make_agent(root, "scribe", running=True)
+
+            resolved = self.module.resolve_agent_dir(root, None, None)
+
+            self.assertEqual(resolved, coordinator)
+
+    def test_resolve_agent_dir_selects_single_agent_by_default(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            only_agent = self.make_agent(root, "scout", running=False)
+
+            resolved = self.module.resolve_agent_dir(root, None, None)
+
+            self.assertEqual(resolved, only_agent)
+
+    def test_resolve_agent_dir_rejects_ambiguous_non_coordinator_agents(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            self.make_agent(root, "scout", running=True)
+            self.make_agent(root, "scribe", running=True)
+
+            with self.assertRaisesRegex(ValueError, "multiple LingTai agents"):
+                self.module.resolve_agent_dir(root, None, None)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/lingtai-workbench/start_rustfs.sh
+++ b/scripts/lingtai-workbench/start_rustfs.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if repo_root="$(git rev-parse --show-toplevel 2>/dev/null)"; then
+  :
+else
+  repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+fi
+data_root="${LINGTAI_WORKBENCH_DATA_ROOT:-${repo_root}/target/lingtai-workbench}"
+container="${LINGTAI_WORKBENCH_RUSTFS_CONTAINER:-lingtai-workbench-rustfs}"
+image="${LINGTAI_WORKBENCH_RUSTFS_IMAGE:-rustfs/rustfs:latest}"
+host="${LINGTAI_WORKBENCH_RUSTFS_HOST:-127.0.0.1}"
+port="${LINGTAI_WORKBENCH_RUSTFS_PORT:-9000}"
+console_port="${LINGTAI_WORKBENCH_RUSTFS_CONSOLE_PORT:-9001}"
+access_key="${LINGTAI_WORKBENCH_S3_ACCESS_KEY_ID:-rustfsadmin}"
+secret_key="${LINGTAI_WORKBENCH_S3_SECRET_ACCESS_KEY:-rustfsadmin}"
+bucket="${LINGTAI_WORKBENCH_S3_BUCKET:-nokv-lingtai-workbench}"
+endpoint="${LINGTAI_WORKBENCH_S3_ENDPOINT:-http://${host}:${port}}"
+rustfs_data="${LINGTAI_WORKBENCH_RUSTFS_DATA_DIR:-${data_root}/rustfs}"
+
+if ! command -v aws >/dev/null 2>&1; then
+  echo "aws CLI is required to create and verify the RustFS bucket" >&2
+  exit 1
+fi
+
+export AWS_ACCESS_KEY_ID="${access_key}"
+export AWS_SECRET_ACCESS_KEY="${secret_key}"
+export AWS_DEFAULT_REGION="${AWS_DEFAULT_REGION:-us-east-1}"
+export AWS_EC2_METADATA_DISABLED=true
+
+endpoint_ready=0
+if aws --endpoint-url "${endpoint}" s3api list-buckets >/dev/null 2>&1; then
+  endpoint_ready=1
+fi
+
+if [ "${endpoint_ready}" != "1" ]; then
+  if ! command -v docker >/dev/null 2>&1; then
+    echo "docker is required to start RustFS when ${endpoint} is not already reachable" >&2
+    exit 1
+  fi
+
+  mkdir -p "${rustfs_data}"
+
+  if docker container inspect "${container}" >/dev/null 2>&1; then
+    if [ "$(docker inspect -f '{{.State.Running}}' "${container}")" != "true" ]; then
+      docker start "${container}" >/dev/null
+    fi
+  else
+    docker run -d \
+      --name "${container}" \
+      -p "${host}:${port}:9000" \
+      -p "${host}:${console_port}:9001" \
+      -e "RUSTFS_ACCESS_KEY=${access_key}" \
+      -e "RUSTFS_SECRET_KEY=${secret_key}" \
+      -e "RUSTFS_CONSOLE_ENABLE=true" \
+      -v "${rustfs_data}:/data" \
+      "${image}" \
+      --address :9000 \
+      --console-enable \
+      --access-key "${access_key}" \
+      --secret-key "${secret_key}" \
+      /data >/dev/null
+  fi
+fi
+
+ready=0
+for _ in $(seq 1 60); do
+  if aws --endpoint-url "${endpoint}" s3api list-buckets >/dev/null 2>&1; then
+    ready=1
+    break
+  fi
+  sleep 1
+done
+
+if [ "${ready}" != "1" ]; then
+  echo "RustFS did not become ready at ${endpoint}" >&2
+  docker logs --tail 80 "${container}" >&2 || true
+  exit 1
+fi
+
+if ! aws --endpoint-url "${endpoint}" s3api head-bucket --bucket "${bucket}" >/dev/null 2>&1; then
+  aws --endpoint-url "${endpoint}" s3api create-bucket --bucket "${bucket}" >/dev/null
+fi
+
+cat <<EOF
+LingTai workbench RustFS ready
+  container: ${container}
+  endpoint:  ${endpoint}
+  bucket:    ${bucket}
+  data:      ${rustfs_data}
+EOF

--- a/scripts/lingtai-workbench/up.sh
+++ b/scripts/lingtai-workbench/up.sh
@@ -1,0 +1,179 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if ROOT_DIR="$(git rev-parse --show-toplevel 2>/dev/null)"; then
+  :
+else
+  ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+fi
+SCRIPT_DIR="${ROOT_DIR}/scripts/lingtai-workbench"
+STATE_DIR="${ROOT_DIR}/target/lingtai-workbench"
+NOKV_BIN="${NOKV_BIN:-${ROOT_DIR}/target/debug/nokv}"
+SERVER_BIND="${LINGTAI_WORKBENCH_SERVER_BIND:-127.0.0.1:7799}"
+S3_ENDPOINT="${LINGTAI_WORKBENCH_S3_ENDPOINT:-http://127.0.0.1:9000}"
+S3_BUCKET="${LINGTAI_WORKBENCH_S3_BUCKET:-nokv-lingtai-workbench}"
+OBJECT_BACKEND="${LINGTAI_WORKBENCH_OBJECT_BACKEND:-rustfs}"
+WORKBENCH_ROOT="${LINGTAI_WORKBENCH_ROOT:-/workbenches}"
+META_DIR="${LINGTAI_WORKBENCH_META_DIR:-${STATE_DIR}/meta}"
+SERVER_LOG="${LINGTAI_WORKBENCH_SERVER_LOG:-${STATE_DIR}/nokv-server.log}"
+SERVER_PID="${LINGTAI_WORKBENCH_SERVER_PID:-${STATE_DIR}/nokv-server.pid}"
+TUI_PYTHON="${LINGTAI_TUI_PYTHON:-${HOME}/.lingtai-tui/runtime/venv/bin/python}"
+
+log() {
+  printf '[lingtai-workbench] %s\n' "$*"
+}
+
+die() {
+  printf '[lingtai-workbench] error: %s\n' "$*" >&2
+  exit 1
+}
+
+resolve_project() {
+  if [[ -n "${LINGTAI_WORKBENCH_PROJECT:-}" ]]; then
+    printf '%s\n' "${LINGTAI_WORKBENCH_PROJECT}"
+    return
+  fi
+  if [[ -d ".lingtai" ]]; then
+    pwd
+    return
+  fi
+  if [[ -d "${HOME}/lingtai-demo/.lingtai" ]]; then
+    printf '%s\n' "${HOME}/lingtai-demo"
+    return
+  fi
+  die "cannot find a LingTai project; set LINGTAI_WORKBENCH_PROJECT=/path/to/project"
+}
+
+require_cmd() {
+  command -v "$1" >/dev/null 2>&1 || die "$1 is required"
+}
+
+check_runtime_skill() {
+  [[ -x "${TUI_PYTHON}" ]] || die "LingTai TUI runtime python not found: ${TUI_PYTHON}"
+  "${TUI_PYTHON}" - <<'PY' || die "LingTai TUI runtime does not expose intrinsic skill nokv-workbench; install a workbench-enabled LingTai runtime first"
+from pathlib import Path
+import lingtai.intrinsic_skills as skills
+
+root = Path(skills.__file__).parent
+if not (root / "nokv-workbench" / "SKILL.md").exists():
+    raise SystemExit(1)
+PY
+  log "LingTai runtime skill ready"
+}
+
+nokv_ls() {
+  "${NOKV_BIN}" \
+    --server-bind "${SERVER_BIND}" \
+    --object-backend "${OBJECT_BACKEND}" \
+    --s3-endpoint "${S3_ENDPOINT}" \
+    --s3-bucket "${S3_BUCKET}" \
+    ls / >/dev/null
+}
+
+port_in_use() {
+  local host="${SERVER_BIND%:*}"
+  local port="${SERVER_BIND##*:}"
+  lsof -nP -iTCP@"${host}:${port}" -sTCP:LISTEN >/dev/null 2>&1
+}
+
+start_nokv_server() {
+  mkdir -p "${STATE_DIR}" "${META_DIR}"
+  log "starting NoKV server at ${SERVER_BIND}"
+  "${NOKV_BIN}" \
+    --server-bind "${SERVER_BIND}" \
+    --object-backend "${OBJECT_BACKEND}" \
+    --s3-endpoint "${S3_ENDPOINT}" \
+    --s3-bucket "${S3_BUCKET}" \
+    --meta "${META_DIR}" \
+    serve >"${SERVER_LOG}" 2>&1 &
+  echo "$!" >"${SERVER_PID}"
+
+  for _ in $(seq 1 60); do
+    if nokv_ls; then
+      log "NoKV server ready pid=$(cat "${SERVER_PID}")"
+      return
+    fi
+    if ! kill -0 "$(cat "${SERVER_PID}")" >/dev/null 2>&1; then
+      tail -80 "${SERVER_LOG}" >&2 || true
+      die "NoKV server exited before becoming ready"
+    fi
+    sleep 1
+  done
+
+  tail -80 "${SERVER_LOG}" >&2 || true
+  die "NoKV server did not become ready at ${SERVER_BIND}"
+}
+
+ensure_nokv_server() {
+  if nokv_ls; then
+    log "NoKV server already ready at ${SERVER_BIND}"
+    return
+  fi
+  if port_in_use; then
+    lsof -nP -iTCP@"${SERVER_BIND}" -sTCP:LISTEN >&2 || true
+    die "${SERVER_BIND} is occupied, but NoKV client preflight failed; stop the conflicting process or change LINGTAI_WORKBENCH_SERVER_BIND"
+  fi
+  start_nokv_server
+}
+
+check_mcp_tools() {
+  local names
+  names="$(
+    printf '%s\n' '{"jsonrpc":"2.0","id":1,"method":"tools/list"}' |
+      "${NOKV_BIN}" \
+        --server-bind "${SERVER_BIND}" \
+        --object-backend "${OBJECT_BACKEND}" \
+        --s3-endpoint "${S3_ENDPOINT}" \
+        --s3-bucket "${S3_BUCKET}" \
+        mcp --profile workbench --workbench-root "${WORKBENCH_ROOT}" |
+      python3 -c 'import json, sys; print("\n".join(tool["name"] for tool in json.loads(sys.stdin.readline())["result"]["tools"]))'
+  )"
+  grep -qx 'workbench_put_file' <<<"${names}" || die "workbench_put_file is missing from MCP tools"
+  if grep -q '^nokv_workbench_' <<<"${names}"; then
+    die "old nokv_workbench_* tools are still exposed; rebuild target/debug/nokv"
+  fi
+  log "MCP tools ready"
+}
+
+main() {
+  require_cmd cargo
+  require_cmd python3
+  require_cmd lsof
+
+  local project
+  project="$(resolve_project)"
+  [[ -d "${project}/.lingtai" ]] || die "not a LingTai project: ${project}"
+
+  log "project: ${project}"
+  log "building nokv"
+  cargo build -p nokv --bin nokv
+
+  "${SCRIPT_DIR}/start_rustfs.sh"
+  ensure_nokv_server
+  check_runtime_skill
+  check_mcp_tools
+
+  "${SCRIPT_DIR}/install_workbench_mcp.py" \
+    --project "${project}" \
+    --nokv-bin "${NOKV_BIN}" \
+    --server-bind "${SERVER_BIND}" \
+    --object-backend "${OBJECT_BACKEND}" \
+    --s3-endpoint "${S3_ENDPOINT}" \
+    --s3-bucket "${S3_BUCKET}" \
+    --workbench-root "${WORKBENCH_ROOT}"
+
+  cat <<EOF
+
+LingTai workbench is ready.
+Run /refresh in the target LingTai agent.
+
+Defaults used:
+  project:        ${project}
+  server_bind:    ${SERVER_BIND}
+  s3_endpoint:    ${S3_ENDPOINT}
+  s3_bucket:      ${S3_BUCKET}
+  workbench_root: ${WORKBENCH_ROOT}
+EOF
+}
+
+main "$@"


### PR DESCRIPTION
## Summary

- add the controlled workbench MCP profile and query tools needed by LingTai workbench flows
- harden workbench MCP path and payload handling, including section-prefixed path rejection and empty unused payload variants
- add LingTai workbench one-click setup scripts and local collaboration guidance

## Why

LingTai kernel workbench support needs a stable NoKV MCP surface that exposes `workbench_*` tools, stores artifacts under NoKV-backed workbenches, and can be brought up reproducibly by downstream developers.

## Validation

- `python3 scripts/lingtai-workbench/install_workbench_mcp_test.py`
- `bash -n scripts/lingtai-workbench/up.sh`
- `bash -n scripts/lingtai-workbench/start_rustfs.sh`
- `cargo fmt --all -- --check`
- `cargo test -p nokv --bin nokv workbench_mcp -- --nocapture`
- `git diff --check`
