### PR TITLE
fix: make the crates release pipeline publishable again

### DIFF
--- a/.github/workflows/release-crates.yml
+++ b/.github/workflows/release-crates.yml
@@ -43,7 +43,8 @@ jobs:
             nokv-protocol
             nokv-object
             nokv-meta
-            nokv-cluster
+            nokv-agent
+            nokv-control
             nokv-server
             nokv-client
             nokv-fuse
@@ -55,17 +56,31 @@ jobs:
             echo "EOF"
           } >>"$GITHUB_OUTPUT"
 
+      - name: Verify crate list matches workspace
+        shell: bash
+        run: |
+          set -euo pipefail
+          expected="$(cargo metadata --no-deps --format-version 1 \
+            | jq -r '.packages[] | select(.publish == null) | .name' | sort)"
+          actual="$(sort <<<"${{ steps.crates.outputs.list }}")"
+          if [[ "$expected" != "$actual" ]]; then
+            echo "::error title=Crate list drift::The workflow crate list does not match the workspace's publishable members."
+            diff <(echo "$expected") <(echo "$actual") || true
+            exit 1
+          fi
+
       - name: Package crates
         if: inputs.dry_run == 'true'
         shell: bash
         run: |
           set -euo pipefail
-          args=()
-          while IFS= read -r crate; do
-            [[ -z "$crate" ]] && continue
-            args+=(-p "$crate")
-          done <<<"${{ steps.crates.outputs.list }}"
-          cargo package --locked "${args[@]}"
+          # Workspace mode resolves not-yet-published workspace siblings from
+          # the local package overlay; a -p list would look them up on
+          # crates.io and fail until every crate has been published once.
+          # This also packages the publish = false members (nokv-bench,
+          # nokv-python) as extra validation; only the publish step below
+          # is gated by the crate list.
+          cargo package --locked --workspace
 
       - name: Publish crates
         if: inputs.dry_run == 'false'

--- a/.github/workflows/release-crates.yml
+++ b/.github/workflows/release-crates.yml
@@ -102,7 +102,9 @@ jobs:
               echo "::error title=Unknown crate::Unable to resolve $crate in workspace metadata."
               exit 1
             fi
-            if curl -fsS -o /dev/null "https://crates.io/api/v1/crates/${crate}/${version}"; then
+            # crates.io rejects requests without a User-Agent (403), which
+            # would make this existence check always fail and re-publish.
+            if curl -fsS -A "nokv-release-workflow (github.com/NoKV-Lab/NoKV)" -o /dev/null "https://crates.io/api/v1/crates/${crate}/${version}"; then
               echo "Skipping ${crate} ${version}; it already exists on crates.io."
               continue
             fi

--- a/crates/nokv-client/Cargo.toml
+++ b/crates/nokv-client/Cargo.toml
@@ -20,5 +20,7 @@ serde_json.workspace = true
 sha2.workspace = true
 
 [dev-dependencies]
-nokv-server.workspace = true
+# Path-only (no version) so cargo strips this dev-dep when packaging;
+# a versioned entry would recreate the client <-> server publish cycle.
+nokv-server = { path = "../nokv-server" }
 tempfile.workspace = true

--- a/crates/nokv-server/Cargo.toml
+++ b/crates/nokv-server/Cargo.toml
@@ -22,5 +22,7 @@ nokv-types.workspace = true
 sha2.workspace = true
 
 [dev-dependencies]
-nokv-client.workspace = true
+# Path-only (no version) so cargo strips this dev-dep when packaging;
+# a versioned entry would recreate the server <-> client publish cycle.
+nokv-client = { path = "../nokv-client" }
 tempfile.workspace = true


### PR DESCRIPTION
## Problem

Dry-running the release-crates workflow end to end surfaced three independent breakages; any one of them is fatal to a publish run:

1. **Stale crate list** — still names the removed `nokv-cluster`, and is missing `nokv-agent` and `nokv-control`, both dependencies of crates already on the list (`nokv` and `nokv-client` depend on `nokv-agent`; `nokv-server` and `nokv-client` depend on `nokv-control`).
2. **Dry-run resolves against crates.io** — `cargo package --locked -p <list>` looks up workspace siblings on crates.io instead of the local package overlay. With none of the crates published yet (all 404), the dry-run fails even with a corrected list. Workspace mode (`cargo package --workspace`) packages in dependency order against the local overlay.
3. **Publish cycle via dev-dependencies** — `nokv-server` ⇄ `nokv-client` reference each other as dev-dependencies through workspace inheritance, which carries a version requirement. Versioned dev-deps survive packaging, so each crate demands the other be on crates.io first: a cycle no publish ordering can solve. Path-only dev-dependencies are stripped at packaging time — the supported cargo pattern for dev-only cycles.

## Fix

- Correct the crate list to the workspace's ten publishable members in dependency order (drop `nokv-cluster`, add `nokv-agent` + `nokv-control`), derived from `cargo metadata`.
- Switch the dry-run step to `cargo package --locked --workspace`.
- Make the `nokv-server` ⇄ `nokv-client` dev-dependencies path-only.
- Add a guard step that fails the workflow when the crate list drifts from the workspace's publishable members (`publish == null` in `cargo metadata`), so the next crate add/remove cannot silently break the pipeline again.

## Verification

- `cargo package --locked --workspace` now packages all twelve members cleanly (was: hard failure at `nokv-server`).
- `Cargo.lock` unchanged (`--locked` passes throughout).
- `cargo test -p nokv-server -p nokv-client`: 67 + 65 pass with the path-only dev-dependencies.
- Guard logic executed locally against `cargo metadata`: PASS, and correctly diffs when a member is removed from the list.

Context: this is part of the release-pipeline breakage identified in the CI audit (publish list drift, dead repo references in the image workflows are tracked separately).