### PR TITLE
docs: relax nokv-agent review guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,10 +30,6 @@ Check for:
   `nokv-client`, `nokv-fuse`, docs, and example files.
 - Missing DCO `Signed-off-by` trailers.
 - Package-boundary violations.
-- `nokv-agent` depending on `nokv-client`, `nokv-protocol`, or `nokv-control`:
-  the agent tool surface stays transport-free, and the embedded
-  `impl AgentNamespace for NoKvFs` lives in `nokv-agent` so `nokv-meta` gains no
-  reverse dependency on it.
 - New helpers that reimplement standard library or existing repository helpers.
 - Misuse of `utils/` for domain-specific or single-use code.
 - Misplaced errors, metrics, stats, validation, recovery, or encoding code.


### PR DESCRIPTION
## Summary
- remove the hard AGENTS.md review rule that flags nokv-agent dependencies on nokv-client, nokv-protocol, or nokv-control
- keep the general package-boundary review guidance as the source of truth

## Rationale
LingTai and future external store integration paths may legitimately require nokv-agent to use those crates. Review guidance should evaluate concrete boundary violations against docs/development/code_contract.md instead of enforcing a categorical transport-free ban.

## Validation
- git diff --check -- AGENTS.md
- rg -n "transport-free|AgentNamespace|nokv-agent.*nokv-client|nokv-client.*nokv-agent|nokv-protocol.*nokv-agent|nokv-control.*nokv-agent" AGENTS.md || true