### PR TITLE
feat: add the agent-native Holt runtime as an additive layer (supersedes #386)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1395,10 +1395,15 @@ dependencies = [
 name = "nokv-agent"
 version = "0.1.0"
 dependencies = [
+ "base64",
+ "holt",
  "nokv-meta",
  "nokv-object",
  "nokv-types",
+ "serde",
  "serde_json",
+ "sha2 0.10.9",
+ "tempfile",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1402,6 +1402,7 @@ dependencies = [
  "nokv-types",
  "serde",
  "serde_json",
+ "serde_yaml",
  "sha2 0.10.9",
  "tempfile",
 ]

--- a/crates/nokv-agent/Cargo.toml
+++ b/crates/nokv-agent/Cargo.toml
@@ -7,10 +7,17 @@ license.workspace = true
 authors.workspace = true
 repository.workspace = true
 homepage.workspace = true
-description = "NoKV agent tool surface: transport-free dispatch over the metadata namespace verbs."
+description = "NoKV agent tool surface: transport-free dispatch over the metadata namespace verbs, plus the agent-native Holt-backed runtime."
 
 [dependencies]
+base64.workspace = true
+holt.workspace = true
 nokv-meta.workspace = true
 nokv-object.workspace = true
 nokv-types.workspace = true
+serde.workspace = true
 serde_json.workspace = true
+sha2.workspace = true
+
+[dev-dependencies]
+tempfile.workspace = true

--- a/crates/nokv-agent/Cargo.toml
+++ b/crates/nokv-agent/Cargo.toml
@@ -17,6 +17,7 @@ nokv-object.workspace = true
 nokv-types.workspace = true
 serde.workspace = true
 serde_json.workspace = true
+serde_yaml.workspace = true
 sha2.workspace = true
 
 [dev-dependencies]

--- a/crates/nokv-agent/src/bin/nokv-agent.rs
+++ b/crates/nokv-agent/src/bin/nokv-agent.rs
@@ -1,0 +1,366 @@
+use std::env;
+use std::error::Error;
+use std::fmt;
+use std::fs;
+use std::io::{self, Write};
+use std::path::PathBuf;
+
+use nokv_agent::{
+    normalize_workbench_root, AgentFs, AgentId, HoltAgentStore, WorkbenchMcpOptions,
+    WorkbenchMcpSurface, DEFAULT_WORKBENCH_MAX_BYTES, DEFAULT_WORKBENCH_ROOT,
+};
+
+const DEFAULT_STORE: &str = ".nokv/agent";
+const DEFAULT_AGENT: &str = "default";
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct Config {
+    store: PathBuf,
+    agent: AgentId,
+    command: Command,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+enum Command {
+    Mcp(McpOptions),
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct McpOptions {
+    profile: McpProfile,
+    workbench_root: String,
+    workbench_max_bytes: usize,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum McpProfile {
+    Agent,
+    Workbench,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+enum CliError {
+    Help,
+    MissingValue(&'static str),
+    MissingCommand,
+    UnknownOption(String),
+    UnknownCommand(String),
+    TooManyCommands,
+    InvalidNumber { field: &'static str, value: String },
+    InvalidOption { field: &'static str, value: String },
+    Io(String),
+    Agent(String),
+}
+
+impl fmt::Display for CliError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Help => write!(f, "help requested"),
+            Self::MissingValue(option) => write!(f, "missing value for {option}"),
+            Self::MissingCommand => write!(f, "missing command"),
+            Self::UnknownOption(option) => write!(f, "unknown option {option}"),
+            Self::UnknownCommand(command) => write!(f, "unknown command {command}"),
+            Self::TooManyCommands => write!(f, "too many commands"),
+            Self::InvalidNumber { field, value } => write!(f, "invalid {field}: {value}"),
+            Self::InvalidOption { field, value } => write!(f, "invalid {field}: {value}"),
+            Self::Io(msg) => write!(f, "io error: {msg}"),
+            Self::Agent(msg) => write!(f, "agent error: {msg}"),
+        }
+    }
+}
+
+impl Error for CliError {}
+
+fn main() {
+    match run(env::args().skip(1).collect()) {
+        Ok(()) | Err(CliError::Help) => {}
+        Err(err) => {
+            eprintln!("error: {err}");
+            eprintln!();
+            print_help(&mut io::stderr()).ok();
+            std::process::exit(2);
+        }
+    }
+}
+
+fn run(args: Vec<String>) -> Result<(), CliError> {
+    let config = parse(args)?;
+    match config.command {
+        Command::Mcp(ref options) => run_mcp(&config, options),
+    }
+}
+
+fn parse(args: Vec<String>) -> Result<Config, CliError> {
+    let mut store = PathBuf::from(DEFAULT_STORE);
+    let mut agent = AgentId::new(DEFAULT_AGENT);
+    let mut command = None;
+    let mut index = 0;
+
+    while index < args.len() {
+        match args[index].as_str() {
+            "-h" | "--help" => {
+                print_help(&mut io::stdout()).map_err(from_io)?;
+                return Err(CliError::Help);
+            }
+            "--store" => {
+                index += 1;
+                store = PathBuf::from(value(&args, index, "--store")?);
+                index += 1;
+            }
+            "--agent" => {
+                index += 1;
+                agent = AgentId::new(value(&args, index, "--agent")?);
+                index += 1;
+            }
+            "--profile" => {
+                index += 1;
+                mcp_options_mut(&mut command)?.profile =
+                    parse_mcp_profile(value(&args, index, "--profile")?)?;
+                index += 1;
+            }
+            "--workbench-root" => {
+                index += 1;
+                mcp_options_mut(&mut command)?.workbench_root =
+                    normalize_workbench_root(value(&args, index, "--workbench-root")?).map_err(
+                        |err| CliError::InvalidOption {
+                            field: "workbench-root",
+                            value: err,
+                        },
+                    )?;
+                index += 1;
+            }
+            "--workbench-max-bytes" => {
+                index += 1;
+                mcp_options_mut(&mut command)?.workbench_max_bytes = parse_usize(
+                    value(&args, index, "--workbench-max-bytes")?,
+                    "workbench-max-bytes",
+                )?;
+                index += 1;
+            }
+            option if option.starts_with('-') => {
+                return Err(CliError::UnknownOption(option.into()))
+            }
+            "mcp" => {
+                if command
+                    .replace(Command::Mcp(McpOptions::default()))
+                    .is_some()
+                {
+                    return Err(CliError::TooManyCommands);
+                }
+                index += 1;
+            }
+            other => return Err(CliError::UnknownCommand(other.into())),
+        }
+    }
+
+    let command = command.ok_or(CliError::MissingCommand)?;
+    validate_command(&command)?;
+    Ok(Config {
+        store,
+        agent,
+        command,
+    })
+}
+
+fn mcp_options_mut(command: &mut Option<Command>) -> Result<&mut McpOptions, CliError> {
+    match command {
+        Some(Command::Mcp(options)) => Ok(options),
+        None => Err(CliError::InvalidOption {
+            field: "mcp",
+            value: "mcp options must follow the mcp command".to_owned(),
+        }),
+    }
+}
+
+fn parse_mcp_profile(raw: &str) -> Result<McpProfile, CliError> {
+    match raw {
+        "agent" => Ok(McpProfile::Agent),
+        "workbench" => Ok(McpProfile::Workbench),
+        _ => Err(CliError::InvalidOption {
+            field: "profile",
+            value: raw.to_owned(),
+        }),
+    }
+}
+
+fn validate_command(command: &Command) -> Result<(), CliError> {
+    match command {
+        Command::Mcp(options)
+            if options.profile == McpProfile::Agent
+                && (options.workbench_root != DEFAULT_WORKBENCH_ROOT
+                    || options.workbench_max_bytes != DEFAULT_WORKBENCH_MAX_BYTES) =>
+        {
+            Err(CliError::InvalidOption {
+                field: "profile",
+                value: "workbench options require --profile workbench".to_owned(),
+            })
+        }
+        _ => Ok(()),
+    }
+}
+
+fn value<'a>(args: &'a [String], index: usize, option: &'static str) -> Result<&'a str, CliError> {
+    args.get(index)
+        .map(String::as_str)
+        .ok_or(CliError::MissingValue(option))
+}
+
+fn parse_usize(raw: &str, field: &'static str) -> Result<usize, CliError> {
+    raw.parse::<usize>().map_err(|_| CliError::InvalidNumber {
+        field,
+        value: raw.to_owned(),
+    })
+}
+
+fn run_mcp(config: &Config, options: &McpOptions) -> Result<(), CliError> {
+    fs::create_dir_all(&config.store).map_err(from_io)?;
+    let store = HoltAgentStore::open(&config.store).map_err(from_agent)?;
+    let agent_fs = AgentFs::new(config.agent.clone(), store);
+    agent_fs.bootstrap().map_err(from_agent)?;
+    match options.profile {
+        McpProfile::Agent => nokv_agent::run_mcp(&agent_fs).map_err(from_io),
+        McpProfile::Workbench => {
+            let surface = WorkbenchMcpSurface::new(
+                &agent_fs,
+                WorkbenchMcpOptions {
+                    root: options.workbench_root.clone(),
+                    max_bytes: options.workbench_max_bytes,
+                },
+            );
+            nokv_agent::run_mcp_surface(&surface).map_err(from_io)
+        }
+    }
+}
+
+fn from_io(err: impl Error) -> CliError {
+    CliError::Io(err.to_string())
+}
+
+fn from_agent(err: impl Error) -> CliError {
+    CliError::Agent(err.to_string())
+}
+
+fn print_help(out: &mut impl Write) -> io::Result<()> {
+    writeln!(
+        out,
+        "NoKV agent runtime CLI\n\
+\n\
+Usage:\n\
+  nokv-agent [--store PATH] [--agent ID] mcp [--profile agent|workbench] [--workbench-root PATH] [--workbench-max-bytes BYTES]\n\
+\n\
+Options:\n\
+  --store PATH  Holt-backed agent store directory; default .nokv/agent\n\
+  --agent ID    Agent identity used for tool state; default default\n\
+\n\
+Commands:\n\
+  mcp           Serve an agent-native MCP tool surface over stdio\n"
+    )
+}
+
+impl Default for McpOptions {
+    fn default() -> Self {
+        Self {
+            profile: McpProfile::Agent,
+            workbench_root: DEFAULT_WORKBENCH_ROOT.to_owned(),
+            workbench_max_bytes: DEFAULT_WORKBENCH_MAX_BYTES,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn s(value: &str) -> String {
+        value.to_owned()
+    }
+
+    #[test]
+    fn parse_mcp_defaults() {
+        let parsed = parse(vec![s("mcp")]).unwrap();
+        assert_eq!(parsed.command, Command::Mcp(McpOptions::default()));
+        assert_eq!(parsed.store, PathBuf::from(DEFAULT_STORE));
+        assert_eq!(parsed.agent, AgentId::new(DEFAULT_AGENT));
+    }
+
+    #[test]
+    fn parse_options_before_or_after_command() {
+        let parsed = parse(vec![
+            s("--store"),
+            s("/tmp/agent"),
+            s("mcp"),
+            s("--agent"),
+            s("lingtai"),
+        ])
+        .unwrap();
+        assert_eq!(parsed.store, PathBuf::from("/tmp/agent"));
+        assert_eq!(parsed.agent, AgentId::new("lingtai"));
+    }
+
+    #[test]
+    fn parse_workbench_profile() {
+        let parsed = parse(vec![
+            s("mcp"),
+            s("--profile"),
+            s("workbench"),
+            s("--workbench-root"),
+            s("/agents/work"),
+            s("--workbench-max-bytes"),
+            s("1024"),
+        ])
+        .unwrap();
+        assert_eq!(
+            parsed.command,
+            Command::Mcp(McpOptions {
+                profile: McpProfile::Workbench,
+                workbench_root: "/agents/work".to_owned(),
+                workbench_max_bytes: 1024,
+            })
+        );
+    }
+
+    #[test]
+    fn parse_rejects_bad_invocations() {
+        assert_eq!(parse(vec![]), Err(CliError::MissingCommand));
+        assert_eq!(
+            parse(vec![s("--store")]),
+            Err(CliError::MissingValue("--store"))
+        );
+        assert_eq!(
+            parse(vec![s("--bad")]),
+            Err(CliError::UnknownOption("--bad".to_owned()))
+        );
+        assert_eq!(
+            parse(vec![s("mcp"), s("mcp")]),
+            Err(CliError::TooManyCommands)
+        );
+        assert_eq!(
+            parse(vec![s("--profile"), s("workbench"), s("mcp")]),
+            Err(CliError::InvalidOption {
+                field: "mcp",
+                value: "mcp options must follow the mcp command".to_owned(),
+            })
+        );
+        assert!(matches!(
+            parse(vec![s("mcp"), s("--profile"), s("unknown")]),
+            Err(CliError::InvalidOption {
+                field: "profile",
+                ..
+            })
+        ));
+        assert!(matches!(
+            parse(vec![s("mcp"), s("--workbench-root"), s("/")]),
+            Err(CliError::InvalidOption {
+                field: "workbench-root",
+                ..
+            })
+        ));
+        assert!(matches!(
+            parse(vec![s("mcp"), s("--workbench-root"), s("/agents/work")]),
+            Err(CliError::InvalidOption {
+                field: "profile",
+                ..
+            })
+        ));
+    }
+}

--- a/crates/nokv-agent/src/bin/nokv-agent.rs
+++ b/crates/nokv-agent/src/bin/nokv-agent.rs
@@ -212,9 +212,29 @@ fn parse_usize(raw: &str, field: &'static str) -> Result<usize, CliError> {
     })
 }
 
+// Emitted on stderr only: stdout carries the JSON-RPC stream. The store path
+// must already be canonicalized so hosts see where the cwd-relative default
+// actually landed.
+fn mcp_banner(options: &McpOptions, store: &std::path::Path) -> String {
+    let profile = match options.profile {
+        McpProfile::Agent => "agent",
+        McpProfile::Workbench => "workbench",
+    };
+    let mut banner = format!(
+        "nokv-agent mcp: backend=embedded-holt profile={profile} store={}",
+        store.display()
+    );
+    if options.profile == McpProfile::Workbench {
+        banner.push_str(&format!(" workbench-root={}", options.workbench_root));
+    }
+    banner
+}
+
 fn run_mcp(config: &Config, options: &McpOptions) -> Result<(), CliError> {
     fs::create_dir_all(&config.store).map_err(from_io)?;
     let store = HoltAgentStore::open(&config.store).map_err(from_agent)?;
+    let store_path = fs::canonicalize(&config.store).map_err(from_io)?;
+    eprintln!("{}", mcp_banner(options, &store_path));
     let agent_fs = AgentFs::new(config.agent.clone(), store);
     agent_fs.bootstrap().map_err(from_agent)?;
     match options.profile {
@@ -316,6 +336,26 @@ mod tests {
                 workbench_root: "/agents/work".to_owned(),
                 workbench_max_bytes: 1024,
             })
+        );
+    }
+
+    #[test]
+    fn mcp_banner_reports_backend_profile_and_store() {
+        let store = std::path::Path::new("/abs/store");
+        assert_eq!(
+            mcp_banner(&McpOptions::default(), store),
+            "nokv-agent mcp: backend=embedded-holt profile=agent store=/abs/store"
+        );
+
+        let options = McpOptions {
+            profile: McpProfile::Workbench,
+            workbench_root: "/agents/work".to_owned(),
+            workbench_max_bytes: 1024,
+        };
+        assert_eq!(
+            mcp_banner(&options, store),
+            "nokv-agent mcp: backend=embedded-holt profile=workbench \
+             store=/abs/store workbench-root=/agents/work"
         );
     }
 

--- a/crates/nokv-agent/src/codec.rs
+++ b/crates/nokv-agent/src/codec.rs
@@ -1,0 +1,23 @@
+use serde::de::DeserializeOwned;
+use serde::Serialize;
+
+use crate::{AgentIndexError, AgentIndexResult};
+
+pub(crate) fn encode_json<T: Serialize>(value: &T) -> AgentIndexResult<Vec<u8>> {
+    serde_json::to_vec(value).map_err(|err| AgentIndexError::Codec(err.to_string()))
+}
+
+pub(crate) fn decode_json<T: DeserializeOwned>(bytes: &[u8]) -> AgentIndexResult<T> {
+    serde_json::from_slice(bytes).map_err(|err| AgentIndexError::Codec(err.to_string()))
+}
+
+pub(crate) fn encode_u64(value: u64) -> [u8; 8] {
+    value.to_be_bytes()
+}
+
+pub(crate) fn decode_u64(bytes: &[u8]) -> AgentIndexResult<u64> {
+    let raw: [u8; 8] = bytes
+        .try_into()
+        .map_err(|_| AgentIndexError::Codec("invalid u64 byte length".to_owned()))?;
+    Ok(u64::from_be_bytes(raw))
+}

--- a/crates/nokv-agent/src/error.rs
+++ b/crates/nokv-agent/src/error.rs
@@ -1,0 +1,26 @@
+use std::fmt;
+
+pub type AgentIndexResult<T> = Result<T, AgentIndexError>;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum AgentIndexError {
+    InvalidArgument(String),
+    Store(String),
+    Codec(String),
+    Conflict(String),
+    NotFound(String),
+}
+
+impl fmt::Display for AgentIndexError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::InvalidArgument(msg) => write!(f, "invalid agent index argument: {msg}"),
+            Self::Store(msg) => write!(f, "agent store error: {msg}"),
+            Self::Codec(msg) => write!(f, "agent index codec error: {msg}"),
+            Self::Conflict(msg) => write!(f, "agent index conflict: {msg}"),
+            Self::NotFound(msg) => write!(f, "agent index entry not found: {msg}"),
+        }
+    }
+}
+
+impl std::error::Error for AgentIndexError {}

--- a/crates/nokv-agent/src/error.rs
+++ b/crates/nokv-agent/src/error.rs
@@ -14,7 +14,7 @@ pub enum AgentIndexError {
 impl fmt::Display for AgentIndexError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            Self::InvalidArgument(msg) => write!(f, "invalid agent index argument: {msg}"),
+            Self::InvalidArgument(msg) => write!(f, "invalid agent argument: {msg}"),
             Self::Store(msg) => write!(f, "agent store error: {msg}"),
             Self::Codec(msg) => write!(f, "agent index codec error: {msg}"),
             Self::Conflict(msg) => write!(f, "agent index conflict: {msg}"),

--- a/crates/nokv-agent/src/event.rs
+++ b/crates/nokv-agent/src/event.rs
@@ -1,0 +1,72 @@
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+pub struct AgentId(pub String);
+
+impl AgentId {
+    pub fn new(raw: impl Into<String>) -> Self {
+        Self(raw.into())
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+pub struct EventId(pub u64);
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SourceRef {
+    pub agent_id: AgentId,
+    pub path: String,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct EventRecord {
+    pub agent_id: AgentId,
+    pub id: EventId,
+    pub ts_micros: i64,
+    pub event_type: String,
+    pub source_file: String,
+    pub source_offset: u64,
+    pub fields: Value,
+    pub raw: Value,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct EventBatch {
+    pub source: SourceRef,
+    pub file_size: u64,
+    pub events: Vec<EventRecord>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct IndexCoverage {
+    pub source: SourceRef,
+    pub file_size: u64,
+    pub min_offset: Option<u64>,
+    pub max_offset: Option<u64>,
+    pub row_count: u64,
+}
+
+impl IndexCoverage {
+    pub fn lag_bytes(&self) -> u64 {
+        match self.max_offset {
+            Some(max_offset) => self.file_size.saturating_sub(max_offset),
+            None => self.file_size,
+        }
+    }
+
+    pub fn has_rows(&self) -> bool {
+        self.row_count > 0 && self.min_offset.is_some() && self.max_offset.is_some()
+    }
+
+    pub fn tail_near_eof(&self, slack_bytes: u64) -> bool {
+        self.has_rows() && self.lag_bytes() <= slack_bytes
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct IngestReport {
+    pub inserted: usize,
+    pub skipped: usize,
+    pub coverage: IndexCoverage,
+}

--- a/crates/nokv-agent/src/fs.rs
+++ b/crates/nokv-agent/src/fs.rs
@@ -1,0 +1,445 @@
+use crate::codec::{decode_json, encode_json};
+use crate::key::{
+    body_key, catalog_key, child_key, child_prefix, node_key, node_prefix, row_key, row_prefix,
+};
+use crate::{
+    AgentBatch, AgentId, AgentIndexError, AgentIndexField, AgentIndexRegistration,
+    AgentIndexResult, AgentIndexRow, AgentNode, AgentNodeKind, AgentScanItem, AgentStore,
+    ScanDirection,
+};
+
+#[derive(Clone)]
+pub struct AgentFs<S> {
+    agent_id: AgentId,
+    store: S,
+}
+
+impl<S> AgentFs<S>
+where
+    S: AgentStore,
+{
+    pub fn new(agent_id: AgentId, store: S) -> Self {
+        Self { agent_id, store }
+    }
+
+    pub fn agent_id(&self) -> &AgentId {
+        &self.agent_id
+    }
+
+    pub fn store(&self) -> &S {
+        &self.store
+    }
+
+    pub fn bootstrap(&self) -> AgentIndexResult<()> {
+        if self.node("/")?.is_some() {
+            return Ok(());
+        }
+        let mut batch = AgentBatch::new();
+        put_node(
+            &mut batch,
+            &self.agent_id,
+            AgentNode {
+                path: "/".to_owned(),
+                name: "/".to_owned(),
+                kind: AgentNodeKind::Directory,
+                size_bytes: None,
+                content_type: None,
+            },
+        )?;
+        self.store.apply(batch)?;
+        Ok(())
+    }
+
+    pub fn create_dir_all(&self, path: &str) -> AgentIndexResult<()> {
+        let path = normalize_path(path)?;
+        let mut batch = AgentBatch::new();
+        self.add_directory_ancestors(&mut batch, &path)?;
+        self.store.apply(batch)?;
+        Ok(())
+    }
+
+    pub fn put_file(
+        &self,
+        path: &str,
+        bytes: Vec<u8>,
+        content_type: impl Into<Option<String>>,
+    ) -> AgentIndexResult<()> {
+        let path = normalize_path(path)?;
+        if let Some(existing) = self.node(&path)? {
+            if existing.kind != AgentNodeKind::File {
+                return Err(AgentIndexError::InvalidArgument(format!(
+                    "path exists but is not a file: {path}"
+                )));
+            }
+        }
+        let parent = parent_path(&path)?;
+        let name = path_name(&path)?;
+        let mut batch = AgentBatch::new();
+        self.add_directory_ancestors(&mut batch, &parent)?;
+        put_node(
+            &mut batch,
+            &self.agent_id,
+            AgentNode {
+                path: path.clone(),
+                name: name.clone(),
+                kind: AgentNodeKind::File,
+                size_bytes: Some(bytes.len() as u64),
+                content_type: content_type.into(),
+            },
+        )?;
+        batch.put(child_key(&self.agent_id, &parent, &name), path.as_bytes());
+        batch.put(body_key(&self.agent_id, &path), bytes);
+        self.store.apply(batch)?;
+        Ok(())
+    }
+
+    pub fn register_index(&self, registration: AgentIndexRegistration) -> AgentIndexResult<()> {
+        let root = normalize_path(&registration.path)?;
+        let mut batch = AgentBatch::new();
+        batch.put(
+            catalog_key(&self.agent_id, &root),
+            encode_json(&registration.fields)?,
+        );
+        for row in registration.rows {
+            let path = normalize_path(&row.path)?;
+            batch.put(row_key(&self.agent_id, &root, &path), encode_json(&row)?);
+        }
+        self.store.apply(batch)?;
+        Ok(())
+    }
+
+    pub fn node(&self, path: &str) -> AgentIndexResult<Option<AgentNode>> {
+        let path = normalize_path(path)?;
+        self.store
+            .get(&node_key(&self.agent_id, &path))?
+            .map(|bytes| decode_json(&bytes))
+            .transpose()
+    }
+
+    pub fn read_file(&self, path: &str) -> AgentIndexResult<Vec<u8>> {
+        let path = normalize_path(path)?;
+        let Some(node) = self.node(&path)? else {
+            return Err(AgentIndexError::NotFound(path));
+        };
+        if node.kind != AgentNodeKind::File {
+            return Err(AgentIndexError::InvalidArgument(format!(
+                "{path} is not a file"
+            )));
+        }
+        self.store
+            .get(&body_key(&self.agent_id, &path))?
+            .ok_or(AgentIndexError::NotFound(path))
+    }
+
+    pub fn list(
+        &self,
+        path: &str,
+        cursor: Option<&[u8]>,
+        limit: usize,
+    ) -> AgentIndexResult<(Vec<AgentNode>, Option<Vec<u8>>, bool)> {
+        let path = normalize_path(path)?;
+        let Some(node) = self.node(&path)? else {
+            return Err(AgentIndexError::NotFound(path));
+        };
+        if node.kind != AgentNodeKind::Directory {
+            return Err(AgentIndexError::InvalidArgument(format!(
+                "{path} is not a directory"
+            )));
+        }
+        let page = self.store.scan(
+            &child_prefix(&self.agent_id, &path),
+            cursor,
+            limit,
+            ScanDirection::Asc,
+        )?;
+        let mut nodes = Vec::new();
+        for item in &page.items {
+            let child_path = String::from_utf8(item.value.clone())
+                .map_err(|err| AgentIndexError::Codec(err.to_string()))?;
+            if let Some(child) = self.node(&child_path)? {
+                nodes.push(child);
+            }
+        }
+        Ok((nodes, page.next_cursor, page.truncated))
+    }
+
+    pub fn catalog(&self, root: &str) -> AgentIndexResult<Vec<AgentIndexField>> {
+        let root = normalize_path(root)?;
+        Ok(self
+            .store
+            .get(&catalog_key(&self.agent_id, &root))?
+            .map(|bytes| decode_json(&bytes))
+            .transpose()?
+            .unwrap_or_default())
+    }
+
+    pub fn index_rows(&self, root: &str) -> AgentIndexResult<Vec<AgentIndexRow>> {
+        let root = normalize_path(root)?;
+        let page = self.scan_all(&row_prefix(&self.agent_id, &root))?;
+        page.into_iter()
+            .map(|item| decode_json(&item.value))
+            .collect()
+    }
+
+    pub fn files_under(&self, path: &str, recursive: bool) -> AgentIndexResult<Vec<AgentNode>> {
+        let path = normalize_path(path)?;
+        let Some(node) = self.node(&path)? else {
+            return Err(AgentIndexError::NotFound(path));
+        };
+        if node.kind == AgentNodeKind::File {
+            return Ok(vec![node]);
+        }
+        if !recursive {
+            return Ok(self
+                .list(&path, None, usize::MAX)?
+                .0
+                .into_iter()
+                .filter(|node| node.kind == AgentNodeKind::File)
+                .collect());
+        }
+        let child_prefix = if path == "/" {
+            "/".to_owned()
+        } else {
+            format!("{path}/")
+        };
+        Ok(self
+            .scan_all(&node_prefix(&self.agent_id))?
+            .into_iter()
+            .filter_map(|item| decode_json::<AgentNode>(&item.value).ok())
+            .filter(|node| {
+                node.kind == AgentNodeKind::File
+                    && (node.path == path || node.path.starts_with(child_prefix.as_str()))
+            })
+            .collect())
+    }
+
+    /// Stage directory nodes for every missing ancestor of `path`.
+    ///
+    /// Components that already exist as directories are left untouched;
+    /// a component that exists as anything else fails the whole call so a
+    /// file is never silently converted into a directory. Checks read
+    /// committed store state: the store is single-writer, so a staged
+    /// batch cannot race its own precondition.
+    fn add_directory_ancestors(&self, batch: &mut AgentBatch, path: &str) -> AgentIndexResult<()> {
+        let path = normalize_path(path)?;
+        let mut current = String::from("/");
+        if self.node(&current)?.is_none() {
+            put_node(
+                batch,
+                &self.agent_id,
+                AgentNode {
+                    path: current.clone(),
+                    name: "/".to_owned(),
+                    kind: AgentNodeKind::Directory,
+                    size_bytes: None,
+                    content_type: None,
+                },
+            )?;
+        }
+        for part in path
+            .trim_matches('/')
+            .split('/')
+            .filter(|part| !part.is_empty())
+        {
+            let parent = current.clone();
+            current = if current == "/" {
+                format!("/{part}")
+            } else {
+                format!("{current}/{part}")
+            };
+            match self.node(&current)? {
+                Some(existing) if existing.kind == AgentNodeKind::Directory => {}
+                Some(_) => {
+                    return Err(AgentIndexError::InvalidArgument(format!(
+                        "path exists but is not a directory: {current}"
+                    )))
+                }
+                None => {
+                    put_node(
+                        batch,
+                        &self.agent_id,
+                        AgentNode {
+                            path: current.clone(),
+                            name: part.to_owned(),
+                            kind: AgentNodeKind::Directory,
+                            size_bytes: None,
+                            content_type: None,
+                        },
+                    )?;
+                    batch.put(child_key(&self.agent_id, &parent, part), current.as_bytes());
+                }
+            }
+        }
+        Ok(())
+    }
+
+    fn scan_all(&self, prefix: &[u8]) -> AgentIndexResult<Vec<AgentScanItem>> {
+        let mut cursor = None;
+        let mut out = Vec::new();
+        loop {
+            let page = self
+                .store
+                .scan(prefix, cursor.as_deref(), 512, ScanDirection::Asc)?;
+            out.extend(page.items);
+            if !page.truncated {
+                return Ok(out);
+            }
+            cursor = page.next_cursor;
+        }
+    }
+}
+
+fn put_node(batch: &mut AgentBatch, agent_id: &AgentId, node: AgentNode) -> AgentIndexResult<()> {
+    batch.put(node_key(agent_id, &node.path), encode_json(&node)?);
+    Ok(())
+}
+
+pub(crate) fn normalize_path(path: &str) -> AgentIndexResult<String> {
+    if path.is_empty() || !path.starts_with('/') {
+        return Err(AgentIndexError::InvalidArgument(format!(
+            "agent path must be absolute: {path}"
+        )));
+    }
+    let mut parts = Vec::new();
+    for part in path.split('/') {
+        if part.is_empty() {
+            continue;
+        }
+        if part == "." || part == ".." {
+            return Err(AgentIndexError::InvalidArgument(format!(
+                "agent path must not contain relative components: {path}"
+            )));
+        }
+        parts.push(part);
+    }
+    if parts.is_empty() {
+        Ok("/".to_owned())
+    } else {
+        Ok(format!("/{}", parts.join("/")))
+    }
+}
+
+pub(crate) fn parent_path(path: &str) -> AgentIndexResult<String> {
+    let path = normalize_path(path)?;
+    if path == "/" {
+        return Err(AgentIndexError::InvalidArgument(
+            "root path has no parent".to_owned(),
+        ));
+    }
+    match path.rsplit_once('/') {
+        Some(("", _)) => Ok("/".to_owned()),
+        Some((parent, _)) => Ok(parent.to_owned()),
+        None => Err(AgentIndexError::InvalidArgument(format!(
+            "invalid path {path}"
+        ))),
+    }
+}
+
+pub(crate) fn path_name(path: &str) -> AgentIndexResult<String> {
+    let path = normalize_path(path)?;
+    if path == "/" {
+        return Ok("/".to_owned());
+    }
+    path.rsplit('/')
+        .next()
+        .filter(|name| !name.is_empty())
+        .map(str::to_owned)
+        .ok_or_else(|| AgentIndexError::InvalidArgument(format!("invalid path {path}")))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::HoltAgentStore;
+
+    fn fs() -> AgentFs<HoltAgentStore> {
+        let fs = AgentFs::new(
+            AgentId::new("fs-test"),
+            HoltAgentStore::open_memory().unwrap(),
+        );
+        fs.bootstrap().unwrap();
+        fs
+    }
+
+    #[test]
+    fn put_file_rejects_existing_directory_target() {
+        let fs = fs();
+        fs.create_dir_all("/w/input/dir").unwrap();
+        fs.put_file("/w/input/dir/child.txt", b"child".to_vec(), None)
+            .unwrap();
+
+        let err = fs
+            .put_file("/w/input/dir", b"x".to_vec(), None)
+            .unwrap_err();
+
+        assert!(
+            matches!(err, AgentIndexError::InvalidArgument(ref message) if message.contains("is not a file")),
+            "unexpected error: {err:?}"
+        );
+        let (children, _, _) = fs.list("/w/input/dir", None, 10).unwrap();
+        assert_eq!(children.len(), 1, "directory subtree must stay intact");
+    }
+
+    #[test]
+    fn put_file_rejects_file_ancestor() {
+        let fs = fs();
+        fs.put_file("/w/input/a", b"body".to_vec(), None).unwrap();
+
+        let err = fs
+            .put_file("/w/input/a/b.txt", b"x".to_vec(), None)
+            .unwrap_err();
+
+        assert!(
+            matches!(err, AgentIndexError::InvalidArgument(ref message) if message.contains("is not a directory")),
+            "unexpected error: {err:?}"
+        );
+        assert_eq!(
+            fs.read_file("/w/input/a").unwrap(),
+            b"body".to_vec(),
+            "original file body must stay readable"
+        );
+    }
+
+    #[test]
+    fn create_dir_all_rejects_file_component() {
+        let fs = fs();
+        fs.put_file("/w/f", b"body".to_vec(), None).unwrap();
+
+        let nested = fs.create_dir_all("/w/f/sub").unwrap_err();
+        assert!(
+            matches!(nested, AgentIndexError::InvalidArgument(ref message) if message.contains("is not a directory")),
+            "unexpected error: {nested:?}"
+        );
+        let direct = fs.create_dir_all("/w/f").unwrap_err();
+        assert!(
+            matches!(direct, AgentIndexError::InvalidArgument(ref message) if message.contains("is not a directory")),
+            "unexpected error: {direct:?}"
+        );
+        assert_eq!(fs.read_file("/w/f").unwrap(), b"body".to_vec());
+    }
+
+    #[test]
+    fn put_file_replaces_existing_file() {
+        let fs = fs();
+        fs.put_file("/w/f", b"old".to_vec(), None).unwrap();
+        fs.put_file("/w/f", b"new".to_vec(), None).unwrap();
+        assert_eq!(fs.read_file("/w/f").unwrap(), b"new".to_vec());
+    }
+
+    #[test]
+    fn files_under_root_recursive_finds_files() {
+        let fs = fs();
+        fs.put_file("/a/b.txt", b"1".to_vec(), None).unwrap();
+        fs.put_file("/c.txt", b"2".to_vec(), None).unwrap();
+
+        let mut paths = fs
+            .files_under("/", true)
+            .unwrap()
+            .into_iter()
+            .map(|node| node.path)
+            .collect::<Vec<_>>();
+        paths.sort();
+
+        assert_eq!(paths, vec!["/a/b.txt".to_owned(), "/c.txt".to_owned()]);
+    }
+}

--- a/crates/nokv-agent/src/holt.rs
+++ b/crates/nokv-agent/src/holt.rs
@@ -1,0 +1,194 @@
+use std::path::Path;
+
+use holt::{RangeEntry, Tree, TreeConfig};
+
+use crate::store::validate_scan_limit;
+use crate::{
+    AgentBatch, AgentCommit, AgentIndexError, AgentIndexResult, AgentMutation, AgentScanItem,
+    AgentScanPage, AgentStore, ScanDirection,
+};
+
+#[derive(Clone)]
+pub struct HoltAgentStore {
+    tree: Tree,
+}
+
+impl HoltAgentStore {
+    pub fn open(path: impl AsRef<Path>) -> AgentIndexResult<Self> {
+        Self::open_with_config(TreeConfig::new(path.as_ref()))
+    }
+
+    pub fn open_with_config(config: TreeConfig) -> AgentIndexResult<Self> {
+        let tree = Tree::open(config).map_err(store_error)?;
+        Ok(Self { tree })
+    }
+
+    #[cfg(test)]
+    pub(crate) fn open_memory() -> AgentIndexResult<Self> {
+        Self::open_with_config(TreeConfig::memory())
+    }
+
+    pub fn checkpoint(&self) -> AgentIndexResult<()> {
+        self.tree.checkpoint().map_err(store_error)
+    }
+}
+
+impl AgentStore for HoltAgentStore {
+    fn get(&self, key: &[u8]) -> AgentIndexResult<Option<Vec<u8>>> {
+        self.tree.get(key).map_err(store_error)
+    }
+
+    fn scan(
+        &self,
+        prefix: &[u8],
+        cursor: Option<&[u8]>,
+        limit: usize,
+        direction: ScanDirection,
+    ) -> AgentIndexResult<AgentScanPage> {
+        validate_scan_limit(limit)?;
+        match direction {
+            ScanDirection::Asc => self.scan_asc(prefix, cursor, limit),
+            ScanDirection::Desc => self.scan_desc(prefix, cursor, limit),
+        }
+    }
+
+    fn apply(&self, batch: AgentBatch) -> AgentIndexResult<AgentCommit> {
+        let mutation_count = batch.len();
+        let committed = self
+            .tree
+            .atomic(|holt_batch| {
+                for mutation in batch.into_mutations() {
+                    match mutation {
+                        AgentMutation::Put { key, value } => holt_batch.put(&key, &value),
+                        AgentMutation::Delete { key } => holt_batch.delete(&key),
+                    }
+                }
+            })
+            .map_err(store_error)?;
+        if !committed {
+            return Err(AgentIndexError::Conflict(
+                "holt rejected agent index batch".to_owned(),
+            ));
+        }
+        Ok(AgentCommit { mutation_count })
+    }
+}
+
+impl HoltAgentStore {
+    fn scan_asc(
+        &self,
+        prefix: &[u8],
+        cursor: Option<&[u8]>,
+        limit: usize,
+    ) -> AgentIndexResult<AgentScanPage> {
+        let mut builder = self.tree.scan(prefix);
+        if let Some(cursor) = cursor {
+            builder = builder.start_after(cursor);
+        }
+        let mut items = Vec::new();
+        let mut next_cursor = None;
+        for entry in builder {
+            let RangeEntry::Key { key, value, .. } = entry.map_err(store_error)? else {
+                continue;
+            };
+            if items.len() == limit {
+                next_cursor = items.last().map(|item: &AgentScanItem| item.key.clone());
+                break;
+            }
+            items.push(AgentScanItem { key, value });
+        }
+        Ok(AgentScanPage {
+            truncated: next_cursor.is_some(),
+            items,
+            next_cursor,
+        })
+    }
+
+    fn scan_desc(
+        &self,
+        prefix: &[u8],
+        cursor: Option<&[u8]>,
+        limit: usize,
+    ) -> AgentIndexResult<AgentScanPage> {
+        let mut all = Vec::new();
+        for entry in self.tree.scan(prefix) {
+            let RangeEntry::Key { key, value, .. } = entry.map_err(store_error)? else {
+                continue;
+            };
+            all.push(AgentScanItem { key, value });
+        }
+
+        let mut items = Vec::new();
+        let mut next_cursor = None;
+        for item in all.into_iter().rev() {
+            if cursor.is_some_and(|cursor| item.key.as_slice() >= cursor) {
+                continue;
+            }
+            if items.len() == limit {
+                next_cursor = items.last().map(|item: &AgentScanItem| item.key.clone());
+                break;
+            }
+            items.push(item);
+        }
+        Ok(AgentScanPage {
+            truncated: next_cursor.is_some(),
+            items,
+            next_cursor,
+        })
+    }
+}
+
+fn store_error(err: holt::Error) -> AgentIndexError {
+    AgentIndexError::Store(err.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn keys(page: &AgentScanPage) -> Vec<String> {
+        page.items
+            .iter()
+            .map(|item| String::from_utf8_lossy(&item.key).to_string())
+            .collect()
+    }
+
+    #[test]
+    fn scans_prefix_in_both_directions() {
+        let store = HoltAgentStore::open_memory().unwrap();
+        let mut batch = AgentBatch::new();
+        batch.put(b"a/001".to_vec(), b"one".to_vec());
+        batch.put(b"a/002".to_vec(), b"two".to_vec());
+        batch.put(b"b/001".to_vec(), b"other".to_vec());
+        store.apply(batch).unwrap();
+
+        let asc = store.scan(b"a/", None, 10, ScanDirection::Asc).unwrap();
+        assert_eq!(keys(&asc), vec!["a/001", "a/002"]);
+
+        let desc = store.scan(b"a/", None, 10, ScanDirection::Desc).unwrap();
+        assert_eq!(keys(&desc), vec!["a/002", "a/001"]);
+    }
+
+    #[test]
+    fn persists_committed_batch_after_reopen() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("agent-index");
+        {
+            let store = HoltAgentStore::open(&path).unwrap();
+            let mut batch = AgentBatch::new();
+            batch.put(b"event/a/00000000000000000001".to_vec(), b"one".to_vec());
+            batch.put(b"event/a/00000000000000000002".to_vec(), b"two".to_vec());
+            assert_eq!(store.apply(batch).unwrap().mutation_count, 2);
+            store.checkpoint().unwrap();
+        }
+
+        let reopened = HoltAgentStore::open(&path).unwrap();
+        assert_eq!(
+            reopened
+                .get(b"event/a/00000000000000000001")
+                .unwrap()
+                .as_deref(),
+            Some(b"one".as_slice())
+        );
+    }
+}

--- a/crates/nokv-agent/src/index.rs
+++ b/crates/nokv-agent/src/index.rs
@@ -1,0 +1,529 @@
+use std::collections::BTreeMap;
+
+use crate::codec::{decode_json, decode_u64, encode_json, encode_u64};
+use crate::key::{
+    coverage_key, decode_cursor, encode_cursor, event_key, event_prefix, source_key, type_id_key,
+    type_id_prefix, type_ts_key, type_ts_prefix,
+};
+use crate::{
+    AgentBatch, AgentId, AgentIndexError, AgentIndexResult, AgentStore, EventBatch, EventId,
+    EventOrder, EventPage, EventQuery, EventRecord, IndexCoverage, IngestReport, ScanDirection,
+    SourceRef,
+};
+
+#[derive(Clone)]
+pub struct AgentEventIndex<S> {
+    store: S,
+}
+
+impl<S> AgentEventIndex<S>
+where
+    S: AgentStore,
+{
+    pub fn new(store: S) -> Self {
+        Self { store }
+    }
+
+    pub fn store(&self) -> &S {
+        &self.store
+    }
+
+    pub fn ingest_events(&self, batch: EventBatch) -> AgentIndexResult<IngestReport> {
+        validate_batch(&batch)?;
+        let mut mutation_batch = AgentBatch::new();
+        let mut inserted = 0_usize;
+        let mut skipped = 0_usize;
+        let mut staged_offsets: BTreeMap<u64, u64> = BTreeMap::new();
+
+        for event in &batch.events {
+            if let Some(&staged_id) = staged_offsets.get(&event.source_offset) {
+                if staged_id != event.id.0 {
+                    return Err(AgentIndexError::Conflict(format!(
+                        "source offset {} already maps to event {}",
+                        event.source_offset, staged_id
+                    )));
+                }
+                skipped += 1;
+                continue;
+            }
+            let source_key = source_key(&event.agent_id, &event.source_file, event.source_offset);
+            if let Some(existing) = self.store.get(&source_key)? {
+                let existing_id = decode_u64(&existing)?;
+                if existing_id != event.id.0 {
+                    return Err(AgentIndexError::Conflict(format!(
+                        "source offset {} already maps to event {}",
+                        event.source_offset, existing_id
+                    )));
+                }
+                staged_offsets.insert(event.source_offset, existing_id);
+                skipped += 1;
+                continue;
+            }
+            mutation_batch.put(event_key(&event.agent_id, event.id), encode_json(event)?);
+            mutation_batch.put(source_key, encode_u64(event.id.0).to_vec());
+            mutation_batch.put(
+                type_id_key(&event.agent_id, &event.event_type, event.id),
+                encode_u64(event.id.0).to_vec(),
+            );
+            mutation_batch.put(
+                type_ts_key(
+                    &event.agent_id,
+                    &event.event_type,
+                    event.ts_micros,
+                    event.id,
+                ),
+                encode_u64(event.id.0).to_vec(),
+            );
+            staged_offsets.insert(event.source_offset, event.id.0);
+            inserted += 1;
+        }
+
+        let coverage = self.next_coverage(&batch, inserted as u64)?;
+        mutation_batch.put(
+            coverage_key(&batch.source.agent_id, &batch.source.path),
+            encode_json(&coverage)?,
+        );
+        self.store.apply(mutation_batch)?;
+
+        Ok(IngestReport {
+            inserted,
+            skipped,
+            coverage,
+        })
+    }
+
+    pub fn query_events(&self, request: EventQuery) -> AgentIndexResult<EventPage> {
+        if request.limit == 0 {
+            return Err(AgentIndexError::InvalidArgument(
+                "event query limit must be greater than zero".to_owned(),
+            ));
+        }
+        if request.event_types.len() > 1 && request.cursor.is_some() {
+            return Err(AgentIndexError::InvalidArgument(
+                "cursor pagination over multiple event types is not supported yet".to_owned(),
+            ));
+        }
+
+        let cursor = match request.cursor.as_deref() {
+            Some(raw) => Some(decode_cursor(raw).ok_or_else(|| {
+                AgentIndexError::InvalidArgument("invalid event cursor".to_owned())
+            })?),
+            None => None,
+        };
+
+        if request.event_types.len() > 1 {
+            return self.query_multiple_types(&request);
+        }
+
+        if request.event_types.is_empty() {
+            return self.query_all_events(&request, cursor.as_deref());
+        }
+
+        let (prefix, direction) = query_scan_prefix(&request.agent_id, &request)?;
+        let page = self
+            .store
+            .scan(&prefix, cursor.as_deref(), request.limit, direction)?;
+        let mut events = Vec::new();
+        for item in &page.items {
+            let event_id = decode_u64(&item.value)?;
+            let Some(event) = self.read_event(&request.agent_id, EventId(event_id))? else {
+                continue;
+            };
+            if event.agent_id != request.agent_id {
+                continue;
+            }
+            if source_offset_matches(&event, request.source_offset_min) {
+                events.push(event);
+            }
+        }
+        Ok(EventPage {
+            events,
+            next_cursor: page.next_cursor.as_deref().map(encode_cursor),
+            truncated: page.truncated,
+        })
+    }
+
+    pub fn read_event(
+        &self,
+        agent_id: &AgentId,
+        id: EventId,
+    ) -> AgentIndexResult<Option<EventRecord>> {
+        self.store
+            .get(&event_key(agent_id, id))?
+            .map(|bytes| decode_json(&bytes))
+            .transpose()
+    }
+
+    pub fn coverage(&self, source: &SourceRef) -> AgentIndexResult<Option<IndexCoverage>> {
+        self.store
+            .get(&coverage_key(&source.agent_id, &source.path))?
+            .map(|bytes| decode_json(&bytes))
+            .transpose()
+    }
+
+    fn next_coverage(&self, batch: &EventBatch, inserted: u64) -> AgentIndexResult<IndexCoverage> {
+        let current = self.coverage(&batch.source)?;
+        let mut coverage = current.unwrap_or_else(|| IndexCoverage {
+            source: batch.source.clone(),
+            file_size: 0,
+            min_offset: None,
+            max_offset: None,
+            row_count: 0,
+        });
+        // Advance-only: replaying an already-ingested batch must never make
+        // coverage claim a shorter source file than previously observed.
+        coverage.file_size = coverage.file_size.max(batch.file_size);
+        for event in &batch.events {
+            coverage.min_offset = Some(
+                coverage
+                    .min_offset
+                    .map(|offset| offset.min(event.source_offset))
+                    .unwrap_or(event.source_offset),
+            );
+            coverage.max_offset = Some(
+                coverage
+                    .max_offset
+                    .map(|offset| offset.max(event.source_offset))
+                    .unwrap_or(event.source_offset),
+            );
+        }
+        coverage.row_count = coverage.row_count.saturating_add(inserted);
+        Ok(coverage)
+    }
+
+    fn query_all_events(
+        &self,
+        request: &EventQuery,
+        cursor: Option<&[u8]>,
+    ) -> AgentIndexResult<EventPage> {
+        let direction = match request.order {
+            EventOrder::IdAsc => ScanDirection::Asc,
+            EventOrder::IdDesc => ScanDirection::Desc,
+            EventOrder::TsDesc => {
+                return Err(AgentIndexError::InvalidArgument(
+                    "global timestamp-desc event queries require an event type".to_owned(),
+                ))
+            }
+        };
+        let page = self.store.scan(
+            &event_prefix(&request.agent_id),
+            cursor,
+            request.limit,
+            direction,
+        )?;
+        let mut events = Vec::new();
+        for item in &page.items {
+            let event: EventRecord = decode_json(&item.value)?;
+            if source_offset_matches(&event, request.source_offset_min) {
+                events.push(event);
+            }
+        }
+        Ok(EventPage {
+            events,
+            next_cursor: page.next_cursor.as_deref().map(encode_cursor),
+            truncated: page.truncated,
+        })
+    }
+
+    fn query_multiple_types(&self, request: &EventQuery) -> AgentIndexResult<EventPage> {
+        let mut events = Vec::new();
+        for event_type in &request.event_types {
+            let subquery = EventQuery {
+                agent_id: request.agent_id.clone(),
+                event_types: vec![event_type.clone()],
+                source_offset_min: request.source_offset_min,
+                order: request.order,
+                limit: request.limit,
+                cursor: None,
+            };
+            events.extend(self.query_events(subquery)?.events);
+        }
+        sort_events(&mut events, request.order);
+        events.truncate(request.limit);
+        Ok(EventPage {
+            events,
+            next_cursor: None,
+            truncated: false,
+        })
+    }
+}
+
+fn validate_batch(batch: &EventBatch) -> AgentIndexResult<()> {
+    for event in &batch.events {
+        if event.agent_id != batch.source.agent_id {
+            return Err(AgentIndexError::InvalidArgument(format!(
+                "event {} belongs to agent {}, not {}",
+                event.id.0, event.agent_id.0, batch.source.agent_id.0
+            )));
+        }
+        if event.source_file != batch.source.path {
+            return Err(AgentIndexError::InvalidArgument(format!(
+                "event {} source {} does not match batch source {}",
+                event.id.0, event.source_file, batch.source.path
+            )));
+        }
+        if event.ts_micros < 0 {
+            return Err(AgentIndexError::InvalidArgument(format!(
+                "event {} has negative ts_micros {}",
+                event.id.0, event.ts_micros
+            )));
+        }
+    }
+    Ok(())
+}
+
+fn query_scan_prefix(
+    agent_id: &AgentId,
+    request: &EventQuery,
+) -> AgentIndexResult<(Vec<u8>, ScanDirection)> {
+    let event_type = request.event_types.first().ok_or_else(|| {
+        AgentIndexError::InvalidArgument("event type is required for typed index scan".to_owned())
+    })?;
+    let scan = match request.order {
+        EventOrder::TsDesc => (type_ts_prefix(agent_id, event_type), ScanDirection::Asc),
+        EventOrder::IdAsc => (type_id_prefix(agent_id, event_type), ScanDirection::Asc),
+        EventOrder::IdDesc => (type_id_prefix(agent_id, event_type), ScanDirection::Desc),
+    };
+    Ok(scan)
+}
+
+#[cfg(test)]
+fn query_ids(index: &AgentEventIndex<crate::HoltAgentStore>, query: EventQuery) -> Vec<u64> {
+    index
+        .query_events(query)
+        .unwrap()
+        .events
+        .iter()
+        .map(|event| event.id.0)
+        .collect()
+}
+
+fn source_offset_matches(event: &EventRecord, source_offset_min: Option<u64>) -> bool {
+    source_offset_min.is_none_or(|min_offset| event.source_offset >= min_offset)
+}
+
+fn sort_events(events: &mut [EventRecord], order: EventOrder) {
+    match order {
+        EventOrder::IdAsc => events.sort_by_key(|event| event.id),
+        EventOrder::IdDesc => events.sort_by_key(|event| std::cmp::Reverse(event.id)),
+        EventOrder::TsDesc => events.sort_by_key(|event| {
+            (
+                std::cmp::Reverse(event.ts_micros),
+                std::cmp::Reverse(event.id),
+            )
+        }),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+
+    use super::*;
+    use crate::HoltAgentStore;
+
+    fn record(id: u64, event_type: &str, ts_micros: i64, source_offset: u64) -> EventRecord {
+        EventRecord {
+            agent_id: AgentId::new("agent-a"),
+            id: EventId(id),
+            ts_micros,
+            event_type: event_type.to_owned(),
+            source_file: "logs/events.jsonl".to_owned(),
+            source_offset,
+            fields: json!({"type": event_type}),
+            raw: json!({"type": event_type}),
+        }
+    }
+
+    fn batch(events: Vec<EventRecord>) -> EventBatch {
+        EventBatch {
+            source: SourceRef {
+                agent_id: AgentId::new("agent-a"),
+                path: "logs/events.jsonl".to_owned(),
+            },
+            file_size: 4096,
+            events,
+        }
+    }
+
+    fn index() -> AgentEventIndex<HoltAgentStore> {
+        AgentEventIndex::new(HoltAgentStore::open_memory().unwrap())
+    }
+
+    #[test]
+    fn ingest_is_idempotent_by_source_offset() {
+        let index = index();
+        let first = index
+            .ingest_events(batch(vec![record(1, "thinking", 10, 0)]))
+            .unwrap();
+        let second = index
+            .ingest_events(batch(vec![record(1, "thinking", 10, 0)]))
+            .unwrap();
+
+        assert_eq!(first.inserted, 1);
+        assert_eq!(second.inserted, 0);
+        assert_eq!(second.skipped, 1);
+        assert_eq!(second.coverage.row_count, 1);
+    }
+
+    #[test]
+    fn queries_single_type_by_newest_timestamp() {
+        let index = index();
+        index
+            .ingest_events(batch(vec![
+                record(1, "thinking", 10, 0),
+                record(2, "tool_call", 20, 100),
+                record(3, "thinking", 30, 200),
+            ]))
+            .unwrap();
+
+        let mut query = EventQuery::new(AgentId::new("agent-a"));
+        query.event_types = vec!["thinking".to_owned()];
+        query.order = EventOrder::TsDesc;
+        query.limit = 10;
+        assert_eq!(query_ids(&index, query), vec![3, 1]);
+    }
+
+    #[test]
+    fn queries_all_events_by_event_id() {
+        let index = index();
+        index
+            .ingest_events(batch(vec![
+                record(1, "thinking", 10, 0),
+                record(2, "tool_call", 20, 100),
+                record(3, "thinking", 30, 200),
+            ]))
+            .unwrap();
+
+        let mut query = EventQuery::new(AgentId::new("agent-a"));
+        query.order = EventOrder::IdDesc;
+        query.limit = 10;
+
+        assert_eq!(query_ids(&index, query), vec![3, 2, 1]);
+    }
+
+    #[test]
+    fn coverage_tracks_source_offsets() {
+        let index = index();
+        let report = index
+            .ingest_events(batch(vec![
+                record(1, "thinking", 10, 64),
+                record(2, "thinking", 20, 128),
+            ]))
+            .unwrap();
+
+        assert_eq!(report.coverage.min_offset, Some(64));
+        assert_eq!(report.coverage.max_offset, Some(128));
+        assert_eq!(report.coverage.row_count, 2);
+        assert_eq!(report.coverage.lag_bytes(), 3968);
+    }
+
+    #[test]
+    fn ingest_skips_duplicate_offsets_within_batch() {
+        let index = index();
+        let report = index
+            .ingest_events(batch(vec![
+                record(1, "thinking", 10, 0),
+                record(1, "thinking", 10, 0),
+            ]))
+            .unwrap();
+        assert_eq!(report.inserted, 1);
+        assert_eq!(report.skipped, 1);
+
+        let replay = index
+            .ingest_events(batch(vec![
+                record(1, "thinking", 10, 0),
+                record(1, "thinking", 10, 0),
+            ]))
+            .unwrap();
+        assert_eq!(replay.inserted, 0);
+        assert_eq!(replay.skipped, 2);
+
+        let page = index
+            .query_events(EventQuery {
+                agent_id: AgentId::new("agent-a"),
+                event_types: vec!["thinking".to_owned()],
+                source_offset_min: None,
+                order: EventOrder::IdAsc,
+                limit: 10,
+                cursor: None,
+            })
+            .unwrap();
+        assert_eq!(
+            page.events.len(),
+            1,
+            "duplicate offset must not double-write"
+        );
+    }
+
+    #[test]
+    fn ingest_rejects_conflicting_duplicate_offset_within_batch() {
+        let index = index();
+        let err = index
+            .ingest_events(batch(vec![
+                record(1, "thinking", 10, 0),
+                record(2, "thinking", 11, 0),
+            ]))
+            .unwrap_err();
+        assert!(
+            matches!(err, AgentIndexError::Conflict(_)),
+            "unexpected error: {err:?}"
+        );
+        let source = SourceRef {
+            agent_id: AgentId::new("agent-a"),
+            path: "logs/events.jsonl".to_owned(),
+        };
+        assert!(
+            index.coverage(&source).unwrap().is_none(),
+            "conflicting batch must not commit partial state"
+        );
+    }
+
+    #[test]
+    fn replaying_older_batch_does_not_regress_coverage() {
+        let index = index();
+        let source = SourceRef {
+            agent_id: AgentId::new("agent-a"),
+            path: "logs/events.jsonl".to_owned(),
+        };
+        index
+            .ingest_events(EventBatch {
+                source: source.clone(),
+                file_size: 4096,
+                events: vec![record(1, "thinking", 10, 0)],
+            })
+            .unwrap();
+        index
+            .ingest_events(EventBatch {
+                source: source.clone(),
+                file_size: 8192,
+                events: vec![record(2, "thinking", 11, 4096)],
+            })
+            .unwrap();
+
+        let replay = index
+            .ingest_events(EventBatch {
+                source: source.clone(),
+                file_size: 4096,
+                events: vec![record(1, "thinking", 10, 0)],
+            })
+            .unwrap();
+
+        assert_eq!(replay.inserted, 0);
+        assert_eq!(replay.skipped, 1);
+        assert_eq!(replay.coverage.file_size, 8192, "coverage must not regress");
+        let stored = index.coverage(&source).unwrap().unwrap();
+        assert_eq!(stored.file_size, 8192);
+    }
+
+    #[test]
+    fn ingest_rejects_negative_timestamp() {
+        let err = index()
+            .ingest_events(batch(vec![record(1, "thinking", -1, 0)]))
+            .unwrap_err();
+        assert!(
+            matches!(err, AgentIndexError::InvalidArgument(ref message) if message.contains("ts_micros")),
+            "unexpected error: {err:?}"
+        );
+    }
+}

--- a/crates/nokv-agent/src/key.rs
+++ b/crates/nokv-agent/src/key.rs
@@ -1,0 +1,157 @@
+use crate::{AgentId, EventId};
+
+pub(crate) fn node_key(agent_id: &AgentId, path: &str) -> Vec<u8> {
+    format!("fs/node/{}/{}", segment(&agent_id.0), segment(path)).into_bytes()
+}
+
+pub(crate) fn node_prefix(agent_id: &AgentId) -> Vec<u8> {
+    format!("fs/node/{}/", segment(&agent_id.0)).into_bytes()
+}
+
+pub(crate) fn body_key(agent_id: &AgentId, path: &str) -> Vec<u8> {
+    format!("fs/body/{}/{}", segment(&agent_id.0), segment(path)).into_bytes()
+}
+
+pub(crate) fn child_key(agent_id: &AgentId, parent: &str, name: &str) -> Vec<u8> {
+    format!(
+        "fs/child/{}/{}/{}",
+        segment(&agent_id.0),
+        segment(parent),
+        segment(name)
+    )
+    .into_bytes()
+}
+
+pub(crate) fn child_prefix(agent_id: &AgentId, parent: &str) -> Vec<u8> {
+    format!("fs/child/{}/{}/", segment(&agent_id.0), segment(parent)).into_bytes()
+}
+
+pub(crate) fn catalog_key(agent_id: &AgentId, root: &str) -> Vec<u8> {
+    format!("fs/catalog/{}/{}", segment(&agent_id.0), segment(root)).into_bytes()
+}
+
+pub(crate) fn row_key(agent_id: &AgentId, root: &str, path: &str) -> Vec<u8> {
+    format!(
+        "fs/row/{}/{}/{}",
+        segment(&agent_id.0),
+        segment(root),
+        segment(path)
+    )
+    .into_bytes()
+}
+
+pub(crate) fn row_prefix(agent_id: &AgentId, root: &str) -> Vec<u8> {
+    format!("fs/row/{}/{}/", segment(&agent_id.0), segment(root)).into_bytes()
+}
+
+pub(crate) fn event_key(agent_id: &AgentId, id: EventId) -> Vec<u8> {
+    format!("event/{}/{:020}", segment(&agent_id.0), id.0).into_bytes()
+}
+
+pub(crate) fn event_prefix(agent_id: &AgentId) -> Vec<u8> {
+    format!("event/{}/", segment(&agent_id.0)).into_bytes()
+}
+
+pub(crate) fn source_key(agent_id: &AgentId, source_file: &str, source_offset: u64) -> Vec<u8> {
+    format!(
+        "source/{}/{}/{:020}",
+        segment(&agent_id.0),
+        segment(source_file),
+        source_offset
+    )
+    .into_bytes()
+}
+
+pub(crate) fn coverage_key(agent_id: &AgentId, source_file: &str) -> Vec<u8> {
+    format!("coverage/{}/{}", segment(&agent_id.0), segment(source_file)).into_bytes()
+}
+
+pub(crate) fn type_id_key(agent_id: &AgentId, event_type: &str, id: EventId) -> Vec<u8> {
+    format!(
+        "type_id/{}/{}/{:020}",
+        segment(&agent_id.0),
+        segment(event_type),
+        id.0
+    )
+    .into_bytes()
+}
+
+pub(crate) fn type_id_prefix(agent_id: &AgentId, event_type: &str) -> Vec<u8> {
+    format!("type_id/{}/{}/", segment(&agent_id.0), segment(event_type)).into_bytes()
+}
+
+pub(crate) fn type_ts_key(
+    agent_id: &AgentId,
+    event_type: &str,
+    ts_micros: i64,
+    id: EventId,
+) -> Vec<u8> {
+    let ts_order = (i64::MAX - ts_micros) as u64;
+    let id_order = u64::MAX - id.0;
+    format!(
+        "type_ts/{}/{}/{:020}/{:020}",
+        segment(&agent_id.0),
+        segment(event_type),
+        ts_order,
+        id_order
+    )
+    .into_bytes()
+}
+
+pub(crate) fn type_ts_prefix(agent_id: &AgentId, event_type: &str) -> Vec<u8> {
+    format!("type_ts/{}/{}/", segment(&agent_id.0), segment(event_type)).into_bytes()
+}
+
+pub(crate) fn encode_cursor(raw: &[u8]) -> String {
+    let mut out = String::with_capacity(raw.len() * 2);
+    for byte in raw {
+        out.push(hex_digit(byte >> 4));
+        out.push(hex_digit(byte & 0x0f));
+    }
+    out
+}
+
+pub(crate) fn decode_cursor(raw: &str) -> Option<Vec<u8>> {
+    if !raw.len().is_multiple_of(2) {
+        return None;
+    }
+    let mut out = Vec::with_capacity(raw.len() / 2);
+    for pair in raw.as_bytes().chunks_exact(2) {
+        let high = from_hex(pair[0])?;
+        let low = from_hex(pair[1])?;
+        out.push((high << 4) | low);
+    }
+    Some(out)
+}
+
+pub(crate) fn segment(raw: &str) -> String {
+    let mut out = String::with_capacity(raw.len());
+    for byte in raw.bytes() {
+        match byte {
+            b'a'..=b'z' | b'A'..=b'Z' | b'0'..=b'9' | b'.' | b'_' | b'-' => out.push(byte as char),
+            _ => {
+                out.push('%');
+                out.push(hex_digit(byte >> 4));
+                out.push(hex_digit(byte & 0x0f));
+            }
+        }
+    }
+    out
+}
+
+fn hex_digit(value: u8) -> char {
+    match value {
+        0..=9 => (b'0' + value) as char,
+        10..=15 => (b'a' + (value - 10)) as char,
+        _ => unreachable!("hex digit out of range"),
+    }
+}
+
+fn from_hex(value: u8) -> Option<u8> {
+    match value {
+        b'0'..=b'9' => Some(value - b'0'),
+        b'a'..=b'f' => Some(10 + value - b'a'),
+        b'A'..=b'F' => Some(10 + value - b'A'),
+        _ => None,
+    }
+}

--- a/crates/nokv-agent/src/lib.rs
+++ b/crates/nokv-agent/src/lib.rs
@@ -1,9 +1,16 @@
-//! NoKV agent tool surface.
+//! NoKV agent tool surface and agent-native runtime.
 //!
-//! Transport-free agent tooling: the JSON tool definitions exposed to a model,
-//! the dispatcher that maps a tool call onto a namespace verb, argument
-//! validation, and result shaping. Depends only on `nokv-meta`, `nokv-object`
-//! and `nokv-types` — never on `nokv-client`, `nokv-protocol` or `nokv-control`.
+//! Two independent layers live in this crate:
+//!
+//! 1. The transport-free namespace tool surface (crate root): the JSON tool
+//!    definitions exposed to a model, the dispatcher that maps a tool call
+//!    onto a namespace verb, argument validation, and result shaping. This
+//!    layer depends only on `nokv-meta`, `nokv-object` and `nokv-types` —
+//!    never on `nokv-client`, `nokv-protocol` or `nokv-control`.
+//! 2. The agent-native runtime (`AgentFs`, `AgentEventIndex`, [`native`],
+//!    the `nokv-agent` binary): an embedded Holt-backed store for agent
+//!    state, independent of the NoKV DFS. It shares tool names and JSON
+//!    shapes with layer 1 where practical but talks to its own store.
 
 use nokv_meta::{
     MetadataStore, NamespaceAggregateGroup, NamespaceAggregateMeasure, NamespaceAggregateOp,
@@ -19,6 +26,50 @@ use nokv_meta::{
 };
 use nokv_object::ObjectStore;
 use serde_json::{json, Map, Value};
+
+mod codec;
+mod error;
+mod event;
+mod fs;
+mod holt;
+mod index;
+mod key;
+mod mcp;
+mod model;
+mod query;
+mod store;
+mod tool;
+mod workbench;
+
+pub use error::{AgentIndexError, AgentIndexResult};
+pub use event::{
+    AgentId, EventBatch, EventId, EventRecord, IndexCoverage, IngestReport, SourceRef,
+};
+pub use fs::AgentFs;
+pub use holt::HoltAgentStore;
+pub use index::AgentEventIndex;
+pub use mcp::{run_mcp, run_mcp_stream, run_mcp_surface, run_mcp_surface_stream, McpToolSurface};
+pub use model::{
+    AgentFindField, AgentIndexField, AgentIndexRegistration, AgentIndexRow, AgentIndexValue,
+    AgentNode, AgentNodeKind, AgentPredicateOp, AgentPredicateValue,
+};
+pub use query::{EventOrder, EventPage, EventQuery};
+pub use store::{
+    AgentBatch, AgentCommit, AgentMutation, AgentScanItem, AgentScanPage, AgentStore, ScanDirection,
+};
+pub use workbench::{
+    normalize_workbench_root, WorkbenchMcpOptions, WorkbenchMcpSurface,
+    DEFAULT_WORKBENCH_MAX_BYTES, DEFAULT_WORKBENCH_ROOT,
+};
+
+/// Agent-native tool dispatch over [`AgentFs`].
+///
+/// Same tool names as the crate-root namespace dispatcher, but executing
+/// against the embedded Holt-backed store instead of the NoKV DFS. Kept in a
+/// named module because the root exports of the same names serve `NoKvFs`.
+pub mod native {
+    pub use crate::tool::{agent_tool_definitions, execute_agent_tool};
+}
 
 /// Error surface for the agent tool layer.
 ///

--- a/crates/nokv-agent/src/mcp.rs
+++ b/crates/nokv-agent/src/mcp.rs
@@ -1,0 +1,377 @@
+use std::io::{self, BufRead, Write};
+
+use serde::Deserialize;
+use serde_json::{json, Value};
+
+use crate::tool::{agent_tool_definitions, execute_agent_tool};
+use crate::{AgentFs, AgentStore, AgentToolDefinition};
+
+#[derive(Deserialize)]
+struct JsonRpcRequest {
+    jsonrpc: Option<String>,
+    #[serde(default, deserialize_with = "deserialize_some")]
+    id: Option<Option<Value>>,
+    method: Option<String>,
+    params: Option<Value>,
+}
+
+fn deserialize_some<'de, D>(deserializer: D) -> Result<Option<Option<Value>>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    Deserialize::deserialize(deserializer).map(Some)
+}
+
+#[derive(Deserialize)]
+struct CallToolParams {
+    name: String,
+    arguments: Option<Value>,
+}
+
+pub trait McpToolSurface {
+    fn tool_definitions(&self) -> Vec<AgentToolDefinition>;
+
+    fn execute_tool(&self, name: &str, args: &Value) -> Result<Value, String>;
+}
+
+impl<S> McpToolSurface for AgentFs<S>
+where
+    S: AgentStore,
+{
+    fn tool_definitions(&self) -> Vec<AgentToolDefinition> {
+        agent_tool_definitions()
+    }
+
+    fn execute_tool(&self, name: &str, args: &Value) -> Result<Value, String> {
+        execute_agent_tool(self, name, args).map_err(|err| err.to_string())
+    }
+}
+
+pub fn run_mcp<S>(fs: &AgentFs<S>) -> io::Result<()>
+where
+    S: AgentStore,
+{
+    let stdin = io::stdin();
+    let stdout = io::stdout();
+    run_mcp_stream(fs, stdin.lock(), stdout.lock())
+}
+
+pub fn run_mcp_surface(surface: &impl McpToolSurface) -> io::Result<()> {
+    let stdin = io::stdin();
+    let stdout = io::stdout();
+    run_mcp_surface_stream(surface, stdin.lock(), stdout.lock())
+}
+
+pub fn run_mcp_stream<S>(
+    fs: &AgentFs<S>,
+    reader: impl BufRead,
+    writer: impl Write,
+) -> io::Result<()>
+where
+    S: AgentStore,
+{
+    run_mcp_surface_stream(fs, reader, writer)
+}
+
+pub fn run_mcp_surface_stream(
+    surface: &impl McpToolSurface,
+    mut reader: impl BufRead,
+    mut writer: impl Write,
+) -> io::Result<()> {
+    let mut line = String::new();
+    while reader.read_line(&mut line)? > 0 {
+        let trimmed = line.trim();
+        if !trimmed.is_empty() {
+            let maybe_response = handle_line(surface, trimmed);
+            if let Some(response) = maybe_response {
+                serde_json::to_writer(&mut writer, &response)?;
+                writer.write_all(b"\n")?;
+                writer.flush()?;
+            }
+        }
+        line.clear();
+    }
+    Ok(())
+}
+
+fn handle_line(surface: &(impl McpToolSurface + ?Sized), trimmed: &str) -> Option<Value> {
+    match serde_json::from_str::<Value>(trimmed) {
+        Err(_) => Some(err_response(None, -32700, "Parse error")),
+        Ok(raw) => {
+            if raw.is_array() {
+                return Some(err_response(
+                    None,
+                    -32600,
+                    "Batch requests are not supported",
+                ));
+            }
+            if !raw.is_object() {
+                return Some(err_response(None, -32600, "Invalid Request"));
+            }
+            match serde_json::from_value::<JsonRpcRequest>(raw) {
+                Err(_) => Some(err_response(None, -32600, "Invalid Request")),
+                Ok(req) => handle_request(surface, req),
+            }
+        }
+    }
+}
+
+fn handle_request(surface: &(impl McpToolSurface + ?Sized), req: JsonRpcRequest) -> Option<Value> {
+    let id = req.id.clone().flatten();
+    if req.jsonrpc.as_deref() != Some("2.0") {
+        return Some(err_response(
+            id,
+            -32600,
+            "Invalid Request: jsonrpc must be \"2.0\"",
+        ));
+    }
+    let Some(method) = req.method else {
+        return Some(err_response(id, -32600, "Invalid Request: missing method"));
+    };
+
+    let is_notification = req.id.is_none();
+    let result = match method.as_str() {
+        "initialize" => initialize_result(req.params.as_ref()),
+        "initialized" | "ping" => Ok(json!({})),
+        "tools/list" => Ok(json!({
+            "tools": surface
+                .tool_definitions()
+                .into_iter()
+                .map(|tool| {
+                    json!({
+                        "name": tool.name,
+                        "description": tool.description,
+                        "inputSchema": tool.parameters,
+                    })
+                })
+                .collect::<Vec<_>>()
+        })),
+        "tools/call" => call_tool_result(surface, req.params),
+        other => Err((-32601_i64, format!("Method not found: {other}"))),
+    };
+
+    if is_notification {
+        None
+    } else {
+        Some(match result {
+            Ok(val) => ok_response(id, val),
+            Err((code, msg)) => err_response(id, code, &msg),
+        })
+    }
+}
+
+fn initialize_result(params: Option<&Value>) -> Result<Value, (i64, String)> {
+    const SUPPORTED_PROTOCOL_VERSIONS: &[&str] =
+        &["2025-11-25", "2025-06-18", "2025-03-26", "2024-11-05"];
+    let requested = params
+        .and_then(|p| p.get("protocolVersion"))
+        .and_then(Value::as_str);
+    let negotiated = match requested {
+        Some(version) if SUPPORTED_PROTOCOL_VERSIONS.contains(&version) => version,
+        _ => SUPPORTED_PROTOCOL_VERSIONS[0],
+    };
+    Ok(json!({
+        "protocolVersion": negotiated,
+        "capabilities": { "tools": {} },
+        "serverInfo": { "name": "nokv-mcp", "version": "0.1.0" }
+    }))
+}
+
+fn call_tool_result(
+    surface: &(impl McpToolSurface + ?Sized),
+    params: Option<Value>,
+) -> Result<Value, (i64, String)> {
+    let params = params.unwrap_or_else(|| json!({}));
+    match serde_json::from_value::<CallToolParams>(params) {
+        Err(e) => Err((-32602_i64, format!("Invalid params: {e}"))),
+        Ok(call) => {
+            let args = call.arguments.unwrap_or_else(|| json!({}));
+            match surface.execute_tool(&call.name, &args) {
+                Ok(val) => Ok(json!({
+                    "content": [{
+                        "type": "text",
+                        "text": serde_json::to_string_pretty(&val).unwrap_or_default()
+                    }],
+                    "structuredContent": val,
+                })),
+                Err(err) => Ok(json!({
+                    "content": [{ "type": "text", "text": err.to_string() }],
+                    "isError": true
+                })),
+            }
+        }
+    }
+}
+
+fn ok_response(id: Option<Value>, result: Value) -> Value {
+    json!({ "jsonrpc": "2.0", "id": id, "result": result })
+}
+
+fn err_response(id: Option<Value>, code: i64, message: &str) -> Value {
+    json!({ "jsonrpc": "2.0", "id": id, "error": { "code": code, "message": message } })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{AgentId, HoltAgentStore};
+
+    fn sample_fs() -> AgentFs<HoltAgentStore> {
+        let fs = AgentFs::new(
+            AgentId::new("mcp-test"),
+            HoltAgentStore::open_memory().unwrap(),
+        );
+        fs.bootstrap().unwrap();
+        fs
+    }
+
+    fn request(line: &str) -> Value {
+        let fs = sample_fs();
+        let reader = io::Cursor::new(format!("{line}\n"));
+        let mut writer = Vec::new();
+        run_mcp_stream(&fs, reader, &mut writer).unwrap();
+        serde_json::from_slice(&writer).unwrap()
+    }
+
+    #[test]
+    fn mcp_server_stdio_initializes_lists_and_calls_tools() {
+        let fs = sample_fs();
+        let reqs = [
+            r#"{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","clientInfo":{"name":"test-client","version":"1.0"}}}"#,
+            r#"{"jsonrpc":"2.0","id":2,"method":"tools/list"}"#,
+            r#"{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"ls","arguments":{"path":"/"}}}"#,
+        ]
+        .join("\n")
+            + "\n";
+        let reader = io::Cursor::new(reqs);
+        let mut writer = Vec::new();
+        run_mcp_stream(&fs, reader, &mut writer).unwrap();
+
+        let output = String::from_utf8(writer).unwrap();
+        let mut lines = output.lines();
+        let resp1: Value = serde_json::from_str(lines.next().unwrap()).unwrap();
+        assert_eq!(resp1["id"], 1);
+        assert_eq!(resp1["result"]["protocolVersion"], "2024-11-05");
+        assert_eq!(resp1["result"]["serverInfo"]["name"], "nokv-mcp");
+
+        let resp2: Value = serde_json::from_str(lines.next().unwrap()).unwrap();
+        let tools = resp2["result"]["tools"].as_array().unwrap();
+        assert!(tools.iter().any(|t| t["name"] == "ls"));
+
+        let resp3: Value = serde_json::from_str(lines.next().unwrap()).unwrap();
+        assert_eq!(resp3["id"], 3);
+        assert!(resp3["result"]["content"][0]["text"].as_str().is_some());
+    }
+
+    #[test]
+    fn tools_list_exposes_exactly_seven_tools() {
+        let resp = request(r#"{"jsonrpc":"2.0","id":1,"method":"tools/list"}"#);
+        let tools = resp["result"]["tools"].as_array().unwrap();
+        let names: Vec<&str> = tools.iter().map(|t| t["name"].as_str().unwrap()).collect();
+        assert_eq!(
+            names,
+            vec!["ls", "stat", "catalog", "read", "aggregate", "find", "grep"]
+        );
+    }
+
+    #[test]
+    fn tools_list_passes_input_schema_unchanged() {
+        let resp = request(r#"{"jsonrpc":"2.0","id":1,"method":"tools/list"}"#);
+        let tools = resp["result"]["tools"].as_array().unwrap();
+        let ls_tool = tools.iter().find(|t| t["name"] == "ls").unwrap();
+        let expected = agent_tool_definitions()
+            .into_iter()
+            .find(|t| t.name == "ls")
+            .unwrap();
+        assert_eq!(ls_tool["inputSchema"], expected.parameters);
+    }
+
+    #[test]
+    fn tools_call_unknown_tool_returns_error_without_crashing() {
+        let resp = request(
+            r#"{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"nonexistent","arguments":{}}}"#,
+        );
+        assert_eq!(resp["result"]["isError"], true);
+    }
+
+    #[test]
+    fn tools_call_invalid_params_returns_jsonrpc_error() {
+        let resp =
+            request(r#"{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"arguments":{}}}"#);
+        assert_eq!(resp["error"]["code"], -32602);
+    }
+
+    #[test]
+    fn unknown_method_returns_method_not_found() {
+        let resp = request(r#"{"jsonrpc":"2.0","id":1,"method":"nonexistent/method"}"#);
+        assert_eq!(resp["error"]["code"], -32601);
+    }
+
+    #[test]
+    fn rejects_malformed_requests() {
+        assert_eq!(
+            request(r#"{"id":1,"method":"tools/list"}"#)["error"]["code"],
+            -32600
+        );
+        assert_eq!(
+            request(r#"{"jsonrpc":"1.0","id":1,"method":"tools/list"}"#)["error"]["code"],
+            -32600
+        );
+        assert_eq!(
+            request(r#"[{"jsonrpc":"2.0","id":1,"method":"tools/list"}]"#)["error"]["code"],
+            -32600
+        );
+    }
+
+    #[test]
+    fn invalid_json_returns_parse_error() {
+        let fs = sample_fs();
+        let mut writer = Vec::new();
+        run_mcp_stream(&fs, io::Cursor::new("not valid json\n"), &mut writer).unwrap();
+        let resp: Value = serde_json::from_slice(&writer).unwrap();
+        assert_eq!(resp["error"]["code"], -32700);
+    }
+
+    #[test]
+    fn null_id_gets_a_response_and_missing_id_is_notification() {
+        let fs = sample_fs();
+        let mut writer = Vec::new();
+        run_mcp_stream(
+            &fs,
+            io::Cursor::new(r#"{"jsonrpc":"2.0","id":null,"method":"tools/list"}"#),
+            &mut writer,
+        )
+        .unwrap();
+        assert!(!writer.is_empty());
+
+        writer.clear();
+        run_mcp_stream(
+            &fs,
+            io::Cursor::new(r#"{"jsonrpc":"2.0","method":"initialized"}"#),
+            &mut writer,
+        )
+        .unwrap();
+        assert!(writer.is_empty());
+    }
+
+    #[test]
+    fn initialize_negotiates_protocol_versions() {
+        assert_eq!(
+            request(
+                r#"{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"1999-01-01"}}"#
+            )["result"]["protocolVersion"],
+            "2025-11-25"
+        );
+        assert_eq!(
+            request(
+                r#"{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18"}}"#
+            )["result"]["protocolVersion"],
+            "2025-06-18"
+        );
+        assert_eq!(
+            request(r#"{"jsonrpc":"2.0","id":1,"method":"initialize"}"#)["result"]
+                ["protocolVersion"],
+            "2025-11-25"
+        );
+    }
+}

--- a/crates/nokv-agent/src/mcp.rs
+++ b/crates/nokv-agent/src/mcp.rs
@@ -173,7 +173,10 @@ fn initialize_result(params: Option<&Value>) -> Result<Value, (i64, String)> {
     Ok(json!({
         "protocolVersion": negotiated,
         "capabilities": { "tools": {} },
-        "serverInfo": { "name": "nokv-mcp", "version": "0.1.0" }
+        // This name must stay distinct from the DFS-backed `nokv mcp` server
+        // ("nokv-mcp"): serverInfo.name is the only handshake field clients
+        // can rely on to tell the two backends apart.
+        "serverInfo": { "name": "nokv-agent-mcp", "version": env!("CARGO_PKG_VERSION") }
     }))
 }
 
@@ -252,7 +255,13 @@ mod tests {
         let resp1: Value = serde_json::from_str(lines.next().unwrap()).unwrap();
         assert_eq!(resp1["id"], 1);
         assert_eq!(resp1["result"]["protocolVersion"], "2024-11-05");
-        assert_eq!(resp1["result"]["serverInfo"]["name"], "nokv-mcp");
+        // Must differ from the DFS-backed `nokv mcp` server ("nokv-mcp") so
+        // clients can tell the two backends apart at handshake time.
+        assert_eq!(resp1["result"]["serverInfo"]["name"], "nokv-agent-mcp");
+        assert_eq!(
+            resp1["result"]["serverInfo"]["version"],
+            env!("CARGO_PKG_VERSION")
+        );
 
         let resp2: Value = serde_json::from_str(lines.next().unwrap()).unwrap();
         let tools = resp2["result"]["tools"].as_array().unwrap();

--- a/crates/nokv-agent/src/model.rs
+++ b/crates/nokv-agent/src/model.rs
@@ -1,0 +1,125 @@
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub enum AgentNodeKind {
+    Directory,
+    File,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AgentNode {
+    pub path: String,
+    pub name: String,
+    pub kind: AgentNodeKind,
+    pub size_bytes: Option<u64>,
+    pub content_type: Option<String>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+pub struct AgentFindField {
+    pub id: String,
+}
+
+impl AgentFindField {
+    pub fn new(id: impl Into<String>) -> Self {
+        Self { id: id.into() }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub enum AgentPredicateOp {
+    Eq,
+    NotEqual,
+    In,
+    Prefix,
+    Suffix,
+    Contains,
+    GreaterThan,
+    GreaterThanOrEqual,
+    LessThan,
+    LessThanOrEqual,
+    Exists,
+    NotExists,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub enum AgentPredicateValue {
+    String(String),
+    U64(u64),
+    F64(f64),
+    List(Vec<AgentPredicateValue>),
+}
+
+impl AgentPredicateValue {
+    pub fn from_json(value: &Value) -> Option<Self> {
+        match value {
+            Value::String(value) => Some(Self::String(value.clone())),
+            Value::Number(value) => value
+                .as_u64()
+                .map(Self::U64)
+                .or_else(|| value.as_f64().map(Self::F64)),
+            Value::Bool(value) => Some(Self::U64(u64::from(*value))),
+            Value::Array(values) => values
+                .iter()
+                .map(Self::from_json)
+                .collect::<Option<Vec<_>>>()
+                .map(Self::List),
+            Value::Null | Value::Object(_) => None,
+        }
+    }
+
+    pub fn to_json(&self) -> Value {
+        match self {
+            Self::String(value) => Value::String(value.clone()),
+            Self::U64(value) => Value::Number((*value).into()),
+            Self::F64(value) if value.is_finite() => serde_json::Number::from_f64(*value)
+                .map(Value::Number)
+                .unwrap_or(Value::Null),
+            Self::F64(_) => Value::Null,
+            Self::List(values) => Value::Array(values.iter().map(Self::to_json).collect()),
+        }
+    }
+
+    pub(crate) fn as_f64(&self) -> Option<f64> {
+        match self {
+            Self::U64(value) => Some(*value as f64),
+            Self::F64(value) if value.is_finite() => Some(*value),
+            _ => None,
+        }
+    }
+
+    pub(crate) fn as_sort_string(&self) -> Option<&str> {
+        match self {
+            Self::String(value) => Some(value),
+            _ => None,
+        }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct AgentIndexValue {
+    pub field: AgentFindField,
+    pub value: AgentPredicateValue,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AgentIndexField {
+    pub field: AgentFindField,
+    pub operators: Vec<AgentPredicateOp>,
+    pub sortable: bool,
+    pub facetable: bool,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct AgentIndexRow {
+    pub path: String,
+    pub values: Vec<AgentIndexValue>,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct AgentIndexRegistration {
+    pub path: String,
+    pub fields: Vec<AgentIndexField>,
+    pub rows: Vec<AgentIndexRow>,
+}

--- a/crates/nokv-agent/src/query.rs
+++ b/crates/nokv-agent/src/query.rs
@@ -1,0 +1,38 @@
+use crate::EventRecord;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum EventOrder {
+    IdAsc,
+    IdDesc,
+    TsDesc,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct EventQuery {
+    pub agent_id: crate::AgentId,
+    pub event_types: Vec<String>,
+    pub source_offset_min: Option<u64>,
+    pub order: EventOrder,
+    pub limit: usize,
+    pub cursor: Option<String>,
+}
+
+impl EventQuery {
+    pub fn new(agent_id: crate::AgentId) -> Self {
+        Self {
+            agent_id,
+            event_types: Vec::new(),
+            source_offset_min: None,
+            order: EventOrder::IdAsc,
+            limit: 100,
+            cursor: None,
+        }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct EventPage {
+    pub events: Vec<EventRecord>,
+    pub next_cursor: Option<String>,
+    pub truncated: bool,
+}

--- a/crates/nokv-agent/src/store.rs
+++ b/crates/nokv-agent/src/store.rs
@@ -1,0 +1,89 @@
+use crate::{AgentIndexError, AgentIndexResult};
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ScanDirection {
+    Asc,
+    Desc,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum AgentMutation {
+    Put { key: Vec<u8>, value: Vec<u8> },
+    Delete { key: Vec<u8> },
+}
+
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct AgentBatch {
+    mutations: Vec<AgentMutation>,
+}
+
+impl AgentBatch {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn put(&mut self, key: impl Into<Vec<u8>>, value: impl Into<Vec<u8>>) {
+        self.mutations.push(AgentMutation::Put {
+            key: key.into(),
+            value: value.into(),
+        });
+    }
+
+    pub fn delete(&mut self, key: impl Into<Vec<u8>>) {
+        self.mutations
+            .push(AgentMutation::Delete { key: key.into() });
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.mutations.is_empty()
+    }
+
+    pub fn len(&self) -> usize {
+        self.mutations.len()
+    }
+
+    pub fn into_mutations(self) -> Vec<AgentMutation> {
+        self.mutations
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct AgentCommit {
+    pub mutation_count: usize,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct AgentScanItem {
+    pub key: Vec<u8>,
+    pub value: Vec<u8>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct AgentScanPage {
+    pub items: Vec<AgentScanItem>,
+    pub next_cursor: Option<Vec<u8>>,
+    pub truncated: bool,
+}
+
+pub trait AgentStore: Clone + Send + Sync + 'static {
+    fn get(&self, key: &[u8]) -> AgentIndexResult<Option<Vec<u8>>>;
+
+    fn scan(
+        &self,
+        prefix: &[u8],
+        cursor: Option<&[u8]>,
+        limit: usize,
+        direction: ScanDirection,
+    ) -> AgentIndexResult<AgentScanPage>;
+
+    fn apply(&self, batch: AgentBatch) -> AgentIndexResult<AgentCommit>;
+}
+
+pub(crate) fn validate_scan_limit(limit: usize) -> AgentIndexResult<()> {
+    if limit == 0 {
+        return Err(AgentIndexError::InvalidArgument(
+            "scan limit must be greater than zero".to_owned(),
+        ));
+    }
+    Ok(())
+}

--- a/crates/nokv-agent/src/tool.rs
+++ b/crates/nokv-agent/src/tool.rs
@@ -1,0 +1,1246 @@
+use std::cmp::Ordering;
+use std::collections::{BTreeMap, BTreeSet};
+
+use serde_json::{json, Map, Value};
+
+use crate::fs::{normalize_path, path_name};
+use crate::{
+    AgentFs, AgentIndexError, AgentIndexField, AgentIndexResult, AgentIndexRow, AgentNode,
+    AgentNodeKind, AgentPredicateOp, AgentPredicateValue, AgentStore,
+};
+
+const DEFAULT_PAGE_LIMIT: usize = 100;
+const MAX_PAGE_LIMIT: usize = 100;
+const DEFAULT_FIND_LIMIT: usize = 10;
+const MAX_FIND_LIMIT: usize = 10;
+const DEFAULT_AGGREGATE_LIMIT: usize = 20;
+const MAX_AGGREGATE_LIMIT: usize = 100;
+const DEFAULT_GREP_LIMIT: usize = 100;
+const MAX_GREP_LIMIT: usize = 100;
+
+pub use crate::AgentToolDefinition;
+
+pub fn agent_tool_definitions() -> Vec<AgentToolDefinition> {
+    vec![
+        AgentToolDefinition {
+            name: "ls",
+            description: "List direct children in the agent-native filesystem-shaped store.",
+            parameters: json!({
+                "type": "object",
+                "required": ["path"],
+                "properties": {
+                    "path": {"type": "string"},
+                    "cursor": {"type": ["string", "null"]},
+                    "limit": {"type": "integer", "minimum": 1, "maximum": MAX_PAGE_LIMIT}
+                },
+                "additionalProperties": false
+            }),
+        },
+        AgentToolDefinition {
+            name: "stat",
+            description: "Inspect one agent-native path and its query catalog/indexed values.",
+            parameters: json!({
+                "type": "object",
+                "required": ["path"],
+                "properties": {"path": {"type": "string"}},
+                "additionalProperties": false
+            }),
+        },
+        AgentToolDefinition {
+            name: "catalog",
+            description: "Discover field ids for find predicates, projections, sort, facets, and aggregate fields.",
+            parameters: json!({
+                "type": "object",
+                "required": ["path"],
+                "properties": {
+                    "path": {"type": "string"},
+                    "field_prefix": {"type": ["string", "null"]},
+                    "include_facets": {"type": "boolean"}
+                },
+                "additionalProperties": false
+            }),
+        },
+        AgentToolDefinition {
+            name: "read",
+            description: "Read file body content from the agent-native store.",
+            parameters: json!({
+                "type": "object",
+                "required": ["path"],
+                "properties": {
+                    "path": {"type": "string"},
+                    "format": {"type": "string", "enum": ["structured", "bytes"]},
+                    "cursor": {"type": ["string", "null"]},
+                    "offset": {"type": "integer", "minimum": 0},
+                    "limit": {"type": "integer", "minimum": 1, "maximum": MAX_PAGE_LIMIT}
+                },
+                "additionalProperties": false
+            }),
+        },
+        AgentToolDefinition {
+            name: "aggregate",
+            description: "Compute summary rows using catalog field ids: count, sum, avg, min, max, group, filter, and sort.",
+            parameters: json!({
+                "type": "object",
+                "required": ["path", "measures"],
+                "properties": {
+                    "path": {"type": "string"},
+                    "predicates": {"type": "array", "items": {"type": "object"}},
+                    "group_by": {"type": "array", "items": {"type": "string"}},
+                    "measures": {"type": "array", "items": {"type": "object"}},
+                    "sort": {"type": "array", "items": {"type": "object"}},
+                    "limit": {"type": "integer", "minimum": 1, "maximum": MAX_AGGREGATE_LIMIT}
+                },
+                "additionalProperties": false
+            }),
+        },
+        AgentToolDefinition {
+            name: "find",
+            description: "Search agent-native indexed paths with predicates, projection fields, sort, and facets.",
+            parameters: json!({
+                "type": "object",
+                "required": ["path"],
+                "properties": {
+                    "path": {"type": "string"},
+                    "predicates": {"type": "array", "items": {"type": "object"}},
+                    "fields": {"type": "array", "items": {"type": "string"}},
+                    "facets": {"type": "array", "items": {"type": "string"}},
+                    "sort": {"type": "array", "items": {"type": "object"}},
+                    "cursor": {"type": ["string", "null"]},
+                    "limit": {"type": "integer", "minimum": 1, "maximum": MAX_FIND_LIMIT}
+                },
+                "additionalProperties": false
+            }),
+        },
+        AgentToolDefinition {
+            name: "grep",
+            description: "Search text files for a case-insensitive literal substring and return matching lines.",
+            parameters: json!({
+                "type": "object",
+                "required": ["path", "pattern", "recursive"],
+                "properties": {
+                    "path": {"type": "string"},
+                    "pattern": {"type": "string"},
+                    "recursive": {"type": "boolean"},
+                    "cursor": {"type": ["string", "null"]},
+                    "limit": {"type": "integer", "minimum": 1, "maximum": MAX_GREP_LIMIT}
+                },
+                "additionalProperties": false
+            }),
+        },
+    ]
+}
+
+pub fn execute_agent_tool<S>(fs: &AgentFs<S>, name: &str, args: &Value) -> AgentIndexResult<Value>
+where
+    S: AgentStore,
+{
+    match name {
+        "ls" => execute_ls(fs, args),
+        "stat" => execute_stat(fs, args),
+        "catalog" => execute_catalog(fs, args),
+        "read" => execute_read(fs, args),
+        "find" => execute_find(fs, args),
+        "aggregate" => execute_aggregate(fs, args),
+        "grep" => execute_grep(fs, args),
+        other => Err(AgentIndexError::InvalidArgument(format!(
+            "unknown agent tool {other}"
+        ))),
+    }
+}
+
+fn execute_ls<S>(fs: &AgentFs<S>, args: &Value) -> AgentIndexResult<Value>
+where
+    S: AgentStore,
+{
+    let path = required_string_arg(args, "path")?;
+    let limit = optional_usize_arg(args, "limit", MAX_PAGE_LIMIT)?.unwrap_or(DEFAULT_PAGE_LIMIT);
+    let cursor = optional_string_arg(args, "cursor")?.and_then(hex_cursor);
+    let (entries, next_cursor, truncated) = fs.list(path, cursor.as_deref(), limit)?;
+    Ok(json!({
+        "path": normalize_path(path)?,
+        "entry_count": entries.len(),
+        "entries": entries.iter().map(list_entry_json).collect::<Vec<_>>(),
+        "next_cursor": next_cursor.as_deref().map(hex_encode),
+        "truncated": truncated,
+    }))
+}
+
+fn execute_stat<S>(fs: &AgentFs<S>, args: &Value) -> AgentIndexResult<Value>
+where
+    S: AgentStore,
+{
+    let path = required_string_arg(args, "path")?;
+    let node = fs
+        .node(path)?
+        .ok_or_else(|| AgentIndexError::NotFound(path.to_owned()))?;
+    let rows = fs.index_rows(path).unwrap_or_default();
+    Ok(json!({
+        "card": card_json(&node, &fs.catalog(path).unwrap_or_default(), rows.first()),
+    }))
+}
+
+fn execute_catalog<S>(fs: &AgentFs<S>, args: &Value) -> AgentIndexResult<Value>
+where
+    S: AgentStore,
+{
+    let path = required_string_arg(args, "path")?;
+    let field_prefix = optional_string_arg(args, "field_prefix")?;
+    let include_facets = optional_bool_arg(args, "include_facets")?.unwrap_or(false);
+    let fields = fs.catalog(path)?;
+    let rows = fs.index_rows(path)?;
+    let catalog = catalog_json(&fields, &rows, field_prefix.as_deref(), include_facets);
+    let catalog_empty = fields.is_empty();
+    Ok(json!({
+        "path": normalize_path(path)?,
+        "catalog_empty": catalog_empty,
+        "catalog": catalog,
+        "child_catalogs": [],
+    }))
+}
+
+fn execute_find<S>(fs: &AgentFs<S>, args: &Value) -> AgentIndexResult<Value>
+where
+    S: AgentStore,
+{
+    let path = required_string_arg(args, "path")?;
+    let fields = fields_arg(args)?;
+    let predicates = predicates_arg(args)?;
+    let sort = sort_arg(args)?;
+    let facets = facets_arg(args)?;
+    let offset = cursor_offset(args)?;
+    let limit = optional_usize_arg(args, "limit", MAX_FIND_LIMIT)?.unwrap_or(DEFAULT_FIND_LIMIT);
+    let mut rows = fs.index_rows(path)?;
+    rows.retain(|row| {
+        predicates
+            .iter()
+            .all(|predicate| row_matches(row, predicate))
+    });
+    sort_rows(&mut rows, &sort);
+    let match_count = rows.len();
+    let facet_json = facets_json(&rows, &facets);
+    let matches = rows
+        .iter()
+        .skip(offset)
+        .take(limit)
+        .map(|row| find_match_json(row, fields.as_deref()))
+        .collect::<Vec<_>>();
+    let next_offset = offset.saturating_add(matches.len());
+    Ok(json!({
+        "path": normalize_path(path)?,
+        "match_count": match_count,
+        "matches": matches,
+        "facets": facet_json,
+        "next_cursor": (next_offset < match_count).then(|| next_offset.to_string()),
+        "truncated": next_offset < match_count,
+    }))
+}
+
+fn execute_aggregate<S>(fs: &AgentFs<S>, args: &Value) -> AgentIndexResult<Value>
+where
+    S: AgentStore,
+{
+    let path = required_string_arg(args, "path")?;
+    let predicates = predicates_arg(args)?;
+    let group_by = string_array_arg(args, "group_by")?.unwrap_or_default();
+    let measures = measures_arg(args)?;
+    let sort = aggregate_sort_arg(args)?;
+    let limit =
+        optional_usize_arg(args, "limit", MAX_AGGREGATE_LIMIT)?.unwrap_or(DEFAULT_AGGREGATE_LIMIT);
+    let mut rows = fs.index_rows(path)?;
+    rows.retain(|row| {
+        predicates
+            .iter()
+            .all(|predicate| row_matches(row, predicate))
+    });
+    let input_match_count = rows.len();
+    let mut groups = aggregate_groups(&rows, &group_by, &measures)?;
+    sort_groups(&mut groups, &sort);
+    let group_count = groups.len();
+    let truncated = groups.len() > limit;
+    groups.truncate(limit);
+    Ok(json!({
+        "path": normalize_path(path)?,
+        "input_match_count": input_match_count,
+        "row_count": groups.len(),
+        "group_count": group_count,
+        "groups": groups,
+        "truncated": truncated,
+    }))
+}
+
+fn execute_grep<S>(fs: &AgentFs<S>, args: &Value) -> AgentIndexResult<Value>
+where
+    S: AgentStore,
+{
+    let path = required_string_arg(args, "path")?;
+    let pattern = required_string_arg(args, "pattern")?;
+    let recursive = optional_bool_arg(args, "recursive")?.ok_or_else(|| {
+        AgentIndexError::InvalidArgument("grep requires a boolean recursive argument".to_owned())
+    })?;
+    let limit = optional_usize_arg(args, "limit", MAX_GREP_LIMIT)?.unwrap_or(DEFAULT_GREP_LIMIT);
+    let offset = cursor_offset(args)?;
+    let needle = pattern.to_lowercase();
+    let mut all_matches = Vec::new();
+    let mut bytes_read = 0_usize;
+    let files = fs.files_under(path, recursive)?;
+    for file in &files {
+        let bytes = fs.read_file(&file.path)?;
+        bytes_read = bytes_read.saturating_add(bytes.len());
+        let text = String::from_utf8_lossy(&bytes);
+        for (line_index, line) in text.lines().enumerate() {
+            if line.to_lowercase().contains(&needle) {
+                all_matches.push(json!({
+                    "path": file.path,
+                    "line_number": line_index + 1,
+                    "snippet": line,
+                }));
+            }
+        }
+    }
+    let match_count = all_matches.len();
+    let matches = all_matches
+        .into_iter()
+        .skip(offset)
+        .take(limit)
+        .collect::<Vec<_>>();
+    let next_offset = offset.saturating_add(matches.len());
+    Ok(json!({
+        "path": normalize_path(path)?,
+        "pattern": pattern,
+        "recursive": recursive,
+        "matches": matches,
+        "files_scanned": files.len(),
+        "bytes_read": bytes_read,
+        "next_cursor": (next_offset < match_count).then(|| next_offset.to_string()),
+        "truncated": next_offset < match_count,
+    }))
+}
+
+fn execute_read<S>(fs: &AgentFs<S>, args: &Value) -> AgentIndexResult<Value>
+where
+    S: AgentStore,
+{
+    let path = required_string_arg(args, "path")?;
+    let format = object_args(args)?
+        .get("format")
+        .and_then(Value::as_str)
+        .unwrap_or("structured");
+    let offset = optional_u64_arg(args, "offset")?.unwrap_or(0) as usize;
+    let limit = optional_usize_arg(args, "limit", MAX_PAGE_LIMIT)?.unwrap_or(DEFAULT_PAGE_LIMIT);
+    let cursor = cursor_offset(args)?;
+    let bytes = fs.read_file(path)?;
+    if format == "bytes" {
+        let end = offset.saturating_add(limit).min(bytes.len());
+        let range = bytes.get(offset..end).unwrap_or_default().to_vec();
+        return Ok(json!({
+            "path": normalize_path(path)?,
+            "total_size_bytes": bytes.len(),
+            "format": "bytes",
+            "record_type": null,
+            "record_count": null,
+            "cursor": offset.to_string(),
+            "next_cursor": (end < bytes.len()).then(|| end.to_string()),
+            "truncated": end < bytes.len(),
+            "items": [],
+            "bytes": range,
+            "bytes_read": end.saturating_sub(offset),
+        }));
+    }
+    if format != "structured" {
+        return Err(AgentIndexError::InvalidArgument(format!(
+            "unsupported read format {format}; expected structured or bytes"
+        )));
+    }
+    let records = structured_records(path, &bytes);
+    let record_count = records.len();
+    let items = records
+        .into_iter()
+        .enumerate()
+        .skip(cursor)
+        .take(limit)
+        .map(|(index, value)| json!({"index": index, "value": value}))
+        .collect::<Vec<_>>();
+    let next_offset = cursor.saturating_add(items.len());
+    Ok(json!({
+        "path": normalize_path(path)?,
+        "total_size_bytes": bytes.len(),
+        "format": "structured",
+        "record_type": "json",
+        "record_count": record_count,
+        "cursor": cursor.to_string(),
+        "next_cursor": (next_offset < record_count).then(|| next_offset.to_string()),
+        "truncated": next_offset < record_count,
+        "items": items,
+        "bytes": null,
+        "bytes_read": bytes.len(),
+    }))
+}
+
+#[derive(Clone)]
+struct Predicate {
+    field: String,
+    op: AgentPredicateOp,
+    value: Option<AgentPredicateValue>,
+}
+
+#[derive(Clone)]
+struct Sort {
+    field: String,
+    desc: bool,
+}
+
+#[derive(Clone)]
+struct Measure {
+    name: String,
+    op: String,
+    field: Option<String>,
+}
+
+fn card_json(node: &AgentNode, catalog: &[AgentIndexField], row: Option<&AgentIndexRow>) -> Value {
+    json!({
+        "path": node.path,
+        "name": node.name,
+        "kind": node_kind_name(&node.kind),
+        "size_bytes": node.size_bytes,
+        "entry_count": null,
+        "record_count": null,
+        "schema": null,
+        "sample": [],
+        "body": (node.kind == AgentNodeKind::File).then(|| json!({
+            "producer": "nokv-agent",
+            "size": node.size_bytes.unwrap_or(0),
+            "content_type": node.content_type.clone().unwrap_or_else(|| "application/octet-stream".to_owned()),
+        })),
+        "catalog": catalog_json(catalog, &[], None, false),
+        "indexed_values": row
+            .map(|row| row.values.iter().map(index_value_json).collect::<Vec<_>>())
+            .unwrap_or_default(),
+    })
+}
+
+fn list_entry_json(node: &AgentNode) -> Value {
+    json!({
+        "path": node.path,
+        "name": node.name,
+        "kind": node_kind_name(&node.kind),
+        "size_bytes": node.size_bytes,
+        "entry_count": null,
+    })
+}
+
+fn find_match_json(row: &AgentIndexRow, fields: Option<&[String]>) -> Value {
+    let Some(fields) = fields else {
+        return json!({"path": row.path});
+    };
+    let values = fields
+        .iter()
+        .filter_map(|field| {
+            let values = values_for_field(row, field)
+                .into_iter()
+                .map(|value| value.to_json())
+                .collect::<Vec<_>>();
+            match values.as_slice() {
+                [] => None,
+                [value] => Some((field.clone(), value.clone())),
+                _ => Some((field.clone(), Value::Array(values))),
+            }
+        })
+        .collect::<Map<_, _>>();
+    json!({"path": row.path, "values": values})
+}
+
+fn catalog_json(
+    fields: &[AgentIndexField],
+    rows: &[AgentIndexRow],
+    field_prefix: Option<&str>,
+    include_facets: bool,
+) -> Value {
+    let fields = fields
+        .iter()
+        .filter(|field| field_prefix.is_none_or(|prefix| field.field.id.starts_with(prefix)))
+        .collect::<Vec<_>>();
+    let mut grouped = BTreeMap::<String, Vec<String>>::new();
+    for field in &fields {
+        let operators = field
+            .operators
+            .iter()
+            .map(predicate_op_name)
+            .collect::<Vec<_>>()
+            .join(",");
+        grouped
+            .entry(operators)
+            .or_default()
+            .push(field.field.id.clone());
+    }
+    json!({
+        "filterable": grouped
+            .into_iter()
+            .map(|(operators, fields)| json!({
+                "operators": operators.split(',').filter(|value| !value.is_empty()).collect::<Vec<_>>(),
+                "fields": fields,
+            }))
+            .collect::<Vec<_>>(),
+        "sortable": fields
+            .iter()
+            .filter(|field| field.sortable)
+            .map(|field| field.field.id.clone())
+            .collect::<Vec<_>>(),
+        "facetable": fields
+            .iter()
+            .filter(|field| field.facetable)
+            .map(|field| field.field.id.clone())
+            .collect::<Vec<_>>(),
+        "facets": if include_facets {
+            let facet_fields = fields
+                .iter()
+                .filter(|field| field.facetable)
+                .map(|field| field.field.id.clone())
+                .collect::<Vec<_>>();
+            facets_json(rows, &facet_fields)
+        } else {
+            Vec::new()
+        },
+    })
+}
+
+fn facets_json(rows: &[AgentIndexRow], facets: &[String]) -> Vec<Value> {
+    facets
+        .iter()
+        .map(|field| {
+            let mut counts = BTreeMap::<String, (Value, usize)>::new();
+            for row in rows {
+                for value in values_for_field(row, field) {
+                    let json = value.to_json();
+                    let key = json.to_string();
+                    let entry = counts.entry(key).or_insert((json, 0));
+                    entry.1 += 1;
+                }
+            }
+            json!({
+                "field": field,
+                "values": counts
+                    .into_values()
+                    .map(|(value, count)| json!({"value": value, "count": count}))
+                    .collect::<Vec<_>>(),
+                "distinct_count": counts_len(rows, field),
+                "truncated": false,
+            })
+        })
+        .collect()
+}
+
+fn counts_len(rows: &[AgentIndexRow], field: &str) -> usize {
+    rows.iter()
+        .flat_map(|row| values_for_field(row, field))
+        .map(|value| value.to_json().to_string())
+        .collect::<BTreeSet<_>>()
+        .len()
+}
+
+fn index_value_json(value: &crate::AgentIndexValue) -> Value {
+    json!({"field": value.field.id, "value": value.value.to_json()})
+}
+
+fn row_matches(row: &AgentIndexRow, predicate: &Predicate) -> bool {
+    let values = values_for_field(row, &predicate.field);
+    match predicate.op {
+        AgentPredicateOp::Exists => !values.is_empty(),
+        AgentPredicateOp::NotExists => values.is_empty(),
+        _ => {
+            let Some(expected) = predicate.value.as_ref() else {
+                return false;
+            };
+            values
+                .iter()
+                .any(|actual| predicate_value_matches(actual, &predicate.op, expected))
+        }
+    }
+}
+
+fn predicate_value_matches(
+    actual: &AgentPredicateValue,
+    op: &AgentPredicateOp,
+    expected: &AgentPredicateValue,
+) -> bool {
+    match op {
+        AgentPredicateOp::Eq => value_eq(actual, expected),
+        AgentPredicateOp::NotEqual => !value_eq(actual, expected),
+        AgentPredicateOp::In => match expected {
+            AgentPredicateValue::List(values) => values.iter().any(|value| value_eq(actual, value)),
+            _ => false,
+        },
+        AgentPredicateOp::Prefix => string_pair(actual, expected)
+            .is_some_and(|(actual, expected)| actual.starts_with(expected)),
+        AgentPredicateOp::Suffix => string_pair(actual, expected)
+            .is_some_and(|(actual, expected)| actual.ends_with(expected)),
+        AgentPredicateOp::Contains => string_pair(actual, expected)
+            .is_some_and(|(actual, expected)| actual.contains(expected)),
+        AgentPredicateOp::GreaterThan => numeric_pair(actual, expected).is_some_and(|(a, b)| a > b),
+        AgentPredicateOp::GreaterThanOrEqual => {
+            numeric_pair(actual, expected).is_some_and(|(a, b)| a >= b)
+        }
+        AgentPredicateOp::LessThan => numeric_pair(actual, expected).is_some_and(|(a, b)| a < b),
+        AgentPredicateOp::LessThanOrEqual => {
+            numeric_pair(actual, expected).is_some_and(|(a, b)| a <= b)
+        }
+        AgentPredicateOp::Exists | AgentPredicateOp::NotExists => false,
+    }
+}
+
+fn value_eq(left: &AgentPredicateValue, right: &AgentPredicateValue) -> bool {
+    if let Some((left, right)) = numeric_pair(left, right) {
+        return (left - right).abs() < f64::EPSILON;
+    }
+    left == right
+}
+
+fn numeric_pair(left: &AgentPredicateValue, right: &AgentPredicateValue) -> Option<(f64, f64)> {
+    Some((left.as_f64()?, right.as_f64()?))
+}
+
+fn string_pair<'a>(
+    left: &'a AgentPredicateValue,
+    right: &'a AgentPredicateValue,
+) -> Option<(&'a str, &'a str)> {
+    match (left, right) {
+        (AgentPredicateValue::String(left), AgentPredicateValue::String(right)) => {
+            Some((left, right))
+        }
+        _ => None,
+    }
+}
+
+fn values_for_field(row: &AgentIndexRow, field: &str) -> Vec<AgentPredicateValue> {
+    match field {
+        "path" => return vec![AgentPredicateValue::String(row.path.clone())],
+        "name" => {
+            return path_name(&row.path)
+                .map(AgentPredicateValue::String)
+                .into_iter()
+                .collect()
+        }
+        "kind" => return vec![AgentPredicateValue::String("file".to_owned())],
+        _ => {}
+    }
+    row.values
+        .iter()
+        .filter(|value| value.field.id == field)
+        .map(|value| value.value.clone())
+        .collect()
+}
+
+fn sort_rows(rows: &mut [AgentIndexRow], sort: &[Sort]) {
+    rows.sort_by(|left, right| {
+        for sort in sort {
+            let ordering = compare_field(left, right, &sort.field);
+            if ordering != Ordering::Equal {
+                return if sort.desc {
+                    ordering.reverse()
+                } else {
+                    ordering
+                };
+            }
+        }
+        left.path.cmp(&right.path)
+    });
+}
+
+fn compare_field(left: &AgentIndexRow, right: &AgentIndexRow, field: &str) -> Ordering {
+    let left = values_for_field(left, field).into_iter().next();
+    let right = values_for_field(right, field).into_iter().next();
+    match (left, right) {
+        (Some(left), Some(right)) => compare_value(&left, &right),
+        (Some(_), None) => Ordering::Less,
+        (None, Some(_)) => Ordering::Greater,
+        (None, None) => Ordering::Equal,
+    }
+}
+
+fn compare_value(left: &AgentPredicateValue, right: &AgentPredicateValue) -> Ordering {
+    if let Some((left, right)) = numeric_pair(left, right) {
+        return left.partial_cmp(&right).unwrap_or(Ordering::Equal);
+    }
+    match (left.as_sort_string(), right.as_sort_string()) {
+        (Some(left), Some(right)) => left.cmp(right),
+        _ => left.to_json().to_string().cmp(&right.to_json().to_string()),
+    }
+}
+
+fn aggregate_groups(
+    rows: &[AgentIndexRow],
+    group_by: &[String],
+    measures: &[Measure],
+) -> AgentIndexResult<Vec<Value>> {
+    let mut groups =
+        BTreeMap::<String, (Vec<(String, AgentPredicateValue)>, Vec<&AgentIndexRow>)>::new();
+    for row in rows {
+        let key_values = group_by
+            .iter()
+            .map(|field| {
+                let value = values_for_field(row, field)
+                    .into_iter()
+                    .next()
+                    .unwrap_or_else(|| AgentPredicateValue::String(String::new()));
+                (field.clone(), value)
+            })
+            .collect::<Vec<_>>();
+        let key = key_values
+            .iter()
+            .map(|(field, value)| format!("{field}={}", value.to_json()))
+            .collect::<Vec<_>>()
+            .join("\u{1f}");
+        groups
+            .entry(key)
+            .or_insert((key_values, Vec::new()))
+            .1
+            .push(row);
+    }
+    if group_by.is_empty() && groups.is_empty() {
+        groups.insert(String::new(), (Vec::new(), Vec::new()));
+    }
+    groups
+        .into_values()
+        .map(|(key_values, rows)| {
+            let key = key_values
+                .into_iter()
+                .map(|(field, value)| (field, value.to_json()))
+                .collect::<Map<_, _>>();
+            let values = measures
+                .iter()
+                .map(|measure| Ok((measure.name.clone(), aggregate_measure(&rows, measure)?)))
+                .collect::<AgentIndexResult<Map<_, _>>>()?;
+            Ok(json!({"key": key, "values": values}))
+        })
+        .collect()
+}
+
+fn aggregate_measure(rows: &[&AgentIndexRow], measure: &Measure) -> AgentIndexResult<Value> {
+    if measure.op == "count" {
+        return Ok(json!(rows.len()));
+    }
+    let field = measure.field.as_deref().ok_or_else(|| {
+        AgentIndexError::InvalidArgument(format!("measure {} requires field", measure.name))
+    })?;
+    let values = rows
+        .iter()
+        .flat_map(|row| values_for_field(row, field))
+        .filter_map(|value| value.as_f64())
+        .collect::<Vec<_>>();
+    if values.is_empty() {
+        return Ok(Value::Null);
+    }
+    let out = match measure.op.as_str() {
+        "sum" => values.iter().sum::<f64>(),
+        "avg" => values.iter().sum::<f64>() / values.len() as f64,
+        "min" => values.iter().copied().reduce(f64::min).unwrap_or(f64::NAN),
+        "max" => values.iter().copied().reduce(f64::max).unwrap_or(f64::NAN),
+        other => {
+            return Err(AgentIndexError::InvalidArgument(format!(
+                "unsupported aggregate op {other}"
+            )))
+        }
+    };
+    Ok(serde_json::Number::from_f64(out)
+        .map(Value::Number)
+        .unwrap_or(Value::Null))
+}
+
+fn sort_groups(groups: &mut [Value], sort: &[Sort]) {
+    groups.sort_by(|left, right| {
+        for sort in sort {
+            let left_value = aggregate_sort_value(left, &sort.field);
+            let right_value = aggregate_sort_value(right, &sort.field);
+            let ordering = json_compare(left_value, right_value);
+            if ordering != Ordering::Equal {
+                return if sort.desc {
+                    ordering.reverse()
+                } else {
+                    ordering
+                };
+            }
+        }
+        Ordering::Equal
+    });
+}
+
+fn aggregate_sort_value<'a>(group: &'a Value, field: &str) -> Option<&'a Value> {
+    group
+        .get("values")
+        .and_then(|values| values.get(field))
+        .or_else(|| group.get("key").and_then(|key| key.get(field)))
+}
+
+fn json_compare(left: Option<&Value>, right: Option<&Value>) -> Ordering {
+    match (left, right) {
+        (Some(Value::Number(left)), Some(Value::Number(right))) => {
+            match (left.as_f64(), right.as_f64()) {
+                (Some(left), Some(right)) => left.partial_cmp(&right).unwrap_or(Ordering::Equal),
+                _ => Ordering::Equal,
+            }
+        }
+        (Some(Value::String(left)), Some(Value::String(right))) => left.cmp(right),
+        (Some(_), None) => Ordering::Less,
+        (None, Some(_)) => Ordering::Greater,
+        (Some(left), Some(right)) => left.to_string().cmp(&right.to_string()),
+        (None, None) => Ordering::Equal,
+    }
+}
+
+fn structured_records(path: &str, bytes: &[u8]) -> Vec<Value> {
+    let text = String::from_utf8_lossy(bytes);
+    if path.ends_with(".jsonl") {
+        return text
+            .lines()
+            .filter_map(|line| serde_json::from_str::<Value>(line).ok())
+            .collect();
+    }
+    if path.ends_with(".json") {
+        return match serde_json::from_slice::<Value>(bytes) {
+            Ok(Value::Array(values)) => values,
+            Ok(value) => vec![value],
+            Err(_) => vec![Value::String(text.to_string())],
+        };
+    }
+    vec![Value::String(text.to_string())]
+}
+
+fn predicates_arg(args: &Value) -> AgentIndexResult<Vec<Predicate>> {
+    let Some(value) = object_args(args)?.get("predicates") else {
+        return Ok(Vec::new());
+    };
+    value
+        .as_array()
+        .ok_or_else(|| AgentIndexError::InvalidArgument("predicates must be an array".to_owned()))?
+        .iter()
+        .map(predicate_arg)
+        .collect()
+}
+
+fn predicate_arg(value: &Value) -> AgentIndexResult<Predicate> {
+    let object = value.as_object().ok_or_else(|| {
+        AgentIndexError::InvalidArgument("predicate must be an object".to_owned())
+    })?;
+    let field = string_property(object, "field")?.to_owned();
+    let op = predicate_op_arg(string_property(object, "op")?)?;
+    let raw_value = object.get("value").filter(|value| !value.is_null());
+    let value = match op {
+        AgentPredicateOp::Exists | AgentPredicateOp::NotExists => None,
+        AgentPredicateOp::In => {
+            let value = raw_value.ok_or_else(|| {
+                AgentIndexError::InvalidArgument("predicate op in requires array value".to_owned())
+            })?;
+            Some(AgentPredicateValue::from_json(value).ok_or_else(|| {
+                AgentIndexError::InvalidArgument("unsupported predicate value".to_owned())
+            })?)
+        }
+        _ => {
+            let value = raw_value.ok_or_else(|| {
+                AgentIndexError::InvalidArgument(format!(
+                    "predicate op {} requires value",
+                    predicate_op_name(&op)
+                ))
+            })?;
+            Some(AgentPredicateValue::from_json(value).ok_or_else(|| {
+                AgentIndexError::InvalidArgument("unsupported predicate value".to_owned())
+            })?)
+        }
+    };
+    Ok(Predicate { field, op, value })
+}
+
+fn predicate_op_arg(op: &str) -> AgentIndexResult<AgentPredicateOp> {
+    match op {
+        "eq" => Ok(AgentPredicateOp::Eq),
+        "ne" => Ok(AgentPredicateOp::NotEqual),
+        "in" => Ok(AgentPredicateOp::In),
+        "prefix" => Ok(AgentPredicateOp::Prefix),
+        "suffix" => Ok(AgentPredicateOp::Suffix),
+        "contains" => Ok(AgentPredicateOp::Contains),
+        "gt" => Ok(AgentPredicateOp::GreaterThan),
+        "gte" => Ok(AgentPredicateOp::GreaterThanOrEqual),
+        "lt" => Ok(AgentPredicateOp::LessThan),
+        "lte" => Ok(AgentPredicateOp::LessThanOrEqual),
+        "exists" => Ok(AgentPredicateOp::Exists),
+        "not_exists" => Ok(AgentPredicateOp::NotExists),
+        other => Err(AgentIndexError::InvalidArgument(format!(
+            "unsupported predicate op {other}"
+        ))),
+    }
+}
+
+fn sort_arg(args: &Value) -> AgentIndexResult<Vec<Sort>> {
+    let Some(value) = object_args(args)?.get("sort") else {
+        return Ok(Vec::new());
+    };
+    value
+        .as_array()
+        .ok_or_else(|| AgentIndexError::InvalidArgument("sort must be an array".to_owned()))?
+        .iter()
+        .map(sort_item_arg)
+        .collect()
+}
+
+fn sort_item_arg(value: &Value) -> AgentIndexResult<Sort> {
+    let object = value.as_object().ok_or_else(|| {
+        AgentIndexError::InvalidArgument("sort item must be an object".to_owned())
+    })?;
+    Ok(Sort {
+        field: string_property(object, "field")?.to_owned(),
+        desc: object
+            .get("direction")
+            .and_then(Value::as_str)
+            .is_some_and(|direction| direction == "desc"),
+    })
+}
+
+fn aggregate_sort_arg(args: &Value) -> AgentIndexResult<Vec<Sort>> {
+    sort_arg(args)
+}
+
+fn fields_arg(args: &Value) -> AgentIndexResult<Option<Vec<String>>> {
+    string_array_arg(args, "fields")
+}
+
+fn facets_arg(args: &Value) -> AgentIndexResult<Vec<String>> {
+    Ok(string_array_arg(args, "facets")?.unwrap_or_default())
+}
+
+fn measures_arg(args: &Value) -> AgentIndexResult<Vec<Measure>> {
+    let value = object_args(args)?.get("measures").ok_or_else(|| {
+        AgentIndexError::InvalidArgument("missing array argument measures".to_owned())
+    })?;
+    let measures = value
+        .as_array()
+        .ok_or_else(|| AgentIndexError::InvalidArgument("measures must be an array".to_owned()))?;
+    if measures.is_empty() {
+        return Err(AgentIndexError::InvalidArgument(
+            "measures must contain at least one measure".to_owned(),
+        ));
+    }
+    measures
+        .iter()
+        .map(|value| {
+            let object = value.as_object().ok_or_else(|| {
+                AgentIndexError::InvalidArgument("measure must be an object".to_owned())
+            })?;
+            Ok(Measure {
+                name: string_property(object, "name")?.to_owned(),
+                op: string_property(object, "op")?.to_owned(),
+                field: object
+                    .get("field")
+                    .and_then(|value| (!value.is_null()).then_some(value))
+                    .map(|value| {
+                        value.as_str().map(str::to_owned).ok_or_else(|| {
+                            AgentIndexError::InvalidArgument(
+                                "measure field must be a string or null".to_owned(),
+                            )
+                        })
+                    })
+                    .transpose()?,
+            })
+        })
+        .collect()
+}
+
+fn string_array_arg(args: &Value, name: &'static str) -> AgentIndexResult<Option<Vec<String>>> {
+    let Some(value) = object_args(args)?.get(name) else {
+        return Ok(None);
+    };
+    if value.is_null() {
+        return Ok(None);
+    }
+    value
+        .as_array()
+        .ok_or_else(|| AgentIndexError::InvalidArgument(format!("{name} must be an array")))?
+        .iter()
+        .map(|value| {
+            value.as_str().map(str::to_owned).ok_or_else(|| {
+                AgentIndexError::InvalidArgument(format!("{name} entries must be strings"))
+            })
+        })
+        .collect::<AgentIndexResult<Vec<_>>>()
+        .map(Some)
+}
+
+fn object_args(args: &Value) -> AgentIndexResult<&Map<String, Value>> {
+    args.as_object().ok_or_else(|| {
+        AgentIndexError::InvalidArgument("agent tool arguments must be a JSON object".to_owned())
+    })
+}
+
+fn required_string_arg<'a>(args: &'a Value, name: &'static str) -> AgentIndexResult<&'a str> {
+    object_args(args)?
+        .get(name)
+        .and_then(Value::as_str)
+        .ok_or_else(|| AgentIndexError::InvalidArgument(format!("missing string argument {name}")))
+}
+
+fn optional_string_arg(args: &Value, name: &'static str) -> AgentIndexResult<Option<String>> {
+    let Some(value) = object_args(args)?.get(name) else {
+        return Ok(None);
+    };
+    if value.is_null() {
+        return Ok(None);
+    }
+    value
+        .as_str()
+        .map(|value| Some(value.to_owned()))
+        .ok_or_else(|| AgentIndexError::InvalidArgument(format!("{name} must be a string or null")))
+}
+
+fn optional_bool_arg(args: &Value, name: &'static str) -> AgentIndexResult<Option<bool>> {
+    let Some(value) = object_args(args)?.get(name) else {
+        return Ok(None);
+    };
+    if value.is_null() {
+        return Ok(None);
+    }
+    value
+        .as_bool()
+        .map(Some)
+        .ok_or_else(|| AgentIndexError::InvalidArgument(format!("{name} must be boolean or null")))
+}
+
+fn optional_u64_arg(args: &Value, name: &'static str) -> AgentIndexResult<Option<u64>> {
+    let Some(value) = object_args(args)?.get(name) else {
+        return Ok(None);
+    };
+    if value.is_null() {
+        return Ok(None);
+    }
+    value.as_u64().map(Some).ok_or_else(|| {
+        AgentIndexError::InvalidArgument(format!("{name} must be a non-negative integer"))
+    })
+}
+
+fn optional_usize_arg(
+    args: &Value,
+    name: &'static str,
+    max: usize,
+) -> AgentIndexResult<Option<usize>> {
+    optional_u64_arg(args, name)?
+        .map(|value| {
+            let value = usize::try_from(value)
+                .map_err(|_| AgentIndexError::InvalidArgument(format!("{name} is too large")))?;
+            if value == 0 || value > max {
+                return Err(AgentIndexError::InvalidArgument(format!(
+                    "{name} must be between 1 and {max}"
+                )));
+            }
+            Ok(value)
+        })
+        .transpose()
+}
+
+fn cursor_offset(args: &Value) -> AgentIndexResult<usize> {
+    optional_string_arg(args, "cursor")?
+        .map(|cursor| {
+            cursor
+                .parse::<usize>()
+                .map_err(|_| AgentIndexError::InvalidArgument(format!("invalid cursor {cursor}")))
+        })
+        .transpose()
+        .map(|value| value.unwrap_or(0))
+}
+
+fn string_property<'a>(
+    object: &'a Map<String, Value>,
+    name: &'static str,
+) -> AgentIndexResult<&'a str> {
+    object
+        .get(name)
+        .and_then(Value::as_str)
+        .ok_or_else(|| AgentIndexError::InvalidArgument(format!("missing string property {name}")))
+}
+
+fn node_kind_name(kind: &AgentNodeKind) -> &'static str {
+    match kind {
+        AgentNodeKind::Directory => "directory",
+        AgentNodeKind::File => "file",
+    }
+}
+
+fn predicate_op_name(op: &AgentPredicateOp) -> &'static str {
+    match op {
+        AgentPredicateOp::Eq => "eq",
+        AgentPredicateOp::NotEqual => "ne",
+        AgentPredicateOp::In => "in",
+        AgentPredicateOp::Prefix => "prefix",
+        AgentPredicateOp::Suffix => "suffix",
+        AgentPredicateOp::Contains => "contains",
+        AgentPredicateOp::GreaterThan => "gt",
+        AgentPredicateOp::GreaterThanOrEqual => "gte",
+        AgentPredicateOp::LessThan => "lt",
+        AgentPredicateOp::LessThanOrEqual => "lte",
+        AgentPredicateOp::Exists => "exists",
+        AgentPredicateOp::NotExists => "not_exists",
+    }
+}
+
+fn hex_encode(raw: &[u8]) -> String {
+    let mut out = String::with_capacity(raw.len() * 2);
+    for byte in raw {
+        out.push_str(&format!("{byte:02x}"));
+    }
+    out
+}
+
+fn hex_cursor(raw: String) -> Option<Vec<u8>> {
+    if !raw.len().is_multiple_of(2) {
+        return None;
+    }
+    raw.as_bytes()
+        .chunks_exact(2)
+        .map(|pair| {
+            std::str::from_utf8(pair)
+                .ok()
+                .and_then(|pair| u8::from_str_radix(pair, 16).ok())
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{AgentFindField, AgentId, AgentIndexRegistration, AgentIndexValue, HoltAgentStore};
+
+    fn sample_agent_fs() -> AgentFs<HoltAgentStore> {
+        let fs = AgentFs::new(
+            AgentId::new("unit-agent"),
+            HoltAgentStore::open_memory().unwrap(),
+        );
+        fs.bootstrap().unwrap();
+        fs.put_file(
+            "/runs/run-1/stdout.txt",
+            b"first\nneedle hit\n".to_vec(),
+            Some("text/plain".to_owned()),
+        )
+        .unwrap();
+        fs.put_file(
+            "/runs/run-2/stdout.txt",
+            b"other\n".to_vec(),
+            Some("text/plain".to_owned()),
+        )
+        .unwrap();
+        fs.register_index(AgentIndexRegistration {
+            path: "/runs".to_owned(),
+            fields: vec![
+                AgentIndexField {
+                    field: AgentFindField::new("run.status"),
+                    operators: vec![
+                        AgentPredicateOp::Eq,
+                        AgentPredicateOp::In,
+                        AgentPredicateOp::Exists,
+                    ],
+                    sortable: true,
+                    facetable: true,
+                },
+                AgentIndexField {
+                    field: AgentFindField::new("metric.loss"),
+                    operators: vec![
+                        AgentPredicateOp::GreaterThan,
+                        AgentPredicateOp::LessThan,
+                        AgentPredicateOp::Exists,
+                    ],
+                    sortable: true,
+                    facetable: false,
+                },
+            ],
+            rows: vec![
+                AgentIndexRow {
+                    path: "/runs/run-1".to_owned(),
+                    values: vec![
+                        index_value("run.status", AgentPredicateValue::String("done".to_owned())),
+                        index_value("metric.loss", AgentPredicateValue::F64(0.2)),
+                    ],
+                },
+                AgentIndexRow {
+                    path: "/runs/run-2".to_owned(),
+                    values: vec![
+                        index_value(
+                            "run.status",
+                            AgentPredicateValue::String("failed".to_owned()),
+                        ),
+                        index_value("metric.loss", AgentPredicateValue::F64(0.7)),
+                    ],
+                },
+            ],
+        })
+        .unwrap();
+        fs
+    }
+
+    fn index_value(field: &str, value: AgentPredicateValue) -> AgentIndexValue {
+        AgentIndexValue {
+            field: AgentFindField::new(field),
+            value,
+        }
+    }
+
+    #[test]
+    fn find_filters_sorts_and_projects_index_rows() {
+        let fs = sample_agent_fs();
+
+        let result = execute_agent_tool(
+            &fs,
+            "find",
+            &json!({
+                "path": "/runs",
+                "predicates": [{"field": "metric.loss", "op": "lt", "value": 0.5}],
+                "fields": ["run.status", "metric.loss"],
+                "sort": [{"field": "metric.loss", "direction": "asc"}],
+                "limit": 10
+            }),
+        )
+        .unwrap();
+
+        assert_eq!(result["match_count"], 1);
+        assert_eq!(result["matches"][0]["path"], "/runs/run-1");
+        assert_eq!(result["matches"][0]["values"]["run.status"], "done");
+        assert_eq!(result["matches"][0]["values"]["metric.loss"], 0.2);
+    }
+
+    #[test]
+    fn aggregate_groups_by_index_field() {
+        let fs = sample_agent_fs();
+
+        let result = execute_agent_tool(
+            &fs,
+            "aggregate",
+            &json!({
+                "path": "/runs",
+                "group_by": ["run.status"],
+                "measures": [{"name": "rows", "op": "count"}],
+                "sort": [{"field": "run.status", "direction": "asc"}],
+                "limit": 10
+            }),
+        )
+        .unwrap();
+
+        assert_eq!(result["input_match_count"], 2);
+        assert_eq!(result["group_count"], 2);
+        assert_eq!(result["groups"][0]["key"]["run.status"], "done");
+        assert_eq!(result["groups"][0]["values"]["rows"], 1);
+    }
+
+    #[test]
+    fn grep_reads_agent_native_file_bodies() {
+        let fs = sample_agent_fs();
+
+        let result = execute_agent_tool(
+            &fs,
+            "grep",
+            &json!({
+                "path": "/runs",
+                "pattern": "needle",
+                "recursive": true,
+                "limit": 10
+            }),
+        )
+        .unwrap();
+
+        assert_eq!(result["matches"][0]["path"], "/runs/run-1/stdout.txt");
+        assert_eq!(result["matches"][0]["line_number"], 2);
+        assert_eq!(result["matches"][0]["snippet"], "needle hit");
+    }
+}

--- a/crates/nokv-agent/src/tool.rs
+++ b/crates/nokv-agent/src/tool.rs
@@ -3,7 +3,7 @@ use std::collections::{BTreeMap, BTreeSet};
 
 use serde_json::{json, Map, Value};
 
-use crate::fs::{normalize_path, path_name};
+use crate::fs::{normalize_path, parent_path, path_name};
 use crate::{
     AgentFs, AgentIndexError, AgentIndexField, AgentIndexResult, AgentIndexRow, AgentNode,
     AgentNodeKind, AgentPredicateOp, AgentPredicateValue, AgentStore,
@@ -21,113 +21,9 @@ const MAX_GREP_LIMIT: usize = 100;
 pub use crate::AgentToolDefinition;
 
 pub fn agent_tool_definitions() -> Vec<AgentToolDefinition> {
-    vec![
-        AgentToolDefinition {
-            name: "ls",
-            description: "List direct children in the agent-native filesystem-shaped store.",
-            parameters: json!({
-                "type": "object",
-                "required": ["path"],
-                "properties": {
-                    "path": {"type": "string"},
-                    "cursor": {"type": ["string", "null"]},
-                    "limit": {"type": "integer", "minimum": 1, "maximum": MAX_PAGE_LIMIT}
-                },
-                "additionalProperties": false
-            }),
-        },
-        AgentToolDefinition {
-            name: "stat",
-            description: "Inspect one agent-native path and its query catalog/indexed values.",
-            parameters: json!({
-                "type": "object",
-                "required": ["path"],
-                "properties": {"path": {"type": "string"}},
-                "additionalProperties": false
-            }),
-        },
-        AgentToolDefinition {
-            name: "catalog",
-            description: "Discover field ids for find predicates, projections, sort, facets, and aggregate fields.",
-            parameters: json!({
-                "type": "object",
-                "required": ["path"],
-                "properties": {
-                    "path": {"type": "string"},
-                    "field_prefix": {"type": ["string", "null"]},
-                    "include_facets": {"type": "boolean"}
-                },
-                "additionalProperties": false
-            }),
-        },
-        AgentToolDefinition {
-            name: "read",
-            description: "Read file body content from the agent-native store.",
-            parameters: json!({
-                "type": "object",
-                "required": ["path"],
-                "properties": {
-                    "path": {"type": "string"},
-                    "format": {"type": "string", "enum": ["structured", "bytes"]},
-                    "cursor": {"type": ["string", "null"]},
-                    "offset": {"type": "integer", "minimum": 0},
-                    "limit": {"type": "integer", "minimum": 1, "maximum": MAX_PAGE_LIMIT}
-                },
-                "additionalProperties": false
-            }),
-        },
-        AgentToolDefinition {
-            name: "aggregate",
-            description: "Compute summary rows using catalog field ids: count, sum, avg, min, max, group, filter, and sort.",
-            parameters: json!({
-                "type": "object",
-                "required": ["path", "measures"],
-                "properties": {
-                    "path": {"type": "string"},
-                    "predicates": {"type": "array", "items": {"type": "object"}},
-                    "group_by": {"type": "array", "items": {"type": "string"}},
-                    "measures": {"type": "array", "items": {"type": "object"}},
-                    "sort": {"type": "array", "items": {"type": "object"}},
-                    "limit": {"type": "integer", "minimum": 1, "maximum": MAX_AGGREGATE_LIMIT}
-                },
-                "additionalProperties": false
-            }),
-        },
-        AgentToolDefinition {
-            name: "find",
-            description: "Search agent-native indexed paths with predicates, projection fields, sort, and facets.",
-            parameters: json!({
-                "type": "object",
-                "required": ["path"],
-                "properties": {
-                    "path": {"type": "string"},
-                    "predicates": {"type": "array", "items": {"type": "object"}},
-                    "fields": {"type": "array", "items": {"type": "string"}},
-                    "facets": {"type": "array", "items": {"type": "string"}},
-                    "sort": {"type": "array", "items": {"type": "object"}},
-                    "cursor": {"type": ["string", "null"]},
-                    "limit": {"type": "integer", "minimum": 1, "maximum": MAX_FIND_LIMIT}
-                },
-                "additionalProperties": false
-            }),
-        },
-        AgentToolDefinition {
-            name: "grep",
-            description: "Search text files for a case-insensitive literal substring and return matching lines.",
-            parameters: json!({
-                "type": "object",
-                "required": ["path", "pattern", "recursive"],
-                "properties": {
-                    "path": {"type": "string"},
-                    "pattern": {"type": "string"},
-                    "recursive": {"type": "boolean"},
-                    "cursor": {"type": ["string", "null"]},
-                    "limit": {"type": "integer", "minimum": 1, "maximum": MAX_GREP_LIMIT}
-                },
-                "additionalProperties": false
-            }),
-        },
-    ]
+    // Shared with the crate-root DFS dispatcher so both backends present
+    // byte-identical tool names, descriptions, and parameter schemas.
+    crate::agent_tool_definitions()
 }
 
 pub fn execute_agent_tool<S>(fs: &AgentFs<S>, name: &str, args: &Value) -> AgentIndexResult<Value>
@@ -154,12 +50,22 @@ where
 {
     let path = required_string_arg(args, "path")?;
     let limit = optional_usize_arg(args, "limit", MAX_PAGE_LIMIT)?.unwrap_or(DEFAULT_PAGE_LIMIT);
-    let cursor = optional_string_arg(args, "cursor")?.and_then(hex_cursor);
+    let cursor = optional_string_arg(args, "cursor")?
+        .map(|raw| {
+            hex_cursor(&raw)
+                .ok_or_else(|| AgentIndexError::InvalidArgument(format!("invalid cursor: {raw}")))
+        })
+        .transpose()?;
+    let entry_count = fs.list(path, None, usize::MAX)?.0.len();
     let (entries, next_cursor, truncated) = fs.list(path, cursor.as_deref(), limit)?;
+    let entries = entries
+        .iter()
+        .map(|node| list_entry_json(fs, node))
+        .collect::<AgentIndexResult<Vec<_>>>()?;
     Ok(json!({
         "path": normalize_path(path)?,
-        "entry_count": entries.len(),
-        "entries": entries.iter().map(list_entry_json).collect::<Vec<_>>(),
+        "entry_count": entry_count,
+        "entries": entries,
         "next_cursor": next_cursor.as_deref().map(hex_encode),
         "truncated": truncated,
     }))
@@ -173,10 +79,34 @@ where
     let node = fs
         .node(path)?
         .ok_or_else(|| AgentIndexError::NotFound(path.to_owned()))?;
-    let rows = fs.index_rows(path).unwrap_or_default();
+    let row = indexed_row_for_path(fs, path)?;
     Ok(json!({
-        "card": card_json(&node, &fs.catalog(path).unwrap_or_default(), rows.first()),
+        "card": card_json(&node, &fs.catalog(path).unwrap_or_default(), row.as_ref()),
     }))
+}
+
+/// Find the index row registered for exactly `path`, searching every
+/// registration root along the ancestor chain (rows live under the root
+/// they were registered with, not under their own path).
+fn indexed_row_for_path<S>(fs: &AgentFs<S>, path: &str) -> AgentIndexResult<Option<AgentIndexRow>>
+where
+    S: AgentStore,
+{
+    let normalized = normalize_path(path)?;
+    let mut ancestor = normalized.clone();
+    loop {
+        if let Some(row) = fs
+            .index_rows(&ancestor)?
+            .into_iter()
+            .find(|row| row.path == normalized)
+        {
+            return Ok(Some(row));
+        }
+        if ancestor == "/" {
+            return Ok(None);
+        }
+        ancestor = parent_path(&ancestor)?;
+    }
 }
 
 fn execute_catalog<S>(fs: &AgentFs<S>, args: &Value) -> AgentIndexResult<Value>
@@ -190,12 +120,55 @@ where
     let rows = fs.index_rows(path)?;
     let catalog = catalog_json(&fields, &rows, field_prefix.as_deref(), include_facets);
     let catalog_empty = fields.is_empty();
+    let child_catalogs = if catalog_empty
+        && fs
+            .node(path)?
+            .is_some_and(|node| node.kind == AgentNodeKind::Directory)
+    {
+        child_catalogs_json(fs, path, include_facets)?
+    } else {
+        Vec::new()
+    };
     Ok(json!({
         "path": normalize_path(path)?,
         "catalog_empty": catalog_empty,
         "catalog": catalog,
-        "child_catalogs": [],
+        "child_catalogs": child_catalogs,
     }))
+}
+
+fn child_catalogs_json<S>(
+    fs: &AgentFs<S>,
+    path: &str,
+    include_facets: bool,
+) -> AgentIndexResult<Vec<Value>>
+where
+    S: AgentStore,
+{
+    let (entries, _, _) = fs.list(path, None, 20)?;
+    let mut children = Vec::new();
+    for entry in entries {
+        if entry.kind != AgentNodeKind::Directory {
+            continue;
+        }
+        let fields = fs.catalog(&entry.path)?;
+        if fields.is_empty() {
+            continue;
+        }
+        let rows = if include_facets {
+            fs.index_rows(&entry.path)?
+        } else {
+            Vec::new()
+        };
+        children.push(json!({
+            "path": entry.path,
+            "catalog": catalog_json(&fields, &rows, None, include_facets),
+        }));
+        if children.len() == 5 {
+            break;
+        }
+    }
+    Ok(children)
 }
 
 fn execute_find<S>(fs: &AgentFs<S>, args: &Value) -> AgentIndexResult<Value>
@@ -204,6 +177,12 @@ where
 {
     let path = required_string_arg(args, "path")?;
     let fields = fields_arg(args)?;
+    if object_args(args)?.contains_key("include") {
+        return Err(AgentIndexError::InvalidArgument(
+            "unsupported argument include; use stat for schema or sample and read for body content"
+                .to_owned(),
+        ));
+    }
     let predicates = predicates_arg(args)?;
     let sort = sort_arg(args)?;
     let facets = facets_arg(args)?;
@@ -281,18 +260,19 @@ where
     let offset = cursor_offset(args)?;
     let needle = pattern.to_lowercase();
     let mut all_matches = Vec::new();
-    let mut bytes_read = 0_usize;
     let files = fs.files_under(path, recursive)?;
     for file in &files {
         let bytes = fs.read_file(&file.path)?;
-        bytes_read = bytes_read.saturating_add(bytes.len());
+        if bytes.contains(&0) {
+            continue;
+        }
         let text = String::from_utf8_lossy(&bytes);
         for (line_index, line) in text.lines().enumerate() {
             if line.to_lowercase().contains(&needle) {
                 all_matches.push(json!({
                     "path": file.path,
                     "line_number": line_index + 1,
-                    "snippet": line,
+                    "snippet": line.chars().take(240).collect::<String>(),
                 }));
             }
         }
@@ -310,7 +290,6 @@ where
         "recursive": recursive,
         "matches": matches,
         "files_scanned": files.len(),
-        "bytes_read": bytes_read,
         "next_cursor": (next_offset < match_count).then(|| next_offset.to_string()),
         "truncated": next_offset < match_count,
     }))
@@ -327,23 +306,34 @@ where
         .unwrap_or("structured");
     let offset = optional_u64_arg(args, "offset")?.unwrap_or(0) as usize;
     let limit = optional_usize_arg(args, "limit", MAX_PAGE_LIMIT)?.unwrap_or(DEFAULT_PAGE_LIMIT);
-    let cursor = cursor_offset(args)?;
-    let bytes = fs.read_file(path)?;
+    let cursor = optional_string_arg(args, "cursor")?;
+    let normalized = normalize_path(path)?;
+    let node = fs
+        .node(&normalized)?
+        .ok_or_else(|| AgentIndexError::NotFound(normalized.clone()))?;
+    let bytes = fs.read_file(&normalized)?;
     if format == "bytes" {
-        let end = offset.saturating_add(limit).min(bytes.len());
-        let range = bytes.get(offset..end).unwrap_or_default().to_vec();
+        // The cursor, when provided, wins over offset; mirrors the DFS
+        // parse_byte_cursor semantics so returned next_cursor values page.
+        let start = match cursor.as_deref() {
+            Some(raw) => raw.parse::<usize>().map_err(|err| {
+                AgentIndexError::InvalidArgument(format!("invalid cursor: {err}"))
+            })?,
+            None => offset,
+        };
+        let end = start.saturating_add(limit).min(bytes.len());
+        let range = bytes.get(start..end).unwrap_or_default().to_vec();
         return Ok(json!({
-            "path": normalize_path(path)?,
+            "path": normalized,
             "total_size_bytes": bytes.len(),
             "format": "bytes",
             "record_type": null,
             "record_count": null,
-            "cursor": offset.to_string(),
+            "cursor": cursor,
             "next_cursor": (end < bytes.len()).then(|| end.to_string()),
             "truncated": end < bytes.len(),
             "items": [],
             "bytes": range,
-            "bytes_read": end.saturating_sub(offset),
         }));
     }
     if format != "structured" {
@@ -351,28 +341,42 @@ where
             "unsupported read format {format}; expected structured or bytes"
         )));
     }
-    let records = structured_records(path, &bytes);
+    let start = match cursor.as_deref() {
+        Some(raw) => raw
+            .parse::<usize>()
+            .map_err(|err| AgentIndexError::InvalidArgument(format!("invalid cursor: {err}")))?,
+        None => 0,
+    };
+    let content_type = node
+        .content_type
+        .as_deref()
+        .unwrap_or("application/octet-stream");
+    let (record_type, records) = structured_records(&normalized, content_type, &bytes)?;
     let record_count = records.len();
+    if record_count > MAX_PAGE_LIMIT {
+        return Err(AgentIndexError::InvalidArgument(format!(
+            "structured pagination for {path} has {record_count} records; use stat record_count or find with catalog predicates and limit=1, then read match_count"
+        )));
+    }
     let items = records
         .into_iter()
         .enumerate()
-        .skip(cursor)
+        .skip(start)
         .take(limit)
         .map(|(index, value)| json!({"index": index, "value": value}))
         .collect::<Vec<_>>();
-    let next_offset = cursor.saturating_add(items.len());
+    let next_offset = start.saturating_add(items.len());
     Ok(json!({
-        "path": normalize_path(path)?,
+        "path": normalized,
         "total_size_bytes": bytes.len(),
         "format": "structured",
-        "record_type": "json",
+        "record_type": record_type,
         "record_count": record_count,
-        "cursor": cursor.to_string(),
+        "cursor": cursor,
         "next_cursor": (next_offset < record_count).then(|| next_offset.to_string()),
         "truncated": next_offset < record_count,
         "items": items,
         "bytes": null,
-        "bytes_read": bytes.len(),
     }))
 }
 
@@ -418,14 +422,21 @@ fn card_json(node: &AgentNode, catalog: &[AgentIndexField], row: Option<&AgentIn
     })
 }
 
-fn list_entry_json(node: &AgentNode) -> Value {
-    json!({
+fn list_entry_json<S>(fs: &AgentFs<S>, node: &AgentNode) -> AgentIndexResult<Value>
+where
+    S: AgentStore,
+{
+    let entry_count = match node.kind {
+        AgentNodeKind::Directory => Some(fs.list(&node.path, None, usize::MAX)?.0.len()),
+        AgentNodeKind::File => None,
+    };
+    Ok(json!({
         "path": node.path,
         "name": node.name,
         "kind": node_kind_name(&node.kind),
         "size_bytes": node.size_bytes,
-        "entry_count": null,
-    })
+        "entry_count": entry_count,
+    }))
 }
 
 fn find_match_json(row: &AgentIndexRow, fields: Option<&[String]>) -> Value {
@@ -588,6 +599,11 @@ fn predicate_value_matches(
 }
 
 fn value_eq(left: &AgentPredicateValue, right: &AgentPredicateValue) -> bool {
+    // Integers compare exactly; the f64 round-trip loses precision above
+    // 2^53 and would report distinct u64 values as equal.
+    if let (AgentPredicateValue::U64(left), AgentPredicateValue::U64(right)) = (left, right) {
+        return left == right;
+    }
     if let Some((left, right)) = numeric_pair(left, right) {
         return (left - right).abs() < f64::EPSILON;
     }
@@ -786,22 +802,99 @@ fn json_compare(left: Option<&Value>, right: Option<&Value>) -> Ordering {
     }
 }
 
-fn structured_records(path: &str, bytes: &[u8]) -> Vec<Value> {
-    let text = String::from_utf8_lossy(bytes);
-    if path.ends_with(".jsonl") {
-        return text
-            .lines()
-            .filter_map(|line| serde_json::from_str::<Value>(line).ok())
-            .collect();
+fn structured_records(
+    path: &str,
+    content_type: &str,
+    bytes: &[u8],
+) -> AgentIndexResult<(&'static str, Vec<Value>)> {
+    if is_json_path(path, content_type) {
+        return json_records(bytes);
     }
-    if path.ends_with(".json") {
-        return match serde_json::from_slice::<Value>(bytes) {
-            Ok(Value::Array(values)) => values,
-            Ok(value) => vec![value],
-            Err(_) => vec![Value::String(text.to_string())],
+    if is_yaml_path(path, content_type) {
+        return yaml_records(bytes);
+    }
+    if is_text_path(path, content_type) {
+        return text_records(bytes);
+    }
+    Err(AgentIndexError::InvalidArgument(format!(
+        "structured read does not support content type {content_type} for {path}"
+    )))
+}
+
+fn is_json_path(path: &str, content_type: &str) -> bool {
+    content_type == "application/json" || path.ends_with(".json")
+}
+
+fn is_yaml_path(path: &str, content_type: &str) -> bool {
+    matches!(
+        content_type,
+        "application/yaml" | "application/x-yaml" | "text/yaml"
+    ) || path.ends_with(".yaml")
+        || path.ends_with(".yml")
+}
+
+fn is_text_path(path: &str, content_type: &str) -> bool {
+    content_type.starts_with("text/") || path.ends_with(".txt") || path.ends_with(".log")
+}
+
+fn json_records(bytes: &[u8]) -> AgentIndexResult<(&'static str, Vec<Value>)> {
+    let value = serde_json::from_slice::<Value>(bytes).map_err(|err| {
+        AgentIndexError::InvalidArgument(format!("structured JSON parse failed: {err}"))
+    })?;
+    match value {
+        Value::Array(items) => Ok(("json_array", items)),
+        Value::Object(map) => {
+            let mut entries = map.into_iter().collect::<Vec<_>>();
+            entries.sort_by(|left, right| left.0.cmp(&right.0));
+            let items = entries
+                .into_iter()
+                .map(|(key, value)| json!({"key": key, "value": value}))
+                .collect();
+            Ok(("json_object", items))
+        }
+        _ => Err(AgentIndexError::InvalidArgument(
+            "structured JSON read supports arrays and objects".to_owned(),
+        )),
+    }
+}
+
+fn yaml_records(bytes: &[u8]) -> AgentIndexResult<(&'static str, Vec<Value>)> {
+    let value = serde_yaml::from_slice::<serde_yaml::Value>(bytes).map_err(|err| {
+        AgentIndexError::InvalidArgument(format!("structured YAML parse failed: {err}"))
+    })?;
+    let serde_yaml::Value::Mapping(map) = value else {
+        return Err(AgentIndexError::InvalidArgument(
+            "structured YAML read supports mappings".to_owned(),
+        ));
+    };
+    let mut entries = Vec::new();
+    for (key, value) in map {
+        let Some(key) = key.as_str() else {
+            continue;
         };
+        entries.push((
+            key.to_owned(),
+            serde_json::to_value(value).unwrap_or(Value::Null),
+        ));
     }
-    vec![Value::String(text.to_string())]
+    entries.sort_by(|left, right| left.0.cmp(&right.0));
+    let items = entries
+        .into_iter()
+        .map(|(key, value)| json!({"key": key, "value": value}))
+        .collect();
+    Ok(("yaml_mapping", items))
+}
+
+fn text_records(bytes: &[u8]) -> AgentIndexResult<(&'static str, Vec<Value>)> {
+    let text = std::str::from_utf8(bytes).map_err(|err| {
+        AgentIndexError::InvalidArgument(format!("structured text parse failed: {err}"))
+    })?;
+    let items = text
+        .lines()
+        .enumerate()
+        .map(|(index, line)| json!({"line": index + 1, "text": line}))
+        .collect();
+    Ok(("text_lines", items))
 }
 
 fn predicates_arg(args: &Value) -> AgentIndexResult<Vec<Predicate>> {
@@ -829,6 +922,11 @@ fn predicate_arg(value: &Value) -> AgentIndexResult<Predicate> {
             let value = raw_value.ok_or_else(|| {
                 AgentIndexError::InvalidArgument("predicate op in requires array value".to_owned())
             })?;
+            if !value.is_array() {
+                return Err(AgentIndexError::InvalidArgument(
+                    "predicate op in requires array value".to_owned(),
+                ));
+            }
             Some(AgentPredicateValue::from_json(value).ok_or_else(|| {
                 AgentIndexError::InvalidArgument("unsupported predicate value".to_owned())
             })?)
@@ -851,19 +949,19 @@ fn predicate_arg(value: &Value) -> AgentIndexResult<Predicate> {
 fn predicate_op_arg(op: &str) -> AgentIndexResult<AgentPredicateOp> {
     match op {
         "eq" => Ok(AgentPredicateOp::Eq),
-        "ne" => Ok(AgentPredicateOp::NotEqual),
+        "ne" | "not_equal" => Ok(AgentPredicateOp::NotEqual),
         "in" => Ok(AgentPredicateOp::In),
         "prefix" => Ok(AgentPredicateOp::Prefix),
         "suffix" => Ok(AgentPredicateOp::Suffix),
         "contains" => Ok(AgentPredicateOp::Contains),
-        "gt" => Ok(AgentPredicateOp::GreaterThan),
-        "gte" => Ok(AgentPredicateOp::GreaterThanOrEqual),
-        "lt" => Ok(AgentPredicateOp::LessThan),
-        "lte" => Ok(AgentPredicateOp::LessThanOrEqual),
+        "gt" | "greater_than" => Ok(AgentPredicateOp::GreaterThan),
+        "gte" | "greater_than_or_equal" => Ok(AgentPredicateOp::GreaterThanOrEqual),
+        "lt" | "less_than" => Ok(AgentPredicateOp::LessThan),
+        "lte" | "less_than_or_equal" => Ok(AgentPredicateOp::LessThanOrEqual),
         "exists" => Ok(AgentPredicateOp::Exists),
         "not_exists" => Ok(AgentPredicateOp::NotExists),
         other => Err(AgentIndexError::InvalidArgument(format!(
-            "unsupported predicate op {other}"
+            "unsupported predicate operator {other}"
         ))),
     }
 }
@@ -884,13 +982,21 @@ fn sort_item_arg(value: &Value) -> AgentIndexResult<Sort> {
     let object = value.as_object().ok_or_else(|| {
         AgentIndexError::InvalidArgument("sort item must be an object".to_owned())
     })?;
-    Ok(Sort {
-        field: string_property(object, "field")?.to_owned(),
-        desc: object
-            .get("direction")
-            .and_then(Value::as_str)
-            .is_some_and(|direction| direction == "desc"),
-    })
+    let field = string_property(object, "field")?.to_owned();
+    let direction = object
+        .get("direction")
+        .and_then(Value::as_str)
+        .unwrap_or("asc");
+    let desc = match direction {
+        "asc" => false,
+        "desc" => true,
+        other => {
+            return Err(AgentIndexError::InvalidArgument(format!(
+                "unsupported sort direction {other}"
+            )))
+        }
+    };
+    Ok(Sort { field, desc })
 }
 
 fn aggregate_sort_arg(args: &Value) -> AgentIndexResult<Vec<Sort>> {
@@ -923,21 +1029,35 @@ fn measures_arg(args: &Value) -> AgentIndexResult<Vec<Measure>> {
             let object = value.as_object().ok_or_else(|| {
                 AgentIndexError::InvalidArgument("measure must be an object".to_owned())
             })?;
-            Ok(Measure {
-                name: string_property(object, "name")?.to_owned(),
-                op: string_property(object, "op")?.to_owned(),
-                field: object
-                    .get("field")
-                    .and_then(|value| (!value.is_null()).then_some(value))
-                    .map(|value| {
-                        value.as_str().map(str::to_owned).ok_or_else(|| {
-                            AgentIndexError::InvalidArgument(
-                                "measure field must be a string or null".to_owned(),
-                            )
-                        })
+            let name = string_property(object, "name")?.to_owned();
+            if name.is_empty() {
+                return Err(AgentIndexError::InvalidArgument(
+                    "measure name must not be empty".to_owned(),
+                ));
+            }
+            let op = string_property(object, "op")?.to_owned();
+            if !matches!(op.as_str(), "count" | "sum" | "avg" | "min" | "max") {
+                return Err(AgentIndexError::InvalidArgument(format!(
+                    "unsupported aggregate op {op}"
+                )));
+            }
+            let field = object
+                .get("field")
+                .and_then(|value| (!value.is_null()).then_some(value))
+                .map(|value| {
+                    value.as_str().map(str::to_owned).ok_or_else(|| {
+                        AgentIndexError::InvalidArgument(
+                            "measure field must be a string or null".to_owned(),
+                        )
                     })
-                    .transpose()?,
-            })
+                })
+                .transpose()?;
+            if op != "count" && field.is_none() {
+                return Err(AgentIndexError::InvalidArgument(format!(
+                    "measure {name} with op {op} requires field"
+                )));
+            }
+            Ok(Measure { name, op, field })
         })
         .collect()
 }
@@ -1037,7 +1157,7 @@ fn cursor_offset(args: &Value) -> AgentIndexResult<usize> {
         .map(|cursor| {
             cursor
                 .parse::<usize>()
-                .map_err(|_| AgentIndexError::InvalidArgument(format!("invalid cursor {cursor}")))
+                .map_err(|err| AgentIndexError::InvalidArgument(format!("invalid cursor: {err}")))
         })
         .transpose()
         .map(|value| value.unwrap_or(0))
@@ -1085,7 +1205,7 @@ fn hex_encode(raw: &[u8]) -> String {
     out
 }
 
-fn hex_cursor(raw: String) -> Option<Vec<u8>> {
+fn hex_cursor(raw: &str) -> Option<Vec<u8>> {
     if !raw.len().is_multiple_of(2) {
         return None;
     }
@@ -1242,5 +1362,586 @@ mod tests {
         assert_eq!(result["matches"][0]["path"], "/runs/run-1/stdout.txt");
         assert_eq!(result["matches"][0]["line_number"], 2);
         assert_eq!(result["matches"][0]["snippet"], "needle hit");
+    }
+
+    #[test]
+    fn tool_definitions_match_root_dispatcher() {
+        let root = crate::agent_tool_definitions();
+        let native = agent_tool_definitions();
+        assert_eq!(native, root);
+    }
+
+    #[test]
+    fn read_bytes_pages_advance_with_cursor() {
+        let fs = sample_agent_fs();
+        fs.put_file("/runs/run-1/blob.bin", b"0123456789".to_vec(), None)
+            .unwrap();
+
+        let first = execute_agent_tool(
+            &fs,
+            "read",
+            &json!({"path": "/runs/run-1/blob.bin", "format": "bytes", "limit": 4}),
+        )
+        .unwrap();
+        assert_eq!(first["bytes"], json!(b"0123".to_vec()));
+        assert_eq!(first["cursor"], Value::Null);
+        assert_eq!(first["next_cursor"], "4");
+        assert_eq!(first["truncated"], true);
+
+        let second = execute_agent_tool(
+            &fs,
+            "read",
+            &json!({
+                "path": "/runs/run-1/blob.bin",
+                "format": "bytes",
+                "limit": 4,
+                "offset": 0,
+                "cursor": first["next_cursor"],
+            }),
+        )
+        .unwrap();
+        assert_eq!(second["bytes"], json!(b"4567".to_vec()));
+        assert_eq!(second["cursor"], "4");
+        assert_eq!(second["next_cursor"], "8");
+
+        let via_offset = execute_agent_tool(
+            &fs,
+            "read",
+            &json!({"path": "/runs/run-1/blob.bin", "format": "bytes", "limit": 4, "offset": 8}),
+        )
+        .unwrap();
+        assert_eq!(via_offset["bytes"], json!(b"89".to_vec()));
+        assert_eq!(via_offset["next_cursor"], Value::Null);
+        assert_eq!(via_offset["truncated"], false);
+    }
+
+    #[test]
+    fn read_rejects_malformed_cursor() {
+        let fs = sample_agent_fs();
+
+        let err = execute_agent_tool(
+            &fs,
+            "read",
+            &json!({"path": "/runs/run-1/stdout.txt", "format": "bytes", "cursor": "zz"}),
+        )
+        .unwrap_err();
+        assert!(
+            err.to_string().contains("invalid cursor:"),
+            "unexpected error: {err}"
+        );
+
+        let err = execute_agent_tool(
+            &fs,
+            "read",
+            &json!({"path": "/runs/run-1/stdout.txt", "format": "structured", "cursor": "zz"}),
+        )
+        .unwrap_err();
+        assert!(
+            err.to_string().contains("invalid cursor:"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn structured_read_returns_sorted_json_object_records() {
+        let fs = sample_agent_fs();
+        fs.put_file(
+            "/runs/run-1/metadata.json",
+            b"{\"b\":2,\"a\":1}".to_vec(),
+            Some("application/json".to_owned()),
+        )
+        .unwrap();
+
+        let result = execute_agent_tool(
+            &fs,
+            "read",
+            &json!({"path": "/runs/run-1/metadata.json", "format": "structured"}),
+        )
+        .unwrap();
+
+        assert_eq!(result["record_type"], "json_object");
+        assert_eq!(result["record_count"], 2);
+        assert_eq!(result["cursor"], Value::Null);
+        assert_eq!(result["items"][0]["value"], json!({"key": "a", "value": 1}));
+        assert_eq!(result["items"][1]["value"], json!({"key": "b", "value": 2}));
+        assert!(result.get("bytes_read").is_none());
+    }
+
+    #[test]
+    fn structured_read_returns_json_array_records() {
+        let fs = sample_agent_fs();
+        fs.put_file(
+            "/runs/run-1/rows.json",
+            b"[{\"loss\":0.2},{\"loss\":0.7}]".to_vec(),
+            Some("application/json".to_owned()),
+        )
+        .unwrap();
+
+        let result = execute_agent_tool(
+            &fs,
+            "read",
+            &json!({"path": "/runs/run-1/rows.json", "format": "structured"}),
+        )
+        .unwrap();
+
+        assert_eq!(result["record_type"], "json_array");
+        assert_eq!(result["record_count"], 2);
+        assert_eq!(result["items"][0]["value"], json!({"loss": 0.2}));
+    }
+
+    #[test]
+    fn structured_read_rejects_json_scalars_and_parse_failures() {
+        let fs = sample_agent_fs();
+        fs.put_file(
+            "/runs/run-1/scalar.json",
+            b"42".to_vec(),
+            Some("application/json".to_owned()),
+        )
+        .unwrap();
+        fs.put_file(
+            "/runs/run-1/broken.json",
+            b"{not json".to_vec(),
+            Some("application/json".to_owned()),
+        )
+        .unwrap();
+
+        let err = execute_agent_tool(
+            &fs,
+            "read",
+            &json!({"path": "/runs/run-1/scalar.json", "format": "structured"}),
+        )
+        .unwrap_err();
+        assert!(
+            err.to_string()
+                .contains("structured JSON read supports arrays and objects"),
+            "unexpected error: {err}"
+        );
+
+        let err = execute_agent_tool(
+            &fs,
+            "read",
+            &json!({"path": "/runs/run-1/broken.json", "format": "structured"}),
+        )
+        .unwrap_err();
+        assert!(
+            err.to_string().contains("structured JSON parse failed"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn structured_read_returns_text_lines_for_text_files() {
+        let fs = sample_agent_fs();
+        fs.put_file("/runs/run-1/tail.log", b"alpha\nbeta\n".to_vec(), None)
+            .unwrap();
+        // .jsonl is not a structured suffix; it reads as text only when the
+        // producer declares a text content type, matching the DFS dispatcher.
+        fs.put_file(
+            "/runs/run-1/events.jsonl",
+            b"{\"a\":1}\n{\"b\":2}\n".to_vec(),
+            Some("text/plain".to_owned()),
+        )
+        .unwrap();
+
+        let log = execute_agent_tool(
+            &fs,
+            "read",
+            &json!({"path": "/runs/run-1/tail.log", "format": "structured"}),
+        )
+        .unwrap();
+        assert_eq!(log["record_type"], "text_lines");
+        assert_eq!(log["record_count"], 2);
+        assert_eq!(
+            log["items"][0]["value"],
+            json!({"line": 1, "text": "alpha"})
+        );
+        assert_eq!(log["items"][1]["value"], json!({"line": 2, "text": "beta"}));
+
+        let jsonl = execute_agent_tool(
+            &fs,
+            "read",
+            &json!({"path": "/runs/run-1/events.jsonl", "format": "structured"}),
+        )
+        .unwrap();
+        assert_eq!(jsonl["record_type"], "text_lines");
+        assert_eq!(
+            jsonl["items"][0]["value"],
+            json!({"line": 1, "text": "{\"a\":1}"})
+        );
+    }
+
+    #[test]
+    fn structured_read_returns_yaml_mapping_records() {
+        let fs = sample_agent_fs();
+        fs.put_file(
+            "/runs/run-1/config.yaml",
+            b"beta: 2\nalpha: 1\n".to_vec(),
+            None,
+        )
+        .unwrap();
+
+        let result = execute_agent_tool(
+            &fs,
+            "read",
+            &json!({"path": "/runs/run-1/config.yaml", "format": "structured"}),
+        )
+        .unwrap();
+
+        assert_eq!(result["record_type"], "yaml_mapping");
+        assert_eq!(
+            result["items"][0]["value"],
+            json!({"key": "alpha", "value": 1})
+        );
+        assert_eq!(
+            result["items"][1]["value"],
+            json!({"key": "beta", "value": 2})
+        );
+    }
+
+    #[test]
+    fn structured_read_rejects_unsupported_content_types() {
+        let fs = sample_agent_fs();
+        fs.put_file("/runs/run-1/blob.bin", vec![1, 2, 3], None)
+            .unwrap();
+
+        let err = execute_agent_tool(
+            &fs,
+            "read",
+            &json!({"path": "/runs/run-1/blob.bin", "format": "structured"}),
+        )
+        .unwrap_err();
+        assert!(
+            err.to_string().contains(
+                "structured read does not support content type application/octet-stream for /runs/run-1/blob.bin"
+            ),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn structured_read_guards_large_record_sets() {
+        let fs = sample_agent_fs();
+        let body = (0..150).map(|i| format!("line-{i}\n")).collect::<String>();
+        fs.put_file(
+            "/runs/run-1/big.log",
+            body.into_bytes(),
+            Some("text/plain".to_owned()),
+        )
+        .unwrap();
+
+        let err = execute_agent_tool(
+            &fs,
+            "read",
+            &json!({"path": "/runs/run-1/big.log", "format": "structured"}),
+        )
+        .unwrap_err();
+        assert!(
+            err.to_string().contains(
+                "structured pagination for /runs/run-1/big.log has 150 records; use stat record_count or find with catalog predicates and limit=1, then read match_count"
+            ),
+            "unexpected error: {err}"
+        );
+
+        let bytes = execute_agent_tool(
+            &fs,
+            "read",
+            &json!({"path": "/runs/run-1/big.log", "format": "bytes", "limit": 8}),
+        )
+        .unwrap();
+        assert_eq!(bytes["truncated"], true);
+    }
+
+    #[test]
+    fn ls_reports_full_entry_counts_and_pages() {
+        let fs = sample_agent_fs();
+        fs.put_file("/runs/run-3/stdout.txt", b"x\n".to_vec(), None)
+            .unwrap();
+
+        let first = execute_agent_tool(&fs, "ls", &json!({"path": "/runs", "limit": 2})).unwrap();
+        assert_eq!(first["entry_count"], 3);
+        assert_eq!(first["entries"].as_array().unwrap().len(), 2);
+        assert_eq!(first["truncated"], true);
+        assert_eq!(first["entries"][0]["kind"], "directory");
+        assert_eq!(first["entries"][0]["entry_count"], 1);
+
+        let cursor = first["next_cursor"].as_str().unwrap().to_owned();
+        let second = execute_agent_tool(
+            &fs,
+            "ls",
+            &json!({"path": "/runs", "cursor": cursor, "limit": 2}),
+        )
+        .unwrap();
+        assert_eq!(second["entry_count"], 3);
+        assert_eq!(second["entries"].as_array().unwrap().len(), 1);
+        assert_eq!(second["truncated"], false);
+
+        let leaf = execute_agent_tool(&fs, "ls", &json!({"path": "/runs/run-1"})).unwrap();
+        assert_eq!(leaf["entries"][0]["kind"], "file");
+        assert_eq!(leaf["entries"][0]["entry_count"], Value::Null);
+    }
+
+    #[test]
+    fn ls_rejects_malformed_cursor() {
+        let fs = sample_agent_fs();
+
+        let err =
+            execute_agent_tool(&fs, "ls", &json!({"path": "/runs", "cursor": "zz"})).unwrap_err();
+        assert_eq!(
+            err,
+            AgentIndexError::InvalidArgument("invalid cursor: zz".to_owned())
+        );
+    }
+
+    #[test]
+    fn stat_resolves_indexed_values_along_ancestor_chain() {
+        let fs = sample_agent_fs();
+
+        let root = execute_agent_tool(&fs, "stat", &json!({"path": "/runs"})).unwrap();
+        assert_eq!(root["card"]["indexed_values"], json!([]));
+
+        let child = execute_agent_tool(&fs, "stat", &json!({"path": "/runs/run-1"})).unwrap();
+        let values = child["card"]["indexed_values"].as_array().unwrap();
+        assert_eq!(values.len(), 2);
+        assert_eq!(values[0]["field"], "run.status");
+        assert_eq!(values[0]["value"], "done");
+        assert_eq!(values[1]["field"], "metric.loss");
+    }
+
+    #[test]
+    fn grep_skips_binary_files_and_truncates_snippets() {
+        let fs = sample_agent_fs();
+        let mut binary = b"needle".to_vec();
+        binary.push(0);
+        fs.put_file("/runs/run-1/binary.dat", binary, None).unwrap();
+        let long_line = format!("needle {}", "x".repeat(500));
+        fs.put_file("/runs/run-2/long.txt", long_line.into_bytes(), None)
+            .unwrap();
+
+        let result = execute_agent_tool(
+            &fs,
+            "grep",
+            &json!({"path": "/runs", "pattern": "needle", "recursive": true}),
+        )
+        .unwrap();
+
+        let matches = result["matches"].as_array().unwrap();
+        assert!(
+            matches
+                .iter()
+                .all(|match_| match_["path"] != "/runs/run-1/binary.dat"),
+            "binary file must be skipped: {matches:?}"
+        );
+        let long_match = matches
+            .iter()
+            .find(|match_| match_["path"] == "/runs/run-2/long.txt")
+            .unwrap();
+        assert_eq!(long_match["snippet"].as_str().unwrap().chars().count(), 240);
+        assert_eq!(result["files_scanned"], 4);
+        assert!(result.get("bytes_read").is_none());
+    }
+
+    #[test]
+    fn value_eq_compares_large_u64_exactly() {
+        let fs = sample_agent_fs();
+        fs.register_index(AgentIndexRegistration {
+            path: "/counters".to_owned(),
+            fields: vec![AgentIndexField {
+                field: AgentFindField::new("seq"),
+                operators: vec![AgentPredicateOp::Eq, AgentPredicateOp::In],
+                sortable: false,
+                facetable: false,
+            }],
+            rows: vec![
+                AgentIndexRow {
+                    path: "/counters/a".to_owned(),
+                    values: vec![index_value(
+                        "seq",
+                        AgentPredicateValue::U64(9007199254740992),
+                    )],
+                },
+                AgentIndexRow {
+                    path: "/counters/b".to_owned(),
+                    values: vec![index_value(
+                        "seq",
+                        AgentPredicateValue::U64(9007199254740993),
+                    )],
+                },
+            ],
+        })
+        .unwrap();
+
+        let result = execute_agent_tool(
+            &fs,
+            "find",
+            &json!({
+                "path": "/counters",
+                "predicates": [{"field": "seq", "op": "eq", "value": 9007199254740993_u64}],
+            }),
+        )
+        .unwrap();
+
+        assert_eq!(result["match_count"], 1);
+        assert_eq!(result["matches"][0]["path"], "/counters/b");
+    }
+
+    #[test]
+    fn in_predicate_rejects_scalar_values() {
+        let fs = sample_agent_fs();
+
+        let err = execute_agent_tool(
+            &fs,
+            "find",
+            &json!({
+                "path": "/runs",
+                "predicates": [{"field": "run.status", "op": "in", "value": "done"}],
+            }),
+        )
+        .unwrap_err();
+        assert_eq!(
+            err,
+            AgentIndexError::InvalidArgument("predicate op in requires array value".to_owned())
+        );
+    }
+
+    #[test]
+    fn predicate_op_aliases_match_root_dispatcher() {
+        let fs = sample_agent_fs();
+
+        let result = execute_agent_tool(
+            &fs,
+            "find",
+            &json!({
+                "path": "/runs",
+                "predicates": [{"field": "metric.loss", "op": "greater_than", "value": 0.5}],
+            }),
+        )
+        .unwrap();
+        assert_eq!(result["match_count"], 1);
+
+        let err = execute_agent_tool(
+            &fs,
+            "find",
+            &json!({
+                "path": "/runs",
+                "predicates": [{"field": "metric.loss", "op": "between", "value": 0.5}],
+            }),
+        )
+        .unwrap_err();
+        assert_eq!(
+            err,
+            AgentIndexError::InvalidArgument("unsupported predicate operator between".to_owned())
+        );
+    }
+
+    #[test]
+    fn sort_rejects_unsupported_direction() {
+        let fs = sample_agent_fs();
+
+        let err = execute_agent_tool(
+            &fs,
+            "find",
+            &json!({
+                "path": "/runs",
+                "sort": [{"field": "metric.loss", "direction": "sideways"}],
+            }),
+        )
+        .unwrap_err();
+        assert_eq!(
+            err,
+            AgentIndexError::InvalidArgument("unsupported sort direction sideways".to_owned())
+        );
+    }
+
+    #[test]
+    fn find_rejects_include_argument() {
+        let fs = sample_agent_fs();
+
+        let err = execute_agent_tool(&fs, "find", &json!({"path": "/runs", "include": ["body"]}))
+            .unwrap_err();
+        assert_eq!(
+            err,
+            AgentIndexError::InvalidArgument(
+                "unsupported argument include; use stat for schema or sample and read for body content"
+                    .to_owned()
+            )
+        );
+    }
+
+    #[test]
+    fn aggregate_validates_measures_at_parse_time() {
+        let fs = sample_agent_fs();
+
+        let err = execute_agent_tool(
+            &fs,
+            "aggregate",
+            &json!({
+                "path": "/runs",
+                "measures": [{"name": "m", "op": "median", "field": "metric.loss"}],
+            }),
+        )
+        .unwrap_err();
+        assert_eq!(
+            err,
+            AgentIndexError::InvalidArgument("unsupported aggregate op median".to_owned())
+        );
+
+        let err = execute_agent_tool(
+            &fs,
+            "aggregate",
+            &json!({
+                "path": "/runs",
+                "measures": [{"name": "", "op": "count"}],
+            }),
+        )
+        .unwrap_err();
+        assert_eq!(
+            err,
+            AgentIndexError::InvalidArgument("measure name must not be empty".to_owned())
+        );
+
+        let err = execute_agent_tool(
+            &fs,
+            "aggregate",
+            &json!({
+                "path": "/runs",
+                "measures": [{"name": "total", "op": "sum"}],
+            }),
+        )
+        .unwrap_err();
+        assert_eq!(
+            err,
+            AgentIndexError::InvalidArgument("measure total with op sum requires field".to_owned())
+        );
+    }
+
+    #[test]
+    fn catalog_surfaces_child_catalogs_for_uncatalogued_directories() {
+        let fs = sample_agent_fs();
+
+        let result = execute_agent_tool(&fs, "catalog", &json!({"path": "/"})).unwrap();
+
+        assert_eq!(result["catalog_empty"], true);
+        let children = result["child_catalogs"].as_array().unwrap();
+        assert_eq!(children.len(), 1);
+        assert_eq!(children[0]["path"], "/runs");
+        assert_eq!(
+            children[0]["catalog"]["sortable"],
+            json!(["run.status", "metric.loss"])
+        );
+
+        let indexed = execute_agent_tool(&fs, "catalog", &json!({"path": "/runs"})).unwrap();
+        assert_eq!(indexed["catalog_empty"], false);
+        assert_eq!(indexed["child_catalogs"], json!([]));
+    }
+
+    #[test]
+    fn invalid_argument_errors_use_neutral_prefix() {
+        let fs = sample_agent_fs();
+
+        let err = execute_agent_tool(&fs, "warp", &json!({})).unwrap_err();
+        assert_eq!(
+            err.to_string(),
+            "invalid agent argument: unknown agent tool warp"
+        );
     }
 }

--- a/crates/nokv-agent/src/workbench.rs
+++ b/crates/nokv-agent/src/workbench.rs
@@ -81,6 +81,9 @@ pub fn normalize_workbench_root(raw: &str) -> Result<String, String> {
     Ok(normalized)
 }
 
+// Parameter schemas below must stay byte-identical to the DFS-backed
+// definitions in crates/nokv/src/bin/nokv/workbench_mcp.rs; the golden
+// constants in tests/workbench_parity.rs pin that contract.
 pub fn tool_definitions() -> Vec<AgentToolDefinition> {
     vec![
         AgentToolDefinition {
@@ -90,7 +93,7 @@ pub fn tool_definitions() -> Vec<AgentToolDefinition> {
                 "type": "object",
                 "required": ["id"],
                 "properties": {
-                    "id": {"type": "string"}
+                    "id": {"type": "string", "description": "Workbench id, e.g. spedas-task-001."}
                 },
                 "additionalProperties": false
             }),
@@ -104,7 +107,7 @@ pub fn tool_definitions() -> Vec<AgentToolDefinition> {
                 "properties": {
                     "id": {"type": "string"},
                     "section": {"type": "string", "enum": SECTIONS},
-                    "path": {"type": "string"},
+                    "path": {"type": "string", "description": "Path relative to section. Do not prefix it with the section name."},
                     "text": {"type": "string"},
                     "base64": {"type": "string"},
                     "content_type": {"type": "string"},
@@ -122,7 +125,7 @@ pub fn tool_definitions() -> Vec<AgentToolDefinition> {
                 "properties": {
                     "id": {"type": "string"},
                     "section": {"type": ["string", "null"], "enum": ["input", "scripts", "outputs", "logs", "metadata", null]},
-                    "path": {"type": ["string", "null"]},
+                    "path": {"type": ["string", "null"], "description": "Optional path relative to section. Do not prefix it with the section name."},
                     "cursor": {"type": ["string", "null"]},
                     "limit": {"type": "integer", "minimum": 1}
                 },
@@ -138,7 +141,7 @@ pub fn tool_definitions() -> Vec<AgentToolDefinition> {
                 "properties": {
                     "id": {"type": "string"},
                     "section": {"type": ["string", "null"], "enum": ["input", "scripts", "outputs", "logs", "metadata", null]},
-                    "path": {"type": ["string", "null"]}
+                    "path": {"type": ["string", "null"], "description": "Optional path relative to section. Do not prefix it with the section name."}
                 },
                 "additionalProperties": false
             }),
@@ -152,7 +155,7 @@ pub fn tool_definitions() -> Vec<AgentToolDefinition> {
                 "properties": {
                     "id": {"type": "string"},
                     "section": {"type": "string", "enum": SECTIONS},
-                    "path": {"type": "string"},
+                    "path": {"type": "string", "description": "Path relative to section. Do not prefix it with the section name."},
                     "format": {"type": "string", "enum": ["structured", "bytes"]},
                     "cursor": {"type": ["string", "null"]},
                     "offset": {"type": "integer", "minimum": 0},
@@ -170,7 +173,7 @@ pub fn tool_definitions() -> Vec<AgentToolDefinition> {
                 "properties": {
                     "id": {"type": "string"},
                     "section": {"type": ["string", "null"], "enum": ["input", "scripts", "outputs", "logs", "metadata", null]},
-                    "path": {"type": ["string", "null"]},
+                    "path": {"type": ["string", "null"], "description": "Optional path relative to section. Do not prefix it with the section name."},
                     "pattern": {"type": "string"},
                     "recursive": {"type": "boolean"},
                     "cursor": {"type": ["string", "null"]},
@@ -185,9 +188,9 @@ pub fn tool_definitions() -> Vec<AgentToolDefinition> {
             parameters: json!({
                 "type": "object",
                 "properties": {
-                    "committed": {"type": ["boolean", "null"]},
-                    "manifest_pattern": {"type": ["string", "null"]},
-                    "include_manifest": {"type": "boolean"},
+                    "committed": {"type": ["boolean", "null"], "description": "Filter by completion marker. Null or omitted returns all workbenches."},
+                    "manifest_pattern": {"type": ["string", "null"], "description": "Case-insensitive literal substring filter over metadata/run_manifest.json."},
+                    "include_manifest": {"type": "boolean", "description": "Include full run_manifest.json envelopes. Defaults false."},
                     "cursor": {"type": ["string", "null"]},
                     "limit": {"type": "integer", "minimum": 1, "maximum": MAX_FIND_LIMIT}
                 },
@@ -310,6 +313,8 @@ where
         "relative_path": rel_path,
         "path": path,
         "size_bytes": size_bytes,
+        "inode": Value::Null,
+        "generation": Value::Null,
         "digest_uri": digest_uri,
         "content_type": content_type,
         "replace": replace,
@@ -361,16 +366,20 @@ where
     }
     let result = execute_agent_tool(fs, read_tool, &Value::Object(forwarded))
         .map_err(|err| WorkbenchToolError::new(err.to_string()))?;
-    shape_read_tool_result(options, &id, &target, read_tool, result)
+    shape_read_tool_result(fs, options, &id, &target, read_tool, result)
 }
 
-fn shape_read_tool_result(
+fn shape_read_tool_result<S>(
+    fs: &AgentFs<S>,
     options: &WorkbenchMcpOptions,
     id: &str,
     target: &str,
     read_tool: &str,
     result: Value,
-) -> Result<Value, WorkbenchToolError> {
+) -> Result<Value, WorkbenchToolError>
+where
+    S: AgentStore,
+{
     let scope = path_scope(options, id, target)?;
     match read_tool {
         "ls" => Ok(json!({
@@ -396,15 +405,21 @@ fn shape_read_tool_result(
             "next_cursor": result.get("next_cursor").cloned().unwrap_or(Value::Null),
             "truncated": result.get("truncated").cloned().unwrap_or(Value::Bool(false)),
         })),
-        "stat" => Ok(json!({
-            "status": "success",
-            "workbench_id": id,
-            "workbench_path": workbench_path(options, id),
-            "section": scope.section,
-            "relative_path": scope.relative_path,
-            "path": scope.path,
-            "card": result.get("card").cloned().unwrap_or(Value::Null),
-        })),
+        "stat" => {
+            let node = fs.node(&scope.path)?.ok_or_else(|| {
+                WorkbenchToolError::new(format!("path not found: {}", scope.path))
+            })?;
+            let card = compact_stat_card(fs, &scope, &node)?;
+            Ok(json!({
+                "status": "success",
+                "workbench_id": id,
+                "workbench_path": workbench_path(options, id),
+                "section": scope.section,
+                "relative_path": scope.relative_path,
+                "path": scope.path,
+                "card": card,
+            }))
+        }
         "read" => Ok(json!({
             "status": "success",
             "workbench_id": id,
@@ -464,9 +479,10 @@ where
     let committed_filter = optional_bool(args, "committed")?;
     let manifest_pattern = optional_string(args, "manifest_pattern")?;
     let include_manifest = optional_bool(args, "include_manifest")?.unwrap_or(false);
-    let offset = optional_string(args, "cursor")?
-        .and_then(|raw| raw.parse::<usize>().ok())
-        .unwrap_or(0);
+    let cursor = optional_string(args, "cursor")?;
+    if let Some(raw) = cursor {
+        validate_list_cursor(raw)?;
+    }
     let limit = optional_usize(args, "limit")?.unwrap_or(DEFAULT_FIND_LIMIT);
     if limit == 0 || limit > MAX_FIND_LIMIT {
         return Err(WorkbenchToolError::new(format!(
@@ -479,17 +495,34 @@ where
             "path": options.root,
             "matches": [],
             "match_count": 0,
+            "entry_count": 0,
             "next_cursor": Value::Null,
             "truncated": false,
         }));
     }
+    // DFS-shaped pagination: page the root directory listing, then filter
+    // only the current page. match_count is per page, so a page may hold
+    // fewer than `limit` matches (or none) while next_cursor is non-null.
+    let list_args = json!({
+        "path": options.root,
+        "cursor": cursor,
+        "limit": limit,
+    });
+    let page = execute_agent_tool(fs, "ls", &list_args)
+        .map_err(|err| WorkbenchToolError::new(err.to_string()))?;
+    let entries = page
+        .get("entries")
+        .and_then(Value::as_array)
+        .ok_or_else(|| WorkbenchToolError::new("workbench root listing missing entries"))?;
     let mut matches = Vec::new();
-    for node in fs.list(&options.root, None, usize::MAX)?.0 {
-        if node.kind != crate::AgentNodeKind::Directory {
+    for entry in entries {
+        if entry.get("kind").and_then(Value::as_str) != Some("directory") {
             continue;
         }
-        let id = node.name.clone();
-        let summary = workbench_manifest_summary(fs, options, &id, include_manifest)?;
+        let Some(id) = entry.get("name").and_then(Value::as_str) else {
+            continue;
+        };
+        let summary = workbench_manifest_summary(fs, options, id, include_manifest)?;
         if let Some(committed) = committed_filter {
             if summary.committed != committed {
                 continue;
@@ -499,27 +532,37 @@ where
             let Some(text) = summary.manifest_text.as_deref() else {
                 continue;
             };
-            if !text.to_lowercase().contains(&pattern.to_lowercase()) {
+            if !text
+                .to_ascii_lowercase()
+                .contains(&pattern.to_ascii_lowercase())
+            {
                 continue;
             }
         }
-        matches.push(summary_json(options, &id, summary));
+        matches.push(summary_json(options, id, summary));
     }
     let match_count = matches.len();
-    let page = matches
-        .into_iter()
-        .skip(offset)
-        .take(limit)
-        .collect::<Vec<_>>();
-    let next_offset = offset.saturating_add(page.len());
     Ok(json!({
         "status": "success",
         "path": options.root,
-        "matches": page,
+        "matches": matches,
         "match_count": match_count,
-        "next_cursor": (next_offset < match_count).then(|| next_offset.to_string()),
-        "truncated": next_offset < match_count,
+        "entry_count": page.get("entry_count").cloned().unwrap_or(Value::Null),
+        "next_cursor": page.get("next_cursor").cloned().unwrap_or(Value::Null),
+        "truncated": page.get("truncated").cloned().unwrap_or(Value::Bool(false)),
     }))
+}
+
+/// The underlying `ls` cursor is a hex-encoded store key. Reject malformed
+/// cursors before forwarding so a bad cursor can never silently restart the
+/// listing from the first page.
+fn validate_list_cursor(raw: &str) -> Result<(), WorkbenchToolError> {
+    let valid = raw.len().is_multiple_of(2) && raw.bytes().all(|byte| byte.is_ascii_hexdigit());
+    if valid {
+        Ok(())
+    } else {
+        Err(WorkbenchToolError::new(format!("invalid cursor {raw}")))
+    }
 }
 
 fn commit_workbench<S>(
@@ -533,8 +576,11 @@ where
     let id = required_workbench_id(args)?;
     let manifest = args
         .get("manifest")
-        .and_then(Value::as_object)
-        .ok_or_else(|| WorkbenchToolError::new("missing object argument manifest"))?;
+        .cloned()
+        .ok_or_else(|| WorkbenchToolError::new("missing required argument manifest"))?;
+    if !manifest.is_object() {
+        return Err(WorkbenchToolError::new("manifest must be a JSON object"));
+    }
     let replace = optional_bool(args, "replace")?.unwrap_or(false);
     ensure_standard_dirs(fs, options, &id)?;
     let path = section_path(options, &id, "metadata", Some("run_manifest.json"));
@@ -543,8 +589,10 @@ where
             "run_manifest.json already exists; set replace=true to overwrite",
         ));
     }
+    // Same data-at-rest schema as the DFS-backed workbench so one consumer
+    // can parse manifests from either backend; "backend" marks lineage.
     let envelope = json!({
-        "schema": "nokv.agent.workbench.run_manifest.v0",
+        "schema": "nokv.workbench.run_manifest.v0",
         "backend": "nokv-agent",
         "workbench_id": id,
         "workbench_path": workbench_path(options, &id),
@@ -552,13 +600,17 @@ where
         "manifest": manifest,
     });
     let bytes = serde_json::to_vec_pretty(&envelope)
-        .map_err(|err| WorkbenchToolError::new(err.to_string()))?;
+        .map_err(|err| WorkbenchToolError::new(format!("failed to encode manifest: {err}")))?;
     let digest_uri = digest_uri(&bytes);
+    let size_bytes = bytes.len();
     fs.put_file(&path, bytes, Some("application/json".to_owned()))?;
     Ok(json!({
         "status": "success",
         "workbench_id": id,
-        "manifest_path": path,
+        "path": path,
+        "size_bytes": size_bytes,
+        "inode": Value::Null,
+        "generation": Value::Null,
         "digest_uri": digest_uri,
         "replace": replace,
         "backend": "nokv-agent",
@@ -575,15 +627,27 @@ where
 {
     let id = required_workbench_id(args)?;
     let manifest_path = section_path(options, &id, "metadata", Some("run_manifest.json"));
-    let manifest = fs
-        .read_file(&manifest_path)
-        .map_err(|_| WorkbenchToolError::new("workbench must be committed before snapshot"))?;
-    let files = fs.files_under(&workbench_path(options, &id), true)?;
+    if fs.node(&manifest_path)?.is_none() {
+        return Err(WorkbenchToolError::new(format!(
+            "workbench {id} is not committed; missing {manifest_path}"
+        )));
+    }
+    let manifest = fs.read_file(&manifest_path)?;
+    let path = workbench_path(options, &id);
+    // Prior snapshot records are excluded from the digest and file manifest
+    // so re-snapshotting unchanged content yields the same snapshot id.
+    let snapshots_prefix = format!(
+        "{}/",
+        section_path(options, &id, "metadata", Some("snapshots"))
+    );
+    let files = fs.files_under(&path, true)?;
     let mut hasher = Sha256::new();
     hasher.update(&manifest);
     let file_manifest = files
         .into_iter()
-        .filter(|node| node.kind == crate::AgentNodeKind::File)
+        .filter(|node| {
+            node.kind == crate::AgentNodeKind::File && !node.path.starts_with(&snapshots_prefix)
+        })
         .map(|node| {
             let bytes = fs.read_file(&node.path)?;
             hasher.update(node.path.as_bytes());
@@ -596,7 +660,10 @@ where
         })
         .collect::<Result<Vec<_>, AgentIndexError>>()?;
     let digest = hasher.finalize();
-    let snapshot_id = u64::from_be_bytes(digest[0..8].try_into().unwrap());
+    // Keep the id within 2^53 so JSON consumers with IEEE-754 numbers do not
+    // lose precision; the full digest travels in snapshot_digest.
+    let snapshot_id = u64::from_be_bytes(digest[0..8].try_into().unwrap()) & ((1 << 53) - 1);
+    let snapshot_digest = format!("sha256:{digest:x}");
     let snapshot_path = section_path(
         options,
         &id,
@@ -608,8 +675,9 @@ where
         "backend": "nokv-agent",
         "snapshot_kind": "logical",
         "snapshot_id": snapshot_id,
+        "snapshot_digest": snapshot_digest,
         "workbench_id": id,
-        "workbench_path": workbench_path(options, &id),
+        "workbench_path": path,
         "manifest_path": manifest_path,
         "created_at_unix_seconds": unix_seconds(),
         "files": file_manifest,
@@ -620,7 +688,9 @@ where
     Ok(json!({
         "status": "success",
         "workbench_id": id,
+        "path": path,
         "snapshot_id": snapshot_id,
+        "snapshot_digest": snapshot_digest,
         "snapshot_kind": "logical",
         "snapshot_path": snapshot_path,
         "read_version": Value::Null,
@@ -632,6 +702,8 @@ where
 struct WorkbenchManifestSummary {
     committed: bool,
     manifest_path: Option<String>,
+    manifest_size_bytes: Option<usize>,
+    manifest_digest_uri: Option<String>,
     manifest_text: Option<String>,
     envelope: Option<Value>,
     include_manifest: bool,
@@ -658,18 +730,25 @@ where
         return Ok(WorkbenchManifestSummary {
             committed: false,
             manifest_path: None,
+            manifest_size_bytes: None,
+            manifest_digest_uri: None,
             manifest_text: None,
             envelope: None,
             include_manifest,
         });
     };
-    let text = String::from_utf8(bytes)
-        .map_err(|err| WorkbenchToolError::new(format!("manifest is not UTF-8: {err}")))?;
+    let manifest_size_bytes = bytes.len();
+    let manifest_digest_uri = digest_uri(&bytes);
+    let text = String::from_utf8(bytes).map_err(|err| {
+        WorkbenchToolError::new(format!("run manifest is not valid UTF-8: {err}"))
+    })?;
     let envelope = serde_json::from_str::<Value>(&text)
-        .map_err(|err| WorkbenchToolError::new(format!("manifest is not JSON: {err}")))?;
+        .map_err(|err| WorkbenchToolError::new(format!("run manifest is not valid JSON: {err}")))?;
     Ok(WorkbenchManifestSummary {
         committed: true,
         manifest_path: Some(manifest_path),
+        manifest_size_bytes: Some(manifest_size_bytes),
+        manifest_digest_uri: Some(manifest_digest_uri),
         manifest_text: Some(text),
         envelope: Some(envelope),
         include_manifest,
@@ -691,6 +770,11 @@ fn summary_json(
         "path": workbench_path(options, id),
         "committed": summary.committed,
         "manifest_path": summary.manifest_path,
+        "manifest_size_bytes": summary.manifest_size_bytes,
+        // The embedded store has no write generations; digest_uri is the
+        // stable cross-backend change signal.
+        "manifest_generation": Value::Null,
+        "manifest_digest_uri": summary.manifest_digest_uri,
         "manifest_summary": manifest_summary,
         "manifest": if summary.include_manifest { summary.envelope } else { None },
     })
@@ -877,9 +961,14 @@ fn normalize_relative_path(
             "{field} must not contain empty components"
         )));
     }
-    if raw.contains('\\') || raw.contains('\0') {
+    if raw.contains('\\') {
         return Err(WorkbenchToolError::new(format!(
-            "{field} must use POSIX separators and contain no NUL bytes"
+            "{field} must use POSIX separators"
+        )));
+    }
+    if raw.contains('\0') {
+        return Err(WorkbenchToolError::new(format!(
+            "{field} contains a NUL byte"
         )));
     }
     for component in raw.split('/') {
@@ -899,10 +988,11 @@ fn normalize_absolute_path(raw: &str, field: &'static str) -> Result<String, Str
     if !raw.starts_with('/') {
         return Err(format!("{field} must be an absolute agent path"));
     }
-    if raw.contains('\\') || raw.contains('\0') {
-        return Err(format!(
-            "{field} must use POSIX separators and contain no NUL bytes"
-        ));
+    if raw.contains('\\') {
+        return Err(format!("{field} must use POSIX separators"));
+    }
+    if raw.contains('\0') {
+        return Err(format!("{field} contains a NUL byte"));
     }
     let trimmed = raw.trim_end_matches('/');
     let path = if trimmed.is_empty() { "/" } else { trimmed };
@@ -978,7 +1068,7 @@ fn scoped_path(
     let prefix = format!("{base}/");
     let Some(rest) = path.strip_prefix(&prefix) else {
         return Err(WorkbenchToolError::new(format!(
-            "path escaped workbench root: {path}"
+            "path {path} is outside workbench {base}"
         )));
     };
     let first = rest.split('/').next().unwrap_or(rest);
@@ -1024,6 +1114,56 @@ fn compact_list_entry(
     }))
 }
 
+/// Same card shape as the DFS-backed workbench stat. Fields the embedded
+/// store has no concept of (inode, generation, record_count) are explicit
+/// nulls so consumers can share one parser across backends.
+fn compact_stat_card<S>(
+    fs: &AgentFs<S>,
+    scope: &WorkbenchPathScope,
+    node: &crate::AgentNode,
+) -> Result<Value, WorkbenchToolError>
+where
+    S: AgentStore,
+{
+    let is_file = node.kind == AgentNodeKind::File;
+    let entry_count = if is_file {
+        Value::Null
+    } else {
+        json!(fs.list(&scope.path, None, usize::MAX)?.0.len())
+    };
+    // The embedded store does not persist digests; hash the body on read.
+    // Bodies are bounded by the workbench max_bytes write path.
+    let digest = if is_file {
+        json!(digest_uri(&fs.read_file(&scope.path)?))
+    } else {
+        Value::Null
+    };
+    let content_type = if is_file {
+        json!(node
+            .content_type
+            .clone()
+            .unwrap_or_else(|| "application/octet-stream".to_owned()))
+    } else {
+        Value::Null
+    };
+    Ok(json!({
+        "name": node.name,
+        "path": scope.path,
+        "section": scope.section,
+        "relative_path": scope.relative_path,
+        "kind": if is_file { "file" } else { "directory" },
+        "size_bytes": node.size_bytes,
+        "entry_count": entry_count,
+        "record_count": Value::Null,
+        "inode": Value::Null,
+        "generation": Value::Null,
+        "content_type": content_type,
+        "digest_uri": digest,
+        "producer": is_file.then_some("nokv-agent"),
+        "manifest_id": is_file.then(|| scope.path.trim_start_matches('/').to_owned()),
+    }))
+}
+
 fn compact_grep_match(
     options: &WorkbenchMcpOptions,
     id: &str,
@@ -1050,6 +1190,20 @@ fn payload_bytes(
     let text = optional_string(args, "text")?;
     let encoded = optional_string(args, "base64")?;
     let (bytes, content_type) = match (text, encoded) {
+        (Some(text), Some("")) if !text.is_empty() => {
+            (text.as_bytes().to_vec(), "text/plain; charset=utf-8")
+        }
+        (Some(""), Some(encoded)) if !encoded.is_empty() => (
+            base64::engine::general_purpose::STANDARD
+                .decode(encoded)
+                .map_err(|err| WorkbenchToolError::new(format!("invalid base64 payload: {err}")))?,
+            "application/octet-stream",
+        ),
+        (Some(_), Some(_)) => {
+            return Err(WorkbenchToolError::new(
+                "provide exactly one of text or base64",
+            ))
+        }
         (Some(text), None) => (text.as_bytes().to_vec(), "text/plain; charset=utf-8"),
         (None, Some(encoded)) => (
             base64::engine::general_purpose::STANDARD
@@ -1057,7 +1211,7 @@ fn payload_bytes(
                 .map_err(|err| WorkbenchToolError::new(format!("invalid base64 payload: {err}")))?,
             "application/octet-stream",
         ),
-        _ => {
+        (None, None) => {
             return Err(WorkbenchToolError::new(
                 "provide exactly one of text or base64",
             ))
@@ -1202,8 +1356,12 @@ mod tests {
             "/workbenches/task-1/input/event.json"
         );
         assert_eq!(
-            responses[2]["result"]["structuredContent"]["items"][0]["value"]["event"],
-            "flare"
+            responses[2]["result"]["structuredContent"]["record_type"],
+            "json_object"
+        );
+        assert_eq!(
+            responses[2]["result"]["structuredContent"]["items"][0]["value"],
+            json!({"key": "event", "value": "flare"})
         );
         assert_eq!(
             responses[3]["result"]["structuredContent"]["backend"],
@@ -1212,6 +1370,391 @@ mod tests {
         assert_eq!(
             responses[4]["result"]["structuredContent"]["snapshot_kind"],
             "logical"
+        );
+    }
+
+    #[test]
+    fn put_file_payload_tolerates_empty_counterpart() {
+        let (fs, options) = surface();
+        // (text, base64="") writes the text payload.
+        let response = execute_tool(
+            &fs,
+            &options,
+            "workbench_put_file",
+            &json!({"id":"task-1","section":"input","path":"a.txt","text":"x","base64":""}),
+        )
+        .unwrap();
+        assert_eq!(response["size_bytes"], 1);
+        assert_eq!(response["content_type"], "text/plain; charset=utf-8");
+        // (text="", base64) decodes the base64 payload.
+        let response = execute_tool(
+            &fs,
+            &options,
+            "workbench_put_file",
+            &json!({"id":"task-1","section":"input","path":"b.bin","text":"","base64":"aGk="}),
+        )
+        .unwrap();
+        assert_eq!(response["size_bytes"], 2);
+        assert_eq!(response["content_type"], "application/octet-stream");
+        assert_eq!(
+            fs.read_file("/workbenches/task-1/input/b.bin").unwrap(),
+            b"hi".to_vec()
+        );
+        // A lone empty text still writes an empty file.
+        let response = execute_tool(
+            &fs,
+            &options,
+            "workbench_put_file",
+            &json!({"id":"task-1","section":"input","path":"c.txt","text":""}),
+        )
+        .unwrap();
+        assert_eq!(response["size_bytes"], 0);
+        // Ambiguous combinations keep failing.
+        for args in [
+            json!({"id":"task-1","section":"input","path":"d","text":"","base64":""}),
+            json!({"id":"task-1","section":"input","path":"d","text":"x","base64":"eQ=="}),
+            json!({"id":"task-1","section":"input","path":"d"}),
+        ] {
+            let err = execute_tool(&fs, &options, "workbench_put_file", &args).unwrap_err();
+            assert_eq!(err.to_string(), "provide exactly one of text or base64");
+        }
+    }
+
+    #[test]
+    fn put_file_reports_null_inode_and_generation() {
+        let (fs, options) = surface();
+        let response = execute_tool(
+            &fs,
+            &options,
+            "workbench_put_file",
+            &json!({"id":"task-1","section":"input","path":"a.txt","text":"x"}),
+        )
+        .unwrap();
+        assert_eq!(response["inode"], Value::Null);
+        assert_eq!(response["generation"], Value::Null);
+    }
+
+    #[test]
+    fn commit_response_and_envelope_align_with_dfs() {
+        let (fs, options) = surface();
+        let response = execute_tool(
+            &fs,
+            &options,
+            "workbench_commit",
+            &json!({"id":"task-1","manifest":{"task":"flare-search"}}),
+        )
+        .unwrap();
+        assert_eq!(
+            response["path"],
+            "/workbenches/task-1/metadata/run_manifest.json"
+        );
+        let bytes = fs
+            .read_file("/workbenches/task-1/metadata/run_manifest.json")
+            .unwrap();
+        assert_eq!(response["size_bytes"], bytes.len());
+        assert_eq!(response["inode"], Value::Null);
+        assert_eq!(response["generation"], Value::Null);
+        assert_eq!(response["digest_uri"], digest_uri(&bytes));
+        assert!(response.get("manifest_path").is_none());
+        let envelope: Value = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(envelope["schema"], "nokv.workbench.run_manifest.v0");
+        assert_eq!(envelope["backend"], "nokv-agent");
+        assert_eq!(envelope["manifest"]["task"], "flare-search");
+    }
+
+    #[test]
+    fn commit_validates_manifest_argument() {
+        let (fs, options) = surface();
+        let err =
+            execute_tool(&fs, &options, "workbench_commit", &json!({"id":"task-1"})).unwrap_err();
+        assert_eq!(err.to_string(), "missing required argument manifest");
+        let err = execute_tool(
+            &fs,
+            &options,
+            "workbench_commit",
+            &json!({"id":"task-1","manifest":"str"}),
+        )
+        .unwrap_err();
+        assert_eq!(err.to_string(), "manifest must be a JSON object");
+    }
+
+    #[test]
+    fn find_pages_root_listing_like_dfs() {
+        let (fs, options) = surface();
+        for index in 1..=5 {
+            execute_tool(
+                &fs,
+                &options,
+                "workbench_create",
+                &json!({"id": format!("wb-{index}")}),
+            )
+            .unwrap();
+        }
+        for index in 1..=3 {
+            execute_tool(
+                &fs,
+                &options,
+                "workbench_commit",
+                &json!({"id": format!("wb-{index}"), "manifest": {"task": "Flare-Search"}}),
+            )
+            .unwrap();
+        }
+        // Page through the root listing; match_count counts the current page.
+        let mut cursor = Value::Null;
+        let mut total = 0;
+        let mut pages = 0;
+        loop {
+            let page = execute_tool(
+                &fs,
+                &options,
+                "workbench_find",
+                &json!({"cursor": cursor, "limit": 2}),
+            )
+            .unwrap();
+            let matches = page["matches"].as_array().unwrap();
+            assert!(matches.len() <= 2);
+            assert_eq!(page["match_count"], matches.len());
+            assert!(page["entry_count"].is_number());
+            total += matches.len();
+            pages += 1;
+            cursor = page["next_cursor"].clone();
+            if cursor.is_null() {
+                assert_eq!(page["truncated"], false);
+                break;
+            }
+        }
+        assert_eq!(total, 5);
+        assert_eq!(pages, 3);
+        // committed filter drops uncommitted workbenches within each page.
+        let committed = execute_tool(
+            &fs,
+            &options,
+            "workbench_find",
+            &json!({"committed": true, "limit": 100}),
+        )
+        .unwrap();
+        assert_eq!(committed["match_count"], 3);
+        let uncommitted = execute_tool(
+            &fs,
+            &options,
+            "workbench_find",
+            &json!({"committed": false, "limit": 100}),
+        )
+        .unwrap();
+        assert_eq!(uncommitted["match_count"], 2);
+        // Manifest pattern matching is ASCII case-insensitive.
+        let pattern = execute_tool(
+            &fs,
+            &options,
+            "workbench_find",
+            &json!({"manifest_pattern": "flare-search", "limit": 100}),
+        )
+        .unwrap();
+        assert_eq!(pattern["match_count"], 3);
+    }
+
+    #[test]
+    fn find_rejects_malformed_cursor() {
+        let (fs, options) = surface();
+        execute_tool(&fs, &options, "workbench_create", &json!({"id":"wb-1"})).unwrap();
+        let err = execute_tool(
+            &fs,
+            &options,
+            "workbench_find",
+            &json!({"cursor": "garbage"}),
+        )
+        .unwrap_err();
+        assert_eq!(err.to_string(), "invalid cursor garbage");
+        let err =
+            execute_tool(&fs, &options, "workbench_find", &json!({"cursor": "zz"})).unwrap_err();
+        assert_eq!(err.to_string(), "invalid cursor zz");
+    }
+
+    #[test]
+    fn find_empty_root_reports_entry_count() {
+        let (fs, options) = surface();
+        let response = execute_tool(&fs, &options, "workbench_find", &json!({})).unwrap();
+        assert_eq!(response["match_count"], 0);
+        assert_eq!(response["entry_count"], 0);
+        assert_eq!(response["next_cursor"], Value::Null);
+        assert_eq!(response["truncated"], false);
+    }
+
+    #[test]
+    fn find_reports_manifest_summary_fields() {
+        let (fs, options) = surface();
+        execute_tool(&fs, &options, "workbench_create", &json!({"id":"wb-1"})).unwrap();
+        let commit = execute_tool(
+            &fs,
+            &options,
+            "workbench_commit",
+            &json!({"id":"wb-1","manifest":{"task":"flare"}}),
+        )
+        .unwrap();
+        let found = execute_tool(&fs, &options, "workbench_find", &json!({})).unwrap();
+        let entry = &found["matches"][0];
+        let bytes = fs
+            .read_file("/workbenches/wb-1/metadata/run_manifest.json")
+            .unwrap();
+        assert_eq!(entry["manifest_size_bytes"], bytes.len());
+        assert_eq!(entry["manifest_digest_uri"], commit["digest_uri"]);
+        assert_eq!(entry["manifest_generation"], Value::Null);
+        assert_eq!(
+            entry["manifest_summary"]["schema"],
+            "nokv.workbench.run_manifest.v0"
+        );
+        // Uncommitted workbenches report the same keys as nulls.
+        execute_tool(&fs, &options, "workbench_create", &json!({"id":"wb-2"})).unwrap();
+        let found = execute_tool(&fs, &options, "workbench_find", &json!({})).unwrap();
+        let entry = found["matches"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .find(|entry| entry["workbench_id"] == "wb-2")
+            .unwrap();
+        assert_eq!(entry["manifest_size_bytes"], Value::Null);
+        assert_eq!(entry["manifest_digest_uri"], Value::Null);
+        assert_eq!(entry["manifest_generation"], Value::Null);
+    }
+
+    #[test]
+    fn stat_returns_compact_card() {
+        let (fs, options) = surface();
+        let put = execute_tool(
+            &fs,
+            &options,
+            "workbench_put_file",
+            &json!({"id":"task-1","section":"input","path":"data.bin","base64":"aGk="}),
+        )
+        .unwrap();
+        let stat = execute_tool(
+            &fs,
+            &options,
+            "workbench_stat",
+            &json!({"id":"task-1","section":"input","path":"data.bin"}),
+        )
+        .unwrap();
+        let card = &stat["card"];
+        assert_eq!(card["name"], "data.bin");
+        assert_eq!(card["path"], "/workbenches/task-1/input/data.bin");
+        assert_eq!(card["section"], "input");
+        assert_eq!(card["relative_path"], "data.bin");
+        assert_eq!(card["kind"], "file");
+        assert_eq!(card["size_bytes"], 2);
+        assert_eq!(card["entry_count"], Value::Null);
+        assert_eq!(card["record_count"], Value::Null);
+        assert_eq!(card["inode"], Value::Null);
+        assert_eq!(card["generation"], Value::Null);
+        assert_eq!(card["content_type"], "application/octet-stream");
+        assert_eq!(card["digest_uri"], put["digest_uri"]);
+        assert_eq!(card["producer"], "nokv-agent");
+        assert_eq!(card["manifest_id"], "workbenches/task-1/input/data.bin");
+        for leaked in ["schema", "sample", "catalog", "indexed_values", "body"] {
+            assert!(card.get(leaked).is_none(), "card leaks {leaked}");
+        }
+        // Workbench root card counts direct children.
+        let stat = execute_tool(&fs, &options, "workbench_stat", &json!({"id":"task-1"})).unwrap();
+        let card = &stat["card"];
+        assert_eq!(card["kind"], "directory");
+        assert_eq!(card["entry_count"], SECTIONS.len());
+        assert_eq!(card["section"], Value::Null);
+        assert_eq!(card["digest_uri"], Value::Null);
+        assert_eq!(card["producer"], Value::Null);
+        assert_eq!(card["manifest_id"], Value::Null);
+    }
+
+    #[test]
+    fn snapshot_is_idempotent_and_stays_within_53_bits() {
+        let (fs, options) = surface();
+        execute_tool(
+            &fs,
+            &options,
+            "workbench_put_file",
+            &json!({"id":"task-1","section":"outputs","path":"result.txt","text":"done"}),
+        )
+        .unwrap();
+        execute_tool(
+            &fs,
+            &options,
+            "workbench_commit",
+            &json!({"id":"task-1","manifest":{"task":"flare"}}),
+        )
+        .unwrap();
+        let first =
+            execute_tool(&fs, &options, "workbench_snapshot", &json!({"id":"task-1"})).unwrap();
+        let second =
+            execute_tool(&fs, &options, "workbench_snapshot", &json!({"id":"task-1"})).unwrap();
+        assert_eq!(first["snapshot_id"], second["snapshot_id"]);
+        assert_eq!(first["snapshot_digest"], second["snapshot_digest"]);
+        let id = first["snapshot_id"].as_u64().unwrap();
+        assert!(id < (1 << 53));
+        let digest = first["snapshot_digest"].as_str().unwrap();
+        assert!(digest.starts_with("sha256:"));
+        assert_eq!(first["path"], "/workbenches/task-1");
+        assert_eq!(first["read_version"], Value::Null);
+        // The record file name uses the same 53-bit id.
+        let snapshot_path = first["snapshot_path"].as_str().unwrap();
+        assert_eq!(
+            snapshot_path,
+            format!("/workbenches/task-1/metadata/snapshots/{id}.json")
+        );
+        let record: Value = serde_json::from_slice(&fs.read_file(snapshot_path).unwrap()).unwrap();
+        assert_eq!(record["snapshot_id"], id);
+        // Prior snapshot records are excluded from the file manifest.
+        let files = record["files"].as_array().unwrap();
+        assert!(files.iter().all(|file| !file["path"]
+            .as_str()
+            .unwrap()
+            .contains("/metadata/snapshots/")));
+    }
+
+    #[test]
+    fn snapshot_requires_commit_with_dfs_message() {
+        let (fs, options) = surface();
+        execute_tool(&fs, &options, "workbench_create", &json!({"id":"task-1"})).unwrap();
+        let err =
+            execute_tool(&fs, &options, "workbench_snapshot", &json!({"id":"task-1"})).unwrap_err();
+        assert_eq!(
+            err.to_string(),
+            "workbench task-1 is not committed; missing /workbenches/task-1/metadata/run_manifest.json"
+        );
+    }
+
+    #[test]
+    fn path_validation_messages_align_with_dfs() {
+        assert_eq!(
+            normalize_relative_path("bad\\path", "path", false)
+                .unwrap_err()
+                .to_string(),
+            "path must use POSIX separators"
+        );
+        assert_eq!(
+            normalize_relative_path("bad\0path", "path", false)
+                .unwrap_err()
+                .to_string(),
+            "path contains a NUL byte"
+        );
+        assert_eq!(
+            normalize_absolute_path("relative", "workbench_root").unwrap_err(),
+            "workbench_root must be an absolute agent path"
+        );
+        assert_eq!(
+            normalize_absolute_path("/a\\b", "workbench_root").unwrap_err(),
+            "workbench_root must use POSIX separators"
+        );
+        assert_eq!(
+            normalize_absolute_path("/a\0b", "workbench_root").unwrap_err(),
+            "workbench_root contains a NUL byte"
+        );
+        let options = WorkbenchMcpOptions {
+            root: DEFAULT_WORKBENCH_ROOT.to_owned(),
+            max_bytes: DEFAULT_WORKBENCH_MAX_BYTES,
+        };
+        assert_eq!(
+            path_scope(&options, "wb", "/elsewhere/file")
+                .unwrap_err()
+                .to_string(),
+            "path /elsewhere/file is outside workbench /workbenches/wb"
         );
     }
 

--- a/crates/nokv-agent/src/workbench.rs
+++ b/crates/nokv-agent/src/workbench.rs
@@ -115,7 +115,7 @@ pub fn tool_definitions() -> Vec<AgentToolDefinition> {
         },
         AgentToolDefinition {
             name: "workbench_list",
-            description: "List a workbench, section, or subdirectory.",
+            description: "List a workbench, section, or subdirectory. Not recursive. Entries written outside the standard sections through the embedded agent store are returned with section null and cannot be addressed by the other workbench tools.",
             parameters: json!({
                 "type": "object",
                 "required": ["id"],
@@ -163,7 +163,7 @@ pub fn tool_definitions() -> Vec<AgentToolDefinition> {
         },
         AgentToolDefinition {
             name: "workbench_grep",
-            description: "Search workbench file bodies for a case-insensitive literal substring.",
+            description: "Search workbench file bodies for a case-insensitive literal substring. This is not regex grep. Matches in files written outside the standard sections through the embedded agent store are returned with section null and cannot be addressed by the other workbench tools.",
             parameters: json!({
                 "type": "object",
                 "required": ["id", "pattern", "recursive"],
@@ -381,7 +381,18 @@ fn shape_read_tool_result(
             "relative_path": scope.relative_path,
             "path": scope.path,
             "entry_count": result.get("entry_count").cloned().unwrap_or(Value::Null),
-            "entries": result.get("entries").cloned().unwrap_or_else(|| json!([])),
+            "entries": result
+                .get("entries")
+                .and_then(Value::as_array)
+                .map(|entries| {
+                    entries
+                        .iter()
+                        .map(|entry| compact_list_entry(options, id, entry))
+                        .collect::<Result<Vec<_>, _>>()
+                })
+                .transpose()?
+                .map(Value::Array)
+                .unwrap_or_else(|| json!([])),
             "next_cursor": result.get("next_cursor").cloned().unwrap_or(Value::Null),
             "truncated": result.get("truncated").cloned().unwrap_or(Value::Bool(false)),
         })),
@@ -420,7 +431,18 @@ fn shape_read_tool_result(
             "path": scope.path,
             "pattern": result.get("pattern").cloned().unwrap_or(Value::Null),
             "recursive": result.get("recursive").cloned().unwrap_or(Value::Bool(false)),
-            "matches": result.get("matches").cloned().unwrap_or_else(|| json!([])),
+            "matches": result
+                .get("matches")
+                .and_then(Value::as_array)
+                .map(|matches| {
+                    matches
+                        .iter()
+                        .map(|match_| compact_grep_match(options, id, match_))
+                        .collect::<Result<Vec<_>, _>>()
+                })
+                .transpose()?
+                .map(Value::Array)
+                .unwrap_or_else(|| json!([])),
             "files_scanned": result.get("files_scanned").cloned().unwrap_or(Value::Null),
             "next_cursor": result.get("next_cursor").cloned().unwrap_or(Value::Null),
             "truncated": result.get("truncated").cloned().unwrap_or(Value::Bool(false)),
@@ -923,6 +945,28 @@ fn path_scope(
     id: &str,
     path: &str,
 ) -> Result<WorkbenchPathScope, WorkbenchToolError> {
+    scoped_path(options, id, path, false)
+}
+
+/// Scope for paths returned by enumeration (list entries, grep matches).
+/// Other embedders of the agent store share the namespace and may have
+/// written entries outside the standard sections; those are surfaced with
+/// `section: null` and a workbench-relative path instead of failing the
+/// whole call.
+fn enumerated_path_scope(
+    options: &WorkbenchMcpOptions,
+    id: &str,
+    path: &str,
+) -> Result<WorkbenchPathScope, WorkbenchToolError> {
+    scoped_path(options, id, path, true)
+}
+
+fn scoped_path(
+    options: &WorkbenchMcpOptions,
+    id: &str,
+    path: &str,
+    tolerate_non_section: bool,
+) -> Result<WorkbenchPathScope, WorkbenchToolError> {
     let base = workbench_path(options, id);
     if path == base {
         return Ok(WorkbenchPathScope {
@@ -937,21 +981,66 @@ fn path_scope(
             "path escaped workbench root: {path}"
         )));
     };
+    let first = rest.split('/').next().unwrap_or(rest);
+    if let Err(err) = validate_section(first) {
+        if !tolerate_non_section {
+            return Err(err);
+        }
+        return Ok(WorkbenchPathScope {
+            path: path.to_owned(),
+            section: None,
+            relative_path: Some(rest.to_owned()),
+        });
+    }
     let (section, relative_path) = match rest.split_once('/') {
-        Some((section, relative_path)) => {
-            validate_section(section)?;
-            (section.to_owned(), Some(relative_path.to_owned()))
-        }
-        None => {
-            validate_section(rest)?;
-            (rest.to_owned(), None)
-        }
+        Some((section, relative_path)) => (section.to_owned(), Some(relative_path.to_owned())),
+        None => (rest.to_owned(), None),
     };
     Ok(WorkbenchPathScope {
         path: path.to_owned(),
         section: Some(section),
         relative_path,
     })
+}
+
+fn compact_list_entry(
+    options: &WorkbenchMcpOptions,
+    id: &str,
+    entry: &Value,
+) -> Result<Value, WorkbenchToolError> {
+    let path = entry
+        .get("path")
+        .and_then(Value::as_str)
+        .ok_or_else(|| WorkbenchToolError::new("list entry missing path"))?;
+    let scope = enumerated_path_scope(options, id, path)?;
+    Ok(json!({
+        "name": entry.get("name").cloned().unwrap_or(Value::Null),
+        "path": scope.path,
+        "section": scope.section,
+        "relative_path": scope.relative_path,
+        "kind": entry.get("kind").cloned().unwrap_or(Value::Null),
+        "size_bytes": entry.get("size_bytes").cloned().unwrap_or(Value::Null),
+        "entry_count": entry.get("entry_count").cloned().unwrap_or(Value::Null),
+    }))
+}
+
+fn compact_grep_match(
+    options: &WorkbenchMcpOptions,
+    id: &str,
+    match_: &Value,
+) -> Result<Value, WorkbenchToolError> {
+    let path = match_
+        .get("path")
+        .and_then(Value::as_str)
+        .ok_or_else(|| WorkbenchToolError::new("grep match missing path"))?;
+    let scope = enumerated_path_scope(options, id, path)?;
+    Ok(json!({
+        "path": scope.path,
+        "section": scope.section,
+        "relative_path": scope.relative_path,
+        "line_number": match_.get("line_number").cloned().unwrap_or(Value::Null),
+        "snippet": match_.get("snippet").cloned().unwrap_or(Value::Null),
+    }))
 }
 
 fn payload_bytes(
@@ -1199,5 +1288,84 @@ mod tests {
         )
         .unwrap();
         assert_eq!(read["path"], "/workbenches/task-1/input/sub/leaf.txt");
+    }
+
+    #[test]
+    fn list_and_grep_tolerate_out_of_band_entries() {
+        let (fs, options) = surface();
+        execute_tool(&fs, &options, "workbench_create", &json!({"id":"task-oob"})).unwrap();
+        execute_tool(
+            &fs,
+            &options,
+            "workbench_put_file",
+            &json!({
+                "id":"task-oob",
+                "section":"outputs",
+                "path":"spectrum.csv",
+                "text":"freq,power\n1,2\n",
+                "content_type":"text/csv"
+            }),
+        )
+        .unwrap();
+        // Out-of-band writes through the embedded API, outside the sections.
+        fs.put_file(
+            "/workbenches/task-oob/note.txt",
+            b"scratch note".to_vec(),
+            None,
+        )
+        .unwrap();
+        fs.put_file(
+            "/workbenches/task-oob/junk/scratch.txt",
+            b"freq rogue\n".to_vec(),
+            None,
+        )
+        .unwrap();
+
+        let list =
+            execute_tool(&fs, &options, "workbench_list", &json!({"id":"task-oob"})).unwrap();
+        let entries = list["entries"].as_array().unwrap();
+        let entry = |name: &str| {
+            entries
+                .iter()
+                .find(|entry| entry["name"] == name)
+                .unwrap_or_else(|| panic!("missing list entry {name}: {entries:?}"))
+        };
+        for section in SECTIONS {
+            assert_eq!(entry(section)["section"], *section);
+        }
+        assert_eq!(entry("note.txt")["section"], Value::Null);
+        assert_eq!(entry("note.txt")["relative_path"], "note.txt");
+        assert_eq!(entry("junk")["section"], Value::Null);
+        assert_eq!(entry("junk")["relative_path"], "junk");
+
+        let grep = execute_tool(
+            &fs,
+            &options,
+            "workbench_grep",
+            &json!({"id":"task-oob","pattern":"freq","recursive":true}),
+        )
+        .unwrap();
+        let matches = grep["matches"].as_array().unwrap();
+        let match_for = |path: &str| {
+            matches
+                .iter()
+                .find(|match_| match_["path"] == path)
+                .unwrap_or_else(|| panic!("missing grep match {path}: {matches:?}"))
+        };
+        let section_match = match_for("/workbenches/task-oob/outputs/spectrum.csv");
+        assert_eq!(section_match["section"], "outputs");
+        assert_eq!(section_match["relative_path"], "spectrum.csv");
+        let alien_match = match_for("/workbenches/task-oob/junk/scratch.txt");
+        assert_eq!(alien_match["section"], Value::Null);
+        assert_eq!(alien_match["relative_path"], "junk/scratch.txt");
+
+        // Request targets stay strict: out-of-band entries are unaddressable.
+        assert!(execute_tool(
+            &fs,
+            &options,
+            "workbench_stat",
+            &json!({"id":"task-oob","section":"junk","path":"scratch.txt"})
+        )
+        .is_err());
     }
 }

--- a/crates/nokv-agent/src/workbench.rs
+++ b/crates/nokv-agent/src/workbench.rs
@@ -1,0 +1,1203 @@
+use std::fmt;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use base64::Engine;
+use serde_json::{json, Value};
+use sha2::{Digest, Sha256};
+
+use crate::mcp::McpToolSurface;
+use crate::tool::execute_agent_tool;
+use crate::{AgentFs, AgentIndexError, AgentNodeKind, AgentStore, AgentToolDefinition};
+
+pub const DEFAULT_WORKBENCH_ROOT: &str = "/workbenches";
+pub const DEFAULT_WORKBENCH_MAX_BYTES: usize = 16 * 1024 * 1024;
+
+const DEFAULT_FIND_LIMIT: usize = 50;
+const MAX_FIND_LIMIT: usize = 100;
+const SECTIONS: &[&str] = &["input", "scripts", "outputs", "logs", "metadata"];
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct WorkbenchMcpOptions {
+    pub root: String,
+    pub max_bytes: usize,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct WorkbenchToolError {
+    message: String,
+}
+
+impl WorkbenchToolError {
+    fn new(message: impl Into<String>) -> Self {
+        Self {
+            message: message.into(),
+        }
+    }
+}
+
+impl fmt::Display for WorkbenchToolError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.message)
+    }
+}
+
+impl std::error::Error for WorkbenchToolError {}
+
+impl From<AgentIndexError> for WorkbenchToolError {
+    fn from(err: AgentIndexError) -> Self {
+        Self::new(err.to_string())
+    }
+}
+
+pub struct WorkbenchMcpSurface<'a, S> {
+    fs: &'a AgentFs<S>,
+    options: WorkbenchMcpOptions,
+}
+
+impl<'a, S> WorkbenchMcpSurface<'a, S> {
+    pub fn new(fs: &'a AgentFs<S>, options: WorkbenchMcpOptions) -> Self {
+        Self { fs, options }
+    }
+}
+
+impl<S> McpToolSurface for WorkbenchMcpSurface<'_, S>
+where
+    S: AgentStore,
+{
+    fn tool_definitions(&self) -> Vec<AgentToolDefinition> {
+        tool_definitions()
+    }
+
+    fn execute_tool(&self, name: &str, args: &Value) -> Result<Value, String> {
+        execute_tool(self.fs, &self.options, name, args).map_err(|err| err.to_string())
+    }
+}
+
+pub fn normalize_workbench_root(raw: &str) -> Result<String, String> {
+    let normalized = normalize_absolute_path(raw, "workbench_root")?;
+    if normalized == "/" {
+        return Err("workbench_root must not be /".to_owned());
+    }
+    Ok(normalized)
+}
+
+pub fn tool_definitions() -> Vec<AgentToolDefinition> {
+    vec![
+        AgentToolDefinition {
+            name: "workbench_create",
+            description: "Create an agent-native workbench directory with standard sections.",
+            parameters: json!({
+                "type": "object",
+                "required": ["id"],
+                "properties": {
+                    "id": {"type": "string"}
+                },
+                "additionalProperties": false
+            }),
+        },
+        AgentToolDefinition {
+            name: "workbench_put_file",
+            description: "Write one file into a workbench section.",
+            parameters: json!({
+                "type": "object",
+                "required": ["id", "section", "path"],
+                "properties": {
+                    "id": {"type": "string"},
+                    "section": {"type": "string", "enum": SECTIONS},
+                    "path": {"type": "string"},
+                    "text": {"type": "string"},
+                    "base64": {"type": "string"},
+                    "content_type": {"type": "string"},
+                    "replace": {"type": "boolean"}
+                },
+                "additionalProperties": false
+            }),
+        },
+        AgentToolDefinition {
+            name: "workbench_list",
+            description: "List a workbench, section, or subdirectory.",
+            parameters: json!({
+                "type": "object",
+                "required": ["id"],
+                "properties": {
+                    "id": {"type": "string"},
+                    "section": {"type": ["string", "null"], "enum": ["input", "scripts", "outputs", "logs", "metadata", null]},
+                    "path": {"type": ["string", "null"]},
+                    "cursor": {"type": ["string", "null"]},
+                    "limit": {"type": "integer", "minimum": 1}
+                },
+                "additionalProperties": false
+            }),
+        },
+        AgentToolDefinition {
+            name: "workbench_stat",
+            description: "Inspect a workbench path compact card.",
+            parameters: json!({
+                "type": "object",
+                "required": ["id"],
+                "properties": {
+                    "id": {"type": "string"},
+                    "section": {"type": ["string", "null"], "enum": ["input", "scripts", "outputs", "logs", "metadata", null]},
+                    "path": {"type": ["string", "null"]}
+                },
+                "additionalProperties": false
+            }),
+        },
+        AgentToolDefinition {
+            name: "workbench_read",
+            description: "Read one workbench file.",
+            parameters: json!({
+                "type": "object",
+                "required": ["id", "section", "path"],
+                "properties": {
+                    "id": {"type": "string"},
+                    "section": {"type": "string", "enum": SECTIONS},
+                    "path": {"type": "string"},
+                    "format": {"type": "string", "enum": ["structured", "bytes"]},
+                    "cursor": {"type": ["string", "null"]},
+                    "offset": {"type": "integer", "minimum": 0},
+                    "limit": {"type": "integer", "minimum": 1}
+                },
+                "additionalProperties": false
+            }),
+        },
+        AgentToolDefinition {
+            name: "workbench_grep",
+            description: "Search workbench file bodies for a case-insensitive literal substring.",
+            parameters: json!({
+                "type": "object",
+                "required": ["id", "pattern", "recursive"],
+                "properties": {
+                    "id": {"type": "string"},
+                    "section": {"type": ["string", "null"], "enum": ["input", "scripts", "outputs", "logs", "metadata", null]},
+                    "path": {"type": ["string", "null"]},
+                    "pattern": {"type": "string"},
+                    "recursive": {"type": "boolean"},
+                    "cursor": {"type": ["string", "null"]},
+                    "limit": {"type": "integer", "minimum": 1}
+                },
+                "additionalProperties": false
+            }),
+        },
+        AgentToolDefinition {
+            name: "workbench_find",
+            description: "List workbenches with optional committed-state and manifest filters.",
+            parameters: json!({
+                "type": "object",
+                "properties": {
+                    "committed": {"type": ["boolean", "null"]},
+                    "manifest_pattern": {"type": ["string", "null"]},
+                    "include_manifest": {"type": "boolean"},
+                    "cursor": {"type": ["string", "null"]},
+                    "limit": {"type": "integer", "minimum": 1, "maximum": MAX_FIND_LIMIT}
+                },
+                "additionalProperties": false
+            }),
+        },
+        AgentToolDefinition {
+            name: "workbench_commit",
+            description: "Mark a workbench complete by writing metadata/run_manifest.json.",
+            parameters: json!({
+                "type": "object",
+                "required": ["id", "manifest"],
+                "properties": {
+                    "id": {"type": "string"},
+                    "manifest": {"type": "object"},
+                    "replace": {"type": "boolean"}
+                },
+                "additionalProperties": false
+            }),
+        },
+        AgentToolDefinition {
+            name: "workbench_snapshot",
+            description: "Write an agent-native logical snapshot record for a committed workbench.",
+            parameters: json!({
+                "type": "object",
+                "required": ["id"],
+                "properties": {
+                    "id": {"type": "string"}
+                },
+                "additionalProperties": false
+            }),
+        },
+    ]
+}
+
+pub fn execute_tool<S>(
+    fs: &AgentFs<S>,
+    options: &WorkbenchMcpOptions,
+    name: &str,
+    args: &Value,
+) -> Result<Value, WorkbenchToolError>
+where
+    S: AgentStore,
+{
+    match name {
+        "workbench_create" => create_workbench(fs, options, args),
+        "workbench_put_file" => put_file(fs, options, args),
+        "workbench_list" => execute_read_tool(fs, options, "ls", args),
+        "workbench_stat" => execute_read_tool(fs, options, "stat", args),
+        "workbench_read" => execute_read_tool(fs, options, "read", args),
+        "workbench_grep" => execute_read_tool(fs, options, "grep", args),
+        "workbench_find" => find_workbenches(fs, options, args),
+        "workbench_commit" => commit_workbench(fs, options, args),
+        "workbench_snapshot" => snapshot_workbench(fs, options, args),
+        other => Err(WorkbenchToolError::new(format!(
+            "unknown workbench tool {other}"
+        ))),
+    }
+}
+
+fn create_workbench<S>(
+    fs: &AgentFs<S>,
+    options: &WorkbenchMcpOptions,
+    args: &Value,
+) -> Result<Value, WorkbenchToolError>
+where
+    S: AgentStore,
+{
+    let id = required_workbench_id(args)?;
+    ensure_standard_dirs(fs, options, &id)?;
+    Ok(json!({
+        "status": "success",
+        "workbench_id": id,
+        "path": workbench_path(options, &id),
+        "sections": SECTIONS,
+        "backend": "nokv-agent",
+    }))
+}
+
+fn put_file<S>(
+    fs: &AgentFs<S>,
+    options: &WorkbenchMcpOptions,
+    args: &Value,
+) -> Result<Value, WorkbenchToolError>
+where
+    S: AgentStore,
+{
+    let id = required_workbench_id(args)?;
+    let section = required_section(args)?;
+    let rel_path = required_section_relative_path(args, section, "path")?;
+    let replace = optional_bool(args, "replace")?.unwrap_or(false);
+    let (bytes, default_content_type) = payload_bytes(args, options.max_bytes)?;
+    let content_type = optional_string(args, "content_type")?
+        .unwrap_or(default_content_type)
+        .to_owned();
+
+    ensure_standard_dirs(fs, options, &id)?;
+    ensure_parent_dirs(fs, options, &id, section, &rel_path)?;
+    let path = section_path(options, &id, section, Some(&rel_path));
+    if let Some(existing) = fs.node(&path)? {
+        if existing.kind != AgentNodeKind::File {
+            return Err(WorkbenchToolError::new(format!(
+                "path exists but is not a file: {path}"
+            )));
+        }
+        if !replace {
+            return Err(WorkbenchToolError::new(format!(
+                "path already exists; set replace=true to overwrite: {path}"
+            )));
+        }
+    }
+    let digest_uri = digest_uri(&bytes);
+    let size_bytes = bytes.len();
+    fs.put_file(&path, bytes, Some(content_type.clone()))?;
+
+    Ok(json!({
+        "status": "success",
+        "workbench_id": id,
+        "section": section,
+        "relative_path": rel_path,
+        "path": path,
+        "size_bytes": size_bytes,
+        "digest_uri": digest_uri,
+        "content_type": content_type,
+        "replace": replace,
+        "backend": "nokv-agent",
+    }))
+}
+
+fn execute_read_tool<S>(
+    fs: &AgentFs<S>,
+    options: &WorkbenchMcpOptions,
+    read_tool: &str,
+    args: &Value,
+) -> Result<Value, WorkbenchToolError>
+where
+    S: AgentStore,
+{
+    let id = required_workbench_id(args)?;
+    let target = match read_tool {
+        "read" => {
+            let section = required_section(args)?;
+            let rel_path = required_section_relative_path(args, section, "path")?;
+            section_path(options, &id, section, Some(&rel_path))
+        }
+        _ => scoped_path_from_optional_args(options, &id, args)?,
+    };
+    let mut forwarded = args
+        .as_object()
+        .cloned()
+        .ok_or_else(|| WorkbenchToolError::new("tool arguments must be a JSON object"))?;
+    forwarded.insert("path".to_owned(), Value::String(target.clone()));
+    forwarded.remove("id");
+    forwarded.remove("section");
+    match read_tool {
+        "ls" | "stat" => {
+            forwarded.remove("format");
+            forwarded.remove("offset");
+            forwarded.remove("pattern");
+            forwarded.remove("recursive");
+        }
+        "read" => {
+            forwarded.remove("pattern");
+            forwarded.remove("recursive");
+        }
+        "grep" => {
+            forwarded.remove("format");
+            forwarded.remove("offset");
+        }
+        _ => {}
+    }
+    let result = execute_agent_tool(fs, read_tool, &Value::Object(forwarded))
+        .map_err(|err| WorkbenchToolError::new(err.to_string()))?;
+    shape_read_tool_result(options, &id, &target, read_tool, result)
+}
+
+fn shape_read_tool_result(
+    options: &WorkbenchMcpOptions,
+    id: &str,
+    target: &str,
+    read_tool: &str,
+    result: Value,
+) -> Result<Value, WorkbenchToolError> {
+    let scope = path_scope(options, id, target)?;
+    match read_tool {
+        "ls" => Ok(json!({
+            "status": "success",
+            "workbench_id": id,
+            "workbench_path": workbench_path(options, id),
+            "section": scope.section,
+            "relative_path": scope.relative_path,
+            "path": scope.path,
+            "entry_count": result.get("entry_count").cloned().unwrap_or(Value::Null),
+            "entries": result.get("entries").cloned().unwrap_or_else(|| json!([])),
+            "next_cursor": result.get("next_cursor").cloned().unwrap_or(Value::Null),
+            "truncated": result.get("truncated").cloned().unwrap_or(Value::Bool(false)),
+        })),
+        "stat" => Ok(json!({
+            "status": "success",
+            "workbench_id": id,
+            "workbench_path": workbench_path(options, id),
+            "section": scope.section,
+            "relative_path": scope.relative_path,
+            "path": scope.path,
+            "card": result.get("card").cloned().unwrap_or(Value::Null),
+        })),
+        "read" => Ok(json!({
+            "status": "success",
+            "workbench_id": id,
+            "workbench_path": workbench_path(options, id),
+            "section": scope.section,
+            "relative_path": scope.relative_path,
+            "path": scope.path,
+            "total_size_bytes": result.get("total_size_bytes").cloned().unwrap_or(Value::Null),
+            "format": result.get("format").cloned().unwrap_or(Value::Null),
+            "record_type": result.get("record_type").cloned().unwrap_or(Value::Null),
+            "record_count": result.get("record_count").cloned().unwrap_or(Value::Null),
+            "cursor": result.get("cursor").cloned().unwrap_or(Value::Null),
+            "next_cursor": result.get("next_cursor").cloned().unwrap_or(Value::Null),
+            "truncated": result.get("truncated").cloned().unwrap_or(Value::Bool(false)),
+            "items": result.get("items").cloned().unwrap_or_else(|| json!([])),
+            "bytes": result.get("bytes").cloned().unwrap_or(Value::Null),
+        })),
+        "grep" => Ok(json!({
+            "status": "success",
+            "workbench_id": id,
+            "workbench_path": workbench_path(options, id),
+            "section": scope.section,
+            "relative_path": scope.relative_path,
+            "path": scope.path,
+            "pattern": result.get("pattern").cloned().unwrap_or(Value::Null),
+            "recursive": result.get("recursive").cloned().unwrap_or(Value::Bool(false)),
+            "matches": result.get("matches").cloned().unwrap_or_else(|| json!([])),
+            "files_scanned": result.get("files_scanned").cloned().unwrap_or(Value::Null),
+            "next_cursor": result.get("next_cursor").cloned().unwrap_or(Value::Null),
+            "truncated": result.get("truncated").cloned().unwrap_or(Value::Bool(false)),
+        })),
+        other => Err(WorkbenchToolError::new(format!(
+            "unsupported read tool {other}"
+        ))),
+    }
+}
+
+fn find_workbenches<S>(
+    fs: &AgentFs<S>,
+    options: &WorkbenchMcpOptions,
+    args: &Value,
+) -> Result<Value, WorkbenchToolError>
+where
+    S: AgentStore,
+{
+    let committed_filter = optional_bool(args, "committed")?;
+    let manifest_pattern = optional_string(args, "manifest_pattern")?;
+    let include_manifest = optional_bool(args, "include_manifest")?.unwrap_or(false);
+    let offset = optional_string(args, "cursor")?
+        .and_then(|raw| raw.parse::<usize>().ok())
+        .unwrap_or(0);
+    let limit = optional_usize(args, "limit")?.unwrap_or(DEFAULT_FIND_LIMIT);
+    if limit == 0 || limit > MAX_FIND_LIMIT {
+        return Err(WorkbenchToolError::new(format!(
+            "limit must be between 1 and {MAX_FIND_LIMIT}"
+        )));
+    }
+    if fs.node(&options.root)?.is_none() {
+        return Ok(json!({
+            "status": "success",
+            "path": options.root,
+            "matches": [],
+            "match_count": 0,
+            "next_cursor": Value::Null,
+            "truncated": false,
+        }));
+    }
+    let mut matches = Vec::new();
+    for node in fs.list(&options.root, None, usize::MAX)?.0 {
+        if node.kind != crate::AgentNodeKind::Directory {
+            continue;
+        }
+        let id = node.name.clone();
+        let summary = workbench_manifest_summary(fs, options, &id, include_manifest)?;
+        if let Some(committed) = committed_filter {
+            if summary.committed != committed {
+                continue;
+            }
+        }
+        if let Some(pattern) = manifest_pattern {
+            let Some(text) = summary.manifest_text.as_deref() else {
+                continue;
+            };
+            if !text.to_lowercase().contains(&pattern.to_lowercase()) {
+                continue;
+            }
+        }
+        matches.push(summary_json(options, &id, summary));
+    }
+    let match_count = matches.len();
+    let page = matches
+        .into_iter()
+        .skip(offset)
+        .take(limit)
+        .collect::<Vec<_>>();
+    let next_offset = offset.saturating_add(page.len());
+    Ok(json!({
+        "status": "success",
+        "path": options.root,
+        "matches": page,
+        "match_count": match_count,
+        "next_cursor": (next_offset < match_count).then(|| next_offset.to_string()),
+        "truncated": next_offset < match_count,
+    }))
+}
+
+fn commit_workbench<S>(
+    fs: &AgentFs<S>,
+    options: &WorkbenchMcpOptions,
+    args: &Value,
+) -> Result<Value, WorkbenchToolError>
+where
+    S: AgentStore,
+{
+    let id = required_workbench_id(args)?;
+    let manifest = args
+        .get("manifest")
+        .and_then(Value::as_object)
+        .ok_or_else(|| WorkbenchToolError::new("missing object argument manifest"))?;
+    let replace = optional_bool(args, "replace")?.unwrap_or(false);
+    ensure_standard_dirs(fs, options, &id)?;
+    let path = section_path(options, &id, "metadata", Some("run_manifest.json"));
+    if !replace && fs.node(&path)?.is_some() {
+        return Err(WorkbenchToolError::new(
+            "run_manifest.json already exists; set replace=true to overwrite",
+        ));
+    }
+    let envelope = json!({
+        "schema": "nokv.agent.workbench.run_manifest.v0",
+        "backend": "nokv-agent",
+        "workbench_id": id,
+        "workbench_path": workbench_path(options, &id),
+        "committed_at_unix_seconds": unix_seconds(),
+        "manifest": manifest,
+    });
+    let bytes = serde_json::to_vec_pretty(&envelope)
+        .map_err(|err| WorkbenchToolError::new(err.to_string()))?;
+    let digest_uri = digest_uri(&bytes);
+    fs.put_file(&path, bytes, Some("application/json".to_owned()))?;
+    Ok(json!({
+        "status": "success",
+        "workbench_id": id,
+        "manifest_path": path,
+        "digest_uri": digest_uri,
+        "replace": replace,
+        "backend": "nokv-agent",
+    }))
+}
+
+fn snapshot_workbench<S>(
+    fs: &AgentFs<S>,
+    options: &WorkbenchMcpOptions,
+    args: &Value,
+) -> Result<Value, WorkbenchToolError>
+where
+    S: AgentStore,
+{
+    let id = required_workbench_id(args)?;
+    let manifest_path = section_path(options, &id, "metadata", Some("run_manifest.json"));
+    let manifest = fs
+        .read_file(&manifest_path)
+        .map_err(|_| WorkbenchToolError::new("workbench must be committed before snapshot"))?;
+    let files = fs.files_under(&workbench_path(options, &id), true)?;
+    let mut hasher = Sha256::new();
+    hasher.update(&manifest);
+    let file_manifest = files
+        .into_iter()
+        .filter(|node| node.kind == crate::AgentNodeKind::File)
+        .map(|node| {
+            let bytes = fs.read_file(&node.path)?;
+            hasher.update(node.path.as_bytes());
+            hasher.update(&bytes);
+            Ok(json!({
+                "path": node.path,
+                "size_bytes": bytes.len(),
+                "digest_uri": digest_uri(&bytes),
+            }))
+        })
+        .collect::<Result<Vec<_>, AgentIndexError>>()?;
+    let digest = hasher.finalize();
+    let snapshot_id = u64::from_be_bytes(digest[0..8].try_into().unwrap());
+    let snapshot_path = section_path(
+        options,
+        &id,
+        "metadata",
+        Some(&format!("snapshots/{snapshot_id}.json")),
+    );
+    let snapshot_record = json!({
+        "schema": "nokv.agent.workbench.snapshot.v0",
+        "backend": "nokv-agent",
+        "snapshot_kind": "logical",
+        "snapshot_id": snapshot_id,
+        "workbench_id": id,
+        "workbench_path": workbench_path(options, &id),
+        "manifest_path": manifest_path,
+        "created_at_unix_seconds": unix_seconds(),
+        "files": file_manifest,
+    });
+    let bytes = serde_json::to_vec_pretty(&snapshot_record)
+        .map_err(|err| WorkbenchToolError::new(err.to_string()))?;
+    fs.put_file(&snapshot_path, bytes, Some("application/json".to_owned()))?;
+    Ok(json!({
+        "status": "success",
+        "workbench_id": id,
+        "snapshot_id": snapshot_id,
+        "snapshot_kind": "logical",
+        "snapshot_path": snapshot_path,
+        "read_version": Value::Null,
+        "backend": "nokv-agent",
+    }))
+}
+
+#[derive(Clone, Debug)]
+struct WorkbenchManifestSummary {
+    committed: bool,
+    manifest_path: Option<String>,
+    manifest_text: Option<String>,
+    envelope: Option<Value>,
+    include_manifest: bool,
+}
+
+#[derive(Clone, Debug)]
+struct WorkbenchPathScope {
+    path: String,
+    section: Option<String>,
+    relative_path: Option<String>,
+}
+
+fn workbench_manifest_summary<S>(
+    fs: &AgentFs<S>,
+    options: &WorkbenchMcpOptions,
+    id: &str,
+    include_manifest: bool,
+) -> Result<WorkbenchManifestSummary, WorkbenchToolError>
+where
+    S: AgentStore,
+{
+    let manifest_path = section_path(options, id, "metadata", Some("run_manifest.json"));
+    let Ok(bytes) = fs.read_file(&manifest_path) else {
+        return Ok(WorkbenchManifestSummary {
+            committed: false,
+            manifest_path: None,
+            manifest_text: None,
+            envelope: None,
+            include_manifest,
+        });
+    };
+    let text = String::from_utf8(bytes)
+        .map_err(|err| WorkbenchToolError::new(format!("manifest is not UTF-8: {err}")))?;
+    let envelope = serde_json::from_str::<Value>(&text)
+        .map_err(|err| WorkbenchToolError::new(format!("manifest is not JSON: {err}")))?;
+    Ok(WorkbenchManifestSummary {
+        committed: true,
+        manifest_path: Some(manifest_path),
+        manifest_text: Some(text),
+        envelope: Some(envelope),
+        include_manifest,
+    })
+}
+
+fn summary_json(
+    options: &WorkbenchMcpOptions,
+    id: &str,
+    summary: WorkbenchManifestSummary,
+) -> Value {
+    let manifest_summary = summary
+        .envelope
+        .as_ref()
+        .map(manifest_summary_json)
+        .unwrap_or(Value::Null);
+    json!({
+        "workbench_id": id,
+        "path": workbench_path(options, id),
+        "committed": summary.committed,
+        "manifest_path": summary.manifest_path,
+        "manifest_summary": manifest_summary,
+        "manifest": if summary.include_manifest { summary.envelope } else { None },
+    })
+}
+
+fn manifest_summary_json(envelope: &Value) -> Value {
+    let manifest_keys = envelope
+        .get("manifest")
+        .and_then(Value::as_object)
+        .map(|object| {
+            let mut keys = object.keys().cloned().collect::<Vec<_>>();
+            keys.sort();
+            keys
+        })
+        .unwrap_or_default();
+    json!({
+        "schema": envelope.get("schema").cloned().unwrap_or(Value::Null),
+        "workbench_id": envelope.get("workbench_id").cloned().unwrap_or(Value::Null),
+        "committed_at_unix_seconds": envelope
+            .get("committed_at_unix_seconds")
+            .cloned()
+            .unwrap_or(Value::Null),
+        "manifest_keys": manifest_keys,
+        "manifest_task": envelope
+            .get("manifest")
+            .and_then(|manifest| manifest.get("task"))
+            .cloned()
+            .unwrap_or(Value::Null),
+    })
+}
+
+fn ensure_standard_dirs<S>(
+    fs: &AgentFs<S>,
+    options: &WorkbenchMcpOptions,
+    id: &str,
+) -> Result<(), WorkbenchToolError>
+where
+    S: AgentStore,
+{
+    fs.create_dir_all(&options.root)?;
+    fs.create_dir_all(&workbench_path(options, id))?;
+    for section in SECTIONS {
+        fs.create_dir_all(&section_path(options, id, section, None))?;
+    }
+    Ok(())
+}
+
+fn ensure_parent_dirs<S>(
+    fs: &AgentFs<S>,
+    options: &WorkbenchMcpOptions,
+    id: &str,
+    section: &str,
+    rel_path: &str,
+) -> Result<(), WorkbenchToolError>
+where
+    S: AgentStore,
+{
+    let Some((parent, _)) = rel_path.rsplit_once('/') else {
+        return Ok(());
+    };
+    fs.create_dir_all(&section_path(options, id, section, Some(parent)))?;
+    Ok(())
+}
+
+fn required_workbench_id(args: &Value) -> Result<String, WorkbenchToolError> {
+    let id = required_string(args, "id")?;
+    validate_workbench_id(id)?;
+    Ok(id.to_owned())
+}
+
+fn validate_workbench_id(id: &str) -> Result<(), WorkbenchToolError> {
+    let mut chars = id.chars();
+    let Some(first) = chars.next() else {
+        return Err(WorkbenchToolError::new("id must not be empty"));
+    };
+    if !first.is_ascii_alphanumeric() {
+        return Err(WorkbenchToolError::new(
+            "id must start with an ASCII letter or digit",
+        ));
+    }
+    if id.len() > 128 {
+        return Err(WorkbenchToolError::new("id must be at most 128 bytes"));
+    }
+    if !chars.all(|c| c.is_ascii_alphanumeric() || c == '_' || c == '-') {
+        return Err(WorkbenchToolError::new(
+            "id may contain only ASCII letters, digits, '_' and '-'",
+        ));
+    }
+    Ok(())
+}
+
+fn required_section(args: &Value) -> Result<&str, WorkbenchToolError> {
+    let section = required_string(args, "section")?;
+    validate_section(section)?;
+    Ok(section)
+}
+
+fn validate_section(section: &str) -> Result<(), WorkbenchToolError> {
+    if SECTIONS.contains(&section) {
+        Ok(())
+    } else {
+        Err(WorkbenchToolError::new(format!(
+            "invalid section {section}; expected one of {}",
+            SECTIONS.join(", ")
+        )))
+    }
+}
+
+fn scoped_path_from_optional_args(
+    options: &WorkbenchMcpOptions,
+    id: &str,
+    args: &Value,
+) -> Result<String, WorkbenchToolError> {
+    let section = optional_string(args, "section")?;
+    let rel_path = optional_string(args, "path")?;
+    match (section, rel_path) {
+        (None, None) => Ok(workbench_path(options, id)),
+        (None, Some("")) => Ok(workbench_path(options, id)),
+        (None, Some(_)) => Err(WorkbenchToolError::new(
+            "path requires section when scoped below a workbench",
+        )),
+        (Some(section), path) => {
+            validate_section(section)?;
+            let rel = match path {
+                Some(raw) => {
+                    let rel_path = normalize_relative_path(raw, "path", true)?;
+                    reject_section_prefixed_path(section, &rel_path, "path")?;
+                    Some(rel_path)
+                }
+                None => None,
+            };
+            Ok(section_path(options, id, section, rel.as_deref()))
+        }
+    }
+}
+
+fn required_section_relative_path(
+    args: &Value,
+    section: &str,
+    field: &'static str,
+) -> Result<String, WorkbenchToolError> {
+    let rel_path = normalize_relative_path(required_string(args, field)?, field, false)?;
+    reject_section_prefixed_path(section, &rel_path, field)?;
+    Ok(rel_path)
+}
+
+fn reject_section_prefixed_path(
+    section: &str,
+    rel_path: &str,
+    field: &'static str,
+) -> Result<(), WorkbenchToolError> {
+    let section_prefix = format!("{section}/");
+    if rel_path == section || rel_path.starts_with(&section_prefix) {
+        return Err(WorkbenchToolError::new(format!(
+            "{field} must be relative to section {section}; do not prefix it with {section}/"
+        )));
+    }
+    Ok(())
+}
+
+fn normalize_relative_path(
+    raw: &str,
+    field: &'static str,
+    allow_empty: bool,
+) -> Result<String, WorkbenchToolError> {
+    if raw.is_empty() {
+        if allow_empty {
+            return Ok(String::new());
+        }
+        return Err(WorkbenchToolError::new(format!(
+            "{field} must not be empty"
+        )));
+    }
+    if raw.starts_with('/') {
+        return Err(WorkbenchToolError::new(format!("{field} must be relative")));
+    }
+    if raw.ends_with('/') {
+        return Err(WorkbenchToolError::new(format!(
+            "{field} must not end with '/'"
+        )));
+    }
+    if raw.contains("//") {
+        return Err(WorkbenchToolError::new(format!(
+            "{field} must not contain empty components"
+        )));
+    }
+    if raw.contains('\\') || raw.contains('\0') {
+        return Err(WorkbenchToolError::new(format!(
+            "{field} must use POSIX separators and contain no NUL bytes"
+        )));
+    }
+    for component in raw.split('/') {
+        if component == "." || component == ".." {
+            return Err(WorkbenchToolError::new(format!(
+                "{field} must not contain '.' or '..' components"
+            )));
+        }
+    }
+    Ok(raw.to_owned())
+}
+
+fn normalize_absolute_path(raw: &str, field: &'static str) -> Result<String, String> {
+    if raw.is_empty() {
+        return Err(format!("{field} must not be empty"));
+    }
+    if !raw.starts_with('/') {
+        return Err(format!("{field} must be an absolute agent path"));
+    }
+    if raw.contains('\\') || raw.contains('\0') {
+        return Err(format!(
+            "{field} must use POSIX separators and contain no NUL bytes"
+        ));
+    }
+    let trimmed = raw.trim_end_matches('/');
+    let path = if trimmed.is_empty() { "/" } else { trimmed };
+    let mut components = Vec::new();
+    for component in path.trim_start_matches('/').split('/') {
+        if component.is_empty() {
+            continue;
+        }
+        if component == "." || component == ".." {
+            return Err(format!("{field} must not contain '.' or '..' components"));
+        }
+        components.push(component);
+    }
+    if components.is_empty() {
+        Ok("/".to_owned())
+    } else {
+        Ok(format!("/{}", components.join("/")))
+    }
+}
+
+fn workbench_path(options: &WorkbenchMcpOptions, id: &str) -> String {
+    format!("{}/{}", options.root, id)
+}
+
+fn section_path(
+    options: &WorkbenchMcpOptions,
+    id: &str,
+    section: &str,
+    rel_path: Option<&str>,
+) -> String {
+    let base = format!("{}/{section}", workbench_path(options, id));
+    match rel_path {
+        Some(path) if !path.is_empty() => format!("{base}/{path}"),
+        _ => base,
+    }
+}
+
+fn path_scope(
+    options: &WorkbenchMcpOptions,
+    id: &str,
+    path: &str,
+) -> Result<WorkbenchPathScope, WorkbenchToolError> {
+    let base = workbench_path(options, id);
+    if path == base {
+        return Ok(WorkbenchPathScope {
+            path: path.to_owned(),
+            section: None,
+            relative_path: None,
+        });
+    }
+    let prefix = format!("{base}/");
+    let Some(rest) = path.strip_prefix(&prefix) else {
+        return Err(WorkbenchToolError::new(format!(
+            "path escaped workbench root: {path}"
+        )));
+    };
+    let (section, relative_path) = match rest.split_once('/') {
+        Some((section, relative_path)) => {
+            validate_section(section)?;
+            (section.to_owned(), Some(relative_path.to_owned()))
+        }
+        None => {
+            validate_section(rest)?;
+            (rest.to_owned(), None)
+        }
+    };
+    Ok(WorkbenchPathScope {
+        path: path.to_owned(),
+        section: Some(section),
+        relative_path,
+    })
+}
+
+fn payload_bytes(
+    args: &Value,
+    max_bytes: usize,
+) -> Result<(Vec<u8>, &'static str), WorkbenchToolError> {
+    let text = optional_string(args, "text")?;
+    let encoded = optional_string(args, "base64")?;
+    let (bytes, content_type) = match (text, encoded) {
+        (Some(text), None) => (text.as_bytes().to_vec(), "text/plain; charset=utf-8"),
+        (None, Some(encoded)) => (
+            base64::engine::general_purpose::STANDARD
+                .decode(encoded)
+                .map_err(|err| WorkbenchToolError::new(format!("invalid base64 payload: {err}")))?,
+            "application/octet-stream",
+        ),
+        _ => {
+            return Err(WorkbenchToolError::new(
+                "provide exactly one of text or base64",
+            ))
+        }
+    };
+    if bytes.len() > max_bytes {
+        return Err(WorkbenchToolError::new(format!(
+            "payload exceeds max_bytes: {} > {max_bytes}",
+            bytes.len()
+        )));
+    }
+    Ok((bytes, content_type))
+}
+
+fn digest_uri(bytes: &[u8]) -> String {
+    let mut digest = Sha256::new();
+    digest.update(bytes);
+    format!("sha256:{:x}", digest.finalize())
+}
+
+fn unix_seconds() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|duration| duration.as_secs())
+        .unwrap_or(0)
+}
+
+fn required_string<'a>(args: &'a Value, name: &'static str) -> Result<&'a str, WorkbenchToolError> {
+    args.get(name)
+        .and_then(Value::as_str)
+        .ok_or_else(|| WorkbenchToolError::new(format!("missing required string argument {name}")))
+}
+
+fn optional_string<'a>(
+    args: &'a Value,
+    name: &'static str,
+) -> Result<Option<&'a str>, WorkbenchToolError> {
+    match args.get(name) {
+        None | Some(Value::Null) => Ok(None),
+        Some(value) => value.as_str().map(Some).ok_or_else(|| {
+            WorkbenchToolError::new(format!("{name} must be a string when provided"))
+        }),
+    }
+}
+
+fn optional_bool(args: &Value, name: &'static str) -> Result<Option<bool>, WorkbenchToolError> {
+    match args.get(name) {
+        None | Some(Value::Null) => Ok(None),
+        Some(value) => value.as_bool().map(Some).ok_or_else(|| {
+            WorkbenchToolError::new(format!("{name} must be a boolean when provided"))
+        }),
+    }
+}
+
+fn optional_usize(args: &Value, name: &'static str) -> Result<Option<usize>, WorkbenchToolError> {
+    match args.get(name) {
+        None | Some(Value::Null) => Ok(None),
+        Some(value) => {
+            let raw = value.as_u64().ok_or_else(|| {
+                WorkbenchToolError::new(format!("{name} must be an integer when provided"))
+            })?;
+            usize::try_from(raw).map(Some).map_err(|_| {
+                WorkbenchToolError::new(format!("{name} is too large for this platform"))
+            })
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{run_mcp_surface_stream, AgentId, HoltAgentStore};
+
+    fn surface() -> (AgentFs<HoltAgentStore>, WorkbenchMcpOptions) {
+        let fs = AgentFs::new(
+            AgentId::new("workbench-test"),
+            HoltAgentStore::open_memory().unwrap(),
+        );
+        fs.bootstrap().unwrap();
+        let options = WorkbenchMcpOptions {
+            root: DEFAULT_WORKBENCH_ROOT.to_owned(),
+            max_bytes: DEFAULT_WORKBENCH_MAX_BYTES,
+        };
+        (fs, options)
+    }
+
+    fn run_requests(requests: Vec<Value>) -> Vec<Value> {
+        let (fs, options) = surface();
+        let surface = WorkbenchMcpSurface::new(&fs, options);
+        let input = requests
+            .into_iter()
+            .map(|value| serde_json::to_string(&value).unwrap())
+            .collect::<Vec<_>>()
+            .join("\n")
+            + "\n";
+        let mut writer = Vec::new();
+        run_mcp_surface_stream(&surface, std::io::Cursor::new(input), &mut writer).unwrap();
+        String::from_utf8(writer)
+            .unwrap()
+            .lines()
+            .map(|line| serde_json::from_str(line).unwrap())
+            .collect()
+    }
+
+    #[test]
+    fn tools_are_workbench_scoped() {
+        let names = tool_definitions()
+            .into_iter()
+            .map(|tool| tool.name)
+            .collect::<Vec<_>>();
+        assert_eq!(
+            names,
+            vec![
+                "workbench_create",
+                "workbench_put_file",
+                "workbench_list",
+                "workbench_stat",
+                "workbench_read",
+                "workbench_grep",
+                "workbench_find",
+                "workbench_commit",
+                "workbench_snapshot",
+            ]
+        );
+    }
+
+    #[test]
+    fn create_put_read_commit_snapshot_flow() {
+        let responses = run_requests(vec![
+            json!({"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"workbench_create","arguments":{"id":"task-1"}}}),
+            json!({"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"workbench_put_file","arguments":{"id":"task-1","section":"input","path":"event.json","text":"{\"event\":\"flare\"}"}}}),
+            json!({"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"workbench_read","arguments":{"id":"task-1","section":"input","path":"event.json","format":"structured"}}}),
+            json!({"jsonrpc":"2.0","id":4,"method":"tools/call","params":{"name":"workbench_commit","arguments":{"id":"task-1","manifest":{"task":"flare-search"}}}}),
+            json!({"jsonrpc":"2.0","id":5,"method":"tools/call","params":{"name":"workbench_snapshot","arguments":{"id":"task-1"}}}),
+        ]);
+        assert_eq!(
+            responses[0]["result"]["structuredContent"]["status"],
+            "success"
+        );
+        assert_eq!(
+            responses[1]["result"]["structuredContent"]["path"],
+            "/workbenches/task-1/input/event.json"
+        );
+        assert_eq!(
+            responses[2]["result"]["structuredContent"]["items"][0]["value"]["event"],
+            "flare"
+        );
+        assert_eq!(
+            responses[3]["result"]["structuredContent"]["backend"],
+            "nokv-agent"
+        );
+        assert_eq!(
+            responses[4]["result"]["structuredContent"]["snapshot_kind"],
+            "logical"
+        );
+    }
+
+    #[test]
+    fn rejects_path_escape_and_default_overwrite() {
+        let (fs, options) = surface();
+        assert!(execute_tool(
+            &fs,
+            &options,
+            "workbench_put_file",
+            &json!({"id":"task-1","section":"input","path":"../x","text":"bad"})
+        )
+        .is_err());
+        execute_tool(
+            &fs,
+            &options,
+            "workbench_put_file",
+            &json!({"id":"task-1","section":"input","path":"event.txt","text":"one"}),
+        )
+        .unwrap();
+        assert!(execute_tool(
+            &fs,
+            &options,
+            "workbench_put_file",
+            &json!({"id":"task-1","section":"input","path":"event.txt","text":"two"})
+        )
+        .is_err());
+    }
+
+    #[test]
+    fn put_file_rejects_directory_targets_and_file_ancestors() {
+        let (fs, options) = surface();
+        execute_tool(
+            &fs,
+            &options,
+            "workbench_put_file",
+            &json!({"id":"task-1","section":"input","path":"sub/leaf.txt","text":"one"}),
+        )
+        .unwrap();
+
+        // Overwriting an existing directory must fail even with replace=true.
+        let err = execute_tool(
+            &fs,
+            &options,
+            "workbench_put_file",
+            &json!({"id":"task-1","section":"input","path":"sub","text":"x","replace":true}),
+        )
+        .unwrap_err();
+        assert!(
+            err.to_string().contains("is not a file"),
+            "unexpected error: {err}"
+        );
+
+        // Writing beneath an existing file must fail instead of silently
+        // turning the file into a directory.
+        let err = execute_tool(
+            &fs,
+            &options,
+            "workbench_put_file",
+            &json!({"id":"task-1","section":"input","path":"sub/leaf.txt/nested.txt","text":"x"}),
+        )
+        .unwrap_err();
+        assert!(
+            err.to_string().contains("is not a directory"),
+            "unexpected error: {err}"
+        );
+
+        // The original file must still be readable afterwards.
+        let read = execute_tool(
+            &fs,
+            &options,
+            "workbench_read",
+            &json!({"id":"task-1","section":"input","path":"sub/leaf.txt"}),
+        )
+        .unwrap();
+        assert_eq!(read["path"], "/workbenches/task-1/input/sub/leaf.txt");
+    }
+}

--- a/crates/nokv-agent/tests/workbench_parity.rs
+++ b/crates/nokv-agent/tests/workbench_parity.rs
@@ -1,0 +1,463 @@
+//! Parity gate between the embedded workbench mirror and the DFS-backed
+//! workbench MCP server.
+//!
+//! The DFS implementation lives in a bin crate
+//! (`crates/nokv/src/bin/nokv/workbench_mcp.rs`) and cannot be imported here,
+//! so its tool schemas and response key sets are pinned as golden constants.
+//! When either side changes its tool surface, update BOTH the other side and
+//! these constants in the same commit.
+
+use serde_json::{json, Value};
+
+use nokv_agent::{
+    AgentFs, AgentId, HoltAgentStore, McpToolSurface, WorkbenchMcpOptions, WorkbenchMcpSurface,
+    DEFAULT_WORKBENCH_MAX_BYTES, DEFAULT_WORKBENCH_ROOT,
+};
+
+fn fs() -> (tempfile::TempDir, AgentFs<HoltAgentStore>) {
+    let dir = tempfile::tempdir().unwrap();
+    let fs = AgentFs::new(
+        AgentId::new("parity-test"),
+        HoltAgentStore::open(dir.path().join("store")).unwrap(),
+    );
+    fs.bootstrap().unwrap();
+    (dir, fs)
+}
+
+fn options() -> WorkbenchMcpOptions {
+    WorkbenchMcpOptions {
+        root: DEFAULT_WORKBENCH_ROOT.to_owned(),
+        max_bytes: DEFAULT_WORKBENCH_MAX_BYTES,
+    }
+}
+
+/// Golden copy of `tool_definitions()` from
+/// `crates/nokv/src/bin/nokv/workbench_mcp.rs` (names and inputSchema only;
+/// tool descriptions intentionally differ per backend).
+fn dfs_tool_schemas() -> Vec<(&'static str, Value)> {
+    let sections = json!(["input", "scripts", "outputs", "logs", "metadata"]);
+    let nullable_section = json!({
+        "type": ["string", "null"],
+        "enum": ["input", "scripts", "outputs", "logs", "metadata", null]
+    });
+    vec![
+        (
+            "workbench_create",
+            json!({
+                "type": "object",
+                "required": ["id"],
+                "properties": {
+                    "id": {"type": "string", "description": "Workbench id, e.g. spedas-task-001."}
+                },
+                "additionalProperties": false
+            }),
+        ),
+        (
+            "workbench_put_file",
+            json!({
+                "type": "object",
+                "required": ["id", "section", "path"],
+                "properties": {
+                    "id": {"type": "string"},
+                    "section": {"type": "string", "enum": sections},
+                    "path": {"type": "string", "description": "Path relative to section. Do not prefix it with the section name."},
+                    "text": {"type": "string"},
+                    "base64": {"type": "string"},
+                    "content_type": {"type": "string"},
+                    "replace": {"type": "boolean"}
+                },
+                "additionalProperties": false
+            }),
+        ),
+        (
+            "workbench_list",
+            json!({
+                "type": "object",
+                "required": ["id"],
+                "properties": {
+                    "id": {"type": "string"},
+                    "section": nullable_section,
+                    "path": {"type": ["string", "null"], "description": "Optional path relative to section. Do not prefix it with the section name."},
+                    "cursor": {"type": ["string", "null"]},
+                    "limit": {"type": "integer", "minimum": 1}
+                },
+                "additionalProperties": false
+            }),
+        ),
+        (
+            "workbench_stat",
+            json!({
+                "type": "object",
+                "required": ["id"],
+                "properties": {
+                    "id": {"type": "string"},
+                    "section": nullable_section,
+                    "path": {"type": ["string", "null"], "description": "Optional path relative to section. Do not prefix it with the section name."}
+                },
+                "additionalProperties": false
+            }),
+        ),
+        (
+            "workbench_read",
+            json!({
+                "type": "object",
+                "required": ["id", "section", "path"],
+                "properties": {
+                    "id": {"type": "string"},
+                    "section": {"type": "string", "enum": sections},
+                    "path": {"type": "string", "description": "Path relative to section. Do not prefix it with the section name."},
+                    "format": {"type": "string", "enum": ["structured", "bytes"]},
+                    "cursor": {"type": ["string", "null"]},
+                    "offset": {"type": "integer", "minimum": 0},
+                    "limit": {"type": "integer", "minimum": 1}
+                },
+                "additionalProperties": false
+            }),
+        ),
+        (
+            "workbench_grep",
+            json!({
+                "type": "object",
+                "required": ["id", "pattern", "recursive"],
+                "properties": {
+                    "id": {"type": "string"},
+                    "section": nullable_section,
+                    "path": {"type": ["string", "null"], "description": "Optional path relative to section. Do not prefix it with the section name."},
+                    "pattern": {"type": "string"},
+                    "recursive": {"type": "boolean"},
+                    "cursor": {"type": ["string", "null"]},
+                    "limit": {"type": "integer", "minimum": 1}
+                },
+                "additionalProperties": false
+            }),
+        ),
+        (
+            "workbench_find",
+            json!({
+                "type": "object",
+                "properties": {
+                    "committed": {"type": ["boolean", "null"], "description": "Filter by completion marker. Null or omitted returns all workbenches."},
+                    "manifest_pattern": {"type": ["string", "null"], "description": "Case-insensitive literal substring filter over metadata/run_manifest.json."},
+                    "include_manifest": {"type": "boolean", "description": "Include full run_manifest.json envelopes. Defaults false."},
+                    "cursor": {"type": ["string", "null"]},
+                    "limit": {"type": "integer", "minimum": 1, "maximum": 100}
+                },
+                "additionalProperties": false
+            }),
+        ),
+        (
+            "workbench_commit",
+            json!({
+                "type": "object",
+                "required": ["id", "manifest"],
+                "properties": {
+                    "id": {"type": "string"},
+                    "manifest": {"type": "object"},
+                    "replace": {"type": "boolean"}
+                },
+                "additionalProperties": false
+            }),
+        ),
+        (
+            "workbench_snapshot",
+            json!({
+                "type": "object",
+                "required": ["id"],
+                "properties": {
+                    "id": {"type": "string"}
+                },
+                "additionalProperties": false
+            }),
+        ),
+    ]
+}
+
+#[test]
+fn mirror_tool_schemas_match_dfs_golden() {
+    let (_dir, fs) = fs();
+    let surface = WorkbenchMcpSurface::new(&fs, options());
+    let actual = surface.tool_definitions();
+    let expected = dfs_tool_schemas();
+    assert_eq!(
+        actual.iter().map(|tool| tool.name).collect::<Vec<_>>(),
+        expected.iter().map(|(name, _)| *name).collect::<Vec<_>>(),
+    );
+    for (tool, (name, parameters)) in actual.iter().zip(&expected) {
+        assert_eq!(
+            &tool.parameters, parameters,
+            "inputSchema of {name} diverged from the DFS golden"
+        );
+    }
+}
+
+fn keys(value: &Value) -> Vec<&str> {
+    let mut keys = value
+        .as_object()
+        .unwrap_or_else(|| panic!("expected object, got {value}"))
+        .keys()
+        .map(String::as_str)
+        .collect::<Vec<_>>();
+    keys.sort_unstable();
+    keys
+}
+
+/// Asserts the mirror response carries exactly the DFS key set plus the
+/// whitelisted mirror-only extras.
+fn assert_key_parity(tool: &str, response: &Value, dfs_keys: &[&str], extras: &[&str]) {
+    let mut expected = dfs_keys.iter().chain(extras).copied().collect::<Vec<_>>();
+    expected.sort_unstable();
+    assert_eq!(
+        keys(response),
+        expected,
+        "{tool} response keys diverged from the DFS golden"
+    );
+}
+
+#[test]
+fn mirror_response_key_sets_match_dfs_golden() {
+    let (_dir, fs) = fs();
+    let surface = WorkbenchMcpSurface::new(&fs, options());
+    let call = |name: &str, args: Value| surface.execute_tool(name, &args).unwrap();
+
+    // DFS key sets transcribed from the success responses in
+    // crates/nokv/src/bin/nokv/workbench_mcp.rs.
+    let create = call("workbench_create", json!({"id": "wb-1"}));
+    assert_key_parity(
+        "workbench_create",
+        &create,
+        &["status", "workbench_id", "path", "sections"],
+        &["backend"],
+    );
+
+    let put = call(
+        "workbench_put_file",
+        json!({"id": "wb-1", "section": "input", "path": "data.json", "text": "{\"event\":\"flare\"}"}),
+    );
+    assert_key_parity(
+        "workbench_put_file",
+        &put,
+        &[
+            "status",
+            "workbench_id",
+            "section",
+            "relative_path",
+            "path",
+            "size_bytes",
+            "inode",
+            "generation",
+            "digest_uri",
+            "content_type",
+            "replace",
+        ],
+        &["backend"],
+    );
+    assert_eq!(put["inode"], Value::Null);
+    assert_eq!(put["generation"], Value::Null);
+
+    let list = call("workbench_list", json!({"id": "wb-1"}));
+    assert_key_parity(
+        "workbench_list",
+        &list,
+        &[
+            "status",
+            "workbench_id",
+            "workbench_path",
+            "section",
+            "relative_path",
+            "path",
+            "entry_count",
+            "entries",
+            "next_cursor",
+            "truncated",
+        ],
+        &[],
+    );
+    assert_key_parity(
+        "workbench_list entry",
+        &list["entries"][0],
+        &[
+            "name",
+            "path",
+            "section",
+            "relative_path",
+            "kind",
+            "size_bytes",
+            "entry_count",
+        ],
+        &[],
+    );
+
+    let stat = call(
+        "workbench_stat",
+        json!({"id": "wb-1", "section": "input", "path": "data.json"}),
+    );
+    assert_key_parity(
+        "workbench_stat",
+        &stat,
+        &[
+            "status",
+            "workbench_id",
+            "workbench_path",
+            "section",
+            "relative_path",
+            "path",
+            "card",
+        ],
+        &[],
+    );
+    assert_key_parity(
+        "workbench_stat card",
+        &stat["card"],
+        &[
+            "name",
+            "path",
+            "section",
+            "relative_path",
+            "kind",
+            "size_bytes",
+            "entry_count",
+            "record_count",
+            "inode",
+            "generation",
+            "content_type",
+            "digest_uri",
+            "producer",
+            "manifest_id",
+        ],
+        &[],
+    );
+    assert_eq!(stat["card"]["inode"], Value::Null);
+    assert_eq!(stat["card"]["generation"], Value::Null);
+
+    let read = call(
+        "workbench_read",
+        json!({"id": "wb-1", "section": "input", "path": "data.json"}),
+    );
+    assert_key_parity(
+        "workbench_read",
+        &read,
+        &[
+            "status",
+            "workbench_id",
+            "workbench_path",
+            "section",
+            "relative_path",
+            "path",
+            "total_size_bytes",
+            "format",
+            "record_type",
+            "record_count",
+            "cursor",
+            "next_cursor",
+            "truncated",
+            "items",
+            "bytes",
+        ],
+        &[],
+    );
+
+    let grep = call(
+        "workbench_grep",
+        json!({"id": "wb-1", "pattern": "flare", "recursive": true}),
+    );
+    assert_key_parity(
+        "workbench_grep",
+        &grep,
+        &[
+            "status",
+            "workbench_id",
+            "workbench_path",
+            "section",
+            "relative_path",
+            "path",
+            "pattern",
+            "recursive",
+            "matches",
+            "files_scanned",
+            "next_cursor",
+            "truncated",
+        ],
+        &[],
+    );
+    assert_key_parity(
+        "workbench_grep match",
+        &grep["matches"][0],
+        &["path", "section", "relative_path", "line_number", "snippet"],
+        &[],
+    );
+
+    let commit = call(
+        "workbench_commit",
+        json!({"id": "wb-1", "manifest": {"task": "flare"}}),
+    );
+    assert_key_parity(
+        "workbench_commit",
+        &commit,
+        &[
+            "status",
+            "workbench_id",
+            "path",
+            "size_bytes",
+            "inode",
+            "generation",
+            "digest_uri",
+            "replace",
+        ],
+        &["backend"],
+    );
+    assert_eq!(commit["inode"], Value::Null);
+    assert_eq!(commit["generation"], Value::Null);
+
+    let find = call("workbench_find", json!({}));
+    assert_key_parity(
+        "workbench_find",
+        &find,
+        &[
+            "status",
+            "path",
+            "matches",
+            "match_count",
+            "entry_count",
+            "next_cursor",
+            "truncated",
+        ],
+        &[],
+    );
+    assert_key_parity(
+        "workbench_find match",
+        &find["matches"][0],
+        &[
+            "workbench_id",
+            "path",
+            "committed",
+            "manifest_path",
+            "manifest_size_bytes",
+            "manifest_generation",
+            "manifest_digest_uri",
+            "manifest_summary",
+            "manifest",
+        ],
+        &[],
+    );
+    assert_eq!(find["matches"][0]["manifest_generation"], Value::Null);
+
+    let snapshot = call("workbench_snapshot", json!({"id": "wb-1"}));
+    assert_key_parity(
+        "workbench_snapshot",
+        &snapshot,
+        &[
+            "status",
+            "workbench_id",
+            "path",
+            "snapshot_id",
+            "read_version",
+        ],
+        &[
+            "backend",
+            "snapshot_kind",
+            "snapshot_path",
+            "snapshot_digest",
+        ],
+    );
+    assert_eq!(snapshot["read_version"], Value::Null);
+}

--- a/crates/nokv/src/bin/nokv.rs
+++ b/crates/nokv/src/bin/nokv.rs
@@ -3584,6 +3584,195 @@ mod tests {
     }
 
     #[test]
+    fn workbench_mcp_list_and_grep_tolerate_out_of_band_entries() {
+        let object_dir = tempdir().unwrap();
+        let object_root = object_dir.path().join("objects");
+        let addr = spawn_test_server_with_object_config(ObjectStoreConfig::tiered_local(
+            object_root.clone(),
+            fake_s3_options(),
+        ));
+        let connect = || {
+            let store =
+                LocalObjectStore::new(LocalObjectStoreOptions::new(object_root.clone())).unwrap();
+            NoKvFsClient::connect(addr, store)
+        };
+        let run_requests = |requests: Vec<serde_json::Value>| -> Vec<serde_json::Value> {
+            let reqs = requests
+                .into_iter()
+                .map(|request| serde_json::to_string(&request).unwrap())
+                .collect::<Vec<_>>()
+                .join("\n")
+                + "\n";
+            let reader = std::io::Cursor::new(reqs);
+            let mut writer = Vec::new();
+            run_mcp_stream_with_options(
+                connect(),
+                workbench_mcp_options(),
+                DEFAULT_UID,
+                DEFAULT_GID,
+                reader,
+                &mut writer,
+            )
+            .unwrap();
+            String::from_utf8(writer)
+                .unwrap()
+                .lines()
+                .map(|line| serde_json::from_str(line).unwrap())
+                .collect()
+        };
+
+        let setup = run_requests(vec![
+            serde_json::json!({
+                "jsonrpc": "2.0",
+                "id": 1,
+                "method": "tools/call",
+                "params": {
+                    "name": "workbench_create",
+                    "arguments": {"id": "spedas-task-003"}
+                }
+            }),
+            serde_json::json!({
+                "jsonrpc": "2.0",
+                "id": 2,
+                "method": "tools/call",
+                "params": {
+                    "name": "workbench_put_file",
+                    "arguments": {
+                        "id": "spedas-task-003",
+                        "section": "outputs",
+                        "path": "spectrum.csv",
+                        "text": "freq,power\n1,2\n",
+                        "content_type": "text/csv"
+                    }
+                }
+            }),
+        ]);
+        for (index, response) in setup.iter().enumerate() {
+            assert_ne!(
+                response["result"]["isError"], true,
+                "setup response {index}: {response}"
+            );
+        }
+
+        let out_of_band_metadata = |name: &str| ArtifactMetadata {
+            producer: "outside-writer".to_owned(),
+            digest_uri: "sha256:demo".to_owned(),
+            content_type: "text/plain".to_owned(),
+            manifest_id: name.to_owned(),
+            mode: DEFAULT_MODE_FILE,
+            uid: DEFAULT_UID,
+            gid: DEFAULT_GID,
+        };
+        let out_of_band = connect();
+        out_of_band
+            .put_artifact(
+                "/workbenches/spedas-task-003/note.txt",
+                b"scratch note".to_vec(),
+                out_of_band_metadata("note.txt"),
+            )
+            .unwrap();
+        out_of_band
+            .metadata()
+            .mkdir(
+                "/workbenches/spedas-task-003/junk",
+                DEFAULT_MODE_DIR,
+                DEFAULT_UID,
+                DEFAULT_GID,
+            )
+            .unwrap();
+        out_of_band
+            .put_artifact(
+                "/workbenches/spedas-task-003/junk/scratch.txt",
+                b"freq rogue\n".to_vec(),
+                out_of_band_metadata("junk/scratch.txt"),
+            )
+            .unwrap();
+
+        let responses = run_requests(vec![
+            serde_json::json!({
+                "jsonrpc": "2.0",
+                "id": 1,
+                "method": "tools/call",
+                "params": {
+                    "name": "workbench_list",
+                    "arguments": {"id": "spedas-task-003"}
+                }
+            }),
+            serde_json::json!({
+                "jsonrpc": "2.0",
+                "id": 2,
+                "method": "tools/call",
+                "params": {
+                    "name": "workbench_grep",
+                    "arguments": {
+                        "id": "spedas-task-003",
+                        "pattern": "freq",
+                        "recursive": true
+                    }
+                }
+            }),
+            serde_json::json!({
+                "jsonrpc": "2.0",
+                "id": 3,
+                "method": "tools/call",
+                "params": {
+                    "name": "workbench_stat",
+                    "arguments": {
+                        "id": "spedas-task-003",
+                        "path": "junk/scratch.txt"
+                    }
+                }
+            }),
+        ]);
+        for (index, response) in responses.iter().take(2).enumerate() {
+            assert_ne!(
+                response["result"]["isError"], true,
+                "response {index}: {response}"
+            );
+        }
+        // Out-of-band entries are enumerable but stay unaddressable: request
+        // targets keep the strict section validation.
+        assert_eq!(
+            responses[2]["result"]["isError"], true,
+            "stat of out-of-band entry must keep failing: {}",
+            responses[2]
+        );
+
+        let entries = responses[0]["result"]["structuredContent"]["entries"]
+            .as_array()
+            .unwrap();
+        let entry = |name: &str| {
+            entries
+                .iter()
+                .find(|entry| entry["name"] == name)
+                .unwrap_or_else(|| panic!("missing list entry {name}: {entries:?}"))
+        };
+        for section in workbench_mcp::SECTIONS {
+            assert_eq!(entry(section)["section"], *section);
+        }
+        assert_eq!(entry("note.txt")["section"], serde_json::Value::Null);
+        assert_eq!(entry("note.txt")["relative_path"], "note.txt");
+        assert_eq!(entry("junk")["section"], serde_json::Value::Null);
+        assert_eq!(entry("junk")["relative_path"], "junk");
+
+        let matches = responses[1]["result"]["structuredContent"]["matches"]
+            .as_array()
+            .unwrap();
+        let match_for = |path: &str| {
+            matches
+                .iter()
+                .find(|match_| match_["path"] == path)
+                .unwrap_or_else(|| panic!("missing grep match {path}: {matches:?}"))
+        };
+        let section_match = match_for("/workbenches/spedas-task-003/outputs/spectrum.csv");
+        assert_eq!(section_match["section"], "outputs");
+        assert_eq!(section_match["relative_path"], "spectrum.csv");
+        let alien_match = match_for("/workbenches/spedas-task-003/junk/scratch.txt");
+        assert_eq!(alien_match["section"], serde_json::Value::Null);
+        assert_eq!(alien_match["relative_path"], "junk/scratch.txt");
+    }
+
+    #[test]
     fn workbench_mcp_put_file_ignores_empty_unused_payload_variant() {
         let responses = run_workbench_mcp_requests(vec![
             serde_json::json!({

--- a/crates/nokv/src/bin/nokv/workbench_mcp.rs
+++ b/crates/nokv/src/bin/nokv/workbench_mcp.rs
@@ -15,7 +15,7 @@ pub const DEFAULT_WORKBENCH_MAX_BYTES: usize = 16 * 1024 * 1024;
 const DEFAULT_WORKBENCH_FIND_LIMIT: usize = 50;
 const MAX_WORKBENCH_FIND_LIMIT: usize = 100;
 
-const SECTIONS: &[&str] = &["input", "scripts", "outputs", "logs", "metadata"];
+pub const SECTIONS: &[&str] = &["input", "scripts", "outputs", "logs", "metadata"];
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct WorkbenchMcpOptions {
@@ -91,7 +91,7 @@ pub fn tool_definitions() -> Vec<AgentToolDefinition> {
         AgentToolDefinition {
             name: "workbench_list",
             description:
-                "List a workbench, section, or subdirectory through the NoKV namespace. Not recursive.",
+                "List a workbench, section, or subdirectory through the NoKV namespace. Not recursive. Entries written outside the standard sections by other NoKV clients are returned with section null; such entries cannot be addressed by the other workbench tools.",
             parameters: json!({
                 "type": "object",
                 "required": ["id"],
@@ -142,7 +142,7 @@ pub fn tool_definitions() -> Vec<AgentToolDefinition> {
         AgentToolDefinition {
             name: "workbench_grep",
             description:
-                "Search workbench file bodies for a case-insensitive literal substring. This is not regex grep.",
+                "Search workbench file bodies for a case-insensitive literal substring. This is not regex grep. Matches in files written outside the standard sections by other NoKV clients are returned with section null; such files cannot be addressed by the other workbench tools.",
             parameters: json!({
                 "type": "object",
                 "required": ["id", "pattern", "recursive"],
@@ -699,6 +699,27 @@ fn path_scope(
     id: &str,
     path: &str,
 ) -> Result<WorkbenchPathScope, WorkbenchToolError> {
+    scoped_path(options, id, path, false)
+}
+
+/// Scope for paths returned by enumeration (list entries, grep matches).
+/// Other NoKV clients share the namespace and may have written entries
+/// outside the standard sections; those are surfaced with `section: null`
+/// and a workbench-relative path instead of failing the whole call.
+fn enumerated_path_scope(
+    options: &WorkbenchMcpOptions,
+    id: &str,
+    path: &str,
+) -> Result<WorkbenchPathScope, WorkbenchToolError> {
+    scoped_path(options, id, path, true)
+}
+
+fn scoped_path(
+    options: &WorkbenchMcpOptions,
+    id: &str,
+    path: &str,
+    tolerate_non_section: bool,
+) -> Result<WorkbenchPathScope, WorkbenchToolError> {
     let base = workbench_path(options, id);
     if path == base {
         return Ok(WorkbenchPathScope {
@@ -711,15 +732,20 @@ fn path_scope(
     let rest = path.strip_prefix(&prefix).ok_or_else(|| {
         WorkbenchToolError::new(format!("path {path} is outside workbench {base}"))
     })?;
+    let first = rest.split('/').next().unwrap_or(rest);
+    if let Err(err) = validate_section(first) {
+        if !tolerate_non_section {
+            return Err(err);
+        }
+        return Ok(WorkbenchPathScope {
+            path: path.to_owned(),
+            section: None,
+            relative_path: Some(rest.to_owned()),
+        });
+    }
     let (section, relative_path) = match rest.split_once('/') {
-        Some((section, relative_path)) => {
-            validate_section(section)?;
-            (section.to_owned(), Some(relative_path.to_owned()))
-        }
-        None => {
-            validate_section(rest)?;
-            (rest.to_owned(), None)
-        }
+        Some((section, relative_path)) => (section.to_owned(), Some(relative_path.to_owned())),
+        None => (rest.to_owned(), None),
     };
     Ok(WorkbenchPathScope {
         path: path.to_owned(),
@@ -737,7 +763,7 @@ fn compact_list_entry(
         .get("path")
         .and_then(Value::as_str)
         .ok_or_else(|| WorkbenchToolError::new("list entry missing path"))?;
-    let scope = path_scope(options, id, path)?;
+    let scope = enumerated_path_scope(options, id, path)?;
     Ok(json!({
         "name": entry.get("name").cloned().unwrap_or(Value::Null),
         "path": scope.path,
@@ -778,7 +804,7 @@ fn compact_grep_match(
         .get("path")
         .and_then(Value::as_str)
         .ok_or_else(|| WorkbenchToolError::new("grep match missing path"))?;
-    let scope = path_scope(options, id, path)?;
+    let scope = enumerated_path_scope(options, id, path)?;
     Ok(json!({
         "path": scope.path,
         "section": scope.section,
@@ -1316,5 +1342,44 @@ mod tests {
         assert!(validate_workbench_id("spedas-task-001").is_ok());
         assert!(validate_workbench_id("_bad").is_err());
         assert!(validate_workbench_id("bad/path").is_err());
+    }
+
+    #[test]
+    fn scopes_enumerated_paths_outside_sections_as_null_section() {
+        let options = WorkbenchMcpOptions {
+            root: "/workbenches".to_owned(),
+            max_bytes: DEFAULT_WORKBENCH_MAX_BYTES,
+            uid: 1000,
+            gid: 1000,
+        };
+        let scope = |path| enumerated_path_scope(&options, "wb", path).unwrap();
+        assert_eq!(
+            scope("/workbenches/wb/outputs/plot.png"),
+            WorkbenchPathScope {
+                path: "/workbenches/wb/outputs/plot.png".to_owned(),
+                section: Some("outputs".to_owned()),
+                relative_path: Some("plot.png".to_owned()),
+            }
+        );
+        assert_eq!(
+            scope("/workbenches/wb/note.txt"),
+            WorkbenchPathScope {
+                path: "/workbenches/wb/note.txt".to_owned(),
+                section: None,
+                relative_path: Some("note.txt".to_owned()),
+            }
+        );
+        assert_eq!(
+            scope("/workbenches/wb/junk/scratch.txt"),
+            WorkbenchPathScope {
+                path: "/workbenches/wb/junk/scratch.txt".to_owned(),
+                section: None,
+                relative_path: Some("junk/scratch.txt".to_owned()),
+            }
+        );
+        assert!(enumerated_path_scope(&options, "wb", "/elsewhere/file").is_err());
+        // The strict variant used for request targets keeps rejecting.
+        assert!(path_scope(&options, "wb", "/workbenches/wb/junk/scratch.txt").is_err());
+        assert!(path_scope(&options, "wb", "/workbenches/wb/note.txt").is_err());
     }
 }

--- a/docs/development/nokv-agent.md
+++ b/docs/development/nokv-agent.md
@@ -198,3 +198,32 @@ design issue before adding a write verb to the trait.
 
 See also the [code contract](code_contract.md) and the
 [PR review checklist](pr_review_checklist.md).
+
+## 8. The agent-native runtime (embedded Holt store)
+
+Alongside the namespace tool surface above, the crate ships an **agent-native
+runtime**: an embedded, Holt-backed store for agent state that does not touch
+the NoKV DFS at all.
+
+- `HoltAgentStore` — embedded Holt tree (`open_file` / `open_memory`); one
+  live process per store directory (Holt holds a `flock` on it).
+- `AgentFs` — fs-shaped records (nodes, file bodies, child edges, catalogs,
+  index rows) keyed per `AgentId`. Write paths refuse to change a node's
+  kind: a file is never silently converted into a directory or vice versa.
+- `AgentEventIndex` — event rows plus typed/secondary indexes and coverage
+  rows, ingested from an append-only source (e.g. `events.jsonl`) in one
+  atomic batch. Ingestion is idempotent by `(source_file, source_offset)`,
+  including duplicates within a single batch; coverage is advance-only so
+  replaying an old batch never regresses `file_size`.
+- `nokv_agent::native::{agent_tool_definitions, execute_agent_tool}` — the
+  same seven read-tool names as the crate root, but executing against
+  `AgentFs` instead of `NoKvFs`. The root exports keep serving the DFS.
+- The `nokv-agent` binary — `nokv-agent mcp` (base profile) and
+  `nokv-agent mcp --profile workbench` serve these tools over MCP stdio
+  against a local store (`--store`, default `.nokv/agent`).
+
+The runtime is **additive**: nothing in the DFS product line depends on it,
+`nokv mcp` (including the DFS-backed workbench profile) is unchanged, and the
+two layers share tool names and JSON shapes but not storage. Treat it as the
+integration seam for agent-local state (LingTai-style derived index
+replacement) rather than a substitute for the namespace surface.


### PR DESCRIPTION
## Summary

Reshapes the `nokv-agent` refactor from #386 so that merging is behavior-idempotent with current `main`: every existing surface (CLI, RPC, MCP profiles, storage formats, workspace dependencies) behaves exactly as before, and the agent-native runtime comes in as a purely additive layer.

Supersedes #386. Includes #388 as a cherry-pick (`8926317911`); once #388 lands on `main`, rebasing this branch drops it automatically.

## What stays exactly as on main

- `nokv` CLI including `mcp --profile workbench` (the DFS-backed workbench MCP)
- `nokv-meta` agent/namespace service verbs, `nokv-protocol` ops, server wire, `nokv-client` agent impls
- The crate-root `nokv-agent` namespace tool surface (seven verbs over `NoKvFs`)
- Workspace dependencies: holt stays at 0.7.3; `Cargo.lock` gains only the `nokv-agent` dependency-list entry
- Metadata log codec (tag 22 kept), the bench harness, and the LingTai setup scripts

## What is added

- `HoltAgentStore`, `AgentFs`, `AgentEventIndex`, the event model/query and key/codec layers from #386
- `nokv_agent::native::{agent_tool_definitions, execute_agent_tool}`: the same seven read-tool names, executing against `AgentFs`; the root exports of the same names keep serving the DFS
- The `nokv-agent` binary: `nokv-agent mcp` (base profile) and `nokv-agent mcp --profile workbench` against a local embedded store (`--store`, default `.nokv/agent`)
- A contributor-handbook section documenting the two layers and the single-writer constraint of the embedded store

## Fixes applied to the imported runtime (each pinned by a new test)

Found during the acceptance review of #386:

1. `AgentFs` write paths refuse node-kind changes: `put_file` cannot clobber a directory (even with `replace=true`) and ancestor creation cannot silently convert a file into a directory, orphaning its body.
2. `files_under` (and therefore grep) no longer returns empty for recursive scans rooted at `/`.
3. Event ingestion dedupes `(source_file, source_offset)` within a batch; conflicting duplicates fail before anything is staged.
4. Coverage `file_size` is advance-only: replaying an already-ingested batch cannot regress lag accounting to a false `lag_bytes = 0`.
5. Negative `ts_micros` is rejected in batch validation instead of overflowing in debug key encoding.

## Out-of-band semantics mirrored onto the native surface

The contract of #388 is ported to the agent-native workbench: list entries and grep matches are shaped with per-entry `section` / `relative_path`, entries outside the five standard sections (written through the embedded store API) surface as `section: null` instead of passing through unscoped, and request targets keep strict section validation.

## Deliberately not carried over from #386

- No deletions: the DFS agent surface, RPC ops, and `nokv mcp` remain. That is the point of this PR.
- No holt 0.7.3 -> 0.8 bump.
- No bench harness rewrite and no README rewrite; the published benchmark numbers keep describing the surface they were measured on.
- Native `workbench_read` structured-record parity with the DFS profile is a known gap, deferred.

## Validation

- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace` (includes the #388 end-to-end test; nokv bin 59, nokv-agent 58 lib + 4 bin + 2 public-surface, nokv-meta 194)
- MCP smoke over stdio for both profiles of the new binary: base profile lists the seven namespace tools with a negotiated `protocolVersion`; the workbench profile lists the nine workbench tools, rejects nested writes under an existing file, and grep matches carry `section` / `relative_path`
- Diff audit: apart from the #388 cherry-pick, all changes are confined to `crates/nokv-agent/`, one appended docs section, and the `Cargo.lock` dependency list
