### PR TITLE
fix: tolerate out-of-band entries in workbench list and grep

### DIFF
--- a/crates/nokv/src/bin/nokv.rs
+++ b/crates/nokv/src/bin/nokv.rs
@@ -3584,6 +3584,195 @@ mod tests {
     }
 
     #[test]
+    fn workbench_mcp_list_and_grep_tolerate_out_of_band_entries() {
+        let object_dir = tempdir().unwrap();
+        let object_root = object_dir.path().join("objects");
+        let addr = spawn_test_server_with_object_config(ObjectStoreConfig::tiered_local(
+            object_root.clone(),
+            fake_s3_options(),
+        ));
+        let connect = || {
+            let store =
+                LocalObjectStore::new(LocalObjectStoreOptions::new(object_root.clone())).unwrap();
+            NoKvFsClient::connect(addr, store)
+        };
+        let run_requests = |requests: Vec<serde_json::Value>| -> Vec<serde_json::Value> {
+            let reqs = requests
+                .into_iter()
+                .map(|request| serde_json::to_string(&request).unwrap())
+                .collect::<Vec<_>>()
+                .join("\n")
+                + "\n";
+            let reader = std::io::Cursor::new(reqs);
+            let mut writer = Vec::new();
+            run_mcp_stream_with_options(
+                connect(),
+                workbench_mcp_options(),
+                DEFAULT_UID,
+                DEFAULT_GID,
+                reader,
+                &mut writer,
+            )
+            .unwrap();
+            String::from_utf8(writer)
+                .unwrap()
+                .lines()
+                .map(|line| serde_json::from_str(line).unwrap())
+                .collect()
+        };
+
+        let setup = run_requests(vec![
+            serde_json::json!({
+                "jsonrpc": "2.0",
+                "id": 1,
+                "method": "tools/call",
+                "params": {
+                    "name": "workbench_create",
+                    "arguments": {"id": "spedas-task-003"}
+                }
+            }),
+            serde_json::json!({
+                "jsonrpc": "2.0",
+                "id": 2,
+                "method": "tools/call",
+                "params": {
+                    "name": "workbench_put_file",
+                    "arguments": {
+                        "id": "spedas-task-003",
+                        "section": "outputs",
+                        "path": "spectrum.csv",
+                        "text": "freq,power\n1,2\n",
+                        "content_type": "text/csv"
+                    }
+                }
+            }),
+        ]);
+        for (index, response) in setup.iter().enumerate() {
+            assert_ne!(
+                response["result"]["isError"], true,
+                "setup response {index}: {response}"
+            );
+        }
+
+        let out_of_band_metadata = |name: &str| ArtifactMetadata {
+            producer: "outside-writer".to_owned(),
+            digest_uri: "sha256:demo".to_owned(),
+            content_type: "text/plain".to_owned(),
+            manifest_id: name.to_owned(),
+            mode: DEFAULT_MODE_FILE,
+            uid: DEFAULT_UID,
+            gid: DEFAULT_GID,
+        };
+        let out_of_band = connect();
+        out_of_band
+            .put_artifact(
+                "/workbenches/spedas-task-003/note.txt",
+                b"scratch note".to_vec(),
+                out_of_band_metadata("note.txt"),
+            )
+            .unwrap();
+        out_of_band
+            .metadata()
+            .mkdir(
+                "/workbenches/spedas-task-003/junk",
+                DEFAULT_MODE_DIR,
+                DEFAULT_UID,
+                DEFAULT_GID,
+            )
+            .unwrap();
+        out_of_band
+            .put_artifact(
+                "/workbenches/spedas-task-003/junk/scratch.txt",
+                b"freq rogue\n".to_vec(),
+                out_of_band_metadata("junk/scratch.txt"),
+            )
+            .unwrap();
+
+        let responses = run_requests(vec![
+            serde_json::json!({
+                "jsonrpc": "2.0",
+                "id": 1,
+                "method": "tools/call",
+                "params": {
+                    "name": "workbench_list",
+                    "arguments": {"id": "spedas-task-003"}
+                }
+            }),
+            serde_json::json!({
+                "jsonrpc": "2.0",
+                "id": 2,
+                "method": "tools/call",
+                "params": {
+                    "name": "workbench_grep",
+                    "arguments": {
+                        "id": "spedas-task-003",
+                        "pattern": "freq",
+                        "recursive": true
+                    }
+                }
+            }),
+            serde_json::json!({
+                "jsonrpc": "2.0",
+                "id": 3,
+                "method": "tools/call",
+                "params": {
+                    "name": "workbench_stat",
+                    "arguments": {
+                        "id": "spedas-task-003",
+                        "path": "junk/scratch.txt"
+                    }
+                }
+            }),
+        ]);
+        for (index, response) in responses.iter().take(2).enumerate() {
+            assert_ne!(
+                response["result"]["isError"], true,
+                "response {index}: {response}"
+            );
+        }
+        // Out-of-band entries are enumerable but stay unaddressable: request
+        // targets keep the strict section validation.
+        assert_eq!(
+            responses[2]["result"]["isError"], true,
+            "stat of out-of-band entry must keep failing: {}",
+            responses[2]
+        );
+
+        let entries = responses[0]["result"]["structuredContent"]["entries"]
+            .as_array()
+            .unwrap();
+        let entry = |name: &str| {
+            entries
+                .iter()
+                .find(|entry| entry["name"] == name)
+                .unwrap_or_else(|| panic!("missing list entry {name}: {entries:?}"))
+        };
+        for section in workbench_mcp::SECTIONS {
+            assert_eq!(entry(section)["section"], *section);
+        }
+        assert_eq!(entry("note.txt")["section"], serde_json::Value::Null);
+        assert_eq!(entry("note.txt")["relative_path"], "note.txt");
+        assert_eq!(entry("junk")["section"], serde_json::Value::Null);
+        assert_eq!(entry("junk")["relative_path"], "junk");
+
+        let matches = responses[1]["result"]["structuredContent"]["matches"]
+            .as_array()
+            .unwrap();
+        let match_for = |path: &str| {
+            matches
+                .iter()
+                .find(|match_| match_["path"] == path)
+                .unwrap_or_else(|| panic!("missing grep match {path}: {matches:?}"))
+        };
+        let section_match = match_for("/workbenches/spedas-task-003/outputs/spectrum.csv");
+        assert_eq!(section_match["section"], "outputs");
+        assert_eq!(section_match["relative_path"], "spectrum.csv");
+        let alien_match = match_for("/workbenches/spedas-task-003/junk/scratch.txt");
+        assert_eq!(alien_match["section"], serde_json::Value::Null);
+        assert_eq!(alien_match["relative_path"], "junk/scratch.txt");
+    }
+
+    #[test]
     fn workbench_mcp_put_file_ignores_empty_unused_payload_variant() {
         let responses = run_workbench_mcp_requests(vec![
             serde_json::json!({

--- a/crates/nokv/src/bin/nokv/workbench_mcp.rs
+++ b/crates/nokv/src/bin/nokv/workbench_mcp.rs
@@ -15,7 +15,7 @@ pub const DEFAULT_WORKBENCH_MAX_BYTES: usize = 16 * 1024 * 1024;
 const DEFAULT_WORKBENCH_FIND_LIMIT: usize = 50;
 const MAX_WORKBENCH_FIND_LIMIT: usize = 100;
 
-const SECTIONS: &[&str] = &["input", "scripts", "outputs", "logs", "metadata"];
+pub const SECTIONS: &[&str] = &["input", "scripts", "outputs", "logs", "metadata"];
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct WorkbenchMcpOptions {
@@ -91,7 +91,7 @@ pub fn tool_definitions() -> Vec<AgentToolDefinition> {
         AgentToolDefinition {
             name: "workbench_list",
             description:
-                "List a workbench, section, or subdirectory through the NoKV namespace. Not recursive.",
+                "List a workbench, section, or subdirectory through the NoKV namespace. Not recursive. Entries written outside the standard sections by other NoKV clients are returned with section null; such entries cannot be addressed by the other workbench tools.",
             parameters: json!({
                 "type": "object",
                 "required": ["id"],
@@ -142,7 +142,7 @@ pub fn tool_definitions() -> Vec<AgentToolDefinition> {
         AgentToolDefinition {
             name: "workbench_grep",
             description:
-                "Search workbench file bodies for a case-insensitive literal substring. This is not regex grep.",
+                "Search workbench file bodies for a case-insensitive literal substring. This is not regex grep. Matches in files written outside the standard sections by other NoKV clients are returned with section null; such files cannot be addressed by the other workbench tools.",
             parameters: json!({
                 "type": "object",
                 "required": ["id", "pattern", "recursive"],
@@ -699,6 +699,27 @@ fn path_scope(
     id: &str,
     path: &str,
 ) -> Result<WorkbenchPathScope, WorkbenchToolError> {
+    scoped_path(options, id, path, false)
+}
+
+/// Scope for paths returned by enumeration (list entries, grep matches).
+/// Other NoKV clients share the namespace and may have written entries
+/// outside the standard sections; those are surfaced with `section: null`
+/// and a workbench-relative path instead of failing the whole call.
+fn enumerated_path_scope(
+    options: &WorkbenchMcpOptions,
+    id: &str,
+    path: &str,
+) -> Result<WorkbenchPathScope, WorkbenchToolError> {
+    scoped_path(options, id, path, true)
+}
+
+fn scoped_path(
+    options: &WorkbenchMcpOptions,
+    id: &str,
+    path: &str,
+    tolerate_non_section: bool,
+) -> Result<WorkbenchPathScope, WorkbenchToolError> {
     let base = workbench_path(options, id);
     if path == base {
         return Ok(WorkbenchPathScope {
@@ -711,15 +732,20 @@ fn path_scope(
     let rest = path.strip_prefix(&prefix).ok_or_else(|| {
         WorkbenchToolError::new(format!("path {path} is outside workbench {base}"))
     })?;
+    let first = rest.split('/').next().unwrap_or(rest);
+    if let Err(err) = validate_section(first) {
+        if !tolerate_non_section {
+            return Err(err);
+        }
+        return Ok(WorkbenchPathScope {
+            path: path.to_owned(),
+            section: None,
+            relative_path: Some(rest.to_owned()),
+        });
+    }
     let (section, relative_path) = match rest.split_once('/') {
-        Some((section, relative_path)) => {
-            validate_section(section)?;
-            (section.to_owned(), Some(relative_path.to_owned()))
-        }
-        None => {
-            validate_section(rest)?;
-            (rest.to_owned(), None)
-        }
+        Some((section, relative_path)) => (section.to_owned(), Some(relative_path.to_owned())),
+        None => (rest.to_owned(), None),
     };
     Ok(WorkbenchPathScope {
         path: path.to_owned(),
@@ -737,7 +763,7 @@ fn compact_list_entry(
         .get("path")
         .and_then(Value::as_str)
         .ok_or_else(|| WorkbenchToolError::new("list entry missing path"))?;
-    let scope = path_scope(options, id, path)?;
+    let scope = enumerated_path_scope(options, id, path)?;
     Ok(json!({
         "name": entry.get("name").cloned().unwrap_or(Value::Null),
         "path": scope.path,
@@ -778,7 +804,7 @@ fn compact_grep_match(
         .get("path")
         .and_then(Value::as_str)
         .ok_or_else(|| WorkbenchToolError::new("grep match missing path"))?;
-    let scope = path_scope(options, id, path)?;
+    let scope = enumerated_path_scope(options, id, path)?;
     Ok(json!({
         "path": scope.path,
         "section": scope.section,
@@ -1316,5 +1342,44 @@ mod tests {
         assert!(validate_workbench_id("spedas-task-001").is_ok());
         assert!(validate_workbench_id("_bad").is_err());
         assert!(validate_workbench_id("bad/path").is_err());
+    }
+
+    #[test]
+    fn scopes_enumerated_paths_outside_sections_as_null_section() {
+        let options = WorkbenchMcpOptions {
+            root: "/workbenches".to_owned(),
+            max_bytes: DEFAULT_WORKBENCH_MAX_BYTES,
+            uid: 1000,
+            gid: 1000,
+        };
+        let scope = |path| enumerated_path_scope(&options, "wb", path).unwrap();
+        assert_eq!(
+            scope("/workbenches/wb/outputs/plot.png"),
+            WorkbenchPathScope {
+                path: "/workbenches/wb/outputs/plot.png".to_owned(),
+                section: Some("outputs".to_owned()),
+                relative_path: Some("plot.png".to_owned()),
+            }
+        );
+        assert_eq!(
+            scope("/workbenches/wb/note.txt"),
+            WorkbenchPathScope {
+                path: "/workbenches/wb/note.txt".to_owned(),
+                section: None,
+                relative_path: Some("note.txt".to_owned()),
+            }
+        );
+        assert_eq!(
+            scope("/workbenches/wb/junk/scratch.txt"),
+            WorkbenchPathScope {
+                path: "/workbenches/wb/junk/scratch.txt".to_owned(),
+                section: None,
+                relative_path: Some("junk/scratch.txt".to_owned()),
+            }
+        );
+        assert!(enumerated_path_scope(&options, "wb", "/elsewhere/file").is_err());
+        // The strict variant used for request targets keeps rejecting.
+        assert!(path_scope(&options, "wb", "/workbenches/wb/junk/scratch.txt").is_err());
+        assert!(path_scope(&options, "wb", "/workbenches/wb/note.txt").is_err());
     }
 }


### PR DESCRIPTION
## Problem

Other NoKV clients share the namespace with the workbench MCP profile and can legitimately write entries outside the five standard sections of a workbench (e.g. `nokv put-artifact` or a FUSE mount). Shaping `ls` entries and `grep` matches through the strict section validation made a single such entry fail the **whole** `workbench_list` / `workbench_grep` call with `invalid section ...`. Since the workbench profile exposes no delete tool, an agent hitting this had no way to recover; the workbench's discovery path stayed broken until an operator intervened with the CLI.

Found during the acceptance review of #387.

## Fix

Path scoping is split into two entry points sharing one core:

- **Strict** (`path_scope`): unchanged behavior, still applied to every request target. The jail is not weakened; out-of-band entries remain unaddressable by `workbench_read`/`workbench_stat`/etc.
- **Enumeration** (`enumerated_path_scope`): used only when shaping `ls` entries and `grep` matches. Entries outside the standard sections are returned with `section: null` and a workbench-relative `relative_path` instead of failing the call, so nothing is silently hidden.

The `workbench_list` / `workbench_grep` tool descriptions document the null-section semantics and note that such entries cannot be addressed by the other workbench tools.

## Testing

- New end-to-end test `workbench_mcp_list_and_grep_tolerate_out_of_band_entries`: writes `note.txt` and `junk/scratch.txt` into a workbench through an out-of-band client, asserts list/grep succeed with correct null-section shapes, standard sections stay scoped, and `workbench_stat` on an out-of-band entry keeps failing (written first, reproduced the exact `invalid section junk` failure before the fix).
- New unit test `scopes_enumerated_paths_outside_sections_as_null_section` pins the strict/enumeration split, including the outside-workbench error path.
- `cargo test --bin nokv`: 59 passed. `cargo fmt --check` / `cargo clippy` clean.
- Live verification against `nokv serve` + RustFS: 40-assertion MCP driver including CLI `put-artifact`/`mkdir` out-of-band writes followed by list/grep over stdio JSON-RPC.