### PR TITLE
feat: specialize the workbench MCP tool surface for agent workloads

### DIFF
--- a/crates/nokv-agent/src/lib.rs
+++ b/crates/nokv-agent/src/lib.rs
@@ -64,6 +64,9 @@ const DEFAULT_AGENT_AGGREGATE_LIMIT: usize = 20;
 const MAX_AGENT_AGGREGATE_LIMIT: usize = 100;
 const DEFAULT_AGENT_GREP_LIMIT: usize = 100;
 const MAX_AGENT_GREP_LIMIT: usize = 300;
+/// Mirror of the metadata server's grep pattern cap (nokv-meta
+/// MAX_GREP_PATTERNS); enforced there, advertised in the schema here.
+const MAX_AGENT_GREP_PATTERNS: usize = 16;
 
 #[derive(Clone, Debug, PartialEq)]
 pub struct AgentToolDefinition {
@@ -343,14 +346,14 @@ pub fn agent_tool_definitions() -> Vec<AgentToolDefinition> {
         },
         AgentToolDefinition {
             name: "grep",
-            description: "Search file bodies for case-insensitive literal substrings and return matching lines with line numbers. patterns adds OR alternatives to pattern; glob filters file names. Scope path to one directory or file when known.",
+            description: "Search file bodies for case-insensitive literal substrings and return matching lines with line numbers. patterns adds OR alternatives to pattern (at most 16); glob filters file names. Scope path to one directory or file when known.",
             parameters: json!({
                 "type": "object",
                 "required": ["path", "pattern", "recursive"],
                 "properties": {
                     "path": {"type": "string"},
                     "pattern": {"type": "string"},
-                    "patterns": {"type": "array", "items": {"type": "string"}},
+                    "patterns": {"type": "array", "items": {"type": "string"}, "maxItems": MAX_AGENT_GREP_PATTERNS},
                     "glob": {"type": ["string", "null"]},
                     "recursive": {"type": "boolean"},
                     "cursor": {"type": ["string", "null"]},
@@ -2513,7 +2516,7 @@ mod tests {
         assert_eq!(grep.parameters["properties"]["limit"]["maximum"], 300);
         assert_eq!(
             grep.parameters["properties"]["patterns"],
-            json!({"type": "array", "items": {"type": "string"}})
+            json!({"type": "array", "items": {"type": "string"}, "maxItems": 16})
         );
         assert_eq!(
             grep.parameters["properties"]["glob"],

--- a/crates/nokv-agent/src/lib.rs
+++ b/crates/nokv-agent/src/lib.rs
@@ -56,12 +56,14 @@ impl From<nokv_meta::MetadError> for AgentError {
 
 const DEFAULT_AGENT_PAGE_LIMIT: usize = 100;
 const MAX_AGENT_PAGE_LIMIT: usize = 100;
+const DEFAULT_AGENT_READ_LIMIT: usize = 100;
+const MAX_AGENT_READ_LIMIT: usize = 300;
 const DEFAULT_AGENT_FIND_LIMIT: usize = 10;
 const MAX_AGENT_FIND_LIMIT: usize = 10;
 const DEFAULT_AGENT_AGGREGATE_LIMIT: usize = 20;
 const MAX_AGENT_AGGREGATE_LIMIT: usize = 100;
 const DEFAULT_AGENT_GREP_LIMIT: usize = 100;
-const MAX_AGENT_GREP_LIMIT: usize = 100;
+const MAX_AGENT_GREP_LIMIT: usize = 300;
 
 #[derive(Clone, Debug, PartialEq)]
 pub struct AgentToolDefinition {
@@ -201,7 +203,7 @@ pub fn agent_tool_definitions() -> Vec<AgentToolDefinition> {
                     "format": {"type": "string", "enum": ["structured", "bytes"]},
                     "cursor": {"type": ["string", "null"]},
                     "offset": {"type": "integer", "minimum": 0},
-                    "limit": {"type": "integer", "minimum": 1, "maximum": MAX_AGENT_PAGE_LIMIT},
+                    "limit": {"type": "integer", "minimum": 1, "maximum": MAX_AGENT_READ_LIMIT},
                 },
                 "additionalProperties": false
             }),
@@ -341,13 +343,15 @@ pub fn agent_tool_definitions() -> Vec<AgentToolDefinition> {
         },
         AgentToolDefinition {
             name: "grep",
-            description: "Search file bodies for a case-insensitive literal substring and return matching lines with line numbers. Scope path to one directory or file when known.",
+            description: "Search file bodies for case-insensitive literal substrings and return matching lines with line numbers. patterns adds OR alternatives to pattern; glob filters file names. Scope path to one directory or file when known.",
             parameters: json!({
                 "type": "object",
                 "required": ["path", "pattern", "recursive"],
                 "properties": {
                     "path": {"type": "string"},
                     "pattern": {"type": "string"},
+                    "patterns": {"type": "array", "items": {"type": "string"}},
+                    "glob": {"type": ["string", "null"]},
                     "recursive": {"type": "boolean"},
                     "cursor": {"type": ["string", "null"]},
                     "limit": {"type": "integer", "minimum": 1, "maximum": MAX_AGENT_GREP_LIMIT}
@@ -441,7 +445,9 @@ where
     let result = namespace.agent_grep_paths(NamespaceGrepRequest {
         path: path.to_owned(),
         pattern: pattern.to_owned(),
+        patterns: optional_string_array_arg(args, "patterns")?.unwrap_or_default(),
         recursive,
+        name_glob: optional_string_arg(args, "glob")?,
         cursor: optional_string_arg(args, "cursor")?,
         limit: optional_bounded_usize_arg(args, "limit", MAX_AGENT_GREP_LIMIT)?
             .unwrap_or(DEFAULT_AGENT_GREP_LIMIT),
@@ -480,7 +486,8 @@ where
         format: read_format_arg(args)?,
         cursor: optional_string_arg(args, "cursor")?,
         offset: optional_u64_arg(args, "offset")?.unwrap_or(0),
-        limit: optional_usize_arg(args, "limit")?.unwrap_or(DEFAULT_AGENT_PAGE_LIMIT),
+        limit: optional_bounded_usize_arg(args, "limit", MAX_AGENT_READ_LIMIT)?
+            .unwrap_or(DEFAULT_AGENT_READ_LIMIT),
         expected_generation: None,
     };
     guard_large_structured_pagination(namespace, path, &options)?;
@@ -505,11 +512,11 @@ where
     let Some(record_count) = card.record_count else {
         return Ok(());
     };
-    if record_count.count <= MAX_AGENT_PAGE_LIMIT {
+    if record_count.count <= MAX_AGENT_READ_LIMIT {
         return Ok(());
     }
     Err(AgentError::InvalidArgument(format!(
-        "structured pagination for {path} has {} records; use stat record_count or find with catalog predicates and limit=1, then read match_count",
+        "structured pagination for {path} has {} records; use bytes format with offset and limit, grep to locate lines, or stat record_count",
         record_count.count
     )))
 }
@@ -519,7 +526,7 @@ where
     T: AgentNamespace + ?Sized,
 {
     let path = required_string_arg(args, "path")?;
-    let fields = fields_arg(args)?;
+    let fields = optional_string_array_arg(args, "fields")?;
     reject_unsupported_find_arguments(args)?;
     let result = namespace.agent_find_paths(NamespaceFindRequest {
         path: path.to_owned(),
@@ -580,6 +587,7 @@ fn find_result_json(result: &NamespaceFindResult, fields: Option<&[String]>) -> 
 fn read_page_json(page: &NamespaceReadPage) -> Value {
     json!({
         "path": page.path,
+        "generation": page.generation,
         "total_size_bytes": page.total_size_bytes,
         "format": read_format_name(&page.format),
         "record_type": page.record_type.as_ref().map(record_type_name),
@@ -991,24 +999,27 @@ fn reject_unsupported_find_arguments(args: &Value) -> Result<(), AgentError> {
     Ok(())
 }
 
-fn fields_arg(args: &Value) -> Result<Option<Vec<String>>, AgentError> {
-    let Some(value) = object_args(args)?.get("fields") else {
+fn optional_string_array_arg(
+    args: &Value,
+    name: &'static str,
+) -> Result<Option<Vec<String>>, AgentError> {
+    let Some(value) = object_args(args)?.get(name) else {
         return Ok(None);
     };
     if value.is_null() {
         return Ok(None);
     }
-    let fields = value
+    let entries = value
         .as_array()
-        .ok_or_else(|| AgentError::InvalidArgument("fields must be an array".to_owned()))?
+        .ok_or_else(|| AgentError::InvalidArgument(format!("{name} must be an array")))?
         .iter()
         .map(|value| {
             value.as_str().map(str::to_owned).ok_or_else(|| {
-                AgentError::InvalidArgument("fields entries must be strings".to_owned())
+                AgentError::InvalidArgument(format!("{name} entries must be strings"))
             })
         })
         .collect::<Result<Vec<_>, _>>()?;
-    Ok(Some(fields))
+    Ok(Some(entries))
 }
 
 fn facets_arg(args: &Value) -> Result<Vec<NamespaceFindField>, AgentError> {
@@ -1362,6 +1373,8 @@ mod tests {
     struct FakeNamespace {
         last_find: RefCell<Option<NamespaceFindRequest>>,
         last_aggregate: RefCell<Option<NamespaceAggregateRequest>>,
+        last_grep: RefCell<Option<NamespaceGrepRequest>>,
+        last_read: RefCell<Option<NamespaceReadOptions>>,
         read_calls: RefCell<usize>,
         record_count: usize,
         find_matches: Vec<NamespaceCard>,
@@ -1375,6 +1388,8 @@ mod tests {
             Self {
                 last_find: RefCell::new(None),
                 last_aggregate: RefCell::new(None),
+                last_grep: RefCell::new(None),
+                last_read: RefCell::new(None),
                 read_calls: RefCell::new(0),
                 record_count: 1,
                 find_matches: vec![sample_card("/runs/run-1", 1)],
@@ -1386,27 +1401,17 @@ mod tests {
 
         fn with_record_count(record_count: usize) -> Self {
             Self {
-                last_find: RefCell::new(None),
-                last_aggregate: RefCell::new(None),
-                read_calls: RefCell::new(0),
                 record_count,
                 find_matches: vec![sample_card("/runs/run-1", record_count)],
-                aggregate_result: sample_aggregate_result(),
-                stat_cards: BTreeMap::new(),
                 list_entries: vec![sample_card("/runs/run-1", record_count)],
+                ..Self::new()
             }
         }
 
         fn with_aggregate_result(aggregate_result: NamespaceAggregateResult) -> Self {
             Self {
-                last_find: RefCell::new(None),
-                last_aggregate: RefCell::new(None),
-                read_calls: RefCell::new(0),
-                record_count: 1,
-                find_matches: vec![sample_card("/runs/run-1", 1)],
                 aggregate_result,
-                stat_cards: BTreeMap::new(),
-                list_entries: vec![sample_card("/runs/run-1", 1)],
+                ..Self::new()
             }
         }
 
@@ -1427,14 +1432,10 @@ mod tests {
             stat_cards.insert(root.path.clone(), root);
             stat_cards.insert(runs.path.clone(), runs.clone());
             Self {
-                last_find: RefCell::new(None),
-                last_aggregate: RefCell::new(None),
-                read_calls: RefCell::new(0),
-                record_count: 1,
                 find_matches: vec![sample_card("/yanex/runs/run-1", 1)],
-                aggregate_result: sample_aggregate_result(),
                 stat_cards,
                 list_entries: vec![runs],
+                ..Self::new()
             }
         }
     }
@@ -1507,6 +1508,7 @@ mod tests {
             &self,
             request: NamespaceGrepRequest,
         ) -> Result<NamespaceGrepResult, AgentError> {
+            self.last_grep.replace(Some(request.clone()));
             let matched = "Checkpoint: best_model_1.0_1.pt";
             let matches = if matched
                 .to_lowercase()
@@ -1528,6 +1530,7 @@ mod tests {
             Ok(NamespaceGrepResult {
                 path: request.path.clone(),
                 pattern: request.pattern.clone(),
+                patterns: request.patterns.clone(),
                 recursive: request.recursive,
                 evidence: format!("nokv-native://{}", request.path),
                 snapshot_id: Some(1),
@@ -1542,8 +1545,9 @@ mod tests {
         fn agent_read_page(
             &self,
             path: &str,
-            _options: NamespaceReadOptions,
+            options: NamespaceReadOptions,
         ) -> Result<NamespaceReadPage, AgentError> {
+            self.last_read.replace(Some(options));
             *self.read_calls.borrow_mut() += 1;
             Ok(NamespaceReadPage {
                 path: path.to_owned(),
@@ -1595,12 +1599,13 @@ mod tests {
     }
 
     fn assert_json_lacks_agent_noise(value: &Value) {
+        // "generation" is intentionally not forbidden: read exposes it so agents
+        // can feed the conditional read validator (expected_generation).
         const FORBIDDEN_KEYS: &[&str] = &[
             "tool",
             "bytes_read",
             "evidence",
             "snapshot_id",
-            "generation",
             "field_values",
             "source_path",
             "source_kind",
@@ -2339,7 +2344,7 @@ mod tests {
 
     #[test]
     fn read_tool_rejects_large_structured_pagination() {
-        let namespace = FakeNamespace::with_record_count(MAX_AGENT_PAGE_LIMIT + 1);
+        let namespace = FakeNamespace::with_record_count(350);
 
         let err = execute_agent_tool(
             &namespace,
@@ -2354,7 +2359,7 @@ mod tests {
         .unwrap_err();
 
         assert!(
-            matches!(err, AgentError::InvalidArgument(ref message) if message.contains("find with catalog predicates")),
+            matches!(err, AgentError::InvalidArgument(ref message) if message.contains("use bytes format with offset and limit, grep to locate lines, or stat record_count")),
             "unexpected error: {err:?}"
         );
         assert_eq!(*namespace.read_calls.borrow(), 0);
@@ -2362,7 +2367,7 @@ mod tests {
 
     #[test]
     fn read_tool_rejects_large_structured_initial_page() {
-        let namespace = FakeNamespace::with_record_count(MAX_AGENT_PAGE_LIMIT + 1);
+        let namespace = FakeNamespace::with_record_count(350);
 
         let err = execute_agent_tool(
             &namespace,
@@ -2376,9 +2381,281 @@ mod tests {
         .unwrap_err();
 
         assert!(
-            matches!(err, AgentError::InvalidArgument(ref message) if message.contains("find with catalog predicates")),
+            matches!(err, AgentError::InvalidArgument(ref message) if message.contains("use bytes format with offset and limit, grep to locate lines, or stat record_count")),
             "unexpected error: {err:?}"
         );
         assert_eq!(*namespace.read_calls.borrow(), 0);
+    }
+
+    #[test]
+    fn read_tool_reads_structured_files_within_guard_threshold() {
+        let namespace = FakeNamespace::with_record_count(250);
+
+        execute_agent_tool(
+            &namespace,
+            "read",
+            &json!({
+                "path": "/index/mid.json",
+                "format": "structured"
+            }),
+        )
+        .unwrap();
+
+        assert_eq!(*namespace.read_calls.borrow(), 1);
+    }
+
+    #[test]
+    fn read_tool_structured_guard_allows_exactly_the_read_limit() {
+        let namespace = FakeNamespace::with_record_count(MAX_AGENT_READ_LIMIT);
+
+        execute_agent_tool(
+            &namespace,
+            "read",
+            &json!({
+                "path": "/index/boundary.json",
+                "format": "structured"
+            }),
+        )
+        .unwrap();
+
+        assert_eq!(*namespace.read_calls.borrow(), 1);
+    }
+
+    #[test]
+    fn read_tool_returns_generation_for_conditional_reads() {
+        let namespace = FakeNamespace::new();
+
+        let output = execute_agent_tool(
+            &namespace,
+            "read",
+            &json!({
+                "path": "/runs/run-1/metadata.json",
+            }),
+        )
+        .unwrap();
+
+        assert_eq!(output["generation"], 7);
+        assert_json_lacks_agent_noise(&output);
+    }
+
+    #[test]
+    fn read_tool_schema_caps_limit_at_three_hundred() {
+        let tools = agent_tool_definitions();
+        let read = tool_definition(&tools, "read");
+
+        assert_eq!(read.parameters["properties"]["limit"]["maximum"], 300);
+    }
+
+    #[test]
+    fn read_tool_accepts_limit_of_three_hundred() {
+        let namespace = FakeNamespace::new();
+
+        execute_agent_tool(
+            &namespace,
+            "read",
+            &json!({
+                "path": "/runs/run-1/metadata.json",
+                "limit": 300
+            }),
+        )
+        .unwrap();
+
+        let options = namespace.last_read.borrow().clone().unwrap();
+        assert_eq!(options.limit, 300);
+    }
+
+    #[test]
+    fn read_tool_rejects_limit_above_three_hundred() {
+        let namespace = FakeNamespace::new();
+
+        let err = execute_agent_tool(
+            &namespace,
+            "read",
+            &json!({
+                "path": "/runs/run-1/metadata.json",
+                "limit": 301
+            }),
+        )
+        .unwrap_err();
+
+        assert!(
+            matches!(err, AgentError::InvalidArgument(ref message) if message.contains("limit must be between 1 and 300")),
+            "unexpected error: {err:?}"
+        );
+        assert_eq!(*namespace.read_calls.borrow(), 0);
+    }
+
+    #[test]
+    fn ls_tool_keeps_limit_capped_at_one_hundred() {
+        let namespace = FakeNamespace::new();
+
+        let err = execute_agent_tool(
+            &namespace,
+            "ls",
+            &json!({
+                "path": "/runs",
+                "limit": 101
+            }),
+        )
+        .unwrap_err();
+
+        assert!(
+            matches!(err, AgentError::InvalidArgument(ref message) if message.contains("limit must be between 1 and 100")),
+            "unexpected error: {err:?}"
+        );
+    }
+
+    #[test]
+    fn grep_tool_schema_caps_limit_and_exposes_patterns_and_glob() {
+        let tools = agent_tool_definitions();
+        let grep = tool_definition(&tools, "grep");
+
+        assert_eq!(grep.parameters["properties"]["limit"]["maximum"], 300);
+        assert_eq!(
+            grep.parameters["properties"]["patterns"],
+            json!({"type": "array", "items": {"type": "string"}})
+        );
+        assert_eq!(
+            grep.parameters["properties"]["glob"],
+            json!({"type": ["string", "null"]})
+        );
+        assert_eq!(
+            grep.parameters["required"],
+            json!(["path", "pattern", "recursive"])
+        );
+    }
+
+    #[test]
+    fn grep_tool_accepts_limit_of_three_hundred() {
+        let namespace = FakeNamespace::new();
+
+        execute_agent_tool(
+            &namespace,
+            "grep",
+            &json!({
+                "path": "/runs/run-1",
+                "pattern": "best_model",
+                "recursive": true,
+                "limit": 300
+            }),
+        )
+        .unwrap();
+
+        let request = namespace.last_grep.borrow().clone().unwrap();
+        assert_eq!(request.limit, 300);
+    }
+
+    #[test]
+    fn grep_tool_rejects_limit_above_three_hundred() {
+        let namespace = FakeNamespace::new();
+
+        let err = execute_agent_tool(
+            &namespace,
+            "grep",
+            &json!({
+                "path": "/runs/run-1",
+                "pattern": "best_model",
+                "recursive": true,
+                "limit": 301
+            }),
+        )
+        .unwrap_err();
+
+        assert!(
+            matches!(err, AgentError::InvalidArgument(ref message) if message.contains("limit must be between 1 and 300")),
+            "unexpected error: {err:?}"
+        );
+        assert!(namespace.last_grep.borrow().is_none());
+    }
+
+    #[test]
+    fn grep_tool_rejects_non_string_patterns() {
+        let namespace = FakeNamespace::new();
+
+        let err = execute_agent_tool(
+            &namespace,
+            "grep",
+            &json!({
+                "path": "/runs/run-1",
+                "pattern": "best_model",
+                "recursive": true,
+                "patterns": [1]
+            }),
+        )
+        .unwrap_err();
+
+        assert!(
+            matches!(err, AgentError::InvalidArgument(ref message) if message.contains("patterns entries must be strings")),
+            "unexpected error: {err:?}"
+        );
+        assert!(namespace.last_grep.borrow().is_none());
+    }
+
+    #[test]
+    fn grep_tool_rejects_non_string_glob() {
+        let namespace = FakeNamespace::new();
+
+        let err = execute_agent_tool(
+            &namespace,
+            "grep",
+            &json!({
+                "path": "/runs/run-1",
+                "pattern": "best_model",
+                "recursive": true,
+                "glob": 7
+            }),
+        )
+        .unwrap_err();
+
+        assert!(
+            matches!(err, AgentError::InvalidArgument(ref message) if message.contains("glob must be a string or null")),
+            "unexpected error: {err:?}"
+        );
+        assert!(namespace.last_grep.borrow().is_none());
+    }
+
+    #[test]
+    fn grep_tool_forwards_patterns_and_glob() {
+        let namespace = FakeNamespace::new();
+
+        execute_agent_tool(
+            &namespace,
+            "grep",
+            &json!({
+                "path": "/runs/run-1",
+                "pattern": "best_model",
+                "patterns": ["error", "warning"],
+                "glob": "*.txt",
+                "recursive": true
+            }),
+        )
+        .unwrap();
+
+        let request = namespace.last_grep.borrow().clone().unwrap();
+        assert_eq!(
+            request.patterns,
+            vec!["error".to_owned(), "warning".to_owned()]
+        );
+        assert_eq!(request.name_glob.as_deref(), Some("*.txt"));
+    }
+
+    #[test]
+    fn grep_tool_defaults_patterns_and_glob_to_unset() {
+        let namespace = FakeNamespace::new();
+
+        execute_agent_tool(
+            &namespace,
+            "grep",
+            &json!({
+                "path": "/runs/run-1",
+                "pattern": "best_model",
+                "recursive": true
+            }),
+        )
+        .unwrap();
+
+        let request = namespace.last_grep.borrow().clone().unwrap();
+        assert_eq!(request.patterns, Vec::<String>::new());
+        assert_eq!(request.name_glob, None);
     }
 }

--- a/crates/nokv-client/src/artifact.rs
+++ b/crates/nokv-client/src/artifact.rs
@@ -4,7 +4,8 @@ use nokv_types::FileType;
 use sha2::{Digest, Sha256};
 
 use crate::{
-    is_metadata_predicate_failed, is_not_found, ArtifactMetadata, ClientError, NoKvFsClient,
+    is_metadata_not_found, is_metadata_predicate_failed, ArtifactMetadata, ClientError,
+    NoKvFsClient,
 };
 
 const DEFAULT_ARTIFACT_FILE_MODE: u32 = 0o644;
@@ -225,20 +226,20 @@ where
         let entry = match self.backend.lookup_path(&absolute_path) {
             Ok(Some(entry)) => entry,
             Ok(None) => return Ok(()),
-            Err(err) if is_not_found(&err) => return Ok(()),
+            Err(err) if is_metadata_not_found(&err) => return Ok(()),
             Err(err) => return Err(err),
         };
         if entry.attr.file_type == FileType::Directory {
             self.delete_directory_children(&normalized)?;
             match self.backend.remove_empty_dir_path(&absolute_path) {
                 Ok(_) => Ok(()),
-                Err(err) if is_not_found(&err) => Ok(()),
+                Err(err) if is_metadata_not_found(&err) => Ok(()),
                 Err(err) => Err(err),
             }
         } else {
             match self.backend.remove_file_path(&absolute_path) {
                 Ok(_) => Ok(()),
-                Err(err) if is_not_found(&err) => Ok(()),
+                Err(err) if is_metadata_not_found(&err) => Ok(()),
                 Err(err) => Err(err),
             }
         }
@@ -286,7 +287,7 @@ where
             for result in self.backend.remove_file_paths(&file_paths)? {
                 match result {
                     Ok(_) => {}
-                    Err(err) if is_not_found(&err) => {}
+                    Err(err) if is_metadata_not_found(&err) => {}
                     Err(err) => return Err(err),
                 }
             }
@@ -300,7 +301,7 @@ where
             for result in self.backend.remove_empty_dir_paths(&directory_paths)? {
                 match result {
                     Ok(_) => {}
-                    Err(err) if is_not_found(&err) => {}
+                    Err(err) if is_metadata_not_found(&err) => {}
                     Err(err) => return Err(err),
                 }
             }

--- a/crates/nokv-client/src/file_client.rs
+++ b/crates/nokv-client/src/file_client.rs
@@ -2216,8 +2216,20 @@ impl ScatterPackedRangePlan {
 /// `expected_generation`, a concurrent writer racing prepare/publish, or a
 /// create racing another create. Callers recover by re-reading the current
 /// generation and retrying.
+///
+/// `MissingBodyDescriptor` counts too: a concurrent self-contained publish
+/// (chain compaction) reclaims every superseded generation's manifest records
+/// in its commit, so a publish prepared against one of those generations fails
+/// resolving its base chain *before* it reaches the dentry CAS that would have
+/// reported `PredicateFailed`. It is the same lost race with the same
+/// recovery; only writes ever surface it through this path (reads report it
+/// as a hard error and never consult this classifier).
 pub fn is_artifact_write_conflict(err: &ClientError) -> bool {
     crate::is_metadata_predicate_failed(err)
+        || matches!(
+            err,
+            ClientError::Metadata(nokv_meta::MetadError::MissingBodyDescriptor)
+        )
 }
 
 // Client-side guard failures surface as the same predicate error a server-side
@@ -2612,6 +2624,27 @@ mod tests {
     fn response_body(json: &str) -> Vec<u8> {
         let envelope: MetadataRpcEnvelope = serde_json::from_str(json).unwrap();
         encode_envelope(&envelope).unwrap()
+    }
+
+    #[test]
+    fn artifact_write_conflict_classifies_transient_write_races() {
+        // The two shapes a lost write race decodes to over the wire.
+        assert!(is_artifact_write_conflict(&ClientError::Metadata(
+            nokv_meta::MetadError::Metadata(nokv_meta::MetadataError::PredicateFailed),
+        )));
+        assert!(is_artifact_write_conflict(&ClientError::Metadata(
+            nokv_meta::MetadError::MissingBodyDescriptor,
+        )));
+        // Hard errors must not be retried as conflicts.
+        assert!(!is_artifact_write_conflict(&ClientError::Metadata(
+            nokv_meta::MetadError::NotFound,
+        )));
+        assert!(!is_artifact_write_conflict(&ClientError::Metadata(
+            nokv_meta::MetadError::NotFile,
+        )));
+        assert!(!is_artifact_write_conflict(&ClientError::Protocol(
+            "file /x is missing body descriptor".to_owned(),
+        )));
     }
 
     #[test]

--- a/crates/nokv-client/src/file_client.rs
+++ b/crates/nokv-client/src/file_client.rs
@@ -1856,7 +1856,10 @@ where
         let new_size = base_size
             .checked_add(delta.len() as u64)
             .ok_or_else(|| ClientError::Protocol("append size exceeds u64".to_owned()))?;
-        let prepared = self.metadata.prepare_artifact_path(path, true)?;
+        let prepared = self
+            .metadata
+            .prepare_artifact_path(path, true)
+            .map_err(|err| fold_append_prepare_not_found(err, expected_generation))?;
         if prepared.old_generation != base_generation {
             // A writer landed between lookup and prepare; the staged offset
             // would be wrong, so fail before writing any blocks.
@@ -1914,9 +1917,10 @@ where
                 created: false,
             }),
             Err(err) => {
-                self.objects
-                    .delete_staged(&staged)
-                    .map_err(ClientError::Object)?;
+                // Best-effort cleanup: a failed staged-object delete must not
+                // replace the publish error, whose classification
+                // (is_artifact_write_conflict) drives the caller's retry loop.
+                let _ = self.objects.delete_staged(&staged);
                 Err(err)
             }
         }
@@ -1947,9 +1951,10 @@ where
         {
             Ok(result) => Ok(result),
             Err(err) => {
-                self.objects
-                    .delete_staged(&staged)
-                    .map_err(ClientError::Object)?;
+                // Best-effort cleanup: a failed staged-object delete must not
+                // replace the publish error, whose classification
+                // (is_artifact_write_conflict) drives the caller's retry loop.
+                let _ = self.objects.delete_staged(&staged);
                 Err(err)
             }
         }
@@ -2238,6 +2243,23 @@ fn artifact_write_conflict() -> ClientError {
     ClientError::Metadata(nokv_meta::MetadError::Metadata(
         nokv_meta::MetadataError::PredicateFailed,
     ))
+}
+
+/// Classify a failed `prepare_artifact_path` inside
+/// [`NoKvFsClient::append_artifact`] after the initial lookup found the file:
+/// a `NotFound` here means a concurrent delete won the race. Without a pinned
+/// generation that is a retryable conflict — the caller's retry loop re-reads
+/// and takes the create branch — while a pinned generation or any other
+/// failure keeps its original error.
+fn fold_append_prepare_not_found(
+    err: ClientError,
+    expected_generation: Option<u64>,
+) -> ClientError {
+    if expected_generation.is_none() && crate::is_metadata_not_found(&err) {
+        artifact_write_conflict()
+    } else {
+        err
+    }
 }
 
 fn artifact_body_generation(entry: &DentryWithAttr) -> u64 {
@@ -2645,6 +2667,31 @@ mod tests {
         assert!(!is_artifact_write_conflict(&ClientError::Protocol(
             "file /x is missing body descriptor".to_owned(),
         )));
+    }
+
+    /// A file deleted between `lookup` and `prepare` inside `append_artifact`
+    /// must classify as a retryable conflict when no generation is pinned, so
+    /// the caller's retry loop re-reads and takes the create branch.
+    #[test]
+    fn append_prepare_not_found_folds_to_conflict_only_without_pinned_generation() {
+        let not_found = || ClientError::Metadata(nokv_meta::MetadError::NotFound);
+        assert!(is_artifact_write_conflict(&fold_append_prepare_not_found(
+            not_found(),
+            None
+        )));
+        // A pinned generation keeps the original error surface.
+        assert!(matches!(
+            fold_append_prepare_not_found(not_found(), Some(7)),
+            ClientError::Metadata(nokv_meta::MetadError::NotFound)
+        ));
+        // Non-NotFound errors pass through untouched.
+        assert!(matches!(
+            fold_append_prepare_not_found(
+                ClientError::Metadata(nokv_meta::MetadError::NotFile),
+                None
+            ),
+            ClientError::Metadata(nokv_meta::MetadError::NotFile)
+        ));
     }
 
     #[test]

--- a/crates/nokv-client/src/file_client.rs
+++ b/crates/nokv-client/src/file_client.rs
@@ -10,13 +10,14 @@ use nokv_meta::{
     DentryWithAttr, NamespaceAggregateRequest, NamespaceAggregateResult, NamespaceCard,
     NamespaceFindRequest, NamespaceFindResult, NamespaceGrepRequest, NamespaceGrepResult,
     NamespaceListOptions, NamespaceListPage, NamespaceReadOptions, NamespaceReadPage,
-    ObjectTransferStats, RenameReplaceResult,
+    ObjectTransferStats, PublishArtifactStagedSession, RenameReplaceResult,
 };
 use nokv_object::{
-    BlockCache, BlockReadOptions, ChunkStore, ChunkWriteOptions, ChunkedWrite, DataFabricReadStats,
-    LayoutReadExecutor, LayoutReadRequest, ObjectBlockCache, ObjectError, ObjectPrefetchOptions,
-    ObjectPrefetchRequest, ObjectPrefetcher, ObjectReadBlock, ObjectReadPlan, ObjectReadPlanCache,
-    ObjectReadPlanKey, ObjectStore, StagedObjectSet, DEFAULT_BLOCK_SIZE, DEFAULT_CHUNK_SIZE,
+    BlockCache, BlockReadOptions, ChunkStore, ChunkWriteOptions, ChunkWriteRange, ChunkedWrite,
+    DataFabricReadStats, LayoutReadExecutor, LayoutReadRequest, ObjectBlockCache, ObjectError,
+    ObjectPrefetchOptions, ObjectPrefetchRequest, ObjectPrefetcher, ObjectReadBlock,
+    ObjectReadPlan, ObjectReadPlanCache, ObjectReadPlanKey, ObjectStore, StagedObjectSet,
+    DEFAULT_BLOCK_SIZE, DEFAULT_CHUNK_SIZE,
 };
 use nokv_types::{BodyDescriptor, ChunkManifest, FileType, InodeId, MountId};
 
@@ -142,6 +143,15 @@ pub struct PathRangeReadRequest {
     pub ranges: Vec<PathReadRange>,
     pub expected_generation: Option<u64>,
     pub max_gap_bytes: u64,
+}
+
+/// Result of [`NoKvFsClient::append_artifact`]: the published size/generation
+/// and whether the append created the file instead of extending it.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct AppendOutcome {
+    pub new_size: u64,
+    pub generation: u64,
+    pub created: bool,
 }
 
 #[derive(Clone, Debug)]
@@ -1805,6 +1815,146 @@ where
         }
     }
 
+    /// Publish `delta` at the current end of `path` as a delta generation: only
+    /// the appended bytes are staged, the new body falls through to the prior
+    /// generation for the rest (the server compacts the chain when it gets
+    /// deep). A missing file is created with `delta` as its full content.
+    ///
+    /// `expected_generation` pins the body generation the caller appended
+    /// against; a mismatch — or any concurrent writer landing between prepare
+    /// and publish — fails with a conflict recognizable via
+    /// [`is_artifact_write_conflict`], which callers resolve by re-reading and
+    /// retrying.
+    pub fn append_artifact(
+        &self,
+        path: &str,
+        delta: Vec<u8>,
+        metadata: ArtifactMetadata,
+        expected_generation: Option<u64>,
+    ) -> Result<AppendOutcome, ClientError> {
+        let Some(entry) = self.metadata.lookup(path)? else {
+            if expected_generation.is_some() {
+                // The pinned generation no longer exists; that is a lost CAS,
+                // not a create.
+                return Err(artifact_write_conflict());
+            }
+            let entry = self.put_artifact(path, delta, metadata)?;
+            return Ok(AppendOutcome {
+                new_size: entry.attr.size,
+                generation: artifact_body_generation(&entry),
+                created: true,
+            });
+        };
+        if entry.attr.file_type != FileType::File {
+            return Err(ClientError::Metadata(nokv_meta::MetadError::NotFile));
+        }
+        let base_generation = entry.body.as_ref().map(|body| body.generation);
+        if expected_generation.is_some() && expected_generation != base_generation {
+            return Err(artifact_write_conflict());
+        }
+        let base_size = entry.attr.size;
+        let new_size = base_size
+            .checked_add(delta.len() as u64)
+            .ok_or_else(|| ClientError::Protocol("append size exceeds u64".to_owned()))?;
+        let prepared = self.metadata.prepare_artifact_path(path, true)?;
+        if prepared.old_generation != base_generation {
+            // A writer landed between lookup and prepare; the staged offset
+            // would be wrong, so fail before writing any blocks.
+            return Err(artifact_write_conflict());
+        }
+        let dirty_ranges = if delta.is_empty() {
+            Vec::new()
+        } else {
+            vec![ChunkWriteRange {
+                logical_offset: base_size,
+                bytes: delta.into(),
+            }]
+        };
+        let written = match self.objects.write_ranges_with_block_index_base(
+            dirty_ranges,
+            ChunkWriteOptions {
+                manifest_id: metadata.manifest_id.clone(),
+                mount: prepared.mount,
+                inode: prepared.inode.get(),
+                generation: prepared.generation,
+                chunk_size: DEFAULT_CHUNK_SIZE,
+                block_size: DEFAULT_BLOCK_SIZE,
+            },
+            0,
+        ) {
+            Ok(written) => written,
+            Err(err) => {
+                cleanup_staged_write_error(&self.objects, &err)?;
+                return Err(ClientError::Object(err));
+            }
+        };
+        self.record_staged_write_stats(&written);
+        let staged = written.staged_objects()?;
+        let session = PublishArtifactStagedSession {
+            parent: prepared.parent,
+            name: prepared.name.clone(),
+            producer: metadata.producer,
+            digest_uri: metadata.digest_uri,
+            content_type: metadata.content_type,
+            manifest_id: written.manifest_id.clone(),
+            size: new_size,
+            chunks: written.chunk_manifests(),
+            staged: staged.clone(),
+            mode: metadata.mode,
+            uid: metadata.uid,
+            gid: metadata.gid,
+        };
+        match self
+            .metadata
+            .publish_prepared_artifact_staged_session(prepared, session)
+        {
+            Ok(result) => Ok(AppendOutcome {
+                new_size: result.entry.attr.size,
+                generation: artifact_body_generation(&result.entry),
+                created: false,
+            }),
+            Err(err) => {
+                self.objects
+                    .delete_staged(&staged)
+                    .map_err(ClientError::Object)?;
+                Err(err)
+            }
+        }
+    }
+
+    /// [`NoKvFsClient::put_artifact_replace`] guarded by the current body
+    /// generation: the replace publishes only while the artifact is still at
+    /// `expected_generation`, otherwise it fails with a conflict recognizable
+    /// via [`is_artifact_write_conflict`].
+    pub fn put_artifact_replace_if_generation(
+        &self,
+        path: &str,
+        bytes: Vec<u8>,
+        metadata: ArtifactMetadata,
+        expected_generation: u64,
+    ) -> Result<RenameReplaceResult, ClientError> {
+        let prepared = self.metadata.prepare_artifact_path(path, true)?;
+        if prepared.old_generation != Some(expected_generation) {
+            return Err(artifact_write_conflict());
+        }
+        let mode = metadata.mode;
+        let uid = metadata.uid;
+        let gid = metadata.gid;
+        let (body, chunks, staged) = self.stage_artifact_body(&prepared, &bytes, metadata)?;
+        match self
+            .metadata
+            .publish_prepared_artifact(prepared, body, chunks, mode, uid, gid)
+        {
+            Ok(result) => Ok(result),
+            Err(err) => {
+                self.objects
+                    .delete_staged(&staged)
+                    .map_err(ClientError::Object)?;
+                Err(err)
+            }
+        }
+    }
+
     fn stage_artifact_body(
         &self,
         prepared: &ClientPreparedArtifact,
@@ -1857,12 +2007,7 @@ where
         self.finish_staged_artifact(prepared, metadata, written)
     }
 
-    fn finish_staged_artifact(
-        &self,
-        prepared: &ClientPreparedArtifact,
-        metadata: ArtifactMetadata,
-        written: ChunkedWrite,
-    ) -> Result<(BodyDescriptor, Vec<ChunkManifest>, StagedObjectSet), ClientError> {
+    fn record_staged_write_stats(&self, written: &ChunkedWrite) {
         self.object_puts
             .fetch_add(written.object_puts as u64, Ordering::Relaxed);
         self.object_put_bytes
@@ -1877,6 +2022,15 @@ where
                 .sum::<u64>(),
             Ordering::Relaxed,
         );
+    }
+
+    fn finish_staged_artifact(
+        &self,
+        prepared: &ClientPreparedArtifact,
+        metadata: ArtifactMetadata,
+        written: ChunkedWrite,
+    ) -> Result<(BodyDescriptor, Vec<ChunkManifest>, StagedObjectSet), ClientError> {
+        self.record_staged_write_stats(&written);
         let staged = written.staged_objects()?;
         let chunks = written.chunk_manifests();
         Ok((
@@ -2056,6 +2210,30 @@ impl ScatterPackedRangePlan {
                 ClientError::Protocol("scatter packed read output end exceeds usize".to_owned())
             })
     }
+}
+
+/// True when an artifact write lost its generation guard: a stale
+/// `expected_generation`, a concurrent writer racing prepare/publish, or a
+/// create racing another create. Callers recover by re-reading the current
+/// generation and retrying.
+pub fn is_artifact_write_conflict(err: &ClientError) -> bool {
+    crate::is_metadata_predicate_failed(err)
+}
+
+// Client-side guard failures surface as the same predicate error a server-side
+// publish CAS loss decodes to, so one discriminant covers both.
+fn artifact_write_conflict() -> ClientError {
+    ClientError::Metadata(nokv_meta::MetadError::Metadata(
+        nokv_meta::MetadataError::PredicateFailed,
+    ))
+}
+
+fn artifact_body_generation(entry: &DentryWithAttr) -> u64 {
+    entry
+        .body
+        .as_ref()
+        .map(|body| body.generation)
+        .unwrap_or(entry.attr.generation)
 }
 
 fn cleanup_staged_write_error<O: ObjectStore>(

--- a/crates/nokv-client/src/lib.rs
+++ b/crates/nokv-client/src/lib.rs
@@ -131,7 +131,12 @@ fn is_metadata_predicate_failed(err: &ClientError) -> bool {
     )
 }
 
-fn is_not_found(err: &ClientError) -> bool {
+/// True when the error reports a missing path rather than a failure: a
+/// client-side component-resolution miss or the server's typed
+/// `MetadError::NotFound`. Multi-level path lookups surface a missing
+/// *ancestor* as this error where a missing leaf would be `Ok(None)`; callers
+/// probing for "does this subtree exist yet" fold both into absence.
+pub fn is_metadata_not_found(err: &ClientError) -> bool {
     matches!(
         err,
         ClientError::NotFound(_) | ClientError::Metadata(MetadError::NotFound)

--- a/crates/nokv-client/src/lib.rs
+++ b/crates/nokv-client/src/lib.rs
@@ -25,7 +25,10 @@ pub use artifact::{
     normalize_artifact_path, ArtifactBackend, ArtifactInfo, ArtifactRepository,
     ArtifactRepositoryOptions,
 };
-pub use file_client::{NoKvFsClient, PathRangeReadRequest, PathReadRange, PreparedPathRangeBatch};
+pub use file_client::{
+    is_artifact_write_conflict, AppendOutcome, NoKvFsClient, PathRangeReadRequest, PathReadRange,
+    PreparedPathRangeBatch,
+};
 pub use nokv_object::{DataFabricReadStats, ObjectReadPlan};
 pub use service::{
     ClientPreparedArtifact, CloneOutcome, MetadataClient, MetadataClientOptions, PathLayoutOpen,

--- a/crates/nokv-client/src/service.rs
+++ b/crates/nokv-client/src/service.rs
@@ -2394,7 +2394,9 @@ fn wire_namespace_grep_request(
     Ok(WireNamespaceGrepRequest {
         path: request.path.clone(),
         pattern: request.pattern.clone(),
+        patterns: request.patterns.clone(),
         recursive: request.recursive,
+        name_glob: request.name_glob.clone(),
         cursor: request.cursor.clone(),
         limit: u64::try_from(request.limit)
             .map_err(|_| ClientError::Protocol("namespace grep limit exceeds u64".to_owned()))?,
@@ -2423,6 +2425,7 @@ fn namespace_grep_result(
     Ok(NamespaceGrepResult {
         path: result.path,
         pattern: result.pattern,
+        patterns: result.patterns,
         recursive: result.recursive,
         evidence: result.evidence,
         snapshot_id: result.snapshot_id,

--- a/crates/nokv-client/src/service.rs
+++ b/crates/nokv-client/src/service.rs
@@ -911,7 +911,7 @@ impl MetadataClient {
         match self.rmdir(prefix_path) {
             Ok(_) => {}
             // Already gone (idempotent re-run, or never created): fine.
-            Err(err) if crate::is_not_found(&err) => {}
+            Err(err) if crate::is_metadata_not_found(&err) => {}
             // ANY other child-removal failure (non-empty, transport, fence, ...)
             // means the subtree still exists, so the graft must stay registered:
             // restore the durable target we cleared in step 1 and surface the

--- a/crates/nokv-client/tests/file_client_append.rs
+++ b/crates/nokv-client/tests/file_client_append.rs
@@ -1,0 +1,322 @@
+//! Append/edit write primitives against a real in-process server.
+//!
+//! The server owns metadata only: block bytes are staged in the client's
+//! `MemoryObjectStore`, so every content assertion reads through the client
+//! (`cat`). Server-side data reads (e.g. `cat_snapshot`) cannot see
+//! client-staged blocks in this harness.
+
+use std::net::{SocketAddr, TcpListener};
+use std::thread;
+use std::time::Duration;
+
+use nokv_client::{is_artifact_write_conflict, ArtifactMetadata, NoKvFsClient};
+use nokv_meta::{HistoryGcOptions, ObjectGcOptions};
+use nokv_object::{MemoryObjectStore, ObjectStoreConfig, S3ObjectStoreOptions};
+use nokv_server::ServerOptions;
+use nokv_types::MountId;
+
+type TestClient = NoKvFsClient<MemoryObjectStore>;
+
+fn client() -> TestClient {
+    NoKvFsClient::connect(spawn_test_server(), MemoryObjectStore::new())
+}
+
+fn spawn_test_server() -> SocketAddr {
+    let dir = tempfile::tempdir().unwrap();
+    let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+    let bind = listener.local_addr().unwrap();
+    let server = nokv_server::Server::open(ServerOptions {
+        bind,
+        mount: MountId::new(1).unwrap(),
+        meta_path: dir.path().join("meta"),
+        metadata_checkpoint_archive_prefix: None,
+        object: fake_object_config(),
+        uid: 1000,
+        gid: 1000,
+        object_gc: ObjectGcOptions {
+            interval: Duration::from_secs(3600),
+            limit: 128,
+            run_immediately: false,
+            read_lease_grace: ObjectGcOptions::default().read_lease_grace,
+        },
+        history_gc: HistoryGcOptions {
+            interval: Duration::from_secs(3600),
+            limit: 128,
+            run_immediately: false,
+        },
+        control: None,
+    })
+    .unwrap();
+    thread::spawn(move || {
+        let _dir = dir;
+        let _ = server.serve(listener);
+    });
+    bind
+}
+
+fn fake_object_config() -> ObjectStoreConfig {
+    ObjectStoreConfig::s3(S3ObjectStoreOptions {
+        bucket: "test".to_owned(),
+        root: "/".to_owned(),
+        region: "auto".to_owned(),
+        endpoint: Some("http://127.0.0.1:1".to_owned()),
+        access_key_id: Some("test".to_owned()),
+        secret_access_key: Some("test".to_owned()),
+        session_token: None,
+        virtual_host_style: false,
+        skip_signature: true,
+    })
+}
+
+fn artifact_metadata(manifest_id: &str) -> ArtifactMetadata {
+    ArtifactMetadata {
+        producer: "file-client-append-tests".to_owned(),
+        digest_uri: format!("sha256:{manifest_id}"),
+        content_type: "text/plain".to_owned(),
+        manifest_id: manifest_id.to_owned(),
+        mode: 0o644,
+        uid: 1000,
+        gid: 1000,
+    }
+}
+
+fn body_generation(client: &TestClient, path: &str) -> u64 {
+    client
+        .metadata()
+        .lookup(path)
+        .unwrap()
+        .unwrap()
+        .body
+        .unwrap()
+        .generation
+}
+
+#[test]
+fn append_extends_existing_artifact_as_delta() {
+    let client = client();
+    client
+        .put_artifact(
+            "/log.txt",
+            b"hello ".to_vec(),
+            artifact_metadata("base.log"),
+        )
+        .unwrap();
+    let base_generation = body_generation(&client, "/log.txt");
+
+    let outcome = client
+        .append_artifact(
+            "/log.txt",
+            b"world".to_vec(),
+            artifact_metadata("delta-1.log"),
+            None,
+        )
+        .unwrap();
+
+    assert!(!outcome.created);
+    assert_eq!(outcome.new_size, 11);
+    assert!(outcome.generation > base_generation);
+    assert_eq!(client.cat("/log.txt").unwrap(), b"hello world");
+    let body = client
+        .metadata()
+        .lookup("/log.txt")
+        .unwrap()
+        .unwrap()
+        .body
+        .unwrap();
+    assert_eq!(body.generation, outcome.generation);
+    // Delta publish: the new body must fall through to the appended-onto
+    // generation for the old bytes instead of re-materializing them.
+    assert_eq!(body.base_generation, base_generation);
+}
+
+#[test]
+fn append_with_matching_expected_generation_succeeds() {
+    let client = client();
+    client
+        .put_artifact("/cas.txt", b"one".to_vec(), artifact_metadata("cas-0.log"))
+        .unwrap();
+    let base_generation = body_generation(&client, "/cas.txt");
+
+    let outcome = client
+        .append_artifact(
+            "/cas.txt",
+            b"two".to_vec(),
+            artifact_metadata("cas-1.log"),
+            Some(base_generation),
+        )
+        .unwrap();
+
+    assert!(!outcome.created);
+    assert_eq!(outcome.new_size, 6);
+    assert_eq!(client.cat("/cas.txt").unwrap(), b"onetwo");
+}
+
+#[test]
+fn append_creates_missing_artifact() {
+    let client = client();
+
+    let outcome = client
+        .append_artifact(
+            "/fresh.txt",
+            b"seed".to_vec(),
+            artifact_metadata("fresh.log"),
+            None,
+        )
+        .unwrap();
+
+    assert!(outcome.created);
+    assert_eq!(outcome.new_size, 4);
+    assert_eq!(outcome.generation, body_generation(&client, "/fresh.txt"));
+    assert_eq!(client.cat("/fresh.txt").unwrap(), b"seed");
+}
+
+#[test]
+fn append_missing_artifact_with_expected_generation_conflicts() {
+    let client = client();
+
+    let err = client
+        .append_artifact(
+            "/ghost.txt",
+            b"x".to_vec(),
+            artifact_metadata("ghost.log"),
+            Some(7),
+        )
+        .unwrap_err();
+
+    assert!(
+        is_artifact_write_conflict(&err),
+        "expected write conflict, got {err:?}"
+    );
+    assert!(client.metadata().lookup("/ghost.txt").unwrap().is_none());
+}
+
+#[test]
+fn append_with_stale_expected_generation_conflicts() {
+    let client = client();
+    client
+        .put_artifact(
+            "/race.txt",
+            b"one".to_vec(),
+            artifact_metadata("race-0.log"),
+        )
+        .unwrap();
+    let base_generation = body_generation(&client, "/race.txt");
+    client
+        .append_artifact(
+            "/race.txt",
+            b"two".to_vec(),
+            artifact_metadata("race-1.log"),
+            Some(base_generation),
+        )
+        .unwrap();
+
+    // A second writer holding the pre-append generation must lose the CAS.
+    let err = client
+        .append_artifact(
+            "/race.txt",
+            b"three".to_vec(),
+            artifact_metadata("race-2.log"),
+            Some(base_generation),
+        )
+        .unwrap_err();
+
+    assert!(
+        is_artifact_write_conflict(&err),
+        "expected write conflict, got {err:?}"
+    );
+    assert_eq!(client.cat("/race.txt").unwrap(), b"onetwo");
+}
+
+#[test]
+fn repeated_appends_stay_readable_across_chain_compaction() {
+    let client = client();
+    let mut expected = b"seg0|".to_vec();
+    client
+        .put_artifact("/chain.txt", expected.clone(), artifact_metadata("chain-0"))
+        .unwrap();
+
+    // Nine appends push the fall-through chain past the server's compaction
+    // depth (8); content must read back whole at every depth.
+    let mut compacted = false;
+    for index in 1..=9_usize {
+        let delta = format!("seg{index}|").into_bytes();
+        expected.extend_from_slice(&delta);
+        let outcome = client
+            .append_artifact(
+                "/chain.txt",
+                delta,
+                artifact_metadata(&format!("chain-{index}")),
+                None,
+            )
+            .unwrap();
+        assert_eq!(outcome.new_size as usize, expected.len());
+        assert_eq!(client.cat("/chain.txt").unwrap(), expected);
+        let body = client
+            .metadata()
+            .lookup("/chain.txt")
+            .unwrap()
+            .unwrap()
+            .body
+            .unwrap();
+        if body.base_generation == 0 {
+            compacted = true;
+        }
+    }
+    assert!(
+        compacted,
+        "nine appends must cross the compaction threshold at least once"
+    );
+}
+
+#[test]
+fn replace_if_generation_matches_current_body() {
+    let client = client();
+    client
+        .put_artifact("/doc.txt", b"v1".to_vec(), artifact_metadata("doc-0"))
+        .unwrap();
+    let base_generation = body_generation(&client, "/doc.txt");
+
+    let result = client
+        .put_artifact_replace_if_generation(
+            "/doc.txt",
+            b"v2-longer".to_vec(),
+            artifact_metadata("doc-1"),
+            base_generation,
+        )
+        .unwrap();
+
+    assert!(result.replaced.is_some());
+    assert_eq!(client.cat("/doc.txt").unwrap(), b"v2-longer");
+}
+
+#[test]
+fn replace_if_generation_rejects_stale_generation() {
+    let client = client();
+    client
+        .put_artifact("/doc.txt", b"v1".to_vec(), artifact_metadata("doc-0"))
+        .unwrap();
+    let base_generation = body_generation(&client, "/doc.txt");
+    client
+        .put_artifact_replace_if_generation(
+            "/doc.txt",
+            b"v2".to_vec(),
+            artifact_metadata("doc-1"),
+            base_generation,
+        )
+        .unwrap();
+
+    let err = client
+        .put_artifact_replace_if_generation(
+            "/doc.txt",
+            b"v3".to_vec(),
+            artifact_metadata("doc-2"),
+            base_generation,
+        )
+        .unwrap_err();
+
+    assert!(
+        is_artifact_write_conflict(&err),
+        "expected write conflict, got {err:?}"
+    );
+    assert_eq!(client.cat("/doc.txt").unwrap(), b"v2");
+}

--- a/crates/nokv-client/tests/file_client_append.rs
+++ b/crates/nokv-client/tests/file_client_append.rs
@@ -6,6 +6,7 @@
 //! client-staged blocks in this harness.
 
 use std::net::{SocketAddr, TcpListener};
+use std::sync::{Arc, Barrier};
 use std::thread;
 use std::time::Duration;
 
@@ -266,6 +267,74 @@ fn repeated_appends_stay_readable_across_chain_compaction() {
         compacted,
         "nine appends must cross the compaction threshold at least once"
     );
+}
+
+/// Two writers with independent clients (sharing one object store so either
+/// side can read blocks the other staged) race 10 appends each — including the
+/// initial create — against one path. Every conflict-shaped error along the
+/// way must be classified by [`is_artifact_write_conflict`] so a
+/// retry-on-conflict loop converges: the file must end up with exactly the 20
+/// complete lines the writers produced.
+#[test]
+fn concurrent_appends_from_two_writers_keep_every_line() {
+    const WRITERS: usize = 2;
+    const APPENDS_PER_WRITER: usize = 10;
+    let address = spawn_test_server();
+    let objects = MemoryObjectStore::new();
+    let barrier = Arc::new(Barrier::new(WRITERS));
+    let handles: Vec<_> = (0..WRITERS)
+        .map(|writer| {
+            let objects = objects.clone();
+            let barrier = Arc::clone(&barrier);
+            thread::spawn(move || {
+                let client: TestClient = NoKvFsClient::connect(address, objects);
+                barrier.wait();
+                for index in 0..APPENDS_PER_WRITER {
+                    let line = format!("writer-{writer}-line-{index}\n").into_bytes();
+                    let manifest = format!("concurrent-{writer}-{index}");
+                    let mut attempts = 0;
+                    loop {
+                        match client.append_artifact(
+                            "/concurrent.txt",
+                            line.clone(),
+                            artifact_metadata(&manifest),
+                            None,
+                        ) {
+                            Ok(_) => break,
+                            Err(err) if is_artifact_write_conflict(&err) && attempts < 100 => {
+                                attempts += 1;
+                                thread::sleep(Duration::from_millis(1));
+                            }
+                            Err(err) => {
+                                panic!("writer {writer} append {index} failed hard: {err:?}")
+                            }
+                        }
+                    }
+                }
+            })
+        })
+        .collect();
+    for handle in handles {
+        handle.join().unwrap();
+    }
+
+    let client: TestClient = NoKvFsClient::connect(address, objects);
+    let content = String::from_utf8(client.cat("/concurrent.txt").unwrap()).unwrap();
+    let lines: Vec<&str> = content.lines().collect();
+    assert_eq!(
+        lines.len(),
+        WRITERS * APPENDS_PER_WRITER,
+        "appends were lost; content:\n{content}"
+    );
+    for writer in 0..WRITERS {
+        for index in 0..APPENDS_PER_WRITER {
+            let expected = format!("writer-{writer}-line-{index}");
+            assert!(
+                lines.contains(&expected.as_str()),
+                "missing line {expected}; content:\n{content}"
+            );
+        }
+    }
 }
 
 #[test]

--- a/crates/nokv-meta/src/service/agent.rs
+++ b/crates/nokv-meta/src/service/agent.rs
@@ -432,8 +432,8 @@ pub struct NamespaceAggregateResult {
 pub struct NamespaceGrepRequest {
     pub path: String,
     pub pattern: String,
-    /// When non-empty, a line matches if it contains any entry; `pattern` is
-    /// then ignored.
+    /// OR alternatives unioned with `pattern`: a line matches if it contains
+    /// `pattern` or any entry (case-insensitive, deduplicated).
     pub patterns: Vec<String>,
     pub recursive: bool,
     /// Basename filter supporting `*` and `?`; unmatched files are skipped

--- a/crates/nokv-meta/src/service/agent.rs
+++ b/crates/nokv-meta/src/service/agent.rs
@@ -912,15 +912,21 @@ where
                 glob_match(&glob, &basename.chars().collect::<Vec<_>>())
             });
         }
-        let needles = if request.patterns.is_empty() {
-            vec![request.pattern.to_lowercase()]
-        } else {
-            request
-                .patterns
-                .iter()
-                .map(|pattern| pattern.to_lowercase())
-                .collect::<Vec<_>>()
-        };
+        // Union semantics: `patterns` adds OR alternatives to `pattern`, it
+        // does not replace it. Case-folded and deduplicated; validation
+        // guarantees at least one non-empty needle survives.
+        let mut needles = Vec::with_capacity(request.patterns.len() + 1);
+        for pattern in std::iter::once(request.pattern.as_str())
+            .chain(request.patterns.iter().map(String::as_str))
+        {
+            if pattern.is_empty() {
+                continue;
+            }
+            let needle = pattern.to_lowercase();
+            if !needles.contains(&needle) {
+                needles.push(needle);
+            }
+        }
         let mut matches = Vec::new();
         let mut files_scanned = 0_usize;
         let mut files_scanned_this_call = 0_usize;

--- a/crates/nokv-meta/src/service/agent.rs
+++ b/crates/nokv-meta/src/service/agent.rs
@@ -4,6 +4,7 @@ use std::cmp::Ordering as CmpOrdering;
 const DEFAULT_PAGE_LIMIT: usize = 100;
 const DEFAULT_SAMPLE_LIMIT: usize = 3;
 const DEFAULT_FACET_VALUE_LIMIT: usize = 10;
+const MAX_GREP_PATTERNS: usize = 16;
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum NamespaceCardKind {
@@ -431,7 +432,13 @@ pub struct NamespaceAggregateResult {
 pub struct NamespaceGrepRequest {
     pub path: String,
     pub pattern: String,
+    /// When non-empty, a line matches if it contains any entry; `pattern` is
+    /// then ignored.
+    pub patterns: Vec<String>,
     pub recursive: bool,
+    /// Basename filter supporting `*` and `?`; unmatched files are skipped
+    /// without being read.
+    pub name_glob: Option<String>,
     pub cursor: Option<String>,
     pub limit: usize,
     pub max_files: Option<usize>,
@@ -451,6 +458,7 @@ pub struct NamespaceGrepMatch {
 pub struct NamespaceGrepResult {
     pub path: String,
     pub pattern: String,
+    pub patterns: Vec<String>,
     pub recursive: bool,
     pub evidence: String,
     pub snapshot_id: Option<u64>,
@@ -892,8 +900,27 @@ where
         let metadata = self
             .stat_path_from_at_version(InodeId::root(), &root, version)?
             .ok_or(MetadError::NotFound)?;
-        let candidates = self.grep_candidates(&root, metadata, request.recursive, version)?;
-        let pattern_lower = request.pattern.to_lowercase();
+        let mut candidates = self.grep_candidates(&root, metadata, request.recursive, version)?;
+        if let Some(name_glob) = request.name_glob.as_deref() {
+            let glob = name_glob.chars().collect::<Vec<_>>();
+            candidates.retain(|candidate| {
+                let basename = candidate
+                    .path
+                    .rsplit('/')
+                    .next()
+                    .unwrap_or(candidate.path.as_str());
+                glob_match(&glob, &basename.chars().collect::<Vec<_>>())
+            });
+        }
+        let needles = if request.patterns.is_empty() {
+            vec![request.pattern.to_lowercase()]
+        } else {
+            request
+                .patterns
+                .iter()
+                .map(|pattern| pattern.to_lowercase())
+                .collect::<Vec<_>>()
+        };
         let mut matches = Vec::new();
         let mut files_scanned = 0_usize;
         let mut files_scanned_this_call = 0_usize;
@@ -948,7 +975,8 @@ where
             };
             let text = String::from_utf8_lossy(&bytes);
             for (line_index, line) in text.lines().enumerate().skip(start_line) {
-                if !line.to_lowercase().contains(&pattern_lower) {
+                let line_lower = line.to_lowercase();
+                if !needles.iter().any(|needle| line_lower.contains(needle)) {
                     continue;
                 }
                 if matches.len() == limit {
@@ -976,6 +1004,7 @@ where
             evidence: namespace_evidence(&root, None),
             path: root,
             pattern: request.pattern,
+            patterns: request.patterns,
             recursive: request.recursive,
             snapshot_id: Some(version.get()),
             matches,
@@ -1439,7 +1468,15 @@ where
         options: NamespaceReadOptions,
     ) -> Result<NamespaceReadPage, MetadError> {
         let limit = bounded_limit(options.limit)?;
-        let offset = parse_cursor(options.cursor.as_deref())?;
+        let offset = match options.cursor.as_deref() {
+            Some(cursor) => parse_cursor(Some(cursor))?,
+            None => usize::try_from(options.offset).map_err(|_| {
+                MetadError::InvalidQuery(format!(
+                    "offset {} does not fit this platform",
+                    options.offset
+                ))
+            })?,
+        };
         let body = metadata
             .body
             .as_ref()
@@ -1560,6 +1597,26 @@ fn path_is_self_or_descendant(root: &str, path: &str) -> bool {
 
 fn validate_grep_request(request: &NamespaceGrepRequest) -> Result<(), MetadError> {
     bounded_limit(request.limit)?;
+    if request.patterns.len() > MAX_GREP_PATTERNS {
+        return Err(MetadError::InvalidQuery(format!(
+            "patterns must not exceed {MAX_GREP_PATTERNS} entries"
+        )));
+    }
+    if request.patterns.iter().any(String::is_empty) {
+        return Err(MetadError::InvalidQuery(
+            "patterns entries must not be empty".to_owned(),
+        ));
+    }
+    if request.pattern.is_empty() && request.patterns.is_empty() {
+        return Err(MetadError::InvalidQuery(
+            "pattern or patterns must be provided".to_owned(),
+        ));
+    }
+    if request.name_glob.as_deref() == Some("") {
+        return Err(MetadError::InvalidQuery(
+            "name_glob must not be empty".to_owned(),
+        ));
+    }
     if let Some(max_files) = request.max_files {
         if max_files == 0 {
             return Err(MetadError::InvalidQuery(
@@ -1575,6 +1632,33 @@ fn validate_grep_request(request: &NamespaceGrepRequest) -> Result<(), MetadErro
         }
     }
     Ok(())
+}
+
+/// Iterative glob match over Unicode scalars: `*` matches any run of
+/// characters, `?` matches exactly one. On mismatch, backtracks to the most
+/// recent `*` and lets it absorb one more character.
+fn glob_match(pattern: &[char], name: &[char]) -> bool {
+    let mut pattern_index = 0;
+    let mut name_index = 0;
+    let mut star: Option<(usize, usize)> = None;
+    while name_index < name.len() {
+        if pattern_index < pattern.len()
+            && (pattern[pattern_index] == '?' || pattern[pattern_index] == name[name_index])
+        {
+            pattern_index += 1;
+            name_index += 1;
+        } else if pattern_index < pattern.len() && pattern[pattern_index] == '*' {
+            star = Some((pattern_index, name_index));
+            pattern_index += 1;
+        } else if let Some((star_pattern, star_name)) = star {
+            pattern_index = star_pattern + 1;
+            name_index = star_name + 1;
+            star = Some((star_pattern, star_name + 1));
+        } else {
+            return false;
+        }
+    }
+    pattern[pattern_index..].iter().all(|glyph| *glyph == '*')
 }
 
 fn namespace_query_catalog(kind: NamespaceCardKind) -> NamespaceQueryCatalog {

--- a/crates/nokv-meta/src/service_tests.rs
+++ b/crates/nokv-meta/src/service_tests.rs
@@ -892,7 +892,9 @@ fn namespace_grep_cursor_resumes_at_next_unemitted_match() {
         .grep_paths(NamespaceGrepRequest {
             path: "/runs/train.log".to_owned(),
             pattern: "loss".to_owned(),
+            patterns: Vec::new(),
             recursive: false,
+            name_glob: None,
             cursor: None,
             limit: 1,
             max_files: None,
@@ -901,12 +903,16 @@ fn namespace_grep_cursor_resumes_at_next_unemitted_match() {
         .unwrap();
     assert_eq!(first.matches.len(), 1);
     assert_eq!(first.matches[0].line_number, 1);
+    assert_eq!(first.pattern, "loss");
+    assert!(first.patterns.is_empty());
 
     let second = service
         .grep_paths(NamespaceGrepRequest {
             path: "/runs/train.log".to_owned(),
             pattern: "loss".to_owned(),
+            patterns: Vec::new(),
             recursive: false,
+            name_glob: None,
             cursor: first.next_cursor,
             limit: 1,
             max_files: None,
@@ -915,6 +921,227 @@ fn namespace_grep_cursor_resumes_at_next_unemitted_match() {
         .unwrap();
     assert_eq!(second.matches.len(), 1);
     assert_eq!(second.matches[0].line_number, 2);
+}
+
+#[test]
+fn namespace_grep_multiple_patterns_match_any() {
+    let service = service();
+    service.create_dir_path("/runs", 0o755, 1000, 1000).unwrap();
+    publish_path_artifact(&service, "/runs/a.log", "runs/a.log", b"alpha metric\n");
+    publish_path_artifact(
+        &service,
+        "/runs/b.log",
+        "runs/b.log",
+        b"nothing here\nbeta metric\n",
+    );
+
+    let result = service
+        .grep_paths(NamespaceGrepRequest {
+            path: "/runs".to_owned(),
+            pattern: String::new(),
+            patterns: vec!["alpha".to_owned(), "beta".to_owned()],
+            recursive: false,
+            name_glob: None,
+            cursor: None,
+            limit: 10,
+            max_files: None,
+            max_bytes: None,
+        })
+        .unwrap();
+
+    assert_eq!(result.matches.len(), 2);
+    assert_eq!(result.matches[0].path, "/runs/a.log");
+    assert_eq!(result.matches[0].line_number, 1);
+    assert_eq!(result.matches[1].path, "/runs/b.log");
+    assert_eq!(result.matches[1].line_number, 2);
+    assert_eq!(result.patterns, vec!["alpha", "beta"]);
+}
+
+#[test]
+fn namespace_grep_multiple_patterns_match_cjk() {
+    let service = service();
+    service.create_dir_path("/runs", 0o755, 1000, 1000).unwrap();
+    publish_path_artifact(
+        &service,
+        "/runs/notes.txt",
+        "runs/notes.txt",
+        "今日营养记录\n普通一行\n食谱更新完成\n".as_bytes(),
+    );
+
+    let result = service
+        .grep_paths(NamespaceGrepRequest {
+            path: "/runs/notes.txt".to_owned(),
+            pattern: String::new(),
+            patterns: vec!["营养".to_owned(), "食谱".to_owned()],
+            recursive: false,
+            name_glob: None,
+            cursor: None,
+            limit: 10,
+            max_files: None,
+            max_bytes: None,
+        })
+        .unwrap();
+
+    let lines = result
+        .matches
+        .iter()
+        .map(|entry| entry.line_number)
+        .collect::<Vec<_>>();
+    assert_eq!(lines, vec![1, 3]);
+}
+
+#[test]
+fn namespace_grep_name_glob_skips_unmatched_files_without_reading() {
+    let service = service();
+    service.create_dir_path("/runs", 0o755, 1000, 1000).unwrap();
+    publish_path_artifact(&service, "/runs/a.md", "runs/a.md", b"needle in md\n");
+    publish_path_artifact(&service, "/runs/b.log", "runs/b.log", b"needle in log\n");
+
+    let result = service
+        .grep_paths(NamespaceGrepRequest {
+            path: "/runs".to_owned(),
+            pattern: "needle".to_owned(),
+            patterns: Vec::new(),
+            recursive: false,
+            name_glob: Some("*.md".to_owned()),
+            cursor: None,
+            limit: 10,
+            max_files: None,
+            max_bytes: None,
+        })
+        .unwrap();
+
+    assert_eq!(result.matches.len(), 1);
+    assert_eq!(result.matches[0].path, "/runs/a.md");
+    assert_eq!(result.files_scanned, 1);
+    assert_eq!(result.bytes_read, b"needle in md\n".len());
+}
+
+#[test]
+fn namespace_grep_name_glob_matches_cjk_substring() {
+    let service = service();
+    service.create_dir_path("/runs", 0o755, 1000, 1000).unwrap();
+    publish_path_artifact(
+        &service,
+        "/runs/营养日志.txt",
+        "runs/nutrition.txt",
+        "记录一\n".as_bytes(),
+    );
+    publish_path_artifact(
+        &service,
+        "/runs/训练日志.txt",
+        "runs/training.txt",
+        "记录二\n".as_bytes(),
+    );
+
+    let result = service
+        .grep_paths(NamespaceGrepRequest {
+            path: "/runs".to_owned(),
+            pattern: "记录".to_owned(),
+            patterns: Vec::new(),
+            recursive: false,
+            name_glob: Some("*营养*".to_owned()),
+            cursor: None,
+            limit: 10,
+            max_files: None,
+            max_bytes: None,
+        })
+        .unwrap();
+
+    assert_eq!(result.matches.len(), 1);
+    assert_eq!(result.matches[0].path, "/runs/营养日志.txt");
+    assert_eq!(result.files_scanned, 1);
+}
+
+#[test]
+fn namespace_grep_rejects_more_than_sixteen_patterns() {
+    let service = service();
+    service.create_dir_path("/runs", 0o755, 1000, 1000).unwrap();
+
+    let err = service
+        .grep_paths(NamespaceGrepRequest {
+            path: "/runs".to_owned(),
+            pattern: String::new(),
+            patterns: (0..17).map(|index| format!("p{index}")).collect(),
+            recursive: false,
+            name_glob: None,
+            cursor: None,
+            limit: 10,
+            max_files: None,
+            max_bytes: None,
+        })
+        .unwrap_err();
+
+    assert!(matches!(err, MetadError::InvalidQuery(message) if message.contains("16")));
+}
+
+#[test]
+fn namespace_grep_rejects_empty_pattern_entry() {
+    let service = service();
+    service.create_dir_path("/runs", 0o755, 1000, 1000).unwrap();
+
+    let err = service
+        .grep_paths(NamespaceGrepRequest {
+            path: "/runs".to_owned(),
+            pattern: String::new(),
+            patterns: vec!["ok".to_owned(), String::new()],
+            recursive: false,
+            name_glob: None,
+            cursor: None,
+            limit: 10,
+            max_files: None,
+            max_bytes: None,
+        })
+        .unwrap_err();
+
+    assert!(matches!(err, MetadError::InvalidQuery(message) if message.contains("empty")));
+}
+
+#[test]
+fn namespace_grep_rejects_missing_pattern_and_patterns() {
+    let service = service();
+    service.create_dir_path("/runs", 0o755, 1000, 1000).unwrap();
+
+    let err = service
+        .grep_paths(NamespaceGrepRequest {
+            path: "/runs".to_owned(),
+            pattern: String::new(),
+            patterns: Vec::new(),
+            recursive: false,
+            name_glob: None,
+            cursor: None,
+            limit: 10,
+            max_files: None,
+            max_bytes: None,
+        })
+        .unwrap_err();
+
+    assert!(matches!(err, MetadError::InvalidQuery(message) if message.contains("pattern")));
+}
+
+#[test]
+fn namespace_read_structured_offset_without_cursor_skips_items() {
+    let service = service();
+    service.create_dir_path("/runs", 0o755, 1000, 1000).unwrap();
+    publish_path_artifact(&service, "/runs/a.json", "runs/a.json", br#"["a","b","c"]"#);
+
+    let page = service
+        .read_page(
+            "/runs/a.json",
+            NamespaceReadOptions {
+                format: NamespaceReadFormat::Structured,
+                cursor: None,
+                offset: 1,
+                limit: 1,
+                expected_generation: None,
+            },
+        )
+        .unwrap();
+
+    assert_eq!(page.items.len(), 1);
+    assert_eq!(page.items[0].index, 1);
+    assert_eq!(page.items[0].value_json, r#""b""#);
+    assert!(page.truncated);
 }
 
 #[test]

--- a/crates/nokv-meta/src/service_tests.rs
+++ b/crates/nokv-meta/src/service_tests.rs
@@ -990,6 +990,99 @@ fn namespace_grep_multiple_patterns_match_cjk() {
     assert_eq!(lines, vec![1, 3]);
 }
 
+/// `patterns` adds OR alternatives to `pattern` (union semantics); a non-empty
+/// `pattern` must keep matching when `patterns` is also provided instead of
+/// being silently dropped.
+#[test]
+fn namespace_grep_unions_pattern_with_patterns() {
+    let service = service();
+    service.create_dir_path("/runs", 0o755, 1000, 1000).unwrap();
+    publish_path_artifact(
+        &service,
+        "/runs/notes.txt",
+        "runs/notes.txt",
+        "食谱更新完成\n无关的一行\n食材已备齐\n新 recipe 上线\n".as_bytes(),
+    );
+
+    let result = service
+        .grep_paths(NamespaceGrepRequest {
+            path: "/runs/notes.txt".to_owned(),
+            pattern: "食谱".to_owned(),
+            patterns: vec!["食材".to_owned(), "recipe".to_owned()],
+            recursive: false,
+            name_glob: None,
+            cursor: None,
+            limit: 10,
+            max_files: None,
+            max_bytes: None,
+        })
+        .unwrap();
+
+    let lines = result
+        .matches
+        .iter()
+        .map(|entry| entry.line_number)
+        .collect::<Vec<_>>();
+    assert_eq!(lines, vec![1, 3, 4]);
+    // The echo reports the request fields verbatim.
+    assert_eq!(result.pattern, "食谱");
+    assert_eq!(result.patterns, vec!["食材", "recipe"]);
+}
+
+/// The workbench pipe-split forwards `pattern: "a|b"` together with
+/// `patterns: ["a", "b"]`. Any line containing the literal "a|b" also contains
+/// each split alternative, so union semantics must return the same match set
+/// as the split alternatives alone.
+#[test]
+fn namespace_grep_piped_pattern_union_matches_split_alternatives() {
+    let service = service();
+    service.create_dir_path("/runs", 0o755, 1000, 1000).unwrap();
+    publish_path_artifact(
+        &service,
+        "/runs/mixed.log",
+        "runs/mixed.log",
+        b"alpha metric\nliteral alpha|beta row\nbeta metric\nnothing\n",
+    );
+    let request = |pattern: &str, patterns: Vec<String>| NamespaceGrepRequest {
+        path: "/runs/mixed.log".to_owned(),
+        pattern: pattern.to_owned(),
+        patterns,
+        recursive: false,
+        name_glob: None,
+        cursor: None,
+        limit: 10,
+        max_files: None,
+        max_bytes: None,
+    };
+
+    let split_only = service
+        .grep_paths(request("", vec!["alpha".to_owned(), "beta".to_owned()]))
+        .unwrap();
+    let piped_union = service
+        .grep_paths(request(
+            "alpha|beta",
+            vec!["alpha".to_owned(), "beta".to_owned()],
+        ))
+        .unwrap();
+
+    let lines = |result: &NamespaceGrepResult| {
+        result
+            .matches
+            .iter()
+            .map(|entry| (entry.path.clone(), entry.line_number))
+            .collect::<Vec<_>>()
+    };
+    assert_eq!(lines(&piped_union), lines(&split_only));
+    assert_eq!(
+        lines(&split_only),
+        vec![
+            ("/runs/mixed.log".to_owned(), 1),
+            ("/runs/mixed.log".to_owned(), 2),
+            ("/runs/mixed.log".to_owned(), 3),
+        ]
+    );
+}
+
 #[test]
 fn namespace_grep_name_glob_skips_unmatched_files_without_reading() {
     let service = service();

--- a/crates/nokv-protocol/src/lib.rs
+++ b/crates/nokv-protocol/src/lib.rs
@@ -934,7 +934,11 @@ pub struct WireNamespaceAggregateResult {
 pub struct WireNamespaceGrepRequest {
     pub path: String,
     pub pattern: String,
+    #[serde(default)]
+    pub patterns: Vec<String>,
     pub recursive: bool,
+    #[serde(default)]
+    pub name_glob: Option<String>,
     pub cursor: Option<String>,
     pub limit: u64,
     pub max_files: Option<u64>,
@@ -954,6 +958,8 @@ pub struct WireNamespaceGrepMatch {
 pub struct WireNamespaceGrepResult {
     pub path: String,
     pub pattern: String,
+    #[serde(default)]
+    pub patterns: Vec<String>,
     pub recursive: bool,
     pub evidence: String,
     pub snapshot_id: Option<u64>,
@@ -1684,7 +1690,9 @@ mod tests {
             request: Box::new(WireNamespaceGrepRequest {
                 path: "/runs".to_owned(),
                 pattern: "needle".to_owned(),
+                patterns: vec!["needle".to_owned(), "营养".to_owned()],
                 recursive: true,
+                name_glob: Some("*.md".to_owned()),
                 cursor: Some("1:0".to_owned()),
                 limit: 10,
                 max_files: Some(20),
@@ -1693,6 +1701,39 @@ mod tests {
         };
         let encoded = encode_request(&request).unwrap();
         assert_eq!(decode_request(&encoded).unwrap(), request);
+    }
+
+    #[test]
+    fn grep_request_decodes_payload_without_patterns_or_name_glob() {
+        // Payload shaped like a pre-`patterns` peer: the fields are absent
+        // from the struct map and must default on decode.
+        #[derive(Serialize)]
+        struct LegacyGrepRequest {
+            path: String,
+            pattern: String,
+            recursive: bool,
+            cursor: Option<String>,
+            limit: u64,
+            max_files: Option<u64>,
+            max_bytes: Option<u64>,
+        }
+        let legacy = LegacyGrepRequest {
+            path: "/runs".to_owned(),
+            pattern: "needle".to_owned(),
+            recursive: true,
+            cursor: None,
+            limit: 10,
+            max_files: None,
+            max_bytes: None,
+        };
+        let mut encoded = Vec::new();
+        legacy
+            .serialize(&mut rmp_serde::Serializer::new(&mut encoded).with_struct_map())
+            .unwrap();
+        let decoded: WireNamespaceGrepRequest = rmp_serde::from_slice(&encoded).unwrap();
+        assert_eq!(decoded.pattern, "needle");
+        assert!(decoded.patterns.is_empty());
+        assert_eq!(decoded.name_glob, None);
     }
 
     #[test]
@@ -1967,6 +2008,7 @@ mod tests {
                 result: Box::new(WireNamespaceGrepResult {
                     path: "/runs".to_owned(),
                     pattern: "needle".to_owned(),
+                    patterns: vec!["needle".to_owned()],
                     recursive: true,
                     evidence: "nokv-native:///runs".to_owned(),
                     snapshot_id: Some(9),

--- a/crates/nokv-server/src/rpc/wire.rs
+++ b/crates/nokv-server/src/rpc/wire.rs
@@ -611,6 +611,7 @@ pub(super) fn wire_namespace_grep_result(
     Ok(WireNamespaceGrepResult {
         path: result.path.clone(),
         pattern: result.pattern.clone(),
+        patterns: result.patterns.clone(),
         recursive: result.recursive,
         evidence: result.evidence.clone(),
         snapshot_id: result.snapshot_id,
@@ -740,7 +741,9 @@ pub(super) fn namespace_grep_request(
     Ok(NamespaceGrepRequest {
         path: request.path,
         pattern: request.pattern,
+        patterns: request.patterns,
         recursive: request.recursive,
+        name_glob: request.name_glob,
         cursor: request.cursor,
         limit: usize::try_from(request.limit).map_err(|_| {
             ServerError::Metadata(MetadError::InvalidQuery(

--- a/crates/nokv/src/bin/nokv.rs
+++ b/crates/nokv/src/bin/nokv.rs
@@ -3969,6 +3969,59 @@ mod tests {
         assert_eq!(result["matches"], serde_json::json!([]));
     }
 
+    /// A multi-level per-agent root (PR #390's default shape) whose ancestors
+    /// were never created must behave like the flat missing-root case: the
+    /// server reports the unresolved ancestor as a NotFound *error*, and the
+    /// workbench layer must fold that into "root not materialized = empty
+    /// results" instead of surfacing isError.
+    #[test]
+    fn workbench_mcp_queries_treat_missing_multilevel_root_as_empty() {
+        let options = McpCliOptions {
+            profile: McpProfile::Workbench,
+            workbench_root: Some(s("/agents/e2e-never/wb")),
+            workbench_max_bytes: workbench_mcp::DEFAULT_WORKBENCH_MAX_BYTES,
+        };
+        let responses = run_workbench_mcp_requests_with_options(
+            options,
+            vec![
+                workbench_tool_call(1, "workbench_find", serde_json::json!({})),
+                workbench_tool_call(2, "workbench_search", serde_json::json!({})),
+                workbench_tool_call(
+                    3,
+                    "workbench_aggregate",
+                    serde_json::json!({
+                        "predicates": [{"field": "kind", "op": "eq", "value": "file"}],
+                        "measures": [{"name": "files", "op": "count"}]
+                    }),
+                ),
+            ],
+        );
+        for (index, response) in responses.iter().enumerate() {
+            assert_ne!(
+                response["result"]["isError"], true,
+                "response {index}: {response}"
+            );
+        }
+
+        let find = &responses[0]["result"]["structuredContent"];
+        assert_eq!(find["status"], "success", "find response: {find}");
+        assert_eq!(find["match_count"], 0);
+        assert_eq!(find["matches"], serde_json::json!([]));
+
+        let search = &responses[1]["result"]["structuredContent"];
+        assert_eq!(search["status"], "success", "search response: {search}");
+        assert_eq!(search["match_count"], 0);
+        assert_eq!(search["matches"], serde_json::json!([]));
+
+        let aggregate = &responses[2]["result"]["structuredContent"];
+        assert_eq!(
+            aggregate["status"], "success",
+            "aggregate response: {aggregate}"
+        );
+        assert_eq!(aggregate["row_count"], 0);
+        assert_eq!(aggregate["groups"], serde_json::json!([]));
+    }
+
     #[test]
     fn workbench_mcp_aggregate_counts_grouped_rows() {
         let responses = run_shared_workbench_mcp_requests(vec![
@@ -4378,6 +4431,60 @@ mod tests {
             .contains("limit must be between 1 and 300"));
     }
 
+    /// Bytes-mode reads must return a base64 string, not a JSON integer
+    /// array (which inflates the token cost of every byte to ~4 tokens).
+    #[test]
+    fn workbench_mcp_read_bytes_returns_base64_payload() {
+        use base64::Engine as _;
+        let payload: Vec<u8> = vec![
+            0x00, 0x01, 0xFE, 0xFF, 0x10, 0x20, 0x30, 0x40, 0x7F, 0x80, 0x90, 0xA0,
+        ];
+        let responses = run_shared_workbench_mcp_requests(vec![
+            workbench_tool_call(1, "workbench_create", serde_json::json!({"id": "wb-bytes"})),
+            workbench_tool_call(
+                2,
+                "workbench_put_file",
+                serde_json::json!({
+                    "id": "wb-bytes",
+                    "section": "outputs",
+                    "path": "blob.bin",
+                    "base64": base64::engine::general_purpose::STANDARD.encode(&payload),
+                    "content_type": "application/octet-stream"
+                }),
+            ),
+            workbench_tool_call(
+                3,
+                "workbench_read",
+                serde_json::json!({
+                    "id": "wb-bytes",
+                    "section": "outputs",
+                    "path": "blob.bin",
+                    "format": "bytes",
+                    "offset": 2,
+                    "limit": 8
+                }),
+            ),
+        ]);
+        for (index, response) in responses.iter().enumerate() {
+            assert_ne!(
+                response["result"]["isError"], true,
+                "response {index}: {response}"
+            );
+        }
+
+        let read = &responses[2]["result"]["structuredContent"];
+        assert_eq!(read["status"], "success", "read response: {read}");
+        assert_eq!(read["bytes_encoding"], "base64", "read response: {read}");
+        let encoded = read["bytes"]
+            .as_str()
+            .unwrap_or_else(|| panic!("bytes must be a base64 string: {read}"));
+        let decoded = base64::engine::general_purpose::STANDARD
+            .decode(encoded)
+            .unwrap();
+        assert_eq!(decoded, payload[2..10].to_vec(), "read response: {read}");
+        assert_eq!(read["total_size_bytes"], payload.len());
+    }
+
     #[test]
     fn workbench_mcp_grep_supports_patterns_glob_and_pipe_split() {
         let responses = run_shared_workbench_mcp_requests(vec![
@@ -4404,6 +4511,16 @@ mod tests {
             ),
             workbench_tool_call(
                 4,
+                "workbench_put_file",
+                serde_json::json!({
+                    "id": "wb-grep",
+                    "section": "outputs",
+                    "path": "three.md",
+                    "text": "gamma note\n"
+                }),
+            ),
+            workbench_tool_call(
+                5,
                 "workbench_grep",
                 serde_json::json!({
                     "id": "wb-grep",
@@ -4412,17 +4529,17 @@ mod tests {
                 }),
             ),
             workbench_tool_call(
-                5,
+                6,
                 "workbench_grep",
                 serde_json::json!({
                     "id": "wb-grep",
-                    "pattern": "unused",
+                    "pattern": "gamma",
                     "patterns": ["alpha", "beta"],
                     "recursive": true
                 }),
             ),
             workbench_tool_call(
-                6,
+                7,
                 "workbench_grep",
                 serde_json::json!({
                     "id": "wb-grep",
@@ -4432,7 +4549,7 @@ mod tests {
                 }),
             ),
             workbench_tool_call(
-                7,
+                8,
                 "workbench_grep",
                 serde_json::json!({
                     "id": "wb-grep",
@@ -4442,7 +4559,7 @@ mod tests {
                 }),
             ),
         ]);
-        for (index, response) in responses.iter().take(6).enumerate() {
+        for (index, response) in responses.iter().take(7).enumerate() {
             assert_ne!(
                 response["result"]["isError"], true,
                 "response {index}: {response}"
@@ -4459,26 +4576,31 @@ mod tests {
         };
 
         // Pipe in `pattern` splits into OR alternatives when `patterns` is absent.
-        let piped = match_paths(&responses[3]);
+        let piped = match_paths(&responses[4]);
         assert!(
             piped.contains(&"/workbenches/wb-grep/outputs/one.txt".to_owned())
                 && piped.contains(&"/workbenches/wb-grep/outputs/two.log".to_owned()),
             "piped matches: {piped:?}"
         );
 
-        // Explicit `patterns` wins over `pattern`.
-        let explicit = match_paths(&responses[4]);
-        assert_eq!(explicit.len(), 2, "explicit matches: {explicit:?}");
+        // `patterns` adds OR alternatives to `pattern` (union), it does not
+        // replace it: the gamma-only file must match alongside alpha/beta.
+        let unioned = match_paths(&responses[5]);
+        assert_eq!(unioned.len(), 3, "union matches: {unioned:?}");
+        assert!(
+            unioned.contains(&"/workbenches/wb-grep/outputs/three.md".to_owned()),
+            "union matches: {unioned:?}"
+        );
 
-        let globbed = match_paths(&responses[5]);
+        let globbed = match_paths(&responses[6]);
         assert_eq!(
             globbed,
             vec!["/workbenches/wb-grep/outputs/one.txt".to_owned()],
             "globbed matches: {globbed:?}"
         );
 
-        assert_eq!(responses[6]["result"]["isError"], true);
-        assert!(responses[6]["result"]["content"][0]["text"]
+        assert_eq!(responses[7]["result"]["isError"], true);
+        assert!(responses[7]["result"]["content"][0]["text"]
             .as_str()
             .unwrap()
             .contains("limit must be between 1 and 300"));

--- a/crates/nokv/src/bin/nokv.rs
+++ b/crates/nokv/src/bin/nokv.rs
@@ -3994,6 +3994,7 @@ mod tests {
                         "measures": [{"name": "files", "op": "count"}]
                     }),
                 ),
+                workbench_tool_call(4, "workbench_catalog", serde_json::json!({})),
             ],
         );
         for (index, response) in responses.iter().enumerate() {
@@ -4020,6 +4021,18 @@ mod tests {
         );
         assert_eq!(aggregate["row_count"], 0);
         assert_eq!(aggregate["groups"], serde_json::json!([]));
+
+        // The empty catalog must be field-level identical in shape to a real
+        // catalog result (path, catalog_empty, catalog buckets, children).
+        let catalog = &responses[3]["result"]["structuredContent"];
+        assert_eq!(catalog["status"], "success", "catalog response: {catalog}");
+        assert_eq!(catalog["path"], "/agents/e2e-never/wb");
+        assert_eq!(catalog["catalog_empty"], true);
+        assert_eq!(catalog["catalog"]["filterable"], serde_json::json!([]));
+        assert_eq!(catalog["catalog"]["sortable"], serde_json::json!([]));
+        assert_eq!(catalog["catalog"]["facetable"], serde_json::json!([]));
+        assert_eq!(catalog["catalog"]["facets"], serde_json::json!([]));
+        assert_eq!(catalog["child_catalogs"], serde_json::json!([]));
     }
 
     #[test]
@@ -5135,5 +5148,950 @@ mod tests {
         let output = String::from_utf8(writer).unwrap();
         let resp: serde_json::Value = serde_json::from_str(output.lines().next().unwrap()).unwrap();
         assert_eq!(resp["result"]["protocolVersion"], "2025-11-25");
+    }
+
+    // ==================== attack_ boundary tests (PR #392 review) ====================
+    //
+    // Adversarial TDD against the new workbench tool surface: append, edit,
+    // conditional read, search, and grep. Each test asserts either an expected
+    // failure mode (explicit error text) or an expected success semantic.
+
+    fn attack_tool_error(response: &serde_json::Value) -> String {
+        assert_eq!(
+            response["result"]["isError"], true,
+            "expected tool error, got: {response}"
+        );
+        response["result"]["content"][0]["text"]
+            .as_str()
+            .unwrap_or_default()
+            .to_owned()
+    }
+
+    fn attack_tool_ok(response: &serde_json::Value) -> serde_json::Value {
+        assert_ne!(
+            response["result"]["isError"], true,
+            "expected tool success, got: {response}"
+        );
+        response["result"]["structuredContent"].clone()
+    }
+
+    fn attack_direct_client() -> NoKvFsClient<LocalObjectStore> {
+        let (addr, object_root) = shared_workbench_mcp_server();
+        let store =
+            LocalObjectStore::new(LocalObjectStoreOptions::new(object_root.clone())).unwrap();
+        NoKvFsClient::connect(*addr, store)
+    }
+
+    // ---------- append ----------
+
+    #[test]
+    fn attack_append_empty_text_creates_empty_file_then_grows() {
+        let wb = "attack-append-empty";
+        let responses = run_shared_workbench_mcp_requests(vec![
+            workbench_tool_call(1, "workbench_create", serde_json::json!({"id": wb})),
+            workbench_tool_call(
+                2,
+                "workbench_append",
+                serde_json::json!({"id": wb, "section": "logs", "path": "run.log", "text": ""}),
+            ),
+            workbench_tool_call(
+                3,
+                "workbench_append",
+                serde_json::json!({"id": wb, "section": "logs", "path": "run.log", "text": "data"}),
+            ),
+        ]);
+        let first = attack_tool_ok(&responses[1]);
+        assert_eq!(first["appended_bytes"], 0, "first append: {first}");
+        assert_eq!(first["size_bytes"], 0, "first append: {first}");
+        assert_eq!(first["created"], true, "first append: {first}");
+        let second = attack_tool_ok(&responses[2]);
+        assert_eq!(second["appended_bytes"], 4);
+        assert_eq!(second["size_bytes"], 4);
+        assert_eq!(second["created"], false);
+        let client = attack_direct_client();
+        assert_eq!(
+            client
+                .cat("/workbenches/attack-append-empty/logs/run.log")
+                .unwrap(),
+            b"data"
+        );
+    }
+
+    #[test]
+    fn attack_append_payload_at_exact_max_bytes_succeeds() {
+        // Dedicated server: the 16 MiB body should not pollute the shared one.
+        let wb = "attack-append-max";
+        let payload = "a".repeat(workbench_mcp::DEFAULT_WORKBENCH_MAX_BYTES);
+        let responses = run_workbench_mcp_requests(vec![
+            workbench_tool_call(1, "workbench_create", serde_json::json!({"id": wb})),
+            workbench_tool_call(
+                2,
+                "workbench_append",
+                serde_json::json!({"id": wb, "section": "outputs", "path": "big.bin", "text": payload}),
+            ),
+        ]);
+        let appended = attack_tool_ok(&responses[1]);
+        assert_eq!(
+            appended["appended_bytes"],
+            workbench_mcp::DEFAULT_WORKBENCH_MAX_BYTES as u64
+        );
+        assert_eq!(
+            appended["size_bytes"],
+            workbench_mcp::DEFAULT_WORKBENCH_MAX_BYTES as u64
+        );
+    }
+
+    #[test]
+    fn attack_append_payload_one_over_max_bytes_rejected() {
+        let wb = "attack-append-over";
+        let payload = "a".repeat(workbench_mcp::DEFAULT_WORKBENCH_MAX_BYTES + 1);
+        let responses = run_workbench_mcp_requests(vec![
+            workbench_tool_call(1, "workbench_create", serde_json::json!({"id": wb})),
+            workbench_tool_call(
+                2,
+                "workbench_append",
+                serde_json::json!({"id": wb, "section": "outputs", "path": "big.bin", "text": payload}),
+            ),
+        ]);
+        let error = attack_tool_error(&responses[1]);
+        assert!(
+            error.contains("payload exceeds max_bytes"),
+            "error: {error}"
+        );
+        assert!(error.contains("16777217 > 16777216"), "error: {error}");
+    }
+
+    #[test]
+    fn attack_append_to_directory_rejected() {
+        let wb = "attack-append-dir";
+        let responses = run_shared_workbench_mcp_requests(vec![
+            workbench_tool_call(1, "workbench_create", serde_json::json!({"id": wb})),
+            workbench_tool_call(
+                2,
+                "workbench_put_file",
+                serde_json::json!({"id": wb, "section": "outputs", "path": "dir/file.txt", "text": "x"}),
+            ),
+            workbench_tool_call(
+                3,
+                "workbench_append",
+                serde_json::json!({"id": wb, "section": "outputs", "path": "dir", "text": "y"}),
+            ),
+        ]);
+        attack_tool_ok(&responses[1]);
+        let error = attack_tool_error(&responses[2]);
+        assert!(
+            error.contains("not a file"),
+            "append onto directory must fail with a not-a-file error, got: {error}"
+        );
+        // The directory must still list its child afterwards.
+        let after = run_shared_workbench_mcp_requests(vec![workbench_tool_call(
+            1,
+            "workbench_list",
+            serde_json::json!({"id": wb, "section": "outputs", "path": "dir"}),
+        )]);
+        let listing = attack_tool_ok(&after[0]);
+        assert_eq!(listing["entries"][0]["name"], "file.txt");
+    }
+
+    #[test]
+    fn attack_append_cannot_address_out_of_band_paths() {
+        let wb = "attack-append-oob";
+        let responses = run_shared_workbench_mcp_requests(vec![workbench_tool_call(
+            1,
+            "workbench_create",
+            serde_json::json!({"id": wb}),
+        )]);
+        attack_tool_ok(&responses[0]);
+        // Another NoKV client drops a file directly under the workbench root,
+        // outside every section.
+        let direct = attack_direct_client();
+        direct
+            .put_artifact(
+                "/workbenches/attack-append-oob/oob.txt",
+                b"out-of-band".to_vec(),
+                ArtifactMetadata {
+                    producer: "outside-writer".to_owned(),
+                    digest_uri: "sha256:demo".to_owned(),
+                    content_type: "text/plain".to_owned(),
+                    manifest_id: "oob.txt".to_owned(),
+                    mode: DEFAULT_MODE_FILE,
+                    uid: DEFAULT_UID,
+                    gid: DEFAULT_GID,
+                },
+            )
+            .unwrap();
+        let attempts = run_shared_workbench_mcp_requests(vec![
+            // Escape through '..' must be rejected.
+            workbench_tool_call(
+                1,
+                "workbench_append",
+                serde_json::json!({"id": wb, "section": "input", "path": "../oob.txt", "text": "hijack"}),
+            ),
+            // A fake section name must be rejected by the section enum guard.
+            workbench_tool_call(
+                2,
+                "workbench_append",
+                serde_json::json!({"id": wb, "section": "oob.txt", "path": "x", "text": "hijack"}),
+            ),
+        ]);
+        let escape = attack_tool_error(&attempts[0]);
+        assert!(
+            escape.contains("'.' or '..'"),
+            "dot-dot escape error: {escape}"
+        );
+        let fake_section = attack_tool_error(&attempts[1]);
+        assert!(
+            fake_section.contains("invalid section"),
+            "fake section error: {fake_section}"
+        );
+        // The out-of-band file must be untouched.
+        assert_eq!(
+            direct
+                .cat("/workbenches/attack-append-oob/oob.txt")
+                .unwrap(),
+            b"out-of-band"
+        );
+    }
+
+    #[test]
+    fn attack_append_thirty_times_preserves_full_content() {
+        let wb = "attack-append-thirty";
+        let mut requests = vec![workbench_tool_call(
+            1,
+            "workbench_create",
+            serde_json::json!({"id": wb}),
+        )];
+        let mut expected = String::new();
+        for index in 0..30u64 {
+            let line = format!("line-{index:02}\n");
+            expected.push_str(&line);
+            requests.push(workbench_tool_call(
+                index + 2,
+                "workbench_append",
+                serde_json::json!({"id": wb, "section": "logs", "path": "run.log", "text": line}),
+            ));
+        }
+        let responses = run_shared_workbench_mcp_requests(requests);
+        let mut running_size = 0u64;
+        for response in &responses[1..] {
+            let appended = attack_tool_ok(response);
+            running_size += appended["appended_bytes"].as_u64().unwrap();
+            assert_eq!(
+                appended["size_bytes"].as_u64().unwrap(),
+                running_size,
+                "append response: {appended}"
+            );
+        }
+        let client = attack_direct_client();
+        assert_eq!(
+            client
+                .cat("/workbenches/attack-append-thirty/logs/run.log")
+                .unwrap(),
+            expected.as_bytes()
+        );
+    }
+
+    #[test]
+    fn attack_append_interleaved_with_put_file_replace() {
+        let wb = "attack-append-interleave";
+        let responses = run_shared_workbench_mcp_requests(vec![
+            workbench_tool_call(1, "workbench_create", serde_json::json!({"id": wb})),
+            workbench_tool_call(
+                2,
+                "workbench_append",
+                serde_json::json!({"id": wb, "section": "outputs", "path": "f.txt", "text": "a"}),
+            ),
+            workbench_tool_call(
+                3,
+                "workbench_put_file",
+                serde_json::json!({"id": wb, "section": "outputs", "path": "f.txt", "text": "RESET", "replace": true}),
+            ),
+            workbench_tool_call(
+                4,
+                "workbench_append",
+                serde_json::json!({"id": wb, "section": "outputs", "path": "f.txt", "text": "b"}),
+            ),
+        ]);
+        let first = attack_tool_ok(&responses[1]);
+        let replaced = attack_tool_ok(&responses[2]);
+        let second = attack_tool_ok(&responses[3]);
+        assert_eq!(second["size_bytes"], 6, "final append: {second}");
+        assert!(
+            second["generation"].as_u64().unwrap() > replaced["generation"].as_u64().unwrap()
+                && replaced["generation"].as_u64().unwrap() > first["generation"].as_u64().unwrap(),
+            "generations must be monotonic: {first} / {replaced} / {second}"
+        );
+        let client = attack_direct_client();
+        assert_eq!(
+            client
+                .cat("/workbenches/attack-append-interleave/outputs/f.txt")
+                .unwrap(),
+            b"RESETb"
+        );
+    }
+
+    // ---------- edit ----------
+
+    #[test]
+    fn attack_edit_old_equals_new_is_noop_without_generation_bump() {
+        let wb = "attack-edit-noop";
+        let responses = run_shared_workbench_mcp_requests(vec![
+            workbench_tool_call(1, "workbench_create", serde_json::json!({"id": wb})),
+            workbench_tool_call(
+                2,
+                "workbench_put_file",
+                serde_json::json!({"id": wb, "section": "scripts", "path": "s.py", "text": "hello world"}),
+            ),
+            workbench_tool_call(
+                3,
+                "workbench_edit",
+                serde_json::json!({"id": wb, "section": "scripts", "path": "s.py", "old_string": "hello", "new_string": "hello"}),
+            ),
+            workbench_tool_call(
+                4,
+                "workbench_stat",
+                serde_json::json!({"id": wb, "section": "scripts", "path": "s.py"}),
+            ),
+        ]);
+        let put = attack_tool_ok(&responses[1]);
+        let edit = attack_tool_ok(&responses[2]);
+        assert_eq!(edit["replacements"], 1, "edit: {edit}");
+        // A byte-identical replacement short-circuits: success without
+        // publishing a new generation, flagged via no_change.
+        assert_eq!(edit["no_change"], true, "edit: {edit}");
+        assert_eq!(
+            edit["generation"].as_u64().unwrap(),
+            put["generation"].as_u64().unwrap(),
+            "no-op edit must not bump generation: put {put} edit {edit}"
+        );
+        let stat = attack_tool_ok(&responses[3]);
+        assert_eq!(
+            stat["card"]["generation"].as_u64().unwrap(),
+            put["generation"].as_u64().unwrap(),
+            "stat after no-op edit: {stat}"
+        );
+        let client = attack_direct_client();
+        assert_eq!(
+            client
+                .cat("/workbenches/attack-edit-noop/scripts/s.py")
+                .unwrap(),
+            b"hello world"
+        );
+    }
+
+    #[test]
+    fn attack_edit_empty_old_string_rejected() {
+        let wb = "attack-edit-emptyold";
+        let responses = run_shared_workbench_mcp_requests(vec![
+            workbench_tool_call(1, "workbench_create", serde_json::json!({"id": wb})),
+            workbench_tool_call(
+                2,
+                "workbench_put_file",
+                serde_json::json!({"id": wb, "section": "scripts", "path": "s.py", "text": "abc"}),
+            ),
+            workbench_tool_call(
+                3,
+                "workbench_edit",
+                serde_json::json!({"id": wb, "section": "scripts", "path": "s.py", "old_string": "", "new_string": "x"}),
+            ),
+        ]);
+        let error = attack_tool_error(&responses[2]);
+        assert!(
+            error.contains("old_string must not be empty"),
+            "error: {error}"
+        );
+    }
+
+    #[test]
+    fn attack_edit_can_empty_a_file() {
+        let wb = "attack-edit-toempty";
+        let responses = run_shared_workbench_mcp_requests(vec![
+            workbench_tool_call(1, "workbench_create", serde_json::json!({"id": wb})),
+            workbench_tool_call(
+                2,
+                "workbench_put_file",
+                serde_json::json!({"id": wb, "section": "outputs", "path": "f.txt", "text": "x"}),
+            ),
+            workbench_tool_call(
+                3,
+                "workbench_edit",
+                serde_json::json!({"id": wb, "section": "outputs", "path": "f.txt", "old_string": "x", "new_string": ""}),
+            ),
+            workbench_tool_call(
+                4,
+                "workbench_stat",
+                serde_json::json!({"id": wb, "section": "outputs", "path": "f.txt"}),
+            ),
+        ]);
+        let edit = attack_tool_ok(&responses[2]);
+        assert_eq!(edit["size_bytes"], 0, "edit: {edit}");
+        let stat = attack_tool_ok(&responses[3]);
+        assert_eq!(stat["card"]["size_bytes"], 0, "stat: {stat}");
+        let client = attack_direct_client();
+        assert_eq!(
+            client
+                .cat("/workbenches/attack-edit-toempty/outputs/f.txt")
+                .unwrap(),
+            b""
+        );
+    }
+
+    #[test]
+    fn attack_edit_binary_file_rejected_as_non_utf8() {
+        use base64::Engine as _;
+        let wb = "attack-edit-binary";
+        let binary = base64::engine::general_purpose::STANDARD.encode([0xff, 0xfe, 0x00, 0x01]);
+        let responses = run_shared_workbench_mcp_requests(vec![
+            workbench_tool_call(1, "workbench_create", serde_json::json!({"id": wb})),
+            workbench_tool_call(
+                2,
+                "workbench_put_file",
+                serde_json::json!({"id": wb, "section": "outputs", "path": "blob.bin", "base64": binary}),
+            ),
+            workbench_tool_call(
+                3,
+                "workbench_edit",
+                serde_json::json!({"id": wb, "section": "outputs", "path": "blob.bin", "old_string": "x", "new_string": "y"}),
+            ),
+        ]);
+        attack_tool_ok(&responses[1]);
+        let error = attack_tool_error(&responses[2]);
+        assert!(
+            error.contains("not valid UTF-8"),
+            "binary edit error: {error}"
+        );
+    }
+
+    #[test]
+    fn attack_edit_replace_all_hundred_occurrences() {
+        let wb = "attack-edit-hundred";
+        let content = "tok\n".repeat(100);
+        let expected = "TOKEN\n".repeat(100);
+        let responses = run_shared_workbench_mcp_requests(vec![
+            workbench_tool_call(1, "workbench_create", serde_json::json!({"id": wb})),
+            workbench_tool_call(
+                2,
+                "workbench_put_file",
+                serde_json::json!({"id": wb, "section": "outputs", "path": "many.txt", "text": content}),
+            ),
+            // Without replace_all a multi-occurrence edit must fail loudly.
+            workbench_tool_call(
+                3,
+                "workbench_edit",
+                serde_json::json!({"id": wb, "section": "outputs", "path": "many.txt", "old_string": "tok", "new_string": "TOKEN"}),
+            ),
+            workbench_tool_call(
+                4,
+                "workbench_edit",
+                serde_json::json!({"id": wb, "section": "outputs", "path": "many.txt", "old_string": "tok", "new_string": "TOKEN", "replace_all": true}),
+            ),
+        ]);
+        let ambiguous = attack_tool_error(&responses[2]);
+        assert!(
+            ambiguous.contains("found 100 times"),
+            "ambiguous edit error: {ambiguous}"
+        );
+        let edit = attack_tool_ok(&responses[3]);
+        assert_eq!(edit["replacements"], 100, "edit: {edit}");
+        let client = attack_direct_client();
+        assert_eq!(
+            client
+                .cat("/workbenches/attack-edit-hundred/outputs/many.txt")
+                .unwrap(),
+            expected.as_bytes()
+        );
+    }
+
+    // ---------- conditional read ----------
+
+    #[test]
+    fn attack_read_if_none_match_zero_returns_body() {
+        let wb = "attack-cond-zero";
+        let responses = run_shared_workbench_mcp_requests(vec![
+            workbench_tool_call(1, "workbench_create", serde_json::json!({"id": wb})),
+            workbench_tool_call(
+                2,
+                "workbench_put_file",
+                serde_json::json!({"id": wb, "section": "outputs", "path": "f.txt", "text": "hello"}),
+            ),
+            workbench_tool_call(
+                3,
+                "workbench_read",
+                serde_json::json!({"id": wb, "section": "outputs", "path": "f.txt", "if_none_match": 0}),
+            ),
+        ]);
+        let put = attack_tool_ok(&responses[1]);
+        // If a fresh artifact ever starts at generation 0, if_none_match=0
+        // would silently skip the first read; guard that invariant.
+        assert_ne!(
+            put["generation"].as_u64().unwrap(),
+            0,
+            "fresh artifact generation must not collide with if_none_match=0: {put}"
+        );
+        let read = attack_tool_ok(&responses[2]);
+        assert_ne!(read["not_modified"], true, "read: {read}");
+        assert_eq!(read["items"][0]["value"]["text"], "hello", "read: {read}");
+    }
+
+    #[test]
+    fn attack_read_if_none_match_negative_rejected() {
+        let wb = "attack-cond-negative";
+        let responses = run_shared_workbench_mcp_requests(vec![
+            workbench_tool_call(1, "workbench_create", serde_json::json!({"id": wb})),
+            workbench_tool_call(
+                2,
+                "workbench_put_file",
+                serde_json::json!({"id": wb, "section": "outputs", "path": "f.txt", "text": "hello"}),
+            ),
+            // The MCP layer does not validate JSON Schema; the tool code must
+            // reject a negative generation itself.
+            workbench_tool_call(
+                3,
+                "workbench_read",
+                serde_json::json!({"id": wb, "section": "outputs", "path": "f.txt", "if_none_match": -1}),
+            ),
+        ]);
+        let error = attack_tool_error(&responses[2]);
+        assert!(
+            error.contains("if_none_match must be an integer"),
+            "error: {error}"
+        );
+    }
+
+    #[test]
+    fn attack_read_if_none_match_on_directory() {
+        let wb = "attack-cond-dir";
+        let responses = run_shared_workbench_mcp_requests(vec![
+            workbench_tool_call(1, "workbench_create", serde_json::json!({"id": wb})),
+            workbench_tool_call(
+                2,
+                "workbench_put_file",
+                serde_json::json!({"id": wb, "section": "outputs", "path": "d/f.txt", "text": "x"}),
+            ),
+            workbench_tool_call(
+                3,
+                "workbench_stat",
+                serde_json::json!({"id": wb, "section": "outputs", "path": "d"}),
+            ),
+            // Unconditional read of a directory must fail.
+            workbench_tool_call(
+                4,
+                "workbench_read",
+                serde_json::json!({"id": wb, "section": "outputs", "path": "d"}),
+            ),
+        ]);
+        let stat = attack_tool_ok(&responses[2]);
+        let dir_generation = stat["card"]["generation"].as_u64().unwrap();
+        attack_tool_error(&responses[3]);
+        // Conditional read of the same directory with a matching generation:
+        // consistent behavior would be the same not-a-file error, not a
+        // not_modified success.
+        let conditional = run_shared_workbench_mcp_requests(vec![workbench_tool_call(
+            1,
+            "workbench_read",
+            serde_json::json!({"id": wb, "section": "outputs", "path": "d", "if_none_match": dir_generation}),
+        )]);
+        assert_eq!(
+            conditional[0]["result"]["isError"], true,
+            "conditional read of a directory must fail like the unconditional \
+             read does, got: {}",
+            conditional[0]
+        );
+    }
+
+    #[test]
+    fn attack_read_if_none_match_missing_file_rejected() {
+        let wb = "attack-cond-missing";
+        let responses = run_shared_workbench_mcp_requests(vec![
+            workbench_tool_call(1, "workbench_create", serde_json::json!({"id": wb})),
+            workbench_tool_call(
+                2,
+                "workbench_read",
+                serde_json::json!({"id": wb, "section": "outputs", "path": "nope.txt", "if_none_match": 1}),
+            ),
+        ]);
+        let error = attack_tool_error(&responses[1]);
+        assert!(error.contains("path not found"), "error: {error}");
+    }
+
+    #[test]
+    fn attack_read_not_modified_then_edit_invalidates_generation() {
+        let wb = "attack-cond-invalidate";
+        let responses = run_shared_workbench_mcp_requests(vec![
+            workbench_tool_call(1, "workbench_create", serde_json::json!({"id": wb})),
+            workbench_tool_call(
+                2,
+                "workbench_put_file",
+                serde_json::json!({"id": wb, "section": "outputs", "path": "f.txt", "text": "before"}),
+            ),
+            workbench_tool_call(
+                3,
+                "workbench_read",
+                serde_json::json!({"id": wb, "section": "outputs", "path": "f.txt"}),
+            ),
+        ]);
+        let read = attack_tool_ok(&responses[2]);
+        let generation = read["generation"].as_u64().unwrap();
+        let round_two = run_shared_workbench_mcp_requests(vec![
+            workbench_tool_call(
+                1,
+                "workbench_read",
+                serde_json::json!({"id": wb, "section": "outputs", "path": "f.txt", "if_none_match": generation}),
+            ),
+            workbench_tool_call(
+                2,
+                "workbench_edit",
+                serde_json::json!({"id": wb, "section": "outputs", "path": "f.txt", "old_string": "before", "new_string": "after"}),
+            ),
+            workbench_tool_call(
+                3,
+                "workbench_read",
+                serde_json::json!({"id": wb, "section": "outputs", "path": "f.txt", "if_none_match": generation}),
+            ),
+        ]);
+        let unchanged = attack_tool_ok(&round_two[0]);
+        assert_eq!(unchanged["not_modified"], true, "unchanged: {unchanged}");
+        assert_eq!(
+            unchanged["generation"].as_u64().unwrap(),
+            generation,
+            "unchanged: {unchanged}"
+        );
+        attack_tool_ok(&round_two[1]);
+        let changed = attack_tool_ok(&round_two[2]);
+        assert_ne!(changed["not_modified"], true, "changed: {changed}");
+        assert!(
+            changed["generation"].as_u64().unwrap() > generation,
+            "changed: {changed}"
+        );
+        assert_eq!(
+            changed["items"][0]["value"]["text"], "after",
+            "changed: {changed}"
+        );
+    }
+
+    // ---------- search ----------
+
+    fn attack_search_fixture() -> &'static str {
+        static FIXTURE: std::sync::OnceLock<()> = std::sync::OnceLock::new();
+        let wb = "attack-search-fixture";
+        FIXTURE.get_or_init(|| {
+            let responses = run_shared_workbench_mcp_requests(vec![
+                workbench_tool_call(1, "workbench_create", serde_json::json!({"id": wb})),
+                workbench_tool_call(
+                    2,
+                    "workbench_put_file",
+                    serde_json::json!({"id": wb, "section": "outputs", "path": "attack-search.csv", "text": "a,b\n1,2\n", "content_type": "text/csv"}),
+                ),
+            ]);
+            for response in &responses {
+                attack_tool_ok(response);
+            }
+        });
+        wb
+    }
+
+    #[test]
+    fn attack_search_empty_predicates_matches_scope() {
+        let wb = attack_search_fixture();
+        let responses = run_shared_workbench_mcp_requests(vec![workbench_tool_call(
+            1,
+            "workbench_search",
+            serde_json::json!({"id": wb, "predicates": []}),
+        )]);
+        let search = attack_tool_ok(&responses[0]);
+        assert_eq!(search["status"], "success", "search: {search}");
+        assert!(
+            search["match_count"].as_u64().unwrap() >= 1,
+            "empty predicates must match the scope, got: {search}"
+        );
+    }
+
+    #[test]
+    fn attack_search_unknown_field_returns_empty_not_error() {
+        let wb = attack_search_fixture();
+        let responses = run_shared_workbench_mcp_requests(vec![workbench_tool_call(
+            1,
+            "workbench_search",
+            serde_json::json!({
+                "id": wb,
+                "predicates": [{"field": "totally_bogus_field", "op": "eq", "value": "x"}]
+            }),
+        )]);
+        // Documented behavior: an unknown field is not an error; the predicate
+        // silently matches nothing. (A typo'd field id is indistinguishable
+        // from a true empty result.)
+        let search = attack_tool_ok(&responses[0]);
+        assert_eq!(search["match_count"], 0, "search: {search}");
+    }
+
+    #[test]
+    fn attack_search_unknown_op_rejected() {
+        let wb = attack_search_fixture();
+        let responses = run_shared_workbench_mcp_requests(vec![workbench_tool_call(
+            1,
+            "workbench_search",
+            serde_json::json!({
+                "id": wb,
+                "predicates": [{"field": "name", "op": "regex", "value": ".*"}]
+            }),
+        )]);
+        let error = attack_tool_error(&responses[0]);
+        assert!(
+            error.contains("unsupported predicate operator regex"),
+            "error: {error}"
+        );
+    }
+
+    #[test]
+    fn attack_search_limit_zero_rejected() {
+        let wb = attack_search_fixture();
+        let responses = run_shared_workbench_mcp_requests(vec![workbench_tool_call(
+            1,
+            "workbench_search",
+            serde_json::json!({"id": wb, "limit": 0}),
+        )]);
+        let error = attack_tool_error(&responses[0]);
+        assert!(
+            error.contains("limit must be between 1 and 10"),
+            "error: {error}"
+        );
+    }
+
+    #[test]
+    fn attack_search_cross_workbench_section_without_id_rejected() {
+        attack_search_fixture();
+        let responses = run_shared_workbench_mcp_requests(vec![
+            workbench_tool_call(
+                1,
+                "workbench_search",
+                serde_json::json!({"section": "outputs"}),
+            ),
+            workbench_tool_call(
+                2,
+                "workbench_search",
+                serde_json::json!({"path": "attack-search.csv"}),
+            ),
+        ]);
+        let section_error = attack_tool_error(&responses[0]);
+        assert!(
+            section_error.contains("section requires id"),
+            "error: {section_error}"
+        );
+        let path_error = attack_tool_error(&responses[1]);
+        assert!(
+            path_error.contains("path requires id"),
+            "error: {path_error}"
+        );
+    }
+
+    #[test]
+    fn attack_search_facets_on_unknown_field_do_not_error() {
+        let wb = attack_search_fixture();
+        let responses = run_shared_workbench_mcp_requests(vec![workbench_tool_call(
+            1,
+            "workbench_search",
+            serde_json::json!({"id": wb, "facets": ["totally_bogus_facet"]}),
+        )]);
+        let search = attack_tool_ok(&responses[0]);
+        assert_eq!(search["status"], "success", "search: {search}");
+        let facets = search["facets"].as_array().unwrap();
+        // Whatever shape comes back, an unknown facet field must not fabricate
+        // values.
+        for facet in facets {
+            assert_eq!(
+                facet["values"].as_array().map(Vec::len).unwrap_or(0),
+                0,
+                "unknown facet must have no values: {facet}"
+            );
+        }
+    }
+
+    // ---------- grep ----------
+
+    fn attack_grep_fixture() -> &'static str {
+        static FIXTURE: std::sync::OnceLock<()> = std::sync::OnceLock::new();
+        let wb = "attack-grep-fixture";
+        FIXTURE.get_or_init(|| {
+            let responses = run_shared_workbench_mcp_requests(vec![
+                workbench_tool_call(1, "workbench_create", serde_json::json!({"id": wb})),
+                workbench_tool_call(
+                    2,
+                    "workbench_put_file",
+                    serde_json::json!({"id": wb, "section": "logs", "path": "run.log", "text": "alpha needle beta\nplain line\n"}),
+                ),
+            ]);
+            for response in &responses {
+                attack_tool_ok(response);
+            }
+        });
+        wb
+    }
+
+    fn attack_grep_args(wb: &str, extra: serde_json::Value) -> serde_json::Value {
+        let mut args = serde_json::json!({
+            "id": wb,
+            "section": "logs",
+            "pattern": "needle",
+            "recursive": true
+        });
+        for (key, value) in extra.as_object().unwrap() {
+            args[key] = value.clone();
+        }
+        args
+    }
+
+    #[test]
+    fn attack_grep_sixteen_patterns_accepted_seventeen_rejected() {
+        let wb = attack_grep_fixture();
+        let sixteen: Vec<String> = (0..16).map(|i| format!("filler-{i}")).collect();
+        let seventeen: Vec<String> = (0..17).map(|i| format!("filler-{i}")).collect();
+        let responses = run_shared_workbench_mcp_requests(vec![
+            workbench_tool_call(
+                1,
+                "workbench_grep",
+                attack_grep_args(wb, serde_json::json!({"patterns": sixteen})),
+            ),
+            workbench_tool_call(
+                2,
+                "workbench_grep",
+                attack_grep_args(wb, serde_json::json!({"patterns": seventeen})),
+            ),
+        ]);
+        let ok = attack_tool_ok(&responses[0]);
+        assert!(
+            ok["matches"]
+                .as_array()
+                .unwrap()
+                .iter()
+                .any(|m| m["snippet"].as_str().unwrap_or("").contains("needle")),
+            "16 patterns + pattern must still match: {ok}"
+        );
+        let error = attack_tool_error(&responses[1]);
+        assert!(
+            error.contains("patterns must not exceed 16"),
+            "error: {error}"
+        );
+    }
+
+    #[test]
+    fn attack_grep_empty_pattern_entry_rejected() {
+        let wb = attack_grep_fixture();
+        let responses = run_shared_workbench_mcp_requests(vec![workbench_tool_call(
+            1,
+            "workbench_grep",
+            attack_grep_args(wb, serde_json::json!({"patterns": ["ok", ""]})),
+        )]);
+        let error = attack_tool_error(&responses[0]);
+        assert!(
+            error.contains("patterns entries must not be empty"),
+            "error: {error}"
+        );
+    }
+
+    #[test]
+    fn attack_grep_glob_star_only_matches_everything() {
+        let wb = attack_grep_fixture();
+        let responses = run_shared_workbench_mcp_requests(vec![workbench_tool_call(
+            1,
+            "workbench_grep",
+            attack_grep_args(wb, serde_json::json!({"glob": "*"})),
+        )]);
+        let ok = attack_tool_ok(&responses[0]);
+        assert_eq!(
+            ok["matches"][0]["relative_path"], "run.log",
+            "glob=* grep: {ok}"
+        );
+    }
+
+    #[test]
+    fn attack_grep_empty_glob_rejected() {
+        let wb = attack_grep_fixture();
+        let responses = run_shared_workbench_mcp_requests(vec![workbench_tool_call(
+            1,
+            "workbench_grep",
+            attack_grep_args(wb, serde_json::json!({"glob": ""})),
+        )]);
+        let error = attack_tool_error(&responses[0]);
+        assert!(
+            error.contains("name_glob must not be empty"),
+            "error: {error}"
+        );
+    }
+
+    #[test]
+    fn attack_grep_empty_pattern_with_patterns_succeeds() {
+        let wb = attack_grep_fixture();
+        let responses = run_shared_workbench_mcp_requests(vec![workbench_tool_call(
+            1,
+            "workbench_grep",
+            serde_json::json!({
+                "id": wb,
+                "section": "logs",
+                "pattern": "",
+                "patterns": ["needle"],
+                "recursive": true
+            }),
+        )]);
+        // Schema requires pattern; an empty string plus non-empty patterns is
+        // the documented escape hatch and must behave like patterns alone.
+        let ok = attack_tool_ok(&responses[0]);
+        assert!(
+            ok["matches"]
+                .as_array()
+                .unwrap()
+                .iter()
+                .any(|m| m["snippet"].as_str().unwrap_or("").contains("needle")),
+            "grep: {ok}"
+        );
+    }
+
+    #[test]
+    fn attack_grep_empty_pattern_without_patterns_rejected() {
+        let wb = attack_grep_fixture();
+        let responses = run_shared_workbench_mcp_requests(vec![workbench_tool_call(
+            1,
+            "workbench_grep",
+            serde_json::json!({"id": wb, "section": "logs", "pattern": "", "recursive": true}),
+        )]);
+        let error = attack_tool_error(&responses[0]);
+        assert!(
+            error.contains("pattern or patterns must be provided"),
+            "error: {error}"
+        );
+    }
+
+    #[test]
+    fn attack_grep_seventeen_piped_alternatives_rejected() {
+        let wb = attack_grep_fixture();
+        let pattern = (0..17)
+            .map(|i| format!("filler-{i}"))
+            .collect::<Vec<_>>()
+            .join("|");
+        let responses = run_shared_workbench_mcp_requests(vec![workbench_tool_call(
+            1,
+            "workbench_grep",
+            serde_json::json!({"id": wb, "section": "logs", "pattern": pattern, "recursive": true}),
+        )]);
+        let error = attack_tool_error(&responses[0]);
+        assert!(
+            error.contains(
+                "pattern contains 17 '|'-separated alternatives; at most 16 are supported"
+            ),
+            "error: {error}"
+        );
+    }
+
+    #[test]
+    fn attack_grep_pipe_only_pattern_stays_literal() {
+        let wb = attack_grep_fixture();
+        let responses = run_shared_workbench_mcp_requests(vec![workbench_tool_call(
+            1,
+            "workbench_grep",
+            serde_json::json!({"id": wb, "section": "logs", "pattern": "|||", "recursive": true}),
+        )]);
+        // Splitting "|||" on '|' yields only empty segments, which are
+        // dropped; the pattern must stay a literal search and match nothing.
+        let ok = attack_tool_ok(&responses[0]);
+        assert_eq!(ok["matches"], serde_json::json!([]), "grep: {ok}");
     }
 }

--- a/crates/nokv/src/bin/nokv.rs
+++ b/crates/nokv/src/bin/nokv.rs
@@ -3060,6 +3060,15 @@ mod tests {
         run_workbench_mcp_requests_with_options(workbench_mcp_options(), requests)
     }
 
+    fn workbench_tool_call(id: u64, name: &str, arguments: serde_json::Value) -> serde_json::Value {
+        serde_json::json!({
+            "jsonrpc": "2.0",
+            "id": id,
+            "method": "tools/call",
+            "params": {"name": name, "arguments": arguments}
+        })
+    }
+
     fn run_workbench_mcp_requests_with_options(
         options: McpCliOptions,
         requests: Vec<serde_json::Value>,
@@ -3075,6 +3084,45 @@ mod tests {
             )),
             client_store,
         );
+        run_workbench_mcp_requests_on_client(client, options, requests)
+    }
+
+    /// One process-lifetime server shared by the workbench MCP tests that only
+    /// need isolation by workbench id. Every spawned test server leaks its
+    /// threads for the process lifetime, so per-test servers exhaust OS
+    /// resources as the suite grows; tests that touch distinct workbench ids
+    /// share this one instead.
+    fn shared_workbench_mcp_server() -> &'static (SocketAddr, PathBuf) {
+        static SERVER: std::sync::OnceLock<(SocketAddr, PathBuf)> = std::sync::OnceLock::new();
+        SERVER.get_or_init(|| {
+            let object_dir = tempdir().unwrap();
+            let object_root = object_dir.path().join("objects");
+            let addr = spawn_test_server_with_object_config(ObjectStoreConfig::tiered_local(
+                object_root.clone(),
+                fake_s3_options(),
+            ));
+            // The server thread serves for the process lifetime; keep its
+            // object root alive with it.
+            std::mem::forget(object_dir);
+            (addr, object_root)
+        })
+    }
+
+    fn run_shared_workbench_mcp_requests(
+        requests: Vec<serde_json::Value>,
+    ) -> Vec<serde_json::Value> {
+        let (addr, object_root) = shared_workbench_mcp_server();
+        let store =
+            LocalObjectStore::new(LocalObjectStoreOptions::new(object_root.clone())).unwrap();
+        let client = NoKvFsClient::connect(*addr, store);
+        run_workbench_mcp_requests_on_client(client, workbench_mcp_options(), requests)
+    }
+
+    fn run_workbench_mcp_requests_on_client(
+        client: NoKvFsClient<LocalObjectStore>,
+        options: McpCliOptions,
+        requests: Vec<serde_json::Value>,
+    ) -> Vec<serde_json::Value> {
         let reqs = requests
             .into_iter()
             .map(|request| serde_json::to_string(&request).unwrap())
@@ -3146,7 +3194,7 @@ mod tests {
 
     #[test]
     fn workbench_mcp_tools_use_workbench_prefix_and_are_isolated() {
-        let responses = run_workbench_mcp_requests(vec![serde_json::json!({
+        let responses = run_shared_workbench_mcp_requests(vec![serde_json::json!({
             "jsonrpc": "2.0",
             "id": 1,
             "method": "tools/list"
@@ -3158,10 +3206,15 @@ mod tests {
             vec![
                 "workbench_create",
                 "workbench_put_file",
+                "workbench_append",
+                "workbench_edit",
                 "workbench_list",
                 "workbench_stat",
                 "workbench_read",
                 "workbench_grep",
+                "workbench_search",
+                "workbench_aggregate",
+                "workbench_catalog",
                 "workbench_find",
                 "workbench_commit",
                 "workbench_snapshot",
@@ -3175,7 +3228,7 @@ mod tests {
 
     #[test]
     fn workbench_mcp_tool_schemas_are_closed() {
-        let responses = run_workbench_mcp_requests(vec![serde_json::json!({
+        let responses = run_shared_workbench_mcp_requests(vec![serde_json::json!({
             "jsonrpc": "2.0",
             "id": 1,
             "method": "tools/list"
@@ -3190,7 +3243,7 @@ mod tests {
 
     #[test]
     fn workbench_mcp_create_put_read_list_stat_grep_commit_snapshot_flow() {
-        let responses = run_workbench_mcp_requests(vec![
+        let responses = run_shared_workbench_mcp_requests(vec![
             serde_json::json!({
                 "jsonrpc": "2.0",
                 "id": 1,
@@ -3526,7 +3579,7 @@ mod tests {
 
     #[test]
     fn workbench_mcp_rejects_path_escape_and_default_overwrite() {
-        let responses = run_workbench_mcp_requests(vec![
+        let responses = run_shared_workbench_mcp_requests(vec![
             serde_json::json!({
                 "jsonrpc": "2.0",
                 "id": 1,
@@ -3773,8 +3826,667 @@ mod tests {
     }
 
     #[test]
+    fn workbench_mcp_search_queries_paths_with_predicates_and_enrichment() {
+        // The "-searchmark.csv" suffix is unique to this test so the
+        // cross-workbench query stays exact on the shared server.
+        let responses = run_shared_workbench_mcp_requests(vec![
+            workbench_tool_call(
+                1,
+                "workbench_create",
+                serde_json::json!({"id": "wb-search-a"}),
+            ),
+            workbench_tool_call(
+                2,
+                "workbench_put_file",
+                serde_json::json!({
+                    "id": "wb-search-a",
+                    "section": "outputs",
+                    "path": "spectrum-searchmark.csv",
+                    "text": "freq,power\n1,2\n",
+                    "content_type": "text/csv"
+                }),
+            ),
+            workbench_tool_call(
+                3,
+                "workbench_put_file",
+                serde_json::json!({
+                    "id": "wb-search-a",
+                    "section": "input",
+                    "path": "event.json",
+                    "text": "{\"event\":\"storm\"}",
+                    "content_type": "application/json"
+                }),
+            ),
+            workbench_tool_call(
+                4,
+                "workbench_create",
+                serde_json::json!({"id": "wb-search-b"}),
+            ),
+            workbench_tool_call(
+                5,
+                "workbench_put_file",
+                serde_json::json!({
+                    "id": "wb-search-b",
+                    "section": "outputs",
+                    "path": "other-searchmark.csv",
+                    "text": "freq,power\n3,4\n",
+                    "content_type": "text/csv"
+                }),
+            ),
+            workbench_tool_call(
+                6,
+                "workbench_search",
+                serde_json::json!({
+                    "id": "wb-search-a",
+                    "predicates": [{"field": "name", "op": "suffix", "value": ".csv"}]
+                }),
+            ),
+            workbench_tool_call(
+                7,
+                "workbench_search",
+                serde_json::json!({
+                    "predicates": [{"field": "name", "op": "suffix", "value": "-searchmark.csv"}],
+                    "fields": ["name"]
+                }),
+            ),
+            workbench_tool_call(
+                8,
+                "workbench_search",
+                serde_json::json!({
+                    "id": "wb-search-a",
+                    "limit": 11
+                }),
+            ),
+            workbench_tool_call(
+                9,
+                "workbench_search",
+                serde_json::json!({
+                    "section": "outputs"
+                }),
+            ),
+        ]);
+        for (index, response) in responses.iter().take(7).enumerate() {
+            assert_ne!(
+                response["result"]["isError"], true,
+                "response {index}: {response}"
+            );
+        }
+
+        let scoped = &responses[5]["result"]["structuredContent"];
+        assert_eq!(scoped["status"], "success", "search response: {scoped}");
+        assert_eq!(scoped["match_count"], 1);
+        assert_eq!(scoped["matches"][0]["workbench_id"], "wb-search-a");
+        assert_eq!(scoped["matches"][0]["section"], "outputs");
+        assert_eq!(
+            scoped["matches"][0]["relative_path"],
+            "spectrum-searchmark.csv"
+        );
+        assert_eq!(
+            scoped["matches"][0]["path"],
+            "/workbenches/wb-search-a/outputs/spectrum-searchmark.csv"
+        );
+
+        let cross = &responses[6]["result"]["structuredContent"];
+        assert_eq!(cross["match_count"], 2, "cross response: {cross}");
+        let matches = cross["matches"].as_array().unwrap();
+        let ids: Vec<&str> = matches
+            .iter()
+            .map(|m| m["workbench_id"].as_str().unwrap())
+            .collect();
+        assert!(ids.contains(&"wb-search-a"), "matches: {matches:?}");
+        assert!(ids.contains(&"wb-search-b"), "matches: {matches:?}");
+        assert!(
+            matches
+                .iter()
+                .all(|m| m["values"]["name"].as_str().unwrap().ends_with(".csv")),
+            "matches: {matches:?}"
+        );
+
+        assert_eq!(responses[7]["result"]["isError"], true);
+        assert!(responses[7]["result"]["content"][0]["text"]
+            .as_str()
+            .unwrap()
+            .contains("limit must be between 1 and 10"));
+        // section/path scoping only makes sense inside one workbench.
+        assert_eq!(responses[8]["result"]["isError"], true);
+    }
+
+    #[test]
+    fn workbench_mcp_search_returns_empty_results_when_root_is_missing() {
+        let responses = run_workbench_mcp_requests(vec![workbench_tool_call(
+            1,
+            "workbench_search",
+            serde_json::json!({}),
+        )]);
+        assert_ne!(
+            responses[0]["result"]["isError"], true,
+            "response: {}",
+            responses[0]
+        );
+        let result = &responses[0]["result"]["structuredContent"];
+        assert_eq!(result["status"], "success");
+        assert_eq!(result["match_count"], 0);
+        assert_eq!(result["matches"], serde_json::json!([]));
+    }
+
+    #[test]
+    fn workbench_mcp_aggregate_counts_grouped_rows() {
+        let responses = run_shared_workbench_mcp_requests(vec![
+            workbench_tool_call(1, "workbench_create", serde_json::json!({"id": "wb-agg"})),
+            workbench_tool_call(
+                2,
+                "workbench_put_file",
+                serde_json::json!({
+                    "id": "wb-agg",
+                    "section": "outputs",
+                    "path": "a.csv",
+                    "text": "a\n",
+                    "content_type": "text/csv"
+                }),
+            ),
+            workbench_tool_call(
+                3,
+                "workbench_put_file",
+                serde_json::json!({
+                    "id": "wb-agg",
+                    "section": "outputs",
+                    "path": "b.csv",
+                    "text": "b\n",
+                    "content_type": "text/csv"
+                }),
+            ),
+            workbench_tool_call(
+                4,
+                "workbench_put_file",
+                serde_json::json!({
+                    "id": "wb-agg",
+                    "section": "input",
+                    "path": "c.json",
+                    "text": "{}",
+                    "content_type": "application/json"
+                }),
+            ),
+            workbench_tool_call(
+                5,
+                "workbench_aggregate",
+                serde_json::json!({
+                    "id": "wb-agg",
+                    "section": "outputs",
+                    "predicates": [{"field": "kind", "op": "eq", "value": "file"}],
+                    "measures": [{"name": "files", "op": "count"}]
+                }),
+            ),
+            workbench_tool_call(
+                6,
+                "workbench_aggregate",
+                serde_json::json!({
+                    "id": "wb-agg",
+                    "predicates": [{"field": "kind", "op": "eq", "value": "file"}],
+                    "group_by": ["body.content_type"],
+                    "measures": [{"name": "n", "op": "count"}]
+                }),
+            ),
+        ]);
+        for (index, response) in responses.iter().enumerate() {
+            assert_ne!(
+                response["result"]["isError"], true,
+                "response {index}: {response}"
+            );
+        }
+
+        let total = &responses[4]["result"]["structuredContent"];
+        assert_eq!(total["status"], "success", "aggregate response: {total}");
+        assert_eq!(total["groups"][0]["values"]["files"], 2);
+
+        let grouped = &responses[5]["result"]["structuredContent"];
+        let groups = grouped["groups"].as_array().unwrap();
+        let group_count = |content_type: &str| {
+            groups
+                .iter()
+                .find(|group| group["key"]["body.content_type"] == content_type)
+                .unwrap_or_else(|| panic!("missing group {content_type}: {groups:?}"))["values"]
+                ["n"]
+                .clone()
+        };
+        assert_eq!(group_count("text/csv"), 2);
+        assert_eq!(group_count("application/json"), 1);
+    }
+
+    #[test]
+    fn workbench_mcp_catalog_returns_builtin_query_fields() {
+        let responses = run_shared_workbench_mcp_requests(vec![
+            workbench_tool_call(1, "workbench_create", serde_json::json!({"id": "wb-cat"})),
+            workbench_tool_call(2, "workbench_catalog", serde_json::json!({"id": "wb-cat"})),
+        ]);
+        for (index, response) in responses.iter().enumerate() {
+            assert_ne!(
+                response["result"]["isError"], true,
+                "response {index}: {response}"
+            );
+        }
+        let result = &responses[1]["result"]["structuredContent"];
+        assert_eq!(result["status"], "success", "catalog response: {result}");
+        assert_eq!(result["catalog_empty"], false);
+        let filterable: Vec<String> = result["catalog"]["filterable"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .flat_map(|group| group["fields"].as_array().unwrap().clone())
+            .map(|field| field.as_str().unwrap().to_owned())
+            .collect();
+        for field in [
+            "path",
+            "name",
+            "kind",
+            "size_bytes",
+            "body.content_type",
+            "body.producer",
+            "body.manifest_id",
+        ] {
+            assert!(
+                filterable.contains(&field.to_owned()),
+                "missing builtin field {field}: {filterable:?}"
+            );
+        }
+        assert_eq!(filterable.len(), 7, "filterable: {filterable:?}");
+    }
+
+    #[test]
+    fn workbench_mcp_append_creates_then_extends_and_reads_back() {
+        let responses = run_shared_workbench_mcp_requests(vec![
+            workbench_tool_call(
+                1,
+                "workbench_create",
+                serde_json::json!({"id": "wb-append"}),
+            ),
+            workbench_tool_call(
+                2,
+                "workbench_append",
+                serde_json::json!({
+                    "id": "wb-append",
+                    "section": "logs",
+                    "path": "run.log",
+                    "text": "line one\n"
+                }),
+            ),
+            workbench_tool_call(
+                3,
+                "workbench_append",
+                serde_json::json!({
+                    "id": "wb-append",
+                    "section": "logs",
+                    "path": "run.log",
+                    "text": "line two\n"
+                }),
+            ),
+            workbench_tool_call(
+                4,
+                "workbench_read",
+                serde_json::json!({
+                    "id": "wb-append",
+                    "section": "logs",
+                    "path": "run.log",
+                    "format": "structured"
+                }),
+            ),
+        ]);
+        for (index, response) in responses.iter().enumerate() {
+            assert_ne!(
+                response["result"]["isError"], true,
+                "response {index}: {response}"
+            );
+        }
+
+        let first = &responses[1]["result"]["structuredContent"];
+        assert_eq!(first["status"], "success", "append response: {first}");
+        assert_eq!(first["created"], true);
+        assert_eq!(first["appended_bytes"], 9);
+        assert_eq!(first["size_bytes"], 9);
+        assert_eq!(first["path"], "/workbenches/wb-append/logs/run.log");
+        assert_eq!(first["section"], "logs");
+        assert_eq!(first["relative_path"], "run.log");
+
+        let second = &responses[2]["result"]["structuredContent"];
+        assert_eq!(second["created"], false);
+        assert_eq!(second["appended_bytes"], 9);
+        assert_eq!(second["size_bytes"], 18);
+        assert!(second["generation"].as_u64().is_some());
+
+        let read = &responses[3]["result"]["structuredContent"];
+        assert_eq!(read["items"][0]["value"]["text"], "line one");
+        assert_eq!(read["items"][1]["value"]["text"], "line two");
+    }
+
+    #[test]
+    fn workbench_mcp_edit_replaces_strings_with_lingtai_error_texts() {
+        let responses = run_shared_workbench_mcp_requests(vec![
+            workbench_tool_call(1, "workbench_create", serde_json::json!({"id": "wb-edit"})),
+            workbench_tool_call(
+                2,
+                "workbench_put_file",
+                serde_json::json!({
+                    "id": "wb-edit",
+                    "section": "outputs",
+                    "path": "notes.txt",
+                    "text": "hello world\nhello moon\n"
+                }),
+            ),
+            workbench_tool_call(
+                3,
+                "workbench_edit",
+                serde_json::json!({
+                    "id": "wb-edit",
+                    "section": "outputs",
+                    "path": "notes.txt",
+                    "old_string": "world",
+                    "new_string": "mars"
+                }),
+            ),
+            workbench_tool_call(
+                4,
+                "workbench_read",
+                serde_json::json!({
+                    "id": "wb-edit",
+                    "section": "outputs",
+                    "path": "notes.txt",
+                    "format": "structured"
+                }),
+            ),
+            workbench_tool_call(
+                5,
+                "workbench_edit",
+                serde_json::json!({
+                    "id": "wb-edit",
+                    "section": "outputs",
+                    "path": "notes.txt",
+                    "old_string": "absent",
+                    "new_string": "x"
+                }),
+            ),
+            workbench_tool_call(
+                6,
+                "workbench_edit",
+                serde_json::json!({
+                    "id": "wb-edit",
+                    "section": "outputs",
+                    "path": "notes.txt",
+                    "old_string": "hello",
+                    "new_string": "hi"
+                }),
+            ),
+            workbench_tool_call(
+                7,
+                "workbench_edit",
+                serde_json::json!({
+                    "id": "wb-edit",
+                    "section": "outputs",
+                    "path": "notes.txt",
+                    "old_string": "hello",
+                    "new_string": "hi",
+                    "replace_all": true
+                }),
+            ),
+        ]);
+
+        let edited = &responses[2]["result"]["structuredContent"];
+        assert_ne!(
+            responses[2]["result"]["isError"], true,
+            "edit response: {}",
+            responses[2]
+        );
+        assert_eq!(edited["status"], "success");
+        assert_eq!(edited["replacements"], 1);
+        assert!(edited["generation"].as_u64().is_some());
+
+        let read = &responses[3]["result"]["structuredContent"];
+        assert_eq!(read["items"][0]["value"]["text"], "hello mars");
+
+        assert_eq!(responses[4]["result"]["isError"], true);
+        assert!(responses[4]["result"]["content"][0]["text"]
+            .as_str()
+            .unwrap()
+            .contains("old_string not found in /workbenches/wb-edit/outputs/notes.txt"));
+
+        assert_eq!(responses[5]["result"]["isError"], true);
+        assert!(responses[5]["result"]["content"][0]["text"]
+            .as_str()
+            .unwrap()
+            .contains("old_string found 2 times — use replace_all=true or provide more context"));
+
+        assert_ne!(
+            responses[6]["result"]["isError"], true,
+            "replace_all response: {}",
+            responses[6]
+        );
+        assert_eq!(
+            responses[6]["result"]["structuredContent"]["replacements"],
+            2
+        );
+    }
+
+    #[test]
+    fn workbench_mcp_read_supports_conditional_generation() {
+        // Two batches on the shared server: the second replays the generation
+        // observed by the first.
+        let setup = run_shared_workbench_mcp_requests(vec![
+            workbench_tool_call(1, "workbench_create", serde_json::json!({"id": "wb-cond"})),
+            workbench_tool_call(
+                2,
+                "workbench_put_file",
+                serde_json::json!({
+                    "id": "wb-cond",
+                    "section": "outputs",
+                    "path": "data.txt",
+                    "text": "v1\n"
+                }),
+            ),
+            workbench_tool_call(
+                3,
+                "workbench_read",
+                serde_json::json!({
+                    "id": "wb-cond",
+                    "section": "outputs",
+                    "path": "data.txt",
+                    "format": "structured"
+                }),
+            ),
+        ]);
+        for (index, response) in setup.iter().enumerate() {
+            assert_ne!(
+                response["result"]["isError"], true,
+                "setup response {index}: {response}"
+            );
+        }
+        let generation = setup[2]["result"]["structuredContent"]["generation"]
+            .as_u64()
+            .unwrap_or_else(|| panic!("read response missing generation: {}", setup[2]));
+
+        let conditional = run_shared_workbench_mcp_requests(vec![
+            workbench_tool_call(
+                1,
+                "workbench_read",
+                serde_json::json!({
+                    "id": "wb-cond",
+                    "section": "outputs",
+                    "path": "data.txt",
+                    "if_none_match": generation
+                }),
+            ),
+            workbench_tool_call(
+                2,
+                "workbench_edit",
+                serde_json::json!({
+                    "id": "wb-cond",
+                    "section": "outputs",
+                    "path": "data.txt",
+                    "old_string": "v1",
+                    "new_string": "v2"
+                }),
+            ),
+            workbench_tool_call(
+                3,
+                "workbench_read",
+                serde_json::json!({
+                    "id": "wb-cond",
+                    "section": "outputs",
+                    "path": "data.txt",
+                    "format": "structured",
+                    "if_none_match": generation
+                }),
+            ),
+            workbench_tool_call(
+                4,
+                "workbench_read",
+                serde_json::json!({
+                    "id": "wb-cond",
+                    "section": "outputs",
+                    "path": "data.txt",
+                    "limit": 301
+                }),
+            ),
+        ]);
+
+        let unchanged = &conditional[0]["result"]["structuredContent"];
+        assert_ne!(
+            conditional[0]["result"]["isError"], true,
+            "conditional response: {}",
+            conditional[0]
+        );
+        assert_eq!(unchanged["status"], "success");
+        assert_eq!(unchanged["not_modified"], true);
+        assert_eq!(unchanged["generation"], generation);
+        assert_eq!(unchanged["section"], "outputs");
+        assert_eq!(unchanged["relative_path"], "data.txt");
+        assert!(unchanged.get("items").is_none(), "unchanged: {unchanged}");
+
+        assert_ne!(conditional[1]["result"]["isError"], true);
+
+        let modified = &conditional[2]["result"]["structuredContent"];
+        assert_ne!(
+            conditional[2]["result"]["isError"], true,
+            "modified response: {}",
+            conditional[2]
+        );
+        assert!(modified["not_modified"].is_null(), "modified: {modified}");
+        assert_eq!(modified["items"][0]["value"]["text"], "v2");
+        assert_ne!(modified["generation"], generation);
+
+        assert_eq!(conditional[3]["result"]["isError"], true);
+        assert!(conditional[3]["result"]["content"][0]["text"]
+            .as_str()
+            .unwrap()
+            .contains("limit must be between 1 and 300"));
+    }
+
+    #[test]
+    fn workbench_mcp_grep_supports_patterns_glob_and_pipe_split() {
+        let responses = run_shared_workbench_mcp_requests(vec![
+            workbench_tool_call(1, "workbench_create", serde_json::json!({"id": "wb-grep"})),
+            workbench_tool_call(
+                2,
+                "workbench_put_file",
+                serde_json::json!({
+                    "id": "wb-grep",
+                    "section": "outputs",
+                    "path": "one.txt",
+                    "text": "alpha signal\n"
+                }),
+            ),
+            workbench_tool_call(
+                3,
+                "workbench_put_file",
+                serde_json::json!({
+                    "id": "wb-grep",
+                    "section": "outputs",
+                    "path": "two.log",
+                    "text": "beta signal\n"
+                }),
+            ),
+            workbench_tool_call(
+                4,
+                "workbench_grep",
+                serde_json::json!({
+                    "id": "wb-grep",
+                    "pattern": "alpha|beta",
+                    "recursive": true
+                }),
+            ),
+            workbench_tool_call(
+                5,
+                "workbench_grep",
+                serde_json::json!({
+                    "id": "wb-grep",
+                    "pattern": "unused",
+                    "patterns": ["alpha", "beta"],
+                    "recursive": true
+                }),
+            ),
+            workbench_tool_call(
+                6,
+                "workbench_grep",
+                serde_json::json!({
+                    "id": "wb-grep",
+                    "pattern": "alpha|beta",
+                    "glob": "*.txt",
+                    "recursive": true
+                }),
+            ),
+            workbench_tool_call(
+                7,
+                "workbench_grep",
+                serde_json::json!({
+                    "id": "wb-grep",
+                    "pattern": "signal",
+                    "recursive": true,
+                    "limit": 301
+                }),
+            ),
+        ]);
+        for (index, response) in responses.iter().take(6).enumerate() {
+            assert_ne!(
+                response["result"]["isError"], true,
+                "response {index}: {response}"
+            );
+        }
+
+        let match_paths = |response: &serde_json::Value| -> Vec<String> {
+            response["result"]["structuredContent"]["matches"]
+                .as_array()
+                .unwrap()
+                .iter()
+                .map(|m| m["path"].as_str().unwrap().to_owned())
+                .collect()
+        };
+
+        // Pipe in `pattern` splits into OR alternatives when `patterns` is absent.
+        let piped = match_paths(&responses[3]);
+        assert!(
+            piped.contains(&"/workbenches/wb-grep/outputs/one.txt".to_owned())
+                && piped.contains(&"/workbenches/wb-grep/outputs/two.log".to_owned()),
+            "piped matches: {piped:?}"
+        );
+
+        // Explicit `patterns` wins over `pattern`.
+        let explicit = match_paths(&responses[4]);
+        assert_eq!(explicit.len(), 2, "explicit matches: {explicit:?}");
+
+        let globbed = match_paths(&responses[5]);
+        assert_eq!(
+            globbed,
+            vec!["/workbenches/wb-grep/outputs/one.txt".to_owned()],
+            "globbed matches: {globbed:?}"
+        );
+
+        assert_eq!(responses[6]["result"]["isError"], true);
+        assert!(responses[6]["result"]["content"][0]["text"]
+            .as_str()
+            .unwrap()
+            .contains("limit must be between 1 and 300"));
+    }
+
+    #[test]
     fn workbench_mcp_put_file_ignores_empty_unused_payload_variant() {
-        let responses = run_workbench_mcp_requests(vec![
+        let responses = run_shared_workbench_mcp_requests(vec![
             serde_json::json!({
                 "jsonrpc": "2.0",
                 "id": 1,
@@ -3863,7 +4575,7 @@ mod tests {
 
     #[test]
     fn workbench_mcp_rejects_section_prefixed_paths() {
-        let responses = run_workbench_mcp_requests(vec![
+        let responses = run_shared_workbench_mcp_requests(vec![
             serde_json::json!({
                 "jsonrpc": "2.0",
                 "id": 1,
@@ -3917,7 +4629,7 @@ mod tests {
 
     #[test]
     fn workbench_mcp_rejects_invalid_ids_sections_payloads_and_manifest() {
-        let responses = run_workbench_mcp_requests(vec![
+        let responses = run_shared_workbench_mcp_requests(vec![
             serde_json::json!({
                 "jsonrpc": "2.0",
                 "id": 1,
@@ -4061,7 +4773,7 @@ mod tests {
 
     #[test]
     fn workbench_mcp_snapshot_requires_commit_manifest() {
-        let responses = run_workbench_mcp_requests(vec![
+        let responses = run_shared_workbench_mcp_requests(vec![
             serde_json::json!({
                 "jsonrpc": "2.0",
                 "id": 1,

--- a/crates/nokv/src/bin/nokv/workbench_mcp.rs
+++ b/crates/nokv/src/bin/nokv/workbench_mcp.rs
@@ -3,7 +3,9 @@ use std::time::{SystemTime, UNIX_EPOCH};
 
 use base64::Engine;
 use nokv_agent::AgentToolDefinition;
-use nokv_client::{is_artifact_write_conflict, ArtifactMetadata, NoKvFsClient};
+use nokv_client::{
+    is_artifact_write_conflict, is_metadata_not_found, ArtifactMetadata, NoKvFsClient,
+};
 use nokv_object::ObjectStore;
 use nokv_types::{FileType, PathMetadata};
 use serde_json::{json, Value};
@@ -21,7 +23,28 @@ const MAX_WORKBENCH_AGGREGATE_LIMIT: usize = 100;
 const MAX_WORKBENCH_READ_LIMIT: usize = 300;
 const MAX_WORKBENCH_GREP_LIMIT: usize = 300;
 /// Retries after a lost artifact-write CAS; every attempt re-reads current state.
-const WRITE_CONFLICT_RETRIES: usize = 3;
+const WRITE_CONFLICT_RETRIES: usize = 5;
+/// Linear backoff step between conflict retries. Zero-interval retries make N
+/// synchronized writers replay the same race until the retry budget runs out;
+/// a growing pause plus per-process jitter (see [`write_conflict_backoff`])
+/// de-synchronizes them.
+const WRITE_CONFLICT_BACKOFF_STEP_MS: u64 = 10;
+
+/// Sleep before retry number `attempt` (1-based) of a conflicted write.
+/// Linear `attempt * 10ms` backoff plus a 0-8ms desync offset derived from the
+/// process id and the current clock nanoseconds, so two workbench processes
+/// that lost the same race do not wake in lockstep (no rand dependency).
+fn write_conflict_backoff(attempt: usize) {
+    let jitter_ms = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|now| now.subsec_nanos() as u64)
+        .unwrap_or(0)
+        .wrapping_add(u64::from(std::process::id()))
+        % 8;
+    std::thread::sleep(std::time::Duration::from_millis(
+        (attempt as u64) * WRITE_CONFLICT_BACKOFF_STEP_MS + jitter_ms,
+    ));
+}
 
 pub const SECTIONS: &[&str] = &["input", "scripts", "outputs", "logs", "metadata"];
 
@@ -167,7 +190,7 @@ pub fn tool_definitions() -> Vec<AgentToolDefinition> {
         AgentToolDefinition {
             name: "workbench_read",
             description:
-                "Read one workbench file through the NoKV namespace. Structured mode returns JSON, YAML, or text records; bytes mode returns byte ranges. Pass if_none_match with a previously returned generation to skip the body when the file is unchanged.",
+                "Read one workbench file through the NoKV namespace. Structured mode returns JSON, YAML, or text records; bytes mode returns byte ranges as a base64 string in bytes (bytes_encoding is \"base64\"). Pass if_none_match with a previously returned generation to skip the body when the file is unchanged.",
             parameters: json!({
                 "type": "object",
                 "required": ["id", "section", "path"],
@@ -505,6 +528,7 @@ where
             Ok(outcome) => break outcome,
             Err(err) if is_artifact_write_conflict(&err) && attempts < WRITE_CONFLICT_RETRIES => {
                 attempts += 1;
+                write_conflict_backoff(attempts);
             }
             Err(err) => return Err(client_error(err)),
         }
@@ -599,6 +623,7 @@ where
             Err(err) if is_artifact_write_conflict(&err) && attempts < WRITE_CONFLICT_RETRIES => {
                 // A writer landed since our read; re-read and re-validate.
                 attempts += 1;
+                write_conflict_backoff(attempts);
             }
             Err(err) => return Err(client_error(err)),
         }
@@ -799,6 +824,29 @@ fn shape_file_read_result(
     scope: &WorkbenchPathScope,
     result: Value,
 ) -> Result<Value, WorkbenchToolError> {
+    // A bytes-mode page arrives as a JSON integer array; re-encode it as
+    // base64 so each output byte costs ~1.3 characters instead of the ~4
+    // tokens an integer element burns. Structured mode has no bytes field.
+    let (bytes, bytes_encoding) = match result.get("bytes") {
+        Some(Value::Array(values)) => {
+            let raw = values
+                .iter()
+                .map(|value| {
+                    value
+                        .as_u64()
+                        .and_then(|byte| u8::try_from(byte).ok())
+                        .ok_or_else(|| {
+                            WorkbenchToolError::new("read result bytes contain a non-byte value")
+                        })
+                })
+                .collect::<Result<Vec<u8>, _>>()?;
+            (
+                Value::String(base64::engine::general_purpose::STANDARD.encode(raw)),
+                json!("base64"),
+            )
+        }
+        _ => (Value::Null, Value::Null),
+    };
     Ok(json!({
         "status": "success",
         "workbench_id": id,
@@ -815,7 +863,8 @@ fn shape_file_read_result(
         "next_cursor": result.get("next_cursor").cloned().unwrap_or(Value::Null),
         "truncated": result.get("truncated").cloned().unwrap_or(Value::Bool(false)),
         "items": result.get("items").cloned().unwrap_or_else(|| json!([])),
-        "bytes": result.get("bytes").cloned().unwrap_or(Value::Null),
+        "bytes": bytes,
+        "bytes_encoding": bytes_encoding,
     }))
 }
 
@@ -887,11 +936,7 @@ where
     // cross-workbench queries, not an error.
     if id.is_none()
         && matches!(query_tool, "find" | "aggregate")
-        && client
-            .metadata()
-            .stat_path(&options.root)
-            .map_err(client_error)?
-            .is_none()
+        && stat_path_or_absent(client, &options.root)?.is_none()
     {
         return Ok(empty_query_result(query_tool, &options.root));
     }
@@ -1018,12 +1063,7 @@ where
         )));
     }
 
-    if client
-        .metadata()
-        .stat_path(&options.root)
-        .map_err(client_error)?
-        .is_none()
-    {
+    if stat_path_or_absent(client, &options.root)?.is_none() {
         return Ok(json!({
             "status": "success",
             "path": options.root.clone(),
@@ -1142,12 +1182,7 @@ where
 {
     let id = required_workbench_id(args)?;
     let manifest_path = section_path(options, &id, "metadata", Some("run_manifest.json"));
-    if client
-        .metadata()
-        .stat_path(&manifest_path)
-        .map_err(client_error)?
-        .is_none()
-    {
+    if stat_path_or_absent(client, &manifest_path)?.is_none() {
         return Err(WorkbenchToolError::new(format!(
             "workbench {id} is not committed; missing {manifest_path}"
         )));
@@ -1347,11 +1382,10 @@ where
     O: ObjectStore + Send + Sync + 'static,
 {
     let manifest_path = section_path(options, id, "metadata", Some("run_manifest.json"));
-    let Some(metadata) = client
-        .metadata()
-        .stat_path(&manifest_path)
-        .map_err(client_error)?
-    else {
+    // An out-of-band directory under the root has no metadata/ section at all;
+    // the missing-ancestor NotFound folds into "uncommitted" like a missing
+    // manifest file does (find must tolerate such entries the way ls does).
+    let Some(metadata) = stat_path_or_absent(client, &manifest_path)? else {
         return Ok(WorkbenchManifestSummary {
             committed: false,
             manifest_path: None,
@@ -1452,6 +1486,25 @@ where
         ensure_dir_path(client, options, &path)?;
     }
     Ok(())
+}
+
+/// `stat_path` that folds "a path component does not exist" into `Ok(None)`.
+/// The metadata server reports a missing *ancestor* as a `NotFound` error
+/// while a missing leaf is `Ok(None)`; probes asking "is this subtree
+/// materialized yet" (a multi-level per-agent root, a workbench's manifest
+/// under an out-of-band directory) treat both as plain absence.
+fn stat_path_or_absent<O>(
+    client: &NoKvFsClient<O>,
+    path: &str,
+) -> Result<Option<PathMetadata>, WorkbenchToolError>
+where
+    O: ObjectStore + Send + Sync + 'static,
+{
+    match client.metadata().stat_path(path) {
+        Ok(metadata) => Ok(metadata),
+        Err(err) if is_metadata_not_found(&err) => Ok(None),
+        Err(err) => Err(client_error(err)),
+    }
 }
 
 /// Ensure `path` exists as a directory, creating any missing ancestors

--- a/crates/nokv/src/bin/nokv/workbench_mcp.rs
+++ b/crates/nokv/src/bin/nokv/workbench_mcp.rs
@@ -3,7 +3,7 @@ use std::time::{SystemTime, UNIX_EPOCH};
 
 use base64::Engine;
 use nokv_agent::AgentToolDefinition;
-use nokv_client::{ArtifactMetadata, NoKvFsClient};
+use nokv_client::{is_artifact_write_conflict, ArtifactMetadata, NoKvFsClient};
 use nokv_object::ObjectStore;
 use nokv_types::{FileType, PathMetadata};
 use serde_json::{json, Value};
@@ -14,6 +14,14 @@ use crate::{DEFAULT_MODE_DIR, DEFAULT_MODE_FILE};
 pub const DEFAULT_WORKBENCH_MAX_BYTES: usize = 16 * 1024 * 1024;
 const DEFAULT_WORKBENCH_FIND_LIMIT: usize = 50;
 const MAX_WORKBENCH_FIND_LIMIT: usize = 100;
+// Schema-declared caps mirroring the agent tool limits (nokv-agent lib.rs);
+// the agent layer enforces them, these keep the advertised schemas honest.
+const MAX_WORKBENCH_SEARCH_LIMIT: usize = 10;
+const MAX_WORKBENCH_AGGREGATE_LIMIT: usize = 100;
+const MAX_WORKBENCH_READ_LIMIT: usize = 300;
+const MAX_WORKBENCH_GREP_LIMIT: usize = 300;
+/// Retries after a lost artifact-write CAS; every attempt re-reads current state.
+const WRITE_CONFLICT_RETRIES: usize = 3;
 
 pub const SECTIONS: &[&str] = &["input", "scripts", "outputs", "logs", "metadata"];
 
@@ -89,6 +97,42 @@ pub fn tool_definitions() -> Vec<AgentToolDefinition> {
             }),
         },
         AgentToolDefinition {
+            name: "workbench_append",
+            description:
+                "Append bytes to the end of one workbench file, creating it when missing. Safe under concurrent writers: conflicting appends are retried automatically. After an append, stat digest_uri describes the appended delta manifest, not the full content sha256.",
+            parameters: json!({
+                "type": "object",
+                "required": ["id", "section", "path"],
+                "properties": {
+                    "id": {"type": "string"},
+                    "section": {"type": "string", "enum": SECTIONS},
+                    "path": {"type": "string", "description": "Path relative to section. Do not prefix it with the section name."},
+                    "text": {"type": "string"},
+                    "base64": {"type": "string"},
+                    "content_type": {"type": "string"}
+                },
+                "additionalProperties": false
+            }),
+        },
+        AgentToolDefinition {
+            name: "workbench_edit",
+            description:
+                "Replace an exact string in one workbench text file. Fails when old_string is missing or not unique unless replace_all=true; concurrent writes are retried with re-validation.",
+            parameters: json!({
+                "type": "object",
+                "required": ["id", "section", "path", "old_string", "new_string"],
+                "properties": {
+                    "id": {"type": "string"},
+                    "section": {"type": "string", "enum": SECTIONS},
+                    "path": {"type": "string", "description": "Path relative to section. Do not prefix it with the section name."},
+                    "old_string": {"type": "string"},
+                    "new_string": {"type": "string"},
+                    "replace_all": {"type": "boolean"}
+                },
+                "additionalProperties": false
+            }),
+        },
+        AgentToolDefinition {
             name: "workbench_list",
             description:
                 "List a workbench, section, or subdirectory through the NoKV namespace. Not recursive. Entries written outside the standard sections by other NoKV clients are returned with section null; such entries cannot be addressed by the other workbench tools.",
@@ -123,7 +167,7 @@ pub fn tool_definitions() -> Vec<AgentToolDefinition> {
         AgentToolDefinition {
             name: "workbench_read",
             description:
-                "Read one workbench file through the NoKV namespace. Structured mode returns JSON, YAML, or text records; bytes mode returns byte ranges.",
+                "Read one workbench file through the NoKV namespace. Structured mode returns JSON, YAML, or text records; bytes mode returns byte ranges. Pass if_none_match with a previously returned generation to skip the body when the file is unchanged.",
             parameters: json!({
                 "type": "object",
                 "required": ["id", "section", "path"],
@@ -134,7 +178,8 @@ pub fn tool_definitions() -> Vec<AgentToolDefinition> {
                     "format": {"type": "string", "enum": ["structured", "bytes"]},
                     "cursor": {"type": ["string", "null"]},
                     "offset": {"type": "integer", "minimum": 0},
-                    "limit": {"type": "integer", "minimum": 1}
+                    "limit": {"type": "integer", "minimum": 1, "maximum": MAX_WORKBENCH_READ_LIMIT},
+                    "if_none_match": {"type": "integer", "minimum": 0, "description": "Generation from a previous response. When it still matches, only not_modified and generation are returned."}
                 },
                 "additionalProperties": false
             }),
@@ -142,7 +187,7 @@ pub fn tool_definitions() -> Vec<AgentToolDefinition> {
         AgentToolDefinition {
             name: "workbench_grep",
             description:
-                "Search workbench file bodies for a case-insensitive literal substring. This is not regex grep. Matches in files written outside the standard sections by other NoKV clients are returned with section null; such files cannot be addressed by the other workbench tools.",
+                "Search workbench file bodies for case-insensitive literal substrings. This is not regex grep. patterns adds OR alternatives; when patterns is omitted and pattern contains '|', pattern is split on '|' into OR alternatives (empty segments dropped). glob filters file basenames with * and ?. Matches in files written outside the standard sections by other NoKV clients are returned with section null; such files cannot be addressed by the other workbench tools.",
             parameters: json!({
                 "type": "object",
                 "required": ["id", "pattern", "recursive"],
@@ -151,9 +196,88 @@ pub fn tool_definitions() -> Vec<AgentToolDefinition> {
                     "section": {"type": ["string", "null"], "enum": ["input", "scripts", "outputs", "logs", "metadata", null]},
                     "path": {"type": ["string", "null"], "description": "Optional path relative to section. Do not prefix it with the section name."},
                     "pattern": {"type": "string"},
+                    "patterns": {"type": "array", "items": {"type": "string"}},
+                    "glob": {"type": ["string", "null"], "description": "Basename filter supporting * and ?."},
                     "recursive": {"type": "boolean"},
                     "cursor": {"type": ["string", "null"]},
-                    "limit": {"type": "integer", "minimum": 1}
+                    "limit": {"type": "integer", "minimum": 1, "maximum": MAX_WORKBENCH_GREP_LIMIT}
+                },
+                "additionalProperties": false
+            }),
+        },
+        AgentToolDefinition {
+            name: "workbench_search",
+            description:
+                "Query workbench paths by metadata with catalog field predicates, sort, projections, and facets. Omit id to search across every workbench under the root. Complements workbench_find, which discovers workbenches by their committed manifest; use workbench_grep for file content search.",
+            parameters: json!({
+                "type": "object",
+                "properties": {
+                    "id": {"type": ["string", "null"], "description": "Workbench id. Omit to search across all workbenches."},
+                    "section": {"type": ["string", "null"], "enum": ["input", "scripts", "outputs", "logs", "metadata", null]},
+                    "path": {"type": ["string", "null"], "description": "Optional path relative to section. Do not prefix it with the section name."},
+                    "predicates": predicates_parameter_schema(),
+                    "sort": sort_parameter_schema(),
+                    "fields": {
+                        "type": "array",
+                        "items": {"type": "string"}
+                    },
+                    "facets": {
+                        "type": "array",
+                        "items": {"type": "string"}
+                    },
+                    "cursor": {"type": ["string", "null"]},
+                    "limit": {"type": "integer", "minimum": 1, "maximum": MAX_WORKBENCH_SEARCH_LIMIT}
+                },
+                "additionalProperties": false
+            }),
+        },
+        AgentToolDefinition {
+            name: "workbench_aggregate",
+            description:
+                "Compute summary rows over workbench paths using catalog field ids: count, sum, avg, min, max, group, filter, and sort. Omit id to aggregate across every workbench under the root.",
+            parameters: json!({
+                "type": "object",
+                "required": ["measures"],
+                "properties": {
+                    "id": {"type": ["string", "null"], "description": "Workbench id. Omit to aggregate across all workbenches."},
+                    "section": {"type": ["string", "null"], "enum": ["input", "scripts", "outputs", "logs", "metadata", null]},
+                    "path": {"type": ["string", "null"], "description": "Optional path relative to section. Do not prefix it with the section name."},
+                    "predicates": predicates_parameter_schema(),
+                    "group_by": {
+                        "type": "array",
+                        "items": {"type": "string"}
+                    },
+                    "measures": {
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "required": ["name", "op"],
+                            "properties": {
+                                "name": {"type": "string"},
+                                "op": {"type": "string", "enum": ["count", "sum", "avg", "min", "max"]},
+                                "field": {"type": ["string", "null"]}
+                            },
+                            "additionalProperties": false
+                        }
+                    },
+                    "sort": sort_parameter_schema(),
+                    "limit": {"type": "integer", "minimum": 1, "maximum": MAX_WORKBENCH_AGGREGATE_LIMIT}
+                },
+                "additionalProperties": false
+            }),
+        },
+        AgentToolDefinition {
+            name: "workbench_catalog",
+            description:
+                "Discover catalog field ids for workbench_search and workbench_aggregate predicates, projections, sort, facets, and measures. Omit id to inspect the workbench root.",
+            parameters: json!({
+                "type": "object",
+                "properties": {
+                    "id": {"type": ["string", "null"], "description": "Workbench id. Omit to inspect the workbench root."},
+                    "section": {"type": ["string", "null"], "enum": ["input", "scripts", "outputs", "logs", "metadata", null]},
+                    "path": {"type": ["string", "null"], "description": "Optional path relative to section. Do not prefix it with the section name."},
+                    "field_prefix": {"type": ["string", "null"]},
+                    "include_facets": {"type": "boolean"}
                 },
                 "additionalProperties": false
             }),
@@ -205,6 +329,54 @@ pub fn tool_definitions() -> Vec<AgentToolDefinition> {
     ]
 }
 
+// Mirrors of the agent find/aggregate sub-schemas (nokv-agent
+// agent_tool_definitions); keep them in sync when the agent schemas change.
+fn predicates_parameter_schema() -> Value {
+    json!({
+        "type": "array",
+        "items": {
+            "type": "object",
+            "required": ["field", "op"],
+            "properties": {
+                "field": {"type": "string"},
+                "op": {
+                    "type": "string",
+                    "enum": ["eq", "ne", "in", "prefix", "suffix", "contains", "gt", "gte", "lt", "lte", "exists", "not_exists"]
+                },
+                "value": {
+                    "anyOf": [
+                        {"type": "string"},
+                        {"type": "integer", "minimum": 0},
+                        {"type": "number"},
+                        {"type": "boolean"},
+                        {
+                            "type": "array",
+                            "items": {"type": ["string", "integer", "number", "boolean"]}
+                        },
+                        {"type": "null"}
+                    ]
+                }
+            },
+            "additionalProperties": false
+        }
+    })
+}
+
+fn sort_parameter_schema() -> Value {
+    json!({
+        "type": "array",
+        "items": {
+            "type": "object",
+            "required": ["field"],
+            "properties": {
+                "field": {"type": "string"},
+                "direction": {"type": "string", "enum": ["asc", "desc"]}
+            },
+            "additionalProperties": false
+        }
+    })
+}
+
 pub fn execute_tool<O>(
     client: &NoKvFsClient<O>,
     options: &WorkbenchMcpOptions,
@@ -217,10 +389,15 @@ where
     match name {
         "workbench_create" => create_workbench(client, options, args),
         "workbench_put_file" => put_file(client, options, args),
+        "workbench_append" => append_file(client, options, args),
+        "workbench_edit" => edit_file(client, options, args),
         "workbench_list" => execute_read_tool(client, options, "ls", args),
         "workbench_stat" => execute_read_tool(client, options, "stat", args),
         "workbench_read" => execute_read_tool(client, options, "read", args),
         "workbench_grep" => execute_read_tool(client, options, "grep", args),
+        "workbench_search" => execute_query_tool(client, options, "find", args),
+        "workbench_aggregate" => execute_query_tool(client, options, "aggregate", args),
+        "workbench_catalog" => execute_query_tool(client, options, "catalog", args),
         "workbench_find" => find_workbenches(client, options, args),
         "workbench_commit" => commit_workbench(client, options, args),
         "workbench_snapshot" => snapshot_workbench(client, options, args),
@@ -296,6 +473,149 @@ where
     }))
 }
 
+fn append_file<O>(
+    client: &NoKvFsClient<O>,
+    options: &WorkbenchMcpOptions,
+    args: &Value,
+) -> Result<Value, WorkbenchToolError>
+where
+    O: ObjectStore + Send + Sync + 'static,
+{
+    let id = required_workbench_id(args)?;
+    let section = required_section(args)?;
+    let rel_path = required_section_relative_path(args, section, "path")?;
+    let (bytes, default_content_type) = payload_bytes(args, options.max_bytes)?;
+    let content_type = optional_string(args, "content_type")?
+        .unwrap_or(default_content_type)
+        .to_owned();
+
+    ensure_standard_dirs(client, options, &id)?;
+    ensure_parent_dirs(client, options, &id, section, &rel_path)?;
+    let path = section_path(options, &id, section, Some(&rel_path));
+    // The digest covers the appended delta only: computing a full-content
+    // sha256 would force a read of the whole file on every append.
+    let digest_uri = digest_uri(&bytes);
+    let appended_bytes = bytes.len();
+    let mut attempts = 0;
+    let outcome = loop {
+        let metadata = artifact_metadata(options, &path, &digest_uri, &content_type);
+        // append_artifact re-reads the current end offset on every call, so a
+        // lost race against a concurrent writer is safe to retry as-is.
+        match client.append_artifact(&path, bytes.clone(), metadata, None) {
+            Ok(outcome) => break outcome,
+            Err(err) if is_artifact_write_conflict(&err) && attempts < WRITE_CONFLICT_RETRIES => {
+                attempts += 1;
+            }
+            Err(err) => return Err(client_error(err)),
+        }
+    };
+
+    Ok(json!({
+        "status": "success",
+        "workbench_id": id,
+        "section": section,
+        "relative_path": rel_path,
+        "path": path,
+        "appended_bytes": appended_bytes,
+        "size_bytes": outcome.new_size,
+        "generation": outcome.generation,
+        "created": outcome.created,
+    }))
+}
+
+fn edit_file<O>(
+    client: &NoKvFsClient<O>,
+    options: &WorkbenchMcpOptions,
+    args: &Value,
+) -> Result<Value, WorkbenchToolError>
+where
+    O: ObjectStore + Send + Sync + 'static,
+{
+    let id = required_workbench_id(args)?;
+    let section = required_section(args)?;
+    let rel_path = required_section_relative_path(args, section, "path")?;
+    let old_string = required_string(args, "old_string")?;
+    if old_string.is_empty() {
+        return Err(WorkbenchToolError::new("old_string must not be empty"));
+    }
+    let new_string = required_string(args, "new_string")?;
+    let replace_all = optional_bool(args, "replace_all")?.unwrap_or(false);
+    let path = section_path(options, &id, section, Some(&rel_path));
+
+    let mut attempts = 0;
+    let (result, replacements) = loop {
+        let entry = client
+            .metadata()
+            .lookup(&path)
+            .map_err(client_error)?
+            .ok_or_else(|| WorkbenchToolError::new(format!("path not found: {path}")))?;
+        if entry.attr.file_type != FileType::File {
+            return Err(WorkbenchToolError::new(format!(
+                "path exists but is not a file: {path}"
+            )));
+        }
+        if entry.attr.size > options.max_bytes as u64 {
+            return Err(WorkbenchToolError::new(format!(
+                "file exceeds max_bytes: {} > {}",
+                entry.attr.size, options.max_bytes
+            )));
+        }
+        let text = String::from_utf8(client.cat(&path).map_err(client_error)?)
+            .map_err(|err| WorkbenchToolError::new(format!("file is not valid UTF-8: {err}")))?;
+        let count = text.matches(old_string).count();
+        if count == 0 {
+            return Err(WorkbenchToolError::new(format!(
+                "old_string not found in {path}"
+            )));
+        }
+        if count > 1 && !replace_all {
+            return Err(WorkbenchToolError::new(format!(
+                "old_string found {count} times — use replace_all=true or provide more context"
+            )));
+        }
+        let replacements = if replace_all { count } else { 1 };
+        let new_text = if replace_all {
+            text.replace(old_string, new_string)
+        } else {
+            text.replacen(old_string, new_string, 1)
+        };
+        let new_bytes = new_text.into_bytes();
+        if new_bytes.len() > options.max_bytes {
+            return Err(WorkbenchToolError::new(format!(
+                "payload exceeds max_bytes: {} > {}",
+                new_bytes.len(),
+                options.max_bytes
+            )));
+        }
+        let body = entry
+            .body
+            .as_ref()
+            .ok_or_else(|| WorkbenchToolError::new(format!("path has no file body: {path}")))?;
+        let digest_uri = digest_uri(&new_bytes);
+        let metadata = artifact_metadata(options, &path, &digest_uri, &body.content_type);
+        match client.put_artifact_replace_if_generation(&path, new_bytes, metadata, body.generation)
+        {
+            Ok(result) => break (result, replacements),
+            Err(err) if is_artifact_write_conflict(&err) && attempts < WRITE_CONFLICT_RETRIES => {
+                // A writer landed since our read; re-read and re-validate.
+                attempts += 1;
+            }
+            Err(err) => return Err(client_error(err)),
+        }
+    };
+
+    Ok(json!({
+        "status": "success",
+        "workbench_id": id,
+        "section": section,
+        "relative_path": rel_path,
+        "path": path,
+        "replacements": replacements,
+        "size_bytes": result.entry.attr.size,
+        "generation": result.entry.attr.generation,
+    }))
+}
+
 fn execute_read_tool<O>(
     client: &NoKvFsClient<O>,
     options: &WorkbenchMcpOptions,
@@ -314,6 +634,28 @@ where
         }
         _ => scoped_path_from_optional_args(options, &id, args)?,
     };
+    if read_tool == "read" {
+        if let Some(expected) = optional_u64(args, "if_none_match")? {
+            let metadata = client
+                .metadata()
+                .stat_path(&target)
+                .map_err(client_error)?
+                .ok_or_else(|| WorkbenchToolError::new(format!("path not found: {target}")))?;
+            if metadata.attr.generation == expected {
+                let scope = path_scope(options, &id, &target)?;
+                return Ok(json!({
+                    "status": "success",
+                    "workbench_id": id,
+                    "workbench_path": workbench_path(options, &id),
+                    "section": scope.section,
+                    "relative_path": scope.relative_path,
+                    "path": scope.path,
+                    "not_modified": true,
+                    "generation": expected,
+                }));
+            }
+        }
+    }
     let mut forwarded = args
         .as_object()
         .cloned()
@@ -331,16 +673,45 @@ where
         "read" => {
             forwarded.remove("pattern");
             forwarded.remove("recursive");
+            forwarded.remove("if_none_match");
         }
         "grep" => {
             forwarded.remove("format");
             forwarded.remove("offset");
+            split_piped_grep_pattern(&mut forwarded);
         }
         _ => {}
     }
     let result = nokv_agent::execute_agent_tool(client, read_tool, &Value::Object(forwarded))
         .map_err(|err| WorkbenchToolError::new(err.to_string()))?;
     shape_read_tool_result(client, options, &id, &target, read_tool, result)
+}
+
+/// `pattern: "a|b"` without an explicit `patterns` array is treated as OR
+/// alternatives, matching what agents expect from grep pipes. Empty segments
+/// are dropped; a pattern of only pipes stays a literal search.
+fn split_piped_grep_pattern(forwarded: &mut serde_json::Map<String, Value>) {
+    let has_patterns = forwarded
+        .get("patterns")
+        .and_then(Value::as_array)
+        .is_some_and(|patterns| !patterns.is_empty());
+    if has_patterns {
+        return;
+    }
+    let Some(pattern) = forwarded.get("pattern").and_then(Value::as_str) else {
+        return;
+    };
+    if !pattern.contains('|') {
+        return;
+    }
+    let alternatives = pattern
+        .split('|')
+        .filter(|part| !part.is_empty())
+        .map(|part| Value::String(part.to_owned()))
+        .collect::<Vec<_>>();
+    if !alternatives.is_empty() {
+        forwarded.insert("patterns".to_owned(), Value::Array(alternatives));
+    }
 }
 
 fn shape_read_tool_result<O>(
@@ -435,6 +806,7 @@ fn shape_file_read_result(
         "section": scope.section.clone(),
         "relative_path": scope.relative_path.clone(),
         "path": scope.path.clone(),
+        "generation": result.get("generation").cloned().unwrap_or(Value::Null),
         "total_size_bytes": result.get("total_size_bytes").cloned().unwrap_or(Value::Null),
         "format": result.get("format").cloned().unwrap_or(Value::Null),
         "record_type": result.get("record_type").cloned().unwrap_or(Value::Null),
@@ -473,6 +845,157 @@ fn shape_grep_result(
         "files_scanned": result.get("files_scanned").cloned().unwrap_or(Value::Null),
         "next_cursor": result.get("next_cursor").cloned().unwrap_or(Value::Null),
         "truncated": result.get("truncated").cloned().unwrap_or(Value::Bool(false)),
+    }))
+}
+
+/// Thin wrapper over the agent query tools (`find`, `aggregate`, `catalog`):
+/// translates workbench scoping into an absolute path, forwards the remaining
+/// arguments untouched, and enriches find matches with workbench coordinates.
+fn execute_query_tool<O>(
+    client: &NoKvFsClient<O>,
+    options: &WorkbenchMcpOptions,
+    query_tool: &str,
+    args: &Value,
+) -> Result<Value, WorkbenchToolError>
+where
+    O: ObjectStore + Send + Sync + 'static,
+{
+    let id = match optional_string(args, "id")? {
+        Some(id) => {
+            validate_workbench_id(id)?;
+            Some(id.to_owned())
+        }
+        None => None,
+    };
+    let target = match &id {
+        Some(id) => scoped_path_from_optional_args(options, id, args)?,
+        None => {
+            if optional_string(args, "section")?.is_some() {
+                return Err(WorkbenchToolError::new(
+                    "section requires id when querying across the workbench root",
+                ));
+            }
+            if optional_string(args, "path")?.is_some() {
+                return Err(WorkbenchToolError::new(
+                    "path requires id when querying across the workbench root",
+                ));
+            }
+            options.root.clone()
+        }
+    };
+    // A root that no workbench has materialized yet is an empty result for
+    // cross-workbench queries, not an error.
+    if id.is_none()
+        && matches!(query_tool, "find" | "aggregate")
+        && client
+            .metadata()
+            .stat_path(&options.root)
+            .map_err(client_error)?
+            .is_none()
+    {
+        return Ok(empty_query_result(query_tool, &options.root));
+    }
+    let mut forwarded = args
+        .as_object()
+        .cloned()
+        .ok_or_else(|| WorkbenchToolError::new("tool arguments must be a JSON object"))?;
+    forwarded.insert("path".to_owned(), Value::String(target.clone()));
+    forwarded.remove("id");
+    forwarded.remove("section");
+    let result = nokv_agent::execute_agent_tool(client, query_tool, &Value::Object(forwarded))
+        .map_err(|err| WorkbenchToolError::new(err.to_string()))?;
+    match query_tool {
+        "find" => shape_search_result(options, &target, result),
+        "aggregate" | "catalog" => {
+            let mut object = result
+                .as_object()
+                .cloned()
+                .ok_or_else(|| WorkbenchToolError::new(format!("{query_tool} result malformed")))?;
+            object.insert("status".to_owned(), json!("success"));
+            Ok(Value::Object(object))
+        }
+        other => Err(WorkbenchToolError::new(format!(
+            "unsupported query tool {other}"
+        ))),
+    }
+}
+
+fn empty_query_result(query_tool: &str, root: &str) -> Value {
+    match query_tool {
+        "find" => json!({
+            "status": "success",
+            "path": root,
+            "match_count": 0,
+            "matches": [],
+            "facets": [],
+            "next_cursor": Value::Null,
+            "truncated": false,
+        }),
+        _ => json!({
+            "status": "success",
+            "path": root,
+            "input_match_count": 0,
+            "row_count": 0,
+            "group_count": 0,
+            "groups": [],
+            "truncated": false,
+        }),
+    }
+}
+
+fn shape_search_result(
+    options: &WorkbenchMcpOptions,
+    target: &str,
+    result: Value,
+) -> Result<Value, WorkbenchToolError> {
+    let matches = result
+        .get("matches")
+        .and_then(Value::as_array)
+        .ok_or_else(|| WorkbenchToolError::new("find result missing matches"))?
+        .iter()
+        .map(|match_| enrich_search_match(options, match_))
+        .collect::<Result<Vec<_>, _>>()?;
+    Ok(json!({
+        "status": "success",
+        "path": target,
+        "match_count": result.get("match_count").cloned().unwrap_or(Value::Null),
+        "matches": matches,
+        "facets": result.get("facets").cloned().unwrap_or_else(|| json!([])),
+        "next_cursor": result.get("next_cursor").cloned().unwrap_or(Value::Null),
+        "truncated": result.get("truncated").cloned().unwrap_or(Value::Bool(false)),
+    }))
+}
+
+/// A match path is `<root>/<workbench_id>[/...]`: the first segment below the
+/// root names the workbench and the rest is scoped like enumeration output.
+fn enrich_search_match(
+    options: &WorkbenchMcpOptions,
+    match_: &Value,
+) -> Result<Value, WorkbenchToolError> {
+    let path = match_
+        .get("path")
+        .and_then(Value::as_str)
+        .ok_or_else(|| WorkbenchToolError::new("find match missing path"))?;
+    let prefix = format!("{}/", options.root);
+    let Some(rest) = path.strip_prefix(&prefix) else {
+        // The root itself can satisfy a predicate; it has no workbench
+        // coordinates to enrich with.
+        return Ok(json!({
+            "workbench_id": Value::Null,
+            "path": path,
+            "section": Value::Null,
+            "relative_path": Value::Null,
+            "values": match_.get("values").cloned().unwrap_or(Value::Null),
+        }));
+    };
+    let workbench_id = rest.split('/').next().unwrap_or(rest);
+    let scope = enumerated_path_scope(options, workbench_id, path)?;
+    Ok(json!({
+        "workbench_id": workbench_id,
+        "path": scope.path,
+        "section": scope.section,
+        "relative_path": scope.relative_path,
+        "values": match_.get("values").cloned().unwrap_or(Value::Null),
     }))
 }
 
@@ -1283,6 +1806,15 @@ fn optional_bool(args: &Value, name: &'static str) -> Result<Option<bool>, Workb
         None | Some(Value::Null) => Ok(None),
         Some(value) => value.as_bool().map(Some).ok_or_else(|| {
             WorkbenchToolError::new(format!("{name} must be a boolean when provided"))
+        }),
+    }
+}
+
+fn optional_u64(args: &Value, name: &'static str) -> Result<Option<u64>, WorkbenchToolError> {
+    match args.get(name) {
+        None | Some(Value::Null) => Ok(None),
+        Some(value) => value.as_u64().map(Some).ok_or_else(|| {
+            WorkbenchToolError::new(format!("{name} must be an integer when provided"))
         }),
     }
 }

--- a/crates/nokv/src/bin/nokv/workbench_mcp.rs
+++ b/crates/nokv/src/bin/nokv/workbench_mcp.rs
@@ -18,10 +18,14 @@ const DEFAULT_WORKBENCH_FIND_LIMIT: usize = 50;
 const MAX_WORKBENCH_FIND_LIMIT: usize = 100;
 // Schema-declared caps mirroring the agent tool limits (nokv-agent lib.rs);
 // the agent layer enforces them, these keep the advertised schemas honest.
+const MAX_WORKBENCH_LIST_LIMIT: usize = 100;
 const MAX_WORKBENCH_SEARCH_LIMIT: usize = 10;
 const MAX_WORKBENCH_AGGREGATE_LIMIT: usize = 100;
 const MAX_WORKBENCH_READ_LIMIT: usize = 300;
 const MAX_WORKBENCH_GREP_LIMIT: usize = 300;
+/// Mirror of the metadata server's grep pattern cap (nokv-meta
+/// MAX_GREP_PATTERNS); enforced there, advertised and pre-checked here.
+const MAX_WORKBENCH_GREP_PATTERNS: usize = 16;
 /// Retries after a lost artifact-write CAS; every attempt re-reads current state.
 const WRITE_CONFLICT_RETRIES: usize = 5;
 /// Linear backoff step between conflict retries. Zero-interval retries make N
@@ -34,6 +38,15 @@ const WRITE_CONFLICT_BACKOFF_STEP_MS: u64 = 10;
 /// Linear `attempt * 10ms` backoff plus a 0-8ms desync offset derived from the
 /// process id and the current clock nanoseconds, so two workbench processes
 /// that lost the same race do not wake in lockstep (no rand dependency).
+/// Wrap a write conflict that survived the whole retry budget into an
+/// actionable error: the caller learns the write is safe to re-issue while
+/// the original error text stays available for diagnosis.
+fn write_conflict_exhausted(attempts: usize, err: impl fmt::Display) -> WorkbenchToolError {
+    WorkbenchToolError::new(format!(
+        "write conflicted with concurrent writers after {attempts} attempts; retry the call ({err})"
+    ))
+}
+
 fn write_conflict_backoff(attempt: usize) {
     let jitter_ms = SystemTime::now()
         .duration_since(UNIX_EPOCH)
@@ -122,7 +135,7 @@ pub fn tool_definitions() -> Vec<AgentToolDefinition> {
         AgentToolDefinition {
             name: "workbench_append",
             description:
-                "Append bytes to the end of one workbench file, creating it when missing. Safe under concurrent writers: conflicting appends are retried automatically. After an append, stat digest_uri describes the appended delta manifest, not the full content sha256.",
+                "Append bytes to the end of one workbench file, creating it when missing. Safe under concurrent writers: conflicting appends are retried automatically. After an append, stat digest_uri describes the appended delta bytes, not the full content sha256.",
             parameters: json!({
                 "type": "object",
                 "required": ["id", "section", "path"],
@@ -167,7 +180,7 @@ pub fn tool_definitions() -> Vec<AgentToolDefinition> {
                     "section": {"type": ["string", "null"], "enum": ["input", "scripts", "outputs", "logs", "metadata", null]},
                     "path": {"type": ["string", "null"], "description": "Optional path relative to section. Do not prefix it with the section name."},
                     "cursor": {"type": ["string", "null"]},
-                    "limit": {"type": "integer", "minimum": 1}
+                    "limit": {"type": "integer", "minimum": 1, "maximum": MAX_WORKBENCH_LIST_LIMIT}
                 },
                 "additionalProperties": false
             }),
@@ -200,9 +213,9 @@ pub fn tool_definitions() -> Vec<AgentToolDefinition> {
                     "path": {"type": "string", "description": "Path relative to section. Do not prefix it with the section name."},
                     "format": {"type": "string", "enum": ["structured", "bytes"]},
                     "cursor": {"type": ["string", "null"]},
-                    "offset": {"type": "integer", "minimum": 0},
+                    "offset": {"type": "integer", "minimum": 0, "description": "Start offset for the read; ignored when cursor is set."},
                     "limit": {"type": "integer", "minimum": 1, "maximum": MAX_WORKBENCH_READ_LIMIT},
-                    "if_none_match": {"type": "integer", "minimum": 0, "description": "Generation from a previous response. When it still matches, only not_modified and generation are returned."}
+                    "if_none_match": {"type": "integer", "minimum": 0, "description": "Generation from a previous response. When it still matches, the file body is skipped and the response carries not_modified=true plus the unchanged generation."}
                 },
                 "additionalProperties": false
             }),
@@ -210,7 +223,7 @@ pub fn tool_definitions() -> Vec<AgentToolDefinition> {
         AgentToolDefinition {
             name: "workbench_grep",
             description:
-                "Search workbench file bodies for case-insensitive literal substrings. This is not regex grep. patterns adds OR alternatives; when patterns is omitted and pattern contains '|', pattern is split on '|' into OR alternatives (empty segments dropped). glob filters file basenames with * and ?. Matches in files written outside the standard sections by other NoKV clients are returned with section null; such files cannot be addressed by the other workbench tools.",
+                "Search workbench file bodies for case-insensitive literal substrings. This is not regex grep. patterns adds OR alternatives (at most 16); when patterns is omitted and pattern contains '|', pattern is split on '|' into OR alternatives (empty segments dropped, same 16-alternative cap). glob filters file basenames with * and ?. Matches in files written outside the standard sections by other NoKV clients are returned with section null; such files cannot be addressed by the other workbench tools.",
             parameters: json!({
                 "type": "object",
                 "required": ["id", "pattern", "recursive"],
@@ -219,7 +232,7 @@ pub fn tool_definitions() -> Vec<AgentToolDefinition> {
                     "section": {"type": ["string", "null"], "enum": ["input", "scripts", "outputs", "logs", "metadata", null]},
                     "path": {"type": ["string", "null"], "description": "Optional path relative to section. Do not prefix it with the section name."},
                     "pattern": {"type": "string"},
-                    "patterns": {"type": "array", "items": {"type": "string"}},
+                    "patterns": {"type": "array", "items": {"type": "string"}, "maxItems": MAX_WORKBENCH_GREP_PATTERNS},
                     "glob": {"type": ["string", "null"], "description": "Basename filter supporting * and ?."},
                     "recursive": {"type": "boolean"},
                     "cursor": {"type": ["string", "null"]},
@@ -231,7 +244,7 @@ pub fn tool_definitions() -> Vec<AgentToolDefinition> {
         AgentToolDefinition {
             name: "workbench_search",
             description:
-                "Query workbench paths by metadata with catalog field predicates, sort, projections, and facets. Omit id to search across every workbench under the root. Complements workbench_find, which discovers workbenches by their committed manifest; use workbench_grep for file content search.",
+                "Query workbench paths by metadata with catalog field predicates, sort, projections, and facets. Omit id to search across every workbench under the root. Complements workbench_find, which discovers workbenches by their committed manifest; use workbench_grep for file content search. Directories created under the root by other NoKV clients appear with their directory name as workbench_id; such entries cannot be addressed by the other workbench tools.",
             parameters: json!({
                 "type": "object",
                 "properties": {
@@ -530,6 +543,9 @@ where
                 attempts += 1;
                 write_conflict_backoff(attempts);
             }
+            Err(err) if is_artifact_write_conflict(&err) => {
+                return Err(write_conflict_exhausted(attempts + 1, err))
+            }
             Err(err) => return Err(client_error(err)),
         }
     };
@@ -603,6 +619,22 @@ where
         } else {
             text.replacen(old_string, new_string, 1)
         };
+        if new_text == text {
+            // A byte-identical replacement publishing a new generation would
+            // invalidate if_none_match caches and CAS pins for nothing;
+            // report success at the current state instead.
+            return Ok(json!({
+                "status": "success",
+                "workbench_id": id,
+                "section": section,
+                "relative_path": rel_path,
+                "path": path,
+                "replacements": replacements,
+                "size_bytes": entry.attr.size,
+                "generation": entry.attr.generation,
+                "no_change": true,
+            }));
+        }
         let new_bytes = new_text.into_bytes();
         if new_bytes.len() > options.max_bytes {
             return Err(WorkbenchToolError::new(format!(
@@ -625,6 +657,9 @@ where
                 attempts += 1;
                 write_conflict_backoff(attempts);
             }
+            Err(err) if is_artifact_write_conflict(&err) => {
+                return Err(write_conflict_exhausted(attempts + 1, err))
+            }
             Err(err) => return Err(client_error(err)),
         }
     };
@@ -638,6 +673,7 @@ where
         "replacements": replacements,
         "size_bytes": result.entry.attr.size,
         "generation": result.entry.attr.generation,
+        "no_change": false,
     }))
 }
 
@@ -661,12 +697,14 @@ where
     };
     if read_tool == "read" {
         if let Some(expected) = optional_u64(args, "if_none_match")? {
-            let metadata = client
-                .metadata()
-                .stat_path(&target)
-                .map_err(client_error)?
+            // A missing ancestor and a missing leaf are the same absence to
+            // the caller; fold both into one not-found message.
+            let metadata = stat_path_or_absent(client, &target)?
                 .ok_or_else(|| WorkbenchToolError::new(format!("path not found: {target}")))?;
-            if metadata.attr.generation == expected {
+            // Only a file body can be conditionally skipped. Anything else
+            // falls through to the main read path so a directory fails with
+            // the same error an unconditional read reports.
+            if metadata.attr.file_type == FileType::File && metadata.attr.generation == expected {
                 let scope = path_scope(options, &id, &target)?;
                 return Ok(json!({
                     "status": "success",
@@ -703,7 +741,7 @@ where
         "grep" => {
             forwarded.remove("format");
             forwarded.remove("offset");
-            split_piped_grep_pattern(&mut forwarded);
+            split_piped_grep_pattern(&mut forwarded)?;
         }
         _ => {}
     }
@@ -714,29 +752,40 @@ where
 
 /// `pattern: "a|b"` without an explicit `patterns` array is treated as OR
 /// alternatives, matching what agents expect from grep pipes. Empty segments
-/// are dropped; a pattern of only pipes stays a literal search.
-fn split_piped_grep_pattern(forwarded: &mut serde_json::Map<String, Value>) {
+/// are dropped; a pattern of only pipes stays a literal search. More
+/// alternatives than the server accepts fail here with an actionable error
+/// instead of the server's opaque `patterns` cap message.
+fn split_piped_grep_pattern(
+    forwarded: &mut serde_json::Map<String, Value>,
+) -> Result<(), WorkbenchToolError> {
     let has_patterns = forwarded
         .get("patterns")
         .and_then(Value::as_array)
         .is_some_and(|patterns| !patterns.is_empty());
     if has_patterns {
-        return;
+        return Ok(());
     }
     let Some(pattern) = forwarded.get("pattern").and_then(Value::as_str) else {
-        return;
+        return Ok(());
     };
     if !pattern.contains('|') {
-        return;
+        return Ok(());
     }
     let alternatives = pattern
         .split('|')
         .filter(|part| !part.is_empty())
         .map(|part| Value::String(part.to_owned()))
         .collect::<Vec<_>>();
+    if alternatives.len() > MAX_WORKBENCH_GREP_PATTERNS {
+        return Err(WorkbenchToolError::new(format!(
+            "pattern contains {} '|'-separated alternatives; at most {MAX_WORKBENCH_GREP_PATTERNS} are supported",
+            alternatives.len()
+        )));
+    }
     if !alternatives.is_empty() {
         forwarded.insert("patterns".to_owned(), Value::Array(alternatives));
     }
+    Ok(())
 }
 
 fn shape_read_tool_result<O>(
@@ -935,7 +984,7 @@ where
     // A root that no workbench has materialized yet is an empty result for
     // cross-workbench queries, not an error.
     if id.is_none()
-        && matches!(query_tool, "find" | "aggregate")
+        && matches!(query_tool, "find" | "aggregate" | "catalog")
         && stat_path_or_absent(client, &options.root)?.is_none()
     {
         return Ok(empty_query_result(query_tool, &options.root));
@@ -975,6 +1024,20 @@ fn empty_query_result(query_tool: &str, root: &str) -> Value {
             "facets": [],
             "next_cursor": Value::Null,
             "truncated": false,
+        }),
+        // Field-level mirror of the agent catalog output (nokv-agent
+        // execute_catalog) for a root with no fields to discover.
+        "catalog" => json!({
+            "status": "success",
+            "path": root,
+            "catalog_empty": true,
+            "catalog": {
+                "filterable": [],
+                "sortable": [],
+                "facetable": [],
+                "facets": [],
+            },
+            "child_catalogs": [],
         }),
         _ => json!({
             "status": "success",
@@ -1927,6 +1990,62 @@ mod tests {
         assert!(validate_workbench_id("spedas-task-001").is_ok());
         assert!(validate_workbench_id("_bad").is_err());
         assert!(validate_workbench_id("bad/path").is_err());
+    }
+
+    #[test]
+    fn write_conflict_exhausted_keeps_inner_error_and_retry_guidance() {
+        let message = write_conflict_exhausted(6, "metadata predicate failed").to_string();
+        assert!(
+            message.contains("conflicted with concurrent writers after 6 attempts; retry the call"),
+            "message: {message}"
+        );
+        assert!(
+            message.contains("metadata predicate failed"),
+            "message: {message}"
+        );
+    }
+
+    #[test]
+    fn split_piped_grep_pattern_enforces_alternative_cap() {
+        let forwarded_for = |pattern: String| {
+            let mut map = serde_json::Map::new();
+            map.insert("pattern".to_owned(), Value::String(pattern));
+            map
+        };
+        let join = |count: usize| {
+            (0..count)
+                .map(|index| format!("alt-{index}"))
+                .collect::<Vec<_>>()
+                .join("|")
+        };
+
+        let mut sixteen = forwarded_for(join(16));
+        split_piped_grep_pattern(&mut sixteen).unwrap();
+        assert_eq!(sixteen["patterns"].as_array().unwrap().len(), 16);
+
+        let mut seventeen = forwarded_for(join(17));
+        let error = split_piped_grep_pattern(&mut seventeen)
+            .unwrap_err()
+            .to_string();
+        assert!(
+            error.contains(
+                "pattern contains 17 '|'-separated alternatives; at most 16 are supported"
+            ),
+            "error: {error}"
+        );
+    }
+
+    #[test]
+    fn empty_catalog_result_mirrors_agent_catalog_shape() {
+        let result = empty_query_result("catalog", "/workbenches");
+        assert_eq!(result["status"], "success");
+        assert_eq!(result["path"], "/workbenches");
+        assert_eq!(result["catalog_empty"], true);
+        assert_eq!(result["catalog"]["filterable"], json!([]));
+        assert_eq!(result["catalog"]["sortable"], json!([]));
+        assert_eq!(result["catalog"]["facetable"], json!([]));
+        assert_eq!(result["catalog"]["facets"], json!([]));
+        assert_eq!(result["child_catalogs"], json!([]));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Specializes the workbench MCP tool surface for what agents actually do, grounded in two real LingTai user traces (50k+ tool calls across 33/49 days of production agent life): 92.7% of real grep patterns are literal alternations (often CJK), edits outnumber whole-file writes, 66% of reads are re-reads of unchanged files, and every cross-workbench lookup was hand-rolled bash over raw logs. The tool surface grows from 9 to 14 workbench tools.

## What changed

**workbench_grep**
- `patterns` array with additive OR semantics (union with `pattern`), single `pattern` containing `|` auto-splits into alternatives
- `glob` basename filter (`*`/`?`, CJK-safe); filtered files are never read server-side
- match limit raised 100 -> 300 (real traces requested >100 in 31% of calls)
- Wire: the grep DTO gains `#[serde(default)]` fields under the existing map-encoded protocol; `pattern` stays populated so old servers degrade to today's literal behavior

**workbench_search / workbench_aggregate / workbench_catalog** (new)
- Namespace query verbs (predicates, sort, projection, facets, group_by aggregation, field discovery) through the workbench jail
- Omit `id` to query across every workbench under the root; matches are enriched with `workbench_id` / `section` / `relative_path`
- One RPC replaces the N+1 manifest sweep: measured 19x faster than the equivalent find+list+stat loop in live e2e
- Never-written multi-level roots (the per-agent default) return empty results instead of raw not-found errors

**workbench_append** (new)
- Delta append on the existing staged-session publish path: chunk reuse via `base_generation`, no new RPC op, O(delta) bytes per call
- Creates the file if missing; generation-CAS with five retries plus backoff/jitter; a compaction/publish race surfacing `MissingBodyDescriptor` is classified as a retryable write conflict (two concurrent writers x10 appends keep all 20 lines, held over 40 consecutive test runs)
- Retires the hand-numbered segmented-log convention from the workbench skill

**workbench_edit** (new)
- `old_string`/`new_string` replacement with error texts aligned to LingTai's local edit tool, generation-CAS optimistic concurrency with bounded retries

**workbench_read**
- `if_none_match` conditional read: unchanged files return a ~300-byte `not_modified` response (73% byte reduction measured on the polling pattern that dominates real traces)
- structured reads honor `offset` when no cursor is given; record limit raised to 300; the large-file guard message now points at usable escapes; bytes mode returns base64 instead of a JSON integer array

## Validation

- `cargo fmt --all -- --check`, `cargo clippy --workspace --all-targets -- -D warnings` clean
- `cargo test --workspace`: 764 tests green (25 suites)
- Live full-stack e2e: RustFS (docker) + `nokv serve` + workbench MCP over stdio, driven through lingtai-kernel's real MCP loading path (`_load_mcp_from_workdir` -> placeholder expansion -> `connect_mcp`): all 14 tools visible to the agent, six scenario suites (SPEDAS-shaped workflow, CJK grep, conditional-read polling, cross-workbench queries, concurrent appends, boundary probing), 166 calls with no call above 500ms
- MCP e2e tests moved onto a shared in-process server to stop per-test thread exhaustion

## Notes

- The MCP envelope still double-sends payloads (`content[0].text` + `structuredContent`); pre-existing behavior, left for a separate cleanup
- Test infrastructure leaks one temp meta dir per in-process server run (no server shutdown handle); pre-existing, worth a follow-up issue
- Companion skill update for lingtai-kernel (SKILL.md v0.2.0 documenting the new tools) rides on Lingtai-AI/lingtai-kernel#637
