### PR TITLE
fix(snapshot): enforce root-bound retained history

### DIFF
--- a/crates/nokv-client/src/file_client.rs
+++ b/crates/nokv-client/src/file_client.rs
@@ -366,19 +366,26 @@ where
         self.read_entry(path, &entry, 0, file_len(entry.attr.size)?)
     }
 
-    pub fn cat_snapshot(&self, snapshot_id: u64, path: &str) -> Result<Vec<u8>, ClientError> {
-        self.metadata.read_artifact_at_snapshot(snapshot_id, path)
+    pub fn cat_snapshot(
+        &self,
+        root_path: &str,
+        snapshot_id: u64,
+        path: &str,
+    ) -> Result<Vec<u8>, ClientError> {
+        self.metadata
+            .read_artifact_at_snapshot(root_path, snapshot_id, path)
     }
 
     pub fn read_snapshot(
         &self,
+        root_path: &str,
         snapshot_id: u64,
         path: &str,
         offset: u64,
         len: usize,
     ) -> Result<Vec<u8>, ClientError> {
         self.metadata
-            .read_file_path_at_snapshot(snapshot_id, path, offset, len)
+            .read_file_path_at_snapshot(root_path, snapshot_id, path, offset, len)
     }
 
     pub fn read(&self, path: &str, offset: u64, len: usize) -> Result<Vec<u8>, ClientError> {

--- a/crates/nokv-client/src/lib.rs
+++ b/crates/nokv-client/src/lib.rs
@@ -30,9 +30,11 @@ pub use file_client::{
     PreparedPathRangeBatch,
 };
 pub use nokv_object::{DataFabricReadStats, ObjectReadPlan};
+pub use nokv_protocol::{decode_name_cursor, encode_name_cursor};
 pub use service::{
-    ClientPreparedArtifact, CloneOutcome, MetadataClient, MetadataClientOptions, PathLayoutOpen,
-    PathLayoutOpenRequest, SnapshotOutcome,
+    ClientPreparedArtifact, ClientPreparedArtifactRecovery, CloneOutcome, MetadataClient,
+    MetadataClientOptions, PathLayoutOpen, PathLayoutOpenRequest, SnapshotOutcome,
+    SnapshotPinStatus,
 };
 
 #[derive(Clone, Debug, PartialEq, Eq)]

--- a/crates/nokv-client/src/service.rs
+++ b/crates/nokv-client/src/service.rs
@@ -18,7 +18,7 @@ use nokv_meta::{
     NamespaceReadItem, NamespaceReadOptions, NamespaceReadPage, NamespaceRecordCount,
     NamespaceRecordType, NamespaceSchema, NamespaceSort, NamespaceSortDirection,
     NamespaceSortField, PublishArtifactStagedSession, RecordCountProvenance, RenameReplaceResult,
-    SubtreeDelta, UpdateAttr, XattrSetMode,
+    SnapshotRenewOutcome, SubtreeDelta, UpdateAttr, XattrSetMode,
 };
 use nokv_object::ObjectReadPlan;
 use nokv_protocol::{
@@ -38,6 +38,7 @@ use nokv_protocol::{
     WireNamespaceReadOptions, WireNamespaceReadPage, WireNamespaceRecordCount,
     WireNamespaceRecordType, WireNamespaceSchema, WireNamespaceSort, WireNamespaceSortDirection,
     WireNamespaceSortField, WireOpenPathReadPlanRequest, WireRecordCountProvenance,
+    WireSnapshotRenewOutcome,
 };
 use nokv_types::{
     AdvisoryLock, AdvisoryLockRequest, BodyDescriptor, ChunkManifest, DentryName, FileType,
@@ -54,6 +55,13 @@ use crate::wire::*;
 
 const DEFAULT_RPC_TIMEOUT: Duration = Duration::from_secs(10);
 const MAX_BATCH_RPC_REQUESTS: usize = 128;
+
+fn snapshot_inode_api_disabled() -> ClientError {
+    ClientError::Protocol(
+        "inode-addressed snapshot reads are disabled; use a root-bound snapshot path API"
+            .to_owned(),
+    )
+}
 
 /// Bound for re-resolve+retry in fleet mode: enough attempts to ride out a
 /// single owner handoff (old owner -> control update -> new owner) without
@@ -111,6 +119,43 @@ pub struct ClientPreparedArtifact {
     pub old_generation: Option<u64>,
 }
 
+/// Stable reconstruction fields persisted by clients that journal a prepared
+/// artifact outside `nokv-client`. Future publish-fencing fields belong on
+/// [`ClientPreparedArtifact`] so external journals can adopt them explicitly
+/// without breaking compilation in the protocol change that introduces them.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ClientPreparedArtifactRecovery {
+    pub mount: u64,
+    pub parent: InodeId,
+    pub name: DentryName,
+    pub path: Option<String>,
+    pub inode: InodeId,
+    pub generation: u64,
+    pub mtime_ms: u64,
+    pub ctime_ms: u64,
+    pub replace: bool,
+    pub dentry_version: Option<u64>,
+    pub old_generation: Option<u64>,
+}
+
+impl ClientPreparedArtifact {
+    pub fn from_recovery(recovery: ClientPreparedArtifactRecovery) -> Self {
+        Self {
+            mount: recovery.mount,
+            parent: recovery.parent,
+            name: recovery.name,
+            path: recovery.path,
+            inode: recovery.inode,
+            generation: recovery.generation,
+            mtime_ms: recovery.mtime_ms,
+            ctime_ms: recovery.ctime_ms,
+            replace: recovery.replace,
+            dentry_version: recovery.dentry_version,
+            old_generation: recovery.old_generation,
+        }
+    }
+}
+
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct ClientCreatedPreparedArtifact {
     pub entry: DentryWithAttr,
@@ -155,6 +200,12 @@ pub struct SnapshotOutcome {
     pub snapshot_id: u64,
     pub read_version: u64,
     pub lease_expires_unix_ms: u64,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct SnapshotPinStatus {
+    pub pin: Option<SnapshotPin>,
+    pub server_now_ms: u64,
 }
 
 const DEFAULT_LIST_PAGE_SIZE: usize = 1024;
@@ -262,14 +313,26 @@ impl MetadataClient {
         }
     }
 
+    /// Temporary fail-closed bridge for the stacked FUSE snapshot adapter.
+    /// The root-bound adapter removes this inode-addressed API.
     pub fn get_attr_at_snapshot(
         &self,
+        _snapshot_id: u64,
+        _inode: InodeId,
+    ) -> Result<Option<InodeAttr>, ClientError> {
+        Err(snapshot_inode_api_disabled())
+    }
+
+    pub fn get_attr_at_snapshot_rooted(
+        &self,
+        root_path: &str,
         snapshot_id: u64,
-        inode: InodeId,
+        path_components: &[DentryName],
     ) -> Result<Option<InodeAttr>, ClientError> {
         match self.call(MetadataRpcRequest::GetAttrAtSnapshot {
+            root_path: root_path.to_owned(),
             snapshot_id,
-            inode: inode.get(),
+            path_components: rpc_components(path_components)?,
         })? {
             MetadataRpcResult::InodeAttr { attr } => attr
                 .map(|attr| attr.into_inode_attr().map_err(protocol_error))
@@ -308,15 +371,28 @@ impl MetadataClient {
         }
     }
 
+    /// Temporary fail-closed bridge for the stacked FUSE snapshot adapter.
+    /// The root-bound adapter removes this inode-addressed API.
     pub fn lookup_plus_at_snapshot(
         &self,
+        _snapshot_id: u64,
+        _parent: InodeId,
+        _name: DentryName,
+    ) -> Result<Option<DentryWithAttr>, ClientError> {
+        Err(snapshot_inode_api_disabled())
+    }
+
+    pub fn lookup_plus_at_snapshot_rooted(
+        &self,
+        root_path: &str,
         snapshot_id: u64,
-        parent: InodeId,
+        parent_components: &[DentryName],
         name: DentryName,
     ) -> Result<Option<DentryWithAttr>, ClientError> {
         match self.call(MetadataRpcRequest::LookupPlusAtSnapshot {
+            root_path: root_path.to_owned(),
             snapshot_id,
-            parent: parent.get(),
+            parent_components: rpc_components(parent_components)?,
             name: rpc_name(&name)?,
         })? {
             MetadataRpcResult::Dentry { entry } => {
@@ -355,14 +431,26 @@ impl MetadataClient {
         }
     }
 
+    /// Temporary fail-closed bridge for the stacked FUSE snapshot adapter.
+    /// The root-bound adapter removes this inode-addressed API.
     pub fn read_dir_plus_at_snapshot(
         &self,
+        _snapshot_id: u64,
+        _inode: InodeId,
+    ) -> Result<Vec<DentryWithAttr>, ClientError> {
+        Err(snapshot_inode_api_disabled())
+    }
+
+    pub fn read_dir_plus_at_snapshot_rooted(
+        &self,
+        root_path: &str,
         snapshot_id: u64,
-        parent: InodeId,
+        path_components: &[DentryName],
     ) -> Result<Vec<DentryWithAttr>, ClientError> {
         match self.call(MetadataRpcRequest::ReadDirPlusAtSnapshot {
+            root_path: root_path.to_owned(),
             snapshot_id,
-            parent: parent.get(),
+            path_components: rpc_components(path_components)?,
         })? {
             MetadataRpcResult::Dentries { entries } => {
                 entries.into_iter().map(wire_dentry).collect()
@@ -1210,10 +1298,12 @@ impl MetadataClient {
 
     pub fn stat_path_at_snapshot(
         &self,
+        root_path: &str,
         snapshot_id: u64,
         path: &str,
     ) -> Result<Option<PathMetadata>, ClientError> {
         match self.call(MetadataRpcRequest::StatPathAtSnapshot {
+            root_path: root_path.to_owned(),
             snapshot_id,
             path: path.to_owned(),
         })? {
@@ -1226,16 +1316,51 @@ impl MetadataClient {
 
     pub fn list_path_at_snapshot(
         &self,
+        root_path: &str,
         snapshot_id: u64,
         path: &str,
     ) -> Result<Vec<DentryWithAttr>, ClientError> {
         match self.call(MetadataRpcRequest::ReadDirPlusPathAtSnapshot {
+            root_path: root_path.to_owned(),
             snapshot_id,
             path: path.to_owned(),
         })? {
             MetadataRpcResult::Dentries { entries } => {
                 entries.into_iter().map(wire_dentry).collect()
             }
+            other => Err(unexpected_result(other)),
+        }
+    }
+
+    pub fn list_path_at_snapshot_page(
+        &self,
+        root_path: &str,
+        snapshot_id: u64,
+        path: &str,
+        after: Option<&DentryName>,
+        limit: usize,
+    ) -> Result<ClientReadDirPlusPage, ClientError> {
+        match self.call(MetadataRpcRequest::ReadDirPlusPathAtSnapshotPage {
+            root_path: root_path.to_owned(),
+            snapshot_id,
+            path: path.to_owned(),
+            after_name_hex: after.map(encode_name_cursor),
+            limit,
+        })? {
+            MetadataRpcResult::DentriesPage {
+                entries,
+                next_name_hex,
+            } => Ok(ClientReadDirPlusPage {
+                entries: entries
+                    .into_iter()
+                    .map(wire_dentry)
+                    .collect::<Result<Vec<_>, _>>()?,
+                next_cursor: next_name_hex
+                    .as_deref()
+                    .map(decode_name_cursor)
+                    .transpose()
+                    .map_err(|err| ClientError::Protocol(err.to_string()))?,
+            }),
             other => Err(unexpected_result(other)),
         }
     }
@@ -1420,7 +1545,8 @@ impl MetadataClient {
 
     pub fn snapshot(&self, path: &str) -> Result<SnapshotPin, ClientError> {
         match self.call(MetadataRpcRequest::SnapshotSubtreePath {
-            path: path.to_owned(),
+            root_path: path.to_owned(),
+            lease_ms: nokv_meta::DEFAULT_SNAPSHOT_LEASE_MS,
         })? {
             MetadataRpcResult::Snapshot { snapshot } => wire_snapshot(snapshot),
             other => Err(unexpected_result(other)),
@@ -1455,8 +1581,17 @@ impl MetadataClient {
     }
 
     pub fn snapshot_subtree_path(&self, path: &str) -> Result<SnapshotOutcome, ClientError> {
+        self.snapshot_subtree_path_with_lease(path, nokv_meta::DEFAULT_SNAPSHOT_LEASE_MS)
+    }
+
+    pub fn snapshot_subtree_path_with_lease(
+        &self,
+        path: &str,
+        lease_ms: u64,
+    ) -> Result<SnapshotOutcome, ClientError> {
         match self.call(MetadataRpcRequest::SnapshotSubtreePath {
-            path: path.to_owned(),
+            root_path: path.to_owned(),
+            lease_ms,
         })? {
             // The wire response already carries the pin's lease; surface it so
             // callers can renew before it expires (do not drop it to 0).
@@ -1479,33 +1614,66 @@ impl MetadataClient {
         }
     }
 
-    pub fn snapshot_subtree(&self, root: InodeId) -> Result<SnapshotPin, ClientError> {
-        match self.call(MetadataRpcRequest::SnapshotSubtree { root: root.get() })? {
-            MetadataRpcResult::Snapshot { snapshot } => wire_snapshot(snapshot),
+    pub fn snapshot_pin(
+        &self,
+        root_path: &str,
+        snapshot_id: u64,
+    ) -> Result<Option<SnapshotPin>, ClientError> {
+        Ok(self.snapshot_pin_status(root_path, snapshot_id)?.pin)
+    }
+
+    pub fn snapshot_pin_status(
+        &self,
+        root_path: &str,
+        snapshot_id: u64,
+    ) -> Result<SnapshotPinStatus, ClientError> {
+        match self.call(MetadataRpcRequest::SnapshotPin {
+            root_path: root_path.to_owned(),
+            snapshot_id,
+        })? {
+            MetadataRpcResult::SnapshotPin {
+                snapshot,
+                server_now_ms,
+            } => Ok(SnapshotPinStatus {
+                pin: snapshot.map(wire_snapshot).transpose()?,
+                server_now_ms,
+            }),
             other => Err(unexpected_result(other)),
         }
     }
 
-    pub fn snapshot_pin(&self, snapshot_id: u64) -> Result<Option<SnapshotPin>, ClientError> {
-        match self.call(MetadataRpcRequest::SnapshotPin { snapshot_id })? {
-            MetadataRpcResult::SnapshotPin { snapshot } => snapshot.map(wire_snapshot).transpose(),
-            other => Err(unexpected_result(other)),
-        }
-    }
-
-    pub fn retire_snapshot(&self, snapshot_id: u64) -> Result<bool, ClientError> {
-        match self.call(MetadataRpcRequest::RetireSnapshot { snapshot_id })? {
+    pub fn retire_snapshot(&self, root_path: &str, snapshot_id: u64) -> Result<bool, ClientError> {
+        match self.call(MetadataRpcRequest::RetireSnapshot {
+            root_path: root_path.to_owned(),
+            snapshot_id,
+        })? {
             MetadataRpcResult::RetiredSnapshot { retired } => Ok(retired),
             other => Err(unexpected_result(other)),
         }
     }
 
-    pub fn renew_snapshot(&self, snapshot_id: u64, lease_ms: u64) -> Result<bool, ClientError> {
+    pub fn renew_snapshot(
+        &self,
+        root_path: &str,
+        snapshot_id: u64,
+        lease_ms: u64,
+    ) -> Result<SnapshotRenewOutcome, ClientError> {
         match self.call(MetadataRpcRequest::RenewSnapshot {
+            root_path: root_path.to_owned(),
             snapshot_id,
             lease_ms,
         })? {
-            MetadataRpcResult::RenewedSnapshot { renewed } => Ok(renewed),
+            MetadataRpcResult::RenewedSnapshot { outcome } => match outcome {
+                WireSnapshotRenewOutcome::Renewed { pin, extended } => {
+                    Ok(SnapshotRenewOutcome::Renewed {
+                        pin: wire_snapshot(pin)?,
+                        extended,
+                    })
+                }
+                WireSnapshotRenewOutcome::Missing { snapshot_id } => {
+                    Ok(SnapshotRenewOutcome::Missing { snapshot_id })
+                }
+            },
             other => Err(unexpected_result(other)),
         }
     }
@@ -1702,10 +1870,12 @@ impl MetadataClient {
 
     pub fn read_artifact_at_snapshot(
         &self,
+        root_path: &str,
         snapshot_id: u64,
         path: &str,
     ) -> Result<Vec<u8>, ClientError> {
         match self.call(MetadataRpcRequest::ReadArtifactPathAtSnapshot {
+            root_path: root_path.to_owned(),
             snapshot_id,
             path: path.to_owned(),
         })? {
@@ -1716,6 +1886,7 @@ impl MetadataClient {
 
     pub fn read_file_path_at_snapshot(
         &self,
+        root_path: &str,
         snapshot_id: u64,
         path: &str,
         offset: u64,
@@ -1724,6 +1895,7 @@ impl MetadataClient {
         let len = u64::try_from(len)
             .map_err(|_| ClientError::Protocol("snapshot read length exceeds u64".to_owned()))?;
         match self.call(MetadataRpcRequest::ReadFilePathAtSnapshot {
+            root_path: root_path.to_owned(),
             snapshot_id,
             path: path.to_owned(),
             offset,
@@ -1734,18 +1906,32 @@ impl MetadataClient {
         }
     }
 
+    /// Temporary fail-closed bridge for the stacked FUSE snapshot adapter.
+    /// The root-bound adapter removes this inode-addressed API.
     pub fn read_file_at_snapshot(
         &self,
+        _snapshot_id: u64,
+        _inode: InodeId,
+        _offset: u64,
+        _len: usize,
+    ) -> Result<Vec<u8>, ClientError> {
+        Err(snapshot_inode_api_disabled())
+    }
+
+    pub fn read_file_at_snapshot_rooted(
+        &self,
+        root_path: &str,
         snapshot_id: u64,
-        inode: InodeId,
+        path_components: &[DentryName],
         offset: u64,
         len: usize,
     ) -> Result<Vec<u8>, ClientError> {
         let len = u64::try_from(len)
             .map_err(|_| ClientError::Protocol("snapshot read length exceeds u64".to_owned()))?;
         match self.call(MetadataRpcRequest::ReadFileAtSnapshot {
+            root_path: root_path.to_owned(),
             snapshot_id,
-            inode: inode.get(),
+            path_components: rpc_components(path_components)?,
             offset,
             len,
         })? {
@@ -1761,14 +1947,26 @@ impl MetadataClient {
         }
     }
 
+    /// Temporary fail-closed bridge for the stacked FUSE snapshot adapter.
+    /// The root-bound adapter removes this inode-addressed API.
     pub fn read_symlink_at_snapshot(
         &self,
+        _snapshot_id: u64,
+        _inode: InodeId,
+    ) -> Result<Vec<u8>, ClientError> {
+        Err(snapshot_inode_api_disabled())
+    }
+
+    pub fn read_symlink_at_snapshot_rooted(
+        &self,
+        root_path: &str,
         snapshot_id: u64,
-        inode: InodeId,
+        path_components: &[DentryName],
     ) -> Result<Vec<u8>, ClientError> {
         match self.call(MetadataRpcRequest::ReadSymlinkAtSnapshot {
+            root_path: root_path.to_owned(),
             snapshot_id,
-            inode: inode.get(),
+            path_components: rpc_components(path_components)?,
         })? {
             MetadataRpcResult::FileBytes { bytes } => Ok(bytes),
             other => Err(unexpected_result(other)),

--- a/crates/nokv-client/src/service_tests.rs
+++ b/crates/nokv-client/src/service_tests.rs
@@ -1010,15 +1010,18 @@ fn service_snapshot_cat_uses_snapshot_file_rpc() {
         let request = decode_request(&request).unwrap();
         assert!(matches!(
             request,
-            MetadataRpcRequest::ReadArtifactPathAtSnapshot { snapshot_id, path }
-                if snapshot_id == 9 && path == "/runs/checkpoint"
+            MetadataRpcRequest::ReadArtifactPathAtSnapshot { root_path, snapshot_id, path }
+                if root_path == "/runs" && snapshot_id == 9 && path == "/checkpoint"
         ));
         let response =
             response_body(r#"{"ok":true,"result":{"type":"file_bytes","bytes":[111,108,100]}}"#);
         write_frame(&mut stream, request_id, flags, &response).unwrap();
     });
     let client = NoKvFsClient::connect(addr, MemoryObjectStore::new());
-    assert_eq!(client.cat_snapshot(9, "/runs/checkpoint").unwrap(), b"old");
+    assert_eq!(
+        client.cat_snapshot("/runs", 9, "/checkpoint").unwrap(),
+        b"old"
+    );
 }
 
 #[test]
@@ -1035,8 +1038,8 @@ fn service_snapshot_namespace_methods_use_snapshot_rooted_rpcs() {
         let request = decode_request(&request).unwrap();
         assert!(matches!(
             request,
-            MetadataRpcRequest::StatPathAtSnapshot { snapshot_id, path }
-                if snapshot_id == 9 && path == "/"
+            MetadataRpcRequest::StatPathAtSnapshot { root_path, snapshot_id, path }
+                if root_path == "/runs" && snapshot_id == 9 && path == "/"
         ));
         write_frame(
                 &mut stream,
@@ -1052,8 +1055,8 @@ fn service_snapshot_namespace_methods_use_snapshot_rooted_rpcs() {
         let request = decode_request(&request).unwrap();
         assert!(matches!(
             request,
-            MetadataRpcRequest::ReadDirPlusPathAtSnapshot { snapshot_id, path }
-                if snapshot_id == 9 && path == "/"
+            MetadataRpcRequest::ReadDirPlusPathAtSnapshot { root_path, snapshot_id, path }
+                if root_path == "/runs" && snapshot_id == 9 && path == "/"
         ));
         write_frame(
                 &mut stream,
@@ -1071,10 +1074,11 @@ fn service_snapshot_namespace_methods_use_snapshot_rooted_rpcs() {
             request,
             MetadataRpcRequest::ReadFilePathAtSnapshot {
                 snapshot_id,
+                root_path,
                 path,
                 offset,
                 len
-            } if snapshot_id == 9 && path == "/nested/model.bin" && offset == 7 && len == 3
+            } if root_path == "/runs" && snapshot_id == 9 && path == "/nested/model.bin" && offset == 7 && len == 3
         ));
         write_frame(
             &mut stream,
@@ -1088,17 +1092,65 @@ fn service_snapshot_namespace_methods_use_snapshot_rooted_rpcs() {
     let client = NoKvFsClient::connect(addr, MemoryObjectStore::new());
     let root = client
         .metadata()
-        .stat_path_at_snapshot(9, "/")
+        .stat_path_at_snapshot("/runs", 9, "/")
         .unwrap()
         .unwrap();
     assert_eq!(root.attr.inode.get(), 2);
-    let entries = client.metadata().list_path_at_snapshot(9, "/").unwrap();
+    let entries = client
+        .metadata()
+        .list_path_at_snapshot("/runs", 9, "/")
+        .unwrap();
     assert_eq!(entries.len(), 1);
     assert_eq!(entries[0].dentry.name.as_bytes(), b"nested");
     assert_eq!(
-        client.read_snapshot(9, "/nested/model.bin", 7, 3).unwrap(),
+        client
+            .read_snapshot("/runs", 9, "/nested/model.bin", 7, 3)
+            .unwrap(),
         b"old"
     );
+}
+
+#[test]
+fn service_snapshot_list_page_uses_cursor_rpc() {
+    let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+    let addr = listener.local_addr().unwrap();
+    thread::spawn(move || {
+        let (mut stream, _) = listener.accept().unwrap();
+        let mut magic = [0_u8; FRAMED_RPC_MAGIC.len()];
+        stream.read_exact(&mut magic).unwrap();
+        assert_eq!(&magic, FRAMED_RPC_MAGIC);
+        let (request_id, flags, request) = read_frame(&mut stream).unwrap();
+        let request = decode_request(&request).unwrap();
+        assert!(matches!(
+            request,
+            MetadataRpcRequest::ReadDirPlusPathAtSnapshotPage {
+                root_path,
+                snapshot_id,
+                path,
+                after_name_hex: Some(after),
+                limit,
+            } if root_path == "/workbench" && snapshot_id == 9 && path == "/outputs" && after == "612e747874" && limit == 2
+        ));
+        write_frame(
+            &mut stream,
+            request_id,
+            flags,
+            &response_body(
+                r#"{"ok":true,"result":{"type":"dentries_page","entries":[{"dentry":{"parent":2,"name_hex":"622e747874","child":3,"child_type":"file","attr_generation":3},"attr":{"inode":3,"file_type":"file","mode":420,"uid":1000,"gid":1000,"rdev":0,"nlink":1,"size":1,"generation":3,"mtime_ms":3,"ctime_ms":3},"body":null}],"next_name_hex":"622e747874"}}"#,
+            ),
+        )
+        .unwrap();
+    });
+
+    let client = NoKvFsClient::connect(addr, MemoryObjectStore::new());
+    let after = DentryName::new(b"a.txt".to_vec()).unwrap();
+    let page = client
+        .metadata()
+        .list_path_at_snapshot_page("/workbench", 9, "/outputs", Some(&after), 2)
+        .unwrap();
+    assert_eq!(page.entries.len(), 1);
+    assert_eq!(page.entries[0].dentry.name.as_bytes(), b"b.txt");
+    assert_eq!(page.next_cursor.unwrap().as_bytes(), b"b.txt");
 }
 
 #[test]
@@ -2523,7 +2575,8 @@ fn service_snapshot_subtree_path_sends_typed_rpc_and_maps_outcome() {
         assert_eq!(
             request,
             MetadataRpcRequest::SnapshotSubtreePath {
-                path: "/base".to_owned(),
+                root_path: "/base".to_owned(),
+                lease_ms: nokv_meta::DEFAULT_SNAPSHOT_LEASE_MS,
             }
         );
         response_body(
@@ -2534,6 +2587,33 @@ fn service_snapshot_subtree_path_sends_typed_rpc_and_maps_outcome() {
     let outcome = client.snapshot_subtree_path("/base").unwrap();
     assert_eq!(outcome.snapshot_id, 7);
     assert_eq!(outcome.read_version, 6);
+}
+
+#[test]
+fn service_snapshot_renew_returns_the_authoritative_pin() {
+    let addr = serve_one_request(|request| {
+        assert_eq!(
+            request,
+            MetadataRpcRequest::RenewSnapshot {
+                root_path: "/base".to_owned(),
+                snapshot_id: 7,
+                lease_ms: 60_000,
+            }
+        );
+        response_body(
+            r#"{"ok":true,"result":{"type":"renewed_snapshot","outcome":{"state":"renewed","pin":{"snapshot_id":7,"root":2,"read_version":6,"created_version":7,"lease_expires_unix_ms":61000},"extended":true}}}"#,
+        )
+    });
+    let client = MetadataClient::connect(addr);
+    let outcome = client.renew_snapshot("/base", 7, 60_000).unwrap();
+    match outcome {
+        nokv_meta::SnapshotRenewOutcome::Renewed { pin, extended } => {
+            assert!(extended);
+            assert_eq!(pin.snapshot_id, 7);
+            assert_eq!(pin.lease_expires_unix_ms, 61_000);
+        }
+        other => panic!("unexpected renew outcome: {other:?}"),
+    }
 }
 
 #[test]

--- a/crates/nokv-client/src/wire.rs
+++ b/crates/nokv-client/src/wire.rs
@@ -33,6 +33,10 @@ pub(crate) fn rpc_name(name: &DentryName) -> Result<String, ClientError> {
         .map_err(|_| ClientError::InvalidName("metadata rpc requires utf-8 names".to_owned()))
 }
 
+pub(crate) fn rpc_components(components: &[DentryName]) -> Result<Vec<String>, ClientError> {
+    components.iter().map(rpc_name).collect()
+}
+
 pub(crate) fn update_attr_to_wire(changes: UpdateAttr) -> WireUpdateAttr {
     WireUpdateAttr {
         mode: changes.mode,
@@ -258,6 +262,44 @@ pub(crate) fn client_error_from_wire_error(error: WireMetadataError) -> ClientEr
             dest_shard,
         }),
         WireMetadataError::GraftPoint => ClientError::Metadata(nokv_meta::MetadError::GraftPoint),
+        WireMetadataError::SnapshotLeaseExpired {
+            snapshot_id,
+            lease_expires_unix_ms,
+            now_ms,
+        } => ClientError::Metadata(nokv_meta::MetadError::SnapshotLeaseExpired {
+            snapshot_id,
+            lease_expires_unix_ms,
+            now_ms,
+        }),
+        WireMetadataError::SnapshotRootMismatch {
+            snapshot_id,
+            expected_root,
+            actual_root,
+            actual_shard,
+        } => match (
+            InodeId::new(expected_root),
+            actual_root.map(InodeId::new).transpose(),
+        ) {
+            (Ok(expected_root), Ok(actual_root)) => {
+                ClientError::Metadata(nokv_meta::MetadError::SnapshotRootMismatch {
+                    snapshot_id,
+                    expected_root,
+                    actual_root,
+                    actual_shard,
+                })
+            }
+            _ => ClientError::Protocol("snapshot root error carries an invalid inode".to_owned()),
+        },
+        WireMetadataError::SnapshotBindingChanged { root_path } => {
+            ClientError::Metadata(nokv_meta::MetadError::SnapshotBindingChanged { root_path })
+        }
+        WireMetadataError::SnapshotRenewContended {
+            snapshot_id,
+            attempts,
+        } => ClientError::Metadata(nokv_meta::MetadError::SnapshotRenewContended {
+            snapshot_id,
+            attempts,
+        }),
         WireMetadataError::SyncLogArchiveFailed { committed, message } => {
             ClientError::Metadata(nokv_meta::MetadError::SyncLogArchiveFailed {
                 committed,

--- a/crates/nokv-fuse/src/filesystem/errors.rs
+++ b/crates/nokv-fuse/src/filesystem/errors.rs
@@ -76,6 +76,12 @@ fn metadata_errno(err: &MetadError) -> Errno {
             eprintln!("nokv-fuse: metadata operation failed -> EIO: {err:?}");
             Errno::EIO
         }
+        // Cross-crate metadata errors fail closed until their feature-specific
+        // FUSE adapter defines an intentional POSIX mapping.
+        _ => {
+            eprintln!("nokv-fuse: unsupported metadata error -> EIO: {err:?}");
+            Errno::EIO
+        }
     }
 }
 

--- a/crates/nokv-meta/src/command.rs
+++ b/crates/nokv-meta/src/command.rs
@@ -145,6 +145,10 @@ pub struct MetadataStoreStats {
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct HistoryPruneRequest {
     pub retain_from: Option<Version>,
+    /// Store-local epoch captured around the durable retention-holder scan.
+    /// Prune must reject this request if any holder was added or removed before
+    /// the delete plan is applied.
+    pub retention_epoch: u64,
     pub limit: usize,
 }
 
@@ -305,6 +309,10 @@ pub trait MetadataStore {
         _request_id: &[u8],
     ) -> Result<Option<CommitResult>, MetadataError> {
         Ok(None)
+    }
+
+    fn history_retention_epoch(&self) -> Result<u64, MetadataError> {
+        Ok(0)
     }
 
     fn prune_history(

--- a/crates/nokv-meta/src/gc.rs
+++ b/crates/nokv-meta/src/gc.rs
@@ -9,7 +9,9 @@ use std::thread::{self, JoinHandle};
 use std::time::Duration;
 
 use crate::command::{HistoryPruneOutcome, MetadataStore};
-use crate::service::{NoKvFs, PendingObjectCleanupOutcome, DEFAULT_READ_LEASE_MS};
+use crate::service::{
+    NoKvFs, PendingObjectCleanupOutcome, SnapshotReapOutcome, DEFAULT_READ_LEASE_MS,
+};
 use nokv_object::ObjectStore;
 
 const DEFAULT_INTERVAL: Duration = Duration::from_secs(30);
@@ -27,6 +29,9 @@ pub struct ObjectGcOptions {
 pub struct ObjectGcWorkerState {
     pub iterations: u64,
     pub last_outcome: Option<PendingObjectCleanupOutcome>,
+    /// Process-lifetime totals retained across empty GC iterations so a renew/
+    /// reaper race remains observable after the iteration that detected it.
+    pub snapshot_reap: SnapshotReapOutcome,
     pub last_error: Option<String>,
 }
 
@@ -233,6 +238,7 @@ fn run_once<M, O>(
         state.iterations += 1;
         match result {
             Ok(outcome) => {
+                accumulate_snapshot_reap(&mut state.snapshot_reap, outcome.snapshot_reap);
                 state.last_outcome = Some(outcome);
                 state.last_error = None;
             }
@@ -241,6 +247,15 @@ fn run_once<M, O>(
             }
         }
     }
+}
+
+fn accumulate_snapshot_reap(total: &mut SnapshotReapOutcome, delta: SnapshotReapOutcome) {
+    total.scanned = total.scanned.saturating_add(delta.scanned);
+    total.expired_candidates = total
+        .expired_candidates
+        .saturating_add(delta.expired_candidates);
+    total.reaped = total.reaped.saturating_add(delta.reaped);
+    total.conflicted = total.conflicted.saturating_add(delta.conflicted);
 }
 
 fn run_history_once<M, O>(service: &NoKvFs<M, O>, limit: usize, state: &Mutex<HistoryGcWorkerState>)
@@ -268,6 +283,37 @@ mod tests {
     use super::*;
     use crate::holtstore::HoltMetadataStore;
     use crate::service::PublishArtifact;
+
+    #[test]
+    fn snapshot_reap_worker_totals_survive_later_empty_iterations() {
+        let mut total = SnapshotReapOutcome::default();
+        accumulate_snapshot_reap(
+            &mut total,
+            SnapshotReapOutcome {
+                scanned: 3,
+                expired_candidates: 2,
+                reaped: 1,
+                conflicted: 1,
+            },
+        );
+        accumulate_snapshot_reap(
+            &mut total,
+            SnapshotReapOutcome {
+                scanned: 4,
+                ..SnapshotReapOutcome::default()
+            },
+        );
+
+        assert_eq!(
+            total,
+            SnapshotReapOutcome {
+                scanned: 7,
+                expired_candidates: 2,
+                reaped: 1,
+                conflicted: 1,
+            }
+        );
+    }
     use nokv_object::{MemoryObjectStore, ObjectKey};
     use nokv_types::{DentryName, InodeId, MountId};
     use std::time::Instant;
@@ -465,7 +511,7 @@ mod tests {
         });
         assert_eq!(
             service
-                .read_artifact_at_snapshot(snapshot.snapshot_id, InodeId::root(), &name)
+                .read_artifact_path_at_snapshot("/", snapshot.snapshot_id, "/snapshot-history.bin",)
                 .unwrap(),
             b"old"
         );

--- a/crates/nokv-meta/src/holtstore.rs
+++ b/crates/nokv-meta/src/holtstore.rs
@@ -4,9 +4,10 @@
 //! Holt family trees. It does not own filesystem semantics, object storage,
 //! Raft replication, FUSE, or protobuf types.
 
+use std::collections::{BTreeMap, HashSet};
 use std::path::Path;
 use std::sync::atomic::{AtomicU64, Ordering};
-use std::sync::Arc;
+use std::sync::{Arc, RwLock};
 use std::time::Instant;
 
 use crate::command::{
@@ -15,10 +16,10 @@ use crate::command::{
     MetadataCommand, MetadataError, MetadataStore, MetadataStoreStats, MetadataStoreStatsProvider,
     MutationOp, Predicate, ReadItem, ReadPurpose, ScanItem, ScanRequest, Value, Version,
 };
-use crate::layout::{history_key, history_prefix};
+use crate::layout::{history_index_key, history_index_prefix, history_key, history_prefix};
 use holt::{
-    CheckpointImage, DBAtomicBatch, Error as HoltError, KeyRangeEntryRef, KeyScanOutcome,
-    RangeEntry, RecordVersion,
+    CheckpointImage, DBAtomicBatch, Durability, Error as HoltError, KeyRangeEntryRef,
+    KeyScanOutcome, RangeEntry, RecordVersion,
 };
 use holt::{Tree, TreeConfig, DB};
 use nokv_types::RecordFamily;
@@ -28,11 +29,62 @@ mod families;
 use codec::*;
 use families::*;
 
+const HISTORY_INDEX_COMPLETE_KEY: &[u8] = b"\0history-key-index-v1-complete";
+const HISTORY_INDEX_PROGRESS_KEY: &[u8] = b"\0history-key-index-v1-progress";
+const HISTORY_INDEX_COMPLETE_VALUE: &[u8] = b"1";
+const HISTORY_INDEX_BACKFILL_BATCH_SIZE: usize = 1_024;
+const HISTORY_PRUNE_CONFLICT_RETRIES: usize = 4;
+
 #[derive(Clone)]
 pub struct HoltMetadataStore {
     db: DB,
     stats: Arc<HoltMetadataStoreCounters>,
-    active_snapshot_pins: Arc<AtomicU64>,
+    history_retention: Arc<HistoryRetentionState>,
+}
+
+#[derive(Default)]
+struct HistoryRetentionState {
+    /// Ordinary commands share the read side from planning through durable
+    /// apply. Snapshot pins and fork-base bindings take the write side, making
+    /// their lifetime transition indivisible from the counters used by planners.
+    planning_fence: RwLock<()>,
+    active_snapshot_pins: AtomicU64,
+    active_fork_bindings: AtomicU64,
+    /// Monotonic process-local sequence for durable holder transitions. It is
+    /// protected by `planning_fence` and serves as the seqlock/CAS token for a
+    /// service-computed retention floor.
+    epoch: AtomicU64,
+    /// Highest snapshot-visible commit applied through this live store handle.
+    /// This deliberately starts at zero on open: no pre-open command can still
+    /// hold this handle's planning fence, while the service restores its durable
+    /// version allocator before accepting work. Scanning the unbounded dedupe
+    /// tree at readiness would turn restart latency into O(command history).
+    max_applied_commit_version: AtomicU64,
+    #[cfg(test)]
+    after_retention_apply_before_state: std::sync::Mutex<Option<TestHook>>,
+    #[cfg(test)]
+    before_ordinary_planning_fence: std::sync::Mutex<Option<TestHook>>,
+}
+
+#[cfg(test)]
+type TestHook = Arc<dyn Fn() + Send + Sync>;
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+struct HistoryRetentionDelta {
+    snapshot_pins: i64,
+    fork_bindings: i64,
+}
+
+impl HistoryRetentionDelta {
+    fn is_zero(self) -> bool {
+        self.snapshot_pins == 0 && self.fork_bindings == 0
+    }
+}
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+struct RecoveredHistoryRetentionState {
+    active_snapshot_pins: u64,
+    active_fork_bindings: u64,
 }
 
 #[derive(Default)]
@@ -98,7 +150,8 @@ struct CommandPlan {
     version_guards: Vec<VersionGuard>,
     prefix_empty_guards: Vec<PrefixEmptyGuard>,
     retain_history: bool,
-    snapshot_retention_delta: i64,
+    history_retention_delta: HistoryRetentionDelta,
+    adds_history_retention: bool,
 }
 
 struct PendingPlannedCommand {
@@ -115,7 +168,8 @@ struct PlannedCommandStats {
     current_delete_count: u64,
     history_write_count: u64,
     watch_write_count: u64,
-    snapshot_retention_delta: i64,
+    history_retention_delta: HistoryRetentionDelta,
+    advances_history_version: bool,
     result: CommitResult,
     dedupe_result: Vec<u8>,
 }
@@ -131,23 +185,142 @@ struct CurrentRecord {
     value: Option<Vec<u8>>,
 }
 
+struct HistoryIndexPruneUpdate {
+    key: Vec<u8>,
+    record_version: RecordVersion,
+    latest_retained: Option<u64>,
+}
+
+struct HistoryPruneDeletePlan {
+    records: Vec<(Vec<u8>, RecordVersion)>,
+    index_updates: Vec<HistoryIndexPruneUpdate>,
+}
+
+type CurrentScanCandidate = (Vec<u8>, Vec<u8>);
+
+impl HistoryRetentionState {
+    fn new(recovered: RecoveredHistoryRetentionState) -> Self {
+        Self {
+            planning_fence: RwLock::new(()),
+            active_snapshot_pins: AtomicU64::new(recovered.active_snapshot_pins),
+            active_fork_bindings: AtomicU64::new(recovered.active_fork_bindings),
+            epoch: AtomicU64::new(1),
+            max_applied_commit_version: AtomicU64::new(0),
+            #[cfg(test)]
+            after_retention_apply_before_state: std::sync::Mutex::new(None),
+            #[cfg(test)]
+            before_ordinary_planning_fence: std::sync::Mutex::new(None),
+        }
+    }
+
+    fn install_recovered(&self, recovered: RecoveredHistoryRetentionState) {
+        self.active_snapshot_pins
+            .store(recovered.active_snapshot_pins, Ordering::Release);
+        self.active_fork_bindings
+            .store(recovered.active_fork_bindings, Ordering::Release);
+        self.epoch.fetch_add(1, Ordering::AcqRel);
+        // A checkpoint install replaces the DB while holding the exclusive
+        // planning fence, so there is no surviving pre-install plan to order.
+        self.max_applied_commit_version.store(0, Ordering::Release);
+    }
+
+    fn has_active_hold(&self) -> bool {
+        self.active_snapshot_pins.load(Ordering::Acquire) > 0
+            || self.active_fork_bindings.load(Ordering::Acquire) > 0
+    }
+
+    fn apply_delta(&self, delta: HistoryRetentionDelta) {
+        if delta.is_zero() {
+            return;
+        }
+        apply_counter_delta(&self.active_snapshot_pins, delta.snapshot_pins);
+        apply_counter_delta(&self.active_fork_bindings, delta.fork_bindings);
+        self.epoch.fetch_add(1, Ordering::AcqRel);
+    }
+
+    #[cfg(test)]
+    fn set_after_retention_apply_before_state_hook(&self, hook: TestHook) {
+        *self
+            .after_retention_apply_before_state
+            .lock()
+            .unwrap_or_else(|err| err.into_inner()) = Some(hook);
+    }
+
+    #[cfg(test)]
+    fn run_after_retention_apply_before_state_hook(&self) {
+        let hook = self
+            .after_retention_apply_before_state
+            .lock()
+            .unwrap_or_else(|err| err.into_inner())
+            .take();
+        if let Some(hook) = hook {
+            hook();
+        }
+    }
+
+    #[cfg(test)]
+    fn set_before_ordinary_planning_fence_hook(&self, hook: TestHook) {
+        *self
+            .before_ordinary_planning_fence
+            .lock()
+            .unwrap_or_else(|err| err.into_inner()) = Some(hook);
+    }
+
+    #[cfg(test)]
+    fn run_before_ordinary_planning_fence_hook(&self) {
+        let hook = self
+            .before_ordinary_planning_fence
+            .lock()
+            .unwrap_or_else(|err| err.into_inner())
+            .take();
+        if let Some(hook) = hook {
+            hook();
+        }
+    }
+}
+
+fn apply_counter_delta(counter: &AtomicU64, delta: i64) {
+    if delta > 0 {
+        counter.fetch_add(delta as u64, Ordering::AcqRel);
+    } else if delta < 0 {
+        let decrement = delta.unsigned_abs();
+        let _ = counter.fetch_update(Ordering::AcqRel, Ordering::Acquire, |current| {
+            Some(current.saturating_sub(decrement))
+        });
+    }
+}
+
 impl HoltMetadataStore {
     pub fn open_memory() -> Result<Self, MetadataError> {
         Self::open(TreeConfig::memory())
     }
 
     pub fn open_file(path: impl AsRef<Path>) -> Result<Self, MetadataError> {
-        Self::open(TreeConfig::new(path.as_ref()))
+        let mut config = TreeConfig::new(path.as_ref());
+        // A successful metadata RPC is a durability promise. Holt's default
+        // async WAL mode leaves a small ACK-to-flusher window in which SIGKILL
+        // can discard a committed namespace change or restore journal state.
+        config.durability = Durability::Wal { sync: true };
+        Self::open(config)
     }
 
     pub fn open(config: TreeConfig) -> Result<Self, MetadataError> {
         let db = DB::open(config).map_err(to_backend_error)?;
-        let active_snapshot_pins = count_active_snapshot_pins(&db)?;
-        Ok(Self {
+        let recovered = recover_history_retention_state(&db)?;
+        let store = Self {
             db,
             stats: Arc::new(HoltMetadataStoreCounters::default()),
-            active_snapshot_pins: Arc::new(AtomicU64::new(active_snapshot_pins)),
-        })
+            history_retention: Arc::new(HistoryRetentionState::new(recovered)),
+        };
+        // Do not create trees in a brand-new database: checkpoint installation
+        // requires a pristine DB. Existing stores, however, are migrated before
+        // they can serve reads.
+        match store.db.open_tree(HISTORY_TREE) {
+            Ok(_) => store.ensure_history_key_index()?,
+            Err(HoltError::TreeNotFound { .. }) => {}
+            Err(err) => return Err(to_backend_error(err)),
+        }
+        Ok(store)
     }
 
     pub fn checkpoint(&self) -> Result<(), MetadataError> {
@@ -166,11 +339,17 @@ impl HoltMetadataStore {
     pub fn install_checkpoint_image(&self, image: &[u8]) -> Result<(), MetadataError> {
         let checkpoint = CheckpointImage::from_bytes(image.to_vec());
         checkpoint.validate().map_err(to_backend_error)?;
+        let _fence = self
+            .history_retention
+            .planning_fence
+            .write()
+            .unwrap_or_else(|err| err.into_inner());
         self.db
             .install_checkpoint(&checkpoint)
             .map_err(to_backend_error)?;
-        self.active_snapshot_pins
-            .store(count_active_snapshot_pins(&self.db)?, Ordering::Relaxed);
+        self.ensure_history_key_index()?;
+        self.history_retention
+            .install_recovered(recover_history_retention_state(&self.db)?);
         Ok(())
     }
 
@@ -190,6 +369,12 @@ impl HoltMetadataStore {
             .map_err(to_backend_error)
     }
 
+    fn history_key_index_tree(&self) -> Result<Tree, MetadataError> {
+        self.db
+            .open_or_create_tree(HISTORY_KEY_INDEX_TREE)
+            .map_err(to_backend_error)
+    }
+
     fn ensure_metadata_trees(&self) -> Result<(), MetadataError> {
         for name in METADATA_TREE_NAMES {
             self.db
@@ -197,6 +382,199 @@ impl HoltMetadataStore {
                 .map_err(to_backend_error)?;
         }
         Ok(())
+    }
+
+    /// Build the derived history candidate index for stores created before the
+    /// index existed. Each batch persists both its entries and the last consumed
+    /// history key, so reopening after a crash resumes without rescanning earlier
+    /// batches. The completion marker makes the steady-state check one point read.
+    fn ensure_history_key_index(&self) -> Result<(), MetadataError> {
+        let history = self.history_tree()?;
+        let index = self.history_key_index_tree()?;
+        if index
+            .get(HISTORY_INDEX_COMPLETE_KEY)
+            .map_err(to_backend_error)?
+            .is_some()
+        {
+            return Ok(());
+        }
+
+        loop {
+            let progress = index
+                .get(HISTORY_INDEX_PROGRESS_KEY)
+                .map_err(to_backend_error)?;
+            let mut range = history.range();
+            if let Some(progress) = progress.as_deref() {
+                range = range.start_after(progress);
+            }
+
+            let mut updates = BTreeMap::<Vec<u8>, u64>::new();
+            let mut last_key = None;
+            let mut scanned = 0_usize;
+            for entry in range {
+                let RangeEntry::Key { key, value, .. } = entry.map_err(to_backend_error)? else {
+                    continue;
+                };
+                let index_key = history_index_key_from_record_key(&key)?;
+                let (version, _) = decode_current_value(&value)?;
+                updates
+                    .entry(index_key)
+                    .and_modify(|latest| *latest = (*latest).max(version.get()))
+                    .or_insert(version.get());
+                last_key = Some(key);
+                scanned += 1;
+                if scanned >= HISTORY_INDEX_BACKFILL_BATCH_SIZE {
+                    break;
+                }
+            }
+
+            let Some(last_key) = last_key else {
+                self.db
+                    .atomic(|batch| {
+                        batch.put(
+                            HISTORY_KEY_INDEX_TREE,
+                            HISTORY_INDEX_COMPLETE_KEY,
+                            HISTORY_INDEX_COMPLETE_VALUE,
+                        );
+                        batch.delete(HISTORY_KEY_INDEX_TREE, HISTORY_INDEX_PROGRESS_KEY);
+                    })
+                    .map_err(to_backend_error)?;
+                return Ok(());
+            };
+
+            for (key, latest) in &mut updates {
+                if let Some(existing) = index.get(key).map_err(to_backend_error)? {
+                    *latest = (*latest).max(decode_history_index_version(&existing)?);
+                }
+            }
+            self.db
+                .atomic(|batch| {
+                    for (key, latest) in &updates {
+                        batch.put(HISTORY_KEY_INDEX_TREE, key, &latest.to_be_bytes());
+                    }
+                    batch.put(
+                        HISTORY_KEY_INDEX_TREE,
+                        HISTORY_INDEX_PROGRESS_KEY,
+                        &last_key,
+                    );
+                })
+                .map_err(to_backend_error)?;
+        }
+    }
+
+    /// Snapshot scans enumerate the union of current keys and keys with retained
+    /// history, then run the same point-visibility resolver used by snapshot get.
+    /// `start_after` and `limit` are deliberately applied to visible rows rather
+    /// than candidate rows: an invisible post-snapshot key must not consume a
+    /// page slot.
+    fn scan_snapshot_rows(
+        &self,
+        request: &ScanRequest,
+    ) -> Result<(Vec<ScanItem>, usize), MetadataError> {
+        let limit = if request.limit == 0 {
+            usize::MAX
+        } else {
+            request.limit
+        };
+        let mut out = Vec::new();
+        let visited = self.visit_snapshot_visible(request, |item| {
+            out.push(item);
+            out.len() < limit
+        })?;
+        Ok((out, visited))
+    }
+
+    /// Merge the ordered current and retained-history candidate streams without
+    /// materializing either prefix. Equal keys are emitted once, preferring the
+    /// captured current value. The visitor controls early termination, which lets
+    /// normal and delimited snapshot pages stop as soon as their visible limit is
+    /// satisfied.
+    fn visit_snapshot_visible(
+        &self,
+        request: &ScanRequest,
+        mut visitor: impl FnMut(ScanItem) -> bool,
+    ) -> Result<usize, MetadataError> {
+        self.ensure_history_key_index()?;
+        let current = self.current_tree(request.family)?;
+        let history = self.history_tree()?;
+        let index = self.history_key_index_tree()?;
+
+        let current_snapshot = current
+            .snapshot(&request.prefix)
+            .map_err(to_backend_error)?;
+        let mut current_range = current_snapshot.view().range();
+        if let Some(start_after) = request.start_after.as_deref() {
+            current_range = current_range.start_after(start_after);
+        }
+        let mut current_iter = current_range.into_iter();
+
+        let index_prefix = history_index_prefix(request.family, &request.prefix);
+        let index_snapshot = index.snapshot(&index_prefix).map_err(to_backend_error)?;
+        let mut index_range = index_snapshot.view().range();
+        let index_start_after;
+        if let Some(start_after) = request.start_after.as_deref() {
+            index_start_after = history_index_key(request.family, start_after);
+            index_range = index_range.start_after(&index_start_after);
+        }
+        let mut index_iter = index_range.into_iter();
+
+        let context = VisibleReadContext {
+            family: request.family,
+            version: request.version,
+            purpose: request.purpose,
+            history: &history,
+            stats: &self.stats,
+        };
+        let mut current_head = next_current_candidate(&mut current_iter)?;
+        let mut index_head = next_history_index_candidate(request.family, &mut index_iter)?;
+        let mut visited = 0_usize;
+        while current_head.is_some() || index_head.is_some() {
+            let (key, current_value) = match (&current_head, &index_head) {
+                (Some((current_key, _)), Some(index_key)) => match current_key.cmp(index_key) {
+                    std::cmp::Ordering::Less => {
+                        let (key, value) = current_head.take().expect("head is present");
+                        current_head = next_current_candidate(&mut current_iter)?;
+                        (key, Some(value))
+                    }
+                    std::cmp::Ordering::Greater => {
+                        let key = index_head.take().expect("head is present");
+                        index_head = next_history_index_candidate(request.family, &mut index_iter)?;
+                        (key, None)
+                    }
+                    std::cmp::Ordering::Equal => {
+                        let (key, value) = current_head.take().expect("head is present");
+                        index_head.take();
+                        current_head = next_current_candidate(&mut current_iter)?;
+                        index_head = next_history_index_candidate(request.family, &mut index_iter)?;
+                        (key, Some(value))
+                    }
+                },
+                (Some(_), None) => {
+                    let (key, value) = current_head.take().expect("head is present");
+                    current_head = next_current_candidate(&mut current_iter)?;
+                    (key, Some(value))
+                }
+                (None, Some(_)) => {
+                    let key = index_head.take().expect("head is present");
+                    index_head = next_history_index_candidate(request.family, &mut index_iter)?;
+                    (key, None)
+                }
+                (None, None) => break,
+            };
+            visited += 1;
+            if let Some((version, value)) =
+                decode_visible_value(&key, current_value.as_deref(), &context)?
+            {
+                if !visitor(ScanItem {
+                    key,
+                    value: Value(value),
+                    version,
+                }) {
+                    break;
+                }
+            }
+        }
+        Ok(visited)
     }
 
     fn current_live_record(
@@ -254,7 +632,10 @@ impl MetadataCheckpointStore for HoltMetadataStore {
 impl MetadataStoreStatsProvider for HoltMetadataStore {
     fn metadata_store_stats(&self) -> MetadataStoreStats {
         let mut stats = self.stats.snapshot();
-        stats.active_snapshot_pin_total = self.active_snapshot_pins.load(Ordering::Relaxed);
+        stats.active_snapshot_pin_total = self
+            .history_retention
+            .active_snapshot_pins
+            .load(Ordering::Acquire);
         stats
     }
 }
@@ -283,6 +664,16 @@ impl MetadataStore for HoltMetadataStore {
     fn scan(&self, request: ScanRequest) -> Result<Vec<ScanItem>, MetadataError> {
         self.stats.scan_total.fetch_add(1, Ordering::Relaxed);
         self.stats.record_scan_purpose(request.purpose);
+        if request.purpose == ReadPurpose::Snapshot {
+            let (out, visited) = self.scan_snapshot_rows(&request)?;
+            self.stats
+                .scan_key_visited_total
+                .fetch_add(visited as u64, Ordering::Relaxed);
+            self.stats
+                .scan_key_returned_total
+                .fetch_add(out.len() as u64, Ordering::Relaxed);
+            return Ok(out);
+        }
         let limit = if request.limit == 0 {
             usize::MAX
         } else {
@@ -332,6 +723,60 @@ impl MetadataStore for HoltMetadataStore {
     ) -> Result<Vec<DelimitedScanItem>, MetadataError> {
         self.stats.scan_total.fetch_add(1, Ordering::Relaxed);
         self.stats.record_scan_purpose(request.purpose);
+        if request.purpose == ReadPurpose::Snapshot {
+            let limit = if request.limit == 0 {
+                usize::MAX
+            } else {
+                request.limit
+            };
+            let mut out = Vec::new();
+            let visited = self.visit_snapshot_visible(
+                &ScanRequest {
+                    family: request.family,
+                    prefix: request.prefix.clone(),
+                    // A delimited cursor names the collapsed key/common prefix,
+                    // not an underlying raw key. Apply it after collapsing so
+                    // children below an already-returned prefix are not repeated.
+                    start_after: None,
+                    version: request.version,
+                    limit: 0,
+                    purpose: request.purpose,
+                },
+                |item| {
+                    let suffix = item.key.get(request.prefix.len()..).unwrap_or_default();
+                    let collapsed = if let Some(offset) =
+                        suffix.iter().position(|byte| *byte == request.delimiter)
+                    {
+                        DelimitedScanItem::CommonPrefix(
+                            item.key[..request.prefix.len() + offset + 1].to_vec(),
+                        )
+                    } else {
+                        DelimitedScanItem::Key(item)
+                    };
+                    let marker = match &collapsed {
+                        DelimitedScanItem::Key(item) => item.key.as_slice(),
+                        DelimitedScanItem::CommonPrefix(prefix) => prefix.as_slice(),
+                    };
+                    if request
+                        .start_after
+                        .as_deref()
+                        .is_some_and(|start_after| marker <= start_after)
+                        || out.last() == Some(&collapsed)
+                    {
+                        return true;
+                    }
+                    out.push(collapsed);
+                    out.len() < limit
+                },
+            )?;
+            self.stats
+                .scan_key_visited_total
+                .fetch_add(visited as u64, Ordering::Relaxed);
+            self.stats
+                .scan_key_returned_total
+                .fetch_add(out.len() as u64, Ordering::Relaxed);
+            return Ok(out);
+        }
         let limit = if request.limit == 0 {
             usize::MAX
         } else {
@@ -406,6 +851,89 @@ impl MetadataStore for HoltMetadataStore {
         &self,
         commands: &[MetadataCommand],
     ) -> Vec<Result<CommitResult, MetadataError>> {
+        if commands.iter().any(command_mutates_history_retention) {
+            let _fence = self
+                .history_retention
+                .planning_fence
+                .write()
+                .unwrap_or_else(|err| err.into_inner());
+            return self.commit_independent_batch_fenced(commands);
+        }
+        let _fence = self
+            .history_retention
+            .planning_fence
+            .read()
+            .unwrap_or_else(|err| err.into_inner());
+        self.commit_independent_batch_fenced(commands)
+    }
+
+    fn commit_metadata(&self, command: MetadataCommand) -> Result<CommitResult, MetadataError> {
+        if command_mutates_history_retention(&command) {
+            let _fence = self
+                .history_retention
+                .planning_fence
+                .write()
+                .unwrap_or_else(|err| err.into_inner());
+            return self.commit_metadata_fenced(command);
+        }
+        #[cfg(test)]
+        self.history_retention
+            .run_before_ordinary_planning_fence_hook();
+        let _fence = self
+            .history_retention
+            .planning_fence
+            .read()
+            .unwrap_or_else(|err| err.into_inner());
+        self.commit_metadata_fenced(command)
+    }
+
+    fn committed_request_result(
+        &self,
+        request_id: &[u8],
+    ) -> Result<Option<CommitResult>, MetadataError> {
+        self.current_tree(RecordFamily::CommandDedupe)?
+            .get(request_id)
+            .map_err(to_backend_error)?
+            .as_deref()
+            .map(decode_dedupe_result)
+            .transpose()
+    }
+
+    fn history_retention_epoch(&self) -> Result<u64, MetadataError> {
+        Ok(self.history_retention.epoch.load(Ordering::Acquire))
+    }
+
+    fn prune_history(
+        &self,
+        request: HistoryPruneRequest,
+    ) -> Result<HistoryPruneOutcome, MetadataError> {
+        let _fence = self
+            .history_retention
+            .planning_fence
+            .write()
+            .unwrap_or_else(|err| err.into_inner());
+        if self.history_retention.epoch.load(Ordering::Acquire) != request.retention_epoch {
+            return Err(MetadataError::PredicateFailed);
+        }
+        for attempt in 0..HISTORY_PRUNE_CONFLICT_RETRIES {
+            match self.prune_history_once(request) {
+                Err(MetadataError::PredicateFailed)
+                    if attempt + 1 < HISTORY_PRUNE_CONFLICT_RETRIES =>
+                {
+                    continue;
+                }
+                result => return result,
+            }
+        }
+        unreachable!("history prune retry loop always returns")
+    }
+}
+
+impl HoltMetadataStore {
+    fn commit_independent_batch_fenced(
+        &self,
+        commands: &[MetadataCommand],
+    ) -> Vec<Result<CommitResult, MetadataError>> {
         let mut results = vec![None; commands.len()];
         let mut pending = Vec::new();
         for (index, command) in commands.iter().cloned().enumerate() {
@@ -417,9 +945,9 @@ impl MetadataStore for HoltMetadataStore {
             match self.prepare_command(&command) {
                 Ok(PreparedCommand::DedupeHit(result)) => results[index] = Some(Ok(result)),
                 Ok(PreparedCommand::Planned(plan)) => {
-                    if plan.snapshot_retention_delta != 0 {
+                    if !plan.history_retention_delta.is_zero() || plan.adds_history_retention {
                         self.commit_pending_batch(&mut pending, &mut results);
-                        results[index] = Some(self.commit_planned_command(command, plan));
+                        results[index] = Some(self.commit_planned_command_fenced(command, plan));
                     } else {
                         pending.push(PendingPlannedCommand {
                             index,
@@ -444,42 +972,40 @@ impl MetadataStore for HoltMetadataStore {
             .collect()
     }
 
-    fn commit_metadata(&self, command: MetadataCommand) -> Result<CommitResult, MetadataError> {
+    fn commit_metadata_fenced(
+        &self,
+        command: MetadataCommand,
+    ) -> Result<CommitResult, MetadataError> {
         match self.prepare_command(&command)? {
             PreparedCommand::DedupeHit(result) => Ok(result),
-            PreparedCommand::Planned(plan) => self.commit_planned_command(command, plan),
+            PreparedCommand::Planned(plan) => self.commit_planned_command_fenced(command, plan),
         }
     }
 
-    fn committed_request_result(
-        &self,
-        request_id: &[u8],
-    ) -> Result<Option<CommitResult>, MetadataError> {
-        self.current_tree(RecordFamily::CommandDedupe)?
-            .get(request_id)
-            .map_err(to_backend_error)?
-            .as_deref()
-            .map(decode_dedupe_result)
-            .transpose()
-    }
-
-    fn prune_history(
+    fn prune_history_once(
         &self,
         request: HistoryPruneRequest,
     ) -> Result<HistoryPruneOutcome, MetadataError> {
+        self.ensure_history_key_index()?;
         let remove_limit = if request.limit == 0 {
             usize::MAX
         } else {
             request.limit
         };
         let history = self.history_tree()?;
+        let index = self.history_key_index_tree()?;
         let mut outcome = HistoryPruneOutcome::default();
-        let mut keys_to_remove = Vec::new();
+        let mut records_to_remove = Vec::new();
         let mut current_prefix = Vec::new();
         let mut kept_anchor_below_floor = false;
 
         for entry in history.range() {
-            let RangeEntry::Key { key, value, .. } = entry.map_err(to_backend_error)? else {
+            let RangeEntry::Key {
+                key,
+                value,
+                version: record_version,
+            } = entry.map_err(to_backend_error)?
+            else {
                 continue;
             };
             let prefix = history_user_prefix(&key)?;
@@ -504,19 +1030,18 @@ impl MetadataStore for HoltMetadataStore {
                 Some(_) => true,
             };
             if remove {
-                keys_to_remove.push(key);
-                if keys_to_remove.len() >= remove_limit {
+                records_to_remove.push((key, record_version));
+                if records_to_remove.len() >= remove_limit {
                     break;
                 }
             }
         }
 
-        outcome.removed = self.delete_history_keys(&history, &keys_to_remove)?;
+        outcome.removed =
+            self.delete_history_records_and_update_index(&history, &index, &records_to_remove)?;
         Ok(outcome)
     }
-}
 
-impl HoltMetadataStore {
     fn prepare_command(&self, command: &MetadataCommand) -> Result<PreparedCommand, MetadataError> {
         command.validate()?;
         if let Some(result) = self.dedupe_result(&command.request_id)? {
@@ -559,7 +1084,7 @@ impl HoltMetadataStore {
             }
             Ok(None) => {
                 for item in batch {
-                    results[item.index] = Some(self.commit_metadata(item.command));
+                    results[item.index] = Some(self.commit_metadata_fenced(item.command));
                 }
             }
             Err(err) => {
@@ -575,6 +1100,7 @@ impl HoltMetadataStore {
         batch_items: &[PendingPlannedCommand],
     ) -> Result<Option<Vec<CommitResult>>, MetadataError> {
         self.ensure_metadata_trees()?;
+        self.ensure_history_key_index()?;
         let stats = batch_items
             .iter()
             .map(|item| planned_command_stats(&item.command, &item.plan))
@@ -682,7 +1208,8 @@ impl HoltMetadataStore {
         }
 
         let retain_history = self.has_active_history_retention();
-        let snapshot_retention_delta = self.snapshot_retention_delta(&mutations)?;
+        let (history_retention_delta, adds_history_retention) =
+            self.history_retention_delta(&mutations)?;
         let mut history_records = Vec::new();
         if retain_history {
             for planned in &mutations {
@@ -709,16 +1236,27 @@ impl HoltMetadataStore {
             version_guards,
             prefix_empty_guards,
             retain_history,
-            snapshot_retention_delta,
+            history_retention_delta,
+            adds_history_retention,
         })
     }
 
-    fn commit_planned_command(
+    fn commit_planned_command_fenced(
         &self,
         command: MetadataCommand,
         plan: CommandPlan,
     ) -> Result<CommitResult, MetadataError> {
+        if plan.adds_history_retention
+            && command.read_version.get()
+                < self
+                    .history_retention
+                    .max_applied_commit_version
+                    .load(Ordering::Acquire)
+        {
+            return Err(MetadataError::PredicateFailed);
+        }
         self.ensure_metadata_trees()?;
+        self.ensure_history_key_index()?;
         let stats = planned_command_stats(&command, &plan);
         let atomic_start = Instant::now();
         let committed = self
@@ -736,12 +1274,23 @@ impl HoltMetadataStore {
             return Err(MetadataError::PredicateFailed);
         }
 
+        #[cfg(test)]
+        if plan.adds_history_retention {
+            self.history_retention
+                .run_after_retention_apply_before_state_hook();
+        }
         self.record_committed_stats(&stats);
         Ok(stats.result)
     }
 
     fn record_committed_stats(&self, stats: &PlannedCommandStats) {
-        self.apply_snapshot_retention_delta(stats.snapshot_retention_delta);
+        self.history_retention
+            .apply_delta(stats.history_retention_delta);
+        if stats.advances_history_version {
+            self.history_retention
+                .max_applied_commit_version
+                .fetch_max(stats.result.commit_version.get(), Ordering::AcqRel);
+        }
         self.stats.commit_total.fetch_add(1, Ordering::Relaxed);
         self.stats
             .predicate_total
@@ -766,60 +1315,148 @@ impl HoltMetadataStore {
             .fetch_add(1, Ordering::Relaxed);
     }
 
-    fn snapshot_retention_delta(
+    fn history_retention_delta(
         &self,
         mutations: &[PlannedMutation],
-    ) -> Result<i64, MetadataError> {
-        let mut delta = 0_i64;
+    ) -> Result<(HistoryRetentionDelta, bool), MetadataError> {
+        let mut final_states = Vec::<(RecordFamily, Vec<u8>, bool)>::new();
         for planned in mutations
             .iter()
-            .filter(|planned| planned.mutation.family == RecordFamily::Snapshot)
+            .filter(|planned| is_history_retention_family(planned.mutation.family))
         {
-            let old_active = self
-                .current_record(RecordFamily::Snapshot, &planned.mutation.key)?
-                .is_some_and(|record| record.value.is_some());
             let new_active = planned.mutation.op == MutationOp::Put;
-            delta += i64::from(new_active) - i64::from(old_active);
+            if let Some((_, _, active)) = final_states.iter_mut().find(|(family, key, _)| {
+                *family == planned.mutation.family
+                    && key.as_slice() == planned.mutation.key.as_slice()
+            }) {
+                *active = new_active;
+            } else {
+                final_states.push((
+                    planned.mutation.family,
+                    planned.mutation.key.clone(),
+                    new_active,
+                ));
+            }
         }
-        Ok(delta)
+
+        let mut delta = HistoryRetentionDelta::default();
+        let mut adds_history_retention = false;
+        for (family, key, new_active) in final_states {
+            let old_active = self
+                .current_record(family, &key)?
+                .is_some_and(|record| record.value.is_some());
+            adds_history_retention |= !old_active && new_active;
+            let family_delta = i64::from(new_active) - i64::from(old_active);
+            match family {
+                RecordFamily::Snapshot => delta.snapshot_pins += family_delta,
+                RecordFamily::ForkBinding => delta.fork_bindings += family_delta,
+                _ => unreachable!("retention family filter accepts only durable holds"),
+            }
+        }
+        Ok((delta, adds_history_retention))
     }
 
     fn has_active_history_retention(&self) -> bool {
-        self.active_snapshot_pins.load(Ordering::Relaxed) > 0
+        self.history_retention.has_active_hold()
     }
 
-    fn apply_snapshot_retention_delta(&self, delta: i64) {
-        if delta > 0 {
-            self.active_snapshot_pins
-                .fetch_add(delta as u64, Ordering::Relaxed);
-            return;
-        }
-        if delta < 0 {
-            let decrement = delta.unsigned_abs();
-            let _ = self.active_snapshot_pins.fetch_update(
-                Ordering::Relaxed,
-                Ordering::Relaxed,
-                |current| Some(current.saturating_sub(decrement)),
-            );
-        }
-    }
-
-    fn delete_history_keys(
+    fn delete_history_records_and_update_index(
         &self,
         history: &Tree,
-        keys: &[Vec<u8>],
+        index: &Tree,
+        records: &[(Vec<u8>, RecordVersion)],
     ) -> Result<usize, MetadataError> {
-        if keys.is_empty() {
+        if records.is_empty() {
             return Ok(0);
         }
-        history
+
+        let plan = self.plan_history_record_deletion(history, index, records)?;
+        self.apply_history_record_deletion(&plan)?;
+        Ok(plan.records.len())
+    }
+
+    fn plan_history_record_deletion(
+        &self,
+        history: &Tree,
+        index: &Tree,
+        records: &[(Vec<u8>, RecordVersion)],
+    ) -> Result<HistoryPruneDeletePlan, MetadataError> {
+        let removed_keys = records
+            .iter()
+            .map(|(key, _)| key.as_slice())
+            .collect::<HashSet<_>>();
+        let affected_prefixes = records
+            .iter()
+            .map(|(key, _)| history_user_prefix(key).map(Vec::from))
+            .collect::<Result<HashSet<_>, _>>()?;
+        let mut index_updates = Vec::with_capacity(affected_prefixes.len());
+        for history_prefix in affected_prefixes {
+            let index_key = history_index_key_from_user_prefix(&history_prefix)?;
+            let index_record = index
+                .get_record(&index_key)
+                .map_err(to_backend_error)?
+                .ok_or_else(|| {
+                    MetadataError::Backend(
+                        "history index is missing a retained history key".to_owned(),
+                    )
+                })?;
+            let mut latest_retained = None::<u64>;
+            for entry in history.range().prefix(&history_prefix) {
+                let RangeEntry::Key { key, value, .. } = entry.map_err(to_backend_error)? else {
+                    continue;
+                };
+                if removed_keys.contains(key.as_slice()) {
+                    continue;
+                }
+                let (version, _) = decode_current_value(&value)?;
+                latest_retained =
+                    Some(latest_retained.map_or(version.get(), |latest| latest.max(version.get())));
+            }
+            index_updates.push(HistoryIndexPruneUpdate {
+                key: index_key,
+                record_version: index_record.version,
+                latest_retained,
+            });
+        }
+
+        Ok(HistoryPruneDeletePlan {
+            records: records.to_vec(),
+            index_updates,
+        })
+    }
+
+    fn apply_history_record_deletion(
+        &self,
+        plan: &HistoryPruneDeletePlan,
+    ) -> Result<(), MetadataError> {
+        let committed = self
+            .db
             .atomic(|batch| {
-                for key in keys {
-                    batch.delete(key);
+                for (key, version) in &plan.records {
+                    batch.delete_if_version(HISTORY_TREE, key, *version);
+                }
+                for update in &plan.index_updates {
+                    if let Some(latest_retained) = update.latest_retained {
+                        batch.compare_and_put(
+                            HISTORY_KEY_INDEX_TREE,
+                            &update.key,
+                            update.record_version,
+                            &latest_retained.to_be_bytes(),
+                        );
+                    } else {
+                        batch.delete_if_version(
+                            HISTORY_KEY_INDEX_TREE,
+                            &update.key,
+                            update.record_version,
+                        );
+                    }
                 }
             })
             .map_err(to_backend_error)?;
-        Ok(keys.len())
+        if !committed {
+            return Err(MetadataError::PredicateFailed);
+        }
+        Ok(())
     }
 }
 
@@ -899,14 +1536,23 @@ impl HoltMetadataStoreCounters {
     }
 }
 
-fn count_active_snapshot_pins(db: &DB) -> Result<u64, MetadataError> {
-    let snapshot = match db.open_tree(SNAPSHOT_CURRENT_TREE) {
-        Ok(snapshot) => snapshot,
+fn recover_history_retention_state(
+    db: &DB,
+) -> Result<RecoveredHistoryRetentionState, MetadataError> {
+    Ok(RecoveredHistoryRetentionState {
+        active_snapshot_pins: count_active_records(db, SNAPSHOT_CURRENT_TREE)?,
+        active_fork_bindings: count_active_records(db, FORK_BINDING_CURRENT_TREE)?,
+    })
+}
+
+fn count_active_records(db: &DB, tree_name: &str) -> Result<u64, MetadataError> {
+    let tree = match db.open_tree(tree_name) {
+        Ok(tree) => tree,
         Err(HoltError::TreeNotFound { .. }) => return Ok(0),
         Err(err) => return Err(to_backend_error(err)),
     };
     let mut total = 0_u64;
-    for entry in snapshot.range() {
+    for entry in tree.range() {
         let RangeEntry::Key { value, .. } = entry.map_err(to_backend_error)? else {
             continue;
         };
@@ -915,6 +1561,23 @@ fn count_active_snapshot_pins(db: &DB) -> Result<u64, MetadataError> {
         }
     }
     Ok(total)
+}
+
+fn is_history_retention_family(family: RecordFamily) -> bool {
+    matches!(family, RecordFamily::Snapshot | RecordFamily::ForkBinding)
+}
+
+fn command_mutates_history_retention(command: &MetadataCommand) -> bool {
+    command
+        .mutations
+        .iter()
+        .any(|mutation| is_history_retention_family(mutation.family))
+}
+
+fn command_advances_history_version(command: &MetadataCommand) -> bool {
+    command.mutations.iter().any(|mutation| {
+        family_requires_history(mutation.family) && !is_history_retention_family(mutation.family)
+    })
 }
 
 fn read_visible(
@@ -977,7 +1640,8 @@ fn planned_command_stats(command: &MetadataCommand, plan: &CommandPlan) -> Plann
             .count() as u64,
         history_write_count: plan.history_records.len() as u64 + history_tombstone_count,
         watch_write_count: command.watch.len() as u64,
-        snapshot_retention_delta: plan.snapshot_retention_delta,
+        history_retention_delta: plan.history_retention_delta,
+        advances_history_version: command_advances_history_version(command),
         result,
         dedupe_result,
     }
@@ -996,6 +1660,11 @@ fn enqueue_planned_command(
                 &history_key(*family, key, old_version.get()),
                 current,
             );
+            batch.put(
+                HISTORY_KEY_INDEX_TREE,
+                &history_index_key(*family, key),
+                &old_version.get().to_be_bytes(),
+            );
         }
     }
     for planned in &plan.mutations {
@@ -1011,6 +1680,11 @@ fn enqueue_planned_command(
                     command.commit_version.get(),
                 ),
                 &encode_tombstone_value(command.commit_version),
+            );
+            batch.put(
+                HISTORY_KEY_INDEX_TREE,
+                &history_index_key(planned.mutation.family, &planned.mutation.key),
+                &command.commit_version.get().to_be_bytes(),
             );
         }
     }
@@ -1232,6 +1906,76 @@ fn push_visible_delimited_scan_item(
             returned: 0,
         }),
     }
+}
+
+fn next_current_candidate(
+    iterator: &mut impl Iterator<Item = Result<RangeEntry, HoltError>>,
+) -> Result<Option<CurrentScanCandidate>, MetadataError> {
+    for entry in iterator {
+        if let RangeEntry::Key { key, value, .. } = entry.map_err(to_backend_error)? {
+            return Ok(Some((key, value)));
+        }
+    }
+    Ok(None)
+}
+
+fn next_history_index_candidate(
+    family: RecordFamily,
+    iterator: &mut impl Iterator<Item = Result<RangeEntry, HoltError>>,
+) -> Result<Option<Vec<u8>>, MetadataError> {
+    for entry in iterator {
+        if let RangeEntry::Key { key, .. } = entry.map_err(to_backend_error)? {
+            return history_index_user_key(family, &key).map(Some);
+        }
+    }
+    Ok(None)
+}
+
+fn history_index_key_from_record_key(history_record_key: &[u8]) -> Result<Vec<u8>, MetadataError> {
+    let user_prefix = history_user_prefix(history_record_key)?;
+    history_index_key_from_user_prefix(user_prefix)
+}
+
+fn history_index_key_from_user_prefix(user_prefix: &[u8]) -> Result<Vec<u8>, MetadataError> {
+    if user_prefix.len() < 5 {
+        return Err(MetadataError::Backend(
+            "history key has a truncated family/user-key header".to_owned(),
+        ));
+    }
+    let user_key_len = u32::from_be_bytes(
+        user_prefix[1..5]
+            .try_into()
+            .expect("history user-key length has fixed width"),
+    ) as usize;
+    if user_prefix.len() != 5 + user_key_len {
+        return Err(MetadataError::Backend(
+            "history key user-key length does not match its payload".to_owned(),
+        ));
+    }
+    let mut out = Vec::with_capacity(1 + user_key_len);
+    out.push(user_prefix[0]);
+    out.extend_from_slice(&user_prefix[5..]);
+    Ok(out)
+}
+
+fn history_index_user_key(
+    family: RecordFamily,
+    index_key: &[u8],
+) -> Result<Vec<u8>, MetadataError> {
+    let expected_prefix = history_index_prefix(family, &[]);
+    let Some(user_key) = index_key.strip_prefix(expected_prefix.as_slice()) else {
+        return Err(MetadataError::Backend(
+            "history index key belongs to the wrong record family".to_owned(),
+        ));
+    };
+    Ok(user_key.to_vec())
+}
+
+fn decode_history_index_version(encoded: &[u8]) -> Result<u64, MetadataError> {
+    let bytes: [u8; 8] = encoded
+        .try_into()
+        .map_err(|_| MetadataError::Backend("history index version is malformed".to_owned()))?;
+    Ok(u64::from_be_bytes(bytes))
 }
 
 fn to_backend_error(err: impl std::fmt::Display) -> MetadataError {

--- a/crates/nokv-meta/src/holtstore/families.rs
+++ b/crates/nokv-meta/src/holtstore/families.rs
@@ -18,6 +18,7 @@ pub(super) const COMMAND_DEDUPE_CURRENT_TREE: &str = "command_dedupe_current";
 pub(super) const FORK_BINDING_CURRENT_TREE: &str = "fork_binding_current";
 pub(super) const FORK_SHADOW_CURRENT_TREE: &str = "fork_shadow_current";
 pub(super) const HISTORY_TREE: &str = "history";
+pub(super) const HISTORY_KEY_INDEX_TREE: &str = "history_key_index";
 pub(super) const METADATA_TREE_NAMES: &[&str] = &[
     SYSTEM_CURRENT_TREE,
     MOUNT_CURRENT_TREE,
@@ -35,6 +36,7 @@ pub(super) const METADATA_TREE_NAMES: &[&str] = &[
     FORK_BINDING_CURRENT_TREE,
     FORK_SHADOW_CURRENT_TREE,
     HISTORY_TREE,
+    HISTORY_KEY_INDEX_TREE,
 ];
 
 pub(super) fn current_tree_name(family: RecordFamily) -> &'static str {

--- a/crates/nokv-meta/src/holtstore/tests.rs
+++ b/crates/nokv-meta/src/holtstore/tests.rs
@@ -5,6 +5,7 @@ use crate::command::{
 };
 use std::sync::{Arc, Barrier};
 use std::thread;
+use tempfile::tempdir;
 
 fn version(raw: u64) -> Version {
     Version::new(raw).unwrap()
@@ -62,24 +63,94 @@ fn replace_command(
     }
 }
 
+fn delete_command(key: &[u8], request_id: &[u8], read: u64, commit: u64) -> MetadataCommand {
+    MetadataCommand {
+        request_id: request_id.to_vec(),
+        kind: CommandKind::RemoveFile,
+        read_version: version(read),
+        commit_version: version(commit),
+        primary_family: RecordFamily::Dentry,
+        primary_key: key.to_vec(),
+        predicates: vec![PredicateRef {
+            family: RecordFamily::Dentry,
+            key: key.to_vec(),
+            predicate: Predicate::Exists,
+        }],
+        mutations: vec![Mutation {
+            family: RecordFamily::Dentry,
+            key: key.to_vec(),
+            op: MutationOp::Delete,
+            value: None,
+        }],
+        watch: Vec::new(),
+    }
+}
+
 fn snapshot_pin_command(request_id: &[u8], commit: u64) -> MetadataCommand {
+    retention_put_command(RecordFamily::Snapshot, b"snapshot/1", request_id, commit)
+}
+
+fn fork_binding_command(request_id: &[u8], commit: u64) -> MetadataCommand {
+    retention_put_command(
+        RecordFamily::ForkBinding,
+        b"fork-binding/1",
+        request_id,
+        commit,
+    )
+}
+
+fn retention_put_command(
+    family: RecordFamily,
+    key: &[u8],
+    request_id: &[u8],
+    commit: u64,
+) -> MetadataCommand {
     MetadataCommand {
         request_id: request_id.to_vec(),
         kind: CommandKind::SnapshotSubtree,
         read_version: version(commit - 1),
         commit_version: version(commit),
-        primary_family: RecordFamily::Snapshot,
-        primary_key: b"snapshot/1".to_vec(),
+        primary_family: family,
+        primary_key: key.to_vec(),
         predicates: vec![PredicateRef {
-            family: RecordFamily::Snapshot,
-            key: b"snapshot/1".to_vec(),
+            family,
+            key: key.to_vec(),
             predicate: Predicate::NotExists,
         }],
         mutations: vec![Mutation {
-            family: RecordFamily::Snapshot,
-            key: b"snapshot/1".to_vec(),
+            family,
+            key: key.to_vec(),
             op: MutationOp::Put,
             value: Some(Value(b"pin".to_vec())),
+        }],
+        watch: Vec::new(),
+    }
+}
+
+fn retention_delete_command(
+    family: RecordFamily,
+    key: &[u8],
+    request_id: &[u8],
+    read: u64,
+    commit: u64,
+) -> MetadataCommand {
+    MetadataCommand {
+        request_id: request_id.to_vec(),
+        kind: CommandKind::RetireSnapshot,
+        read_version: version(read),
+        commit_version: version(commit),
+        primary_family: family,
+        primary_key: key.to_vec(),
+        predicates: vec![PredicateRef {
+            family,
+            key: key.to_vec(),
+            predicate: Predicate::VersionEquals(version(read)),
+        }],
+        mutations: vec![Mutation {
+            family,
+            key: key.to_vec(),
+            op: MutationOp::Delete,
+            value: None,
         }],
         watch: Vec::new(),
     }
@@ -408,6 +479,286 @@ fn independent_batch_isolates_snapshot_retention_changes() {
 }
 
 #[test]
+fn independent_batch_orders_fork_binding_retention_transitions() {
+    let store = HoltMetadataStore::open_memory().unwrap();
+    store
+        .commit_metadata(put_command(b"dir/a", b"req-1", b"value-a", 2))
+        .unwrap();
+
+    let results = store.commit_independent_batch(&[
+        fork_binding_command(b"fork-1", 3),
+        replace_command(b"dir/a", b"req-2", b"value-b", 2, 4),
+    ]);
+    assert!(results.iter().all(Result::is_ok));
+    assert_eq!(
+        store
+            .history_retention
+            .active_fork_bindings
+            .load(Ordering::Acquire),
+        1
+    );
+    assert_eq!(
+        store
+            .get(
+                RecordFamily::Dentry,
+                b"dir/a",
+                version(2),
+                ReadPurpose::Snapshot,
+            )
+            .unwrap(),
+        Some(Value(b"value-a".to_vec()))
+    );
+
+    let history_before_release = store.metadata_store_stats().history_write_total;
+    let results = store.commit_independent_batch(&[
+        retention_delete_command(
+            RecordFamily::ForkBinding,
+            b"fork-binding/1",
+            b"fork-retire",
+            3,
+            5,
+        ),
+        replace_command(b"dir/a", b"req-3", b"value-c", 4, 6),
+    ]);
+    assert!(results.iter().all(Result::is_ok));
+    assert_eq!(
+        store
+            .history_retention
+            .active_fork_bindings
+            .load(Ordering::Acquire),
+        0
+    );
+    assert_eq!(
+        store.metadata_store_stats().history_write_total,
+        history_before_release
+    );
+}
+
+#[test]
+fn independent_batch_rejects_a_pin_older_than_an_earlier_writer() {
+    let store = HoltMetadataStore::open_memory().unwrap();
+    store
+        .commit_metadata(put_command(b"dir/a", b"req-1", b"value-a", 2))
+        .unwrap();
+
+    let results = store.commit_independent_batch(&[
+        replace_command(b"dir/a", b"req-2", b"value-b", 2, 4),
+        snapshot_pin_command(b"snapshot-stale", 3),
+    ]);
+    assert!(results[0].is_ok());
+    assert_eq!(results[1], Err(MetadataError::PredicateFailed));
+    assert_eq!(store.metadata_store_stats().active_snapshot_pin_total, 0);
+    assert!(store
+        .get(
+            RecordFamily::Snapshot,
+            b"snapshot/1",
+            version(4),
+            ReadPurpose::UserStrong,
+        )
+        .unwrap()
+        .is_none());
+}
+
+#[test]
+fn snapshot_pin_rejects_a_read_version_older_than_an_applied_writer() {
+    let store = HoltMetadataStore::open_memory().unwrap();
+    store
+        .commit_metadata(put_command(b"dir/a", b"req-1", b"value-a", 2))
+        .unwrap();
+    store
+        .commit_metadata(replace_command(b"dir/a", b"req-2", b"value-b", 2, 4))
+        .unwrap();
+
+    let stale_pin = snapshot_pin_command(b"snapshot-stale", 3);
+    assert_eq!(
+        store.commit_metadata(stale_pin),
+        Err(MetadataError::PredicateFailed)
+    );
+    assert_eq!(store.metadata_store_stats().active_snapshot_pin_total, 0);
+
+    store
+        .commit_metadata(snapshot_pin_command(b"snapshot-retry", 5))
+        .unwrap();
+    store
+        .commit_metadata(replace_command(b"dir/a", b"req-3", b"value-c", 4, 6))
+        .unwrap();
+    assert_eq!(
+        store
+            .get(
+                RecordFamily::Dentry,
+                b"dir/a",
+                version(4),
+                ReadPurpose::Snapshot,
+            )
+            .unwrap(),
+        Some(Value(b"value-b".to_vec()))
+    );
+}
+
+#[test]
+fn fork_binding_retains_point_reads_and_snapshot_scans() {
+    let store = HoltMetadataStore::open_memory().unwrap();
+    store
+        .commit_metadata(put_command(b"dir/a", b"req-1", b"value-a", 2))
+        .unwrap();
+    store
+        .commit_metadata(fork_binding_command(b"fork-1", 3))
+        .unwrap();
+    store
+        .commit_metadata(replace_command(b"dir/a", b"req-2", b"value-b", 2, 4))
+        .unwrap();
+
+    assert_eq!(
+        store
+            .get(
+                RecordFamily::Dentry,
+                b"dir/a",
+                version(2),
+                ReadPurpose::Snapshot,
+            )
+            .unwrap(),
+        Some(Value(b"value-a".to_vec()))
+    );
+    assert_eq!(
+        store
+            .scan(ScanRequest {
+                family: RecordFamily::Dentry,
+                prefix: b"dir/".to_vec(),
+                start_after: None,
+                version: version(2),
+                limit: 10,
+                purpose: ReadPurpose::Snapshot,
+            })
+            .unwrap(),
+        vec![ScanItem {
+            key: b"dir/a".to_vec(),
+            value: Value(b"value-a".to_vec()),
+            version: version(2),
+        }]
+    );
+}
+
+#[test]
+fn retention_counts_change_only_after_successful_commands() {
+    let store = HoltMetadataStore::open_memory().unwrap();
+    let pin = snapshot_pin_command(b"snapshot-1", 2);
+    store.commit_metadata(pin.clone()).unwrap();
+    assert_eq!(store.metadata_store_stats().active_snapshot_pin_total, 1);
+
+    assert_eq!(
+        store.commit_metadata(pin).unwrap().commit_version,
+        version(2)
+    );
+    assert_eq!(store.metadata_store_stats().active_snapshot_pin_total, 1);
+    assert_eq!(
+        store.commit_metadata(snapshot_pin_command(b"snapshot-conflict", 3)),
+        Err(MetadataError::PredicateFailed)
+    );
+    assert_eq!(store.metadata_store_stats().active_snapshot_pin_total, 1);
+
+    assert_eq!(
+        store.commit_metadata(retention_delete_command(
+            RecordFamily::Snapshot,
+            b"snapshot/1",
+            b"retire-stale",
+            3,
+            4,
+        )),
+        Err(MetadataError::PredicateFailed)
+    );
+    assert_eq!(store.metadata_store_stats().active_snapshot_pin_total, 1);
+    store
+        .commit_metadata(retention_delete_command(
+            RecordFamily::Snapshot,
+            b"snapshot/1",
+            b"retire-live",
+            2,
+            5,
+        ))
+        .unwrap();
+    assert_eq!(store.metadata_store_stats().active_snapshot_pin_total, 0);
+}
+
+#[test]
+fn retention_apply_and_counter_update_share_one_planning_fence() {
+    let store = HoltMetadataStore::open_memory().unwrap();
+    store
+        .commit_metadata(put_command(b"dir/a", b"req-1", b"value-a", 2))
+        .unwrap();
+
+    let retention_applied = Arc::new(Barrier::new(2));
+    let release_retention = Arc::new(Barrier::new(2));
+    let hook_applied = Arc::clone(&retention_applied);
+    let hook_release = Arc::clone(&release_retention);
+    store
+        .history_retention
+        .set_after_retention_apply_before_state_hook(Arc::new(move || {
+            hook_applied.wait();
+            hook_release.wait();
+        }));
+    let pin_store = store.clone();
+    let pin_thread =
+        thread::spawn(move || pin_store.commit_metadata(snapshot_pin_command(b"snapshot-1", 3)));
+
+    retention_applied.wait();
+    assert_eq!(store.metadata_store_stats().active_snapshot_pin_total, 0);
+    assert_eq!(
+        store
+            .get(
+                RecordFamily::Snapshot,
+                b"snapshot/1",
+                version(3),
+                ReadPurpose::UserStrong,
+            )
+            .unwrap(),
+        Some(Value(b"pin".to_vec()))
+    );
+
+    let writer_at_fence = Arc::new(Barrier::new(2));
+    let writer_hook = Arc::clone(&writer_at_fence);
+    store
+        .history_retention
+        .set_before_ordinary_planning_fence_hook(Arc::new(move || {
+            writer_hook.wait();
+        }));
+    let writer_store = store.clone();
+    let writer = thread::spawn(move || {
+        writer_store.commit_metadata(replace_command(b"dir/a", b"req-2", b"value-b", 2, 4))
+    });
+    writer_at_fence.wait();
+    release_retention.wait();
+
+    pin_thread.join().unwrap().unwrap();
+    writer.join().unwrap().unwrap();
+    assert_eq!(store.metadata_store_stats().active_snapshot_pin_total, 1);
+    assert_eq!(
+        store
+            .get(
+                RecordFamily::Dentry,
+                b"dir/a",
+                version(2),
+                ReadPurpose::Snapshot,
+            )
+            .unwrap(),
+        Some(Value(b"value-a".to_vec()))
+    );
+    assert_eq!(
+        store
+            .scan(ScanRequest {
+                family: RecordFamily::Dentry,
+                prefix: b"dir/".to_vec(),
+                start_after: None,
+                version: version(2),
+                limit: 10,
+                purpose: ReadPurpose::Snapshot,
+            })
+            .unwrap()
+            .len(),
+        1
+    );
+}
+
+#[test]
 fn checkpoint_image_round_trips_current_history_and_dedupe() {
     let store = HoltMetadataStore::open_memory().unwrap();
     store
@@ -451,6 +802,208 @@ fn checkpoint_image_round_trips_current_history_and_dedupe() {
         Some(replace)
     );
     assert_eq!(restored.metadata_store_stats().active_snapshot_pin_total, 1);
+}
+
+#[test]
+fn checkpoint_install_and_file_reopen_restore_all_retention_state() {
+    let source = HoltMetadataStore::open_memory().unwrap();
+    source
+        .commit_metadata(snapshot_pin_command(b"snapshot-1", 2))
+        .unwrap();
+    source
+        .commit_metadata(fork_binding_command(b"fork-1", 3))
+        .unwrap();
+    let image = source.export_checkpoint_image().unwrap();
+
+    let restored = HoltMetadataStore::open_memory().unwrap();
+    restored.install_checkpoint_image(&image).unwrap();
+    assert_eq!(restored.metadata_store_stats().active_snapshot_pin_total, 1);
+    assert_eq!(
+        restored
+            .history_retention
+            .active_fork_bindings
+            .load(Ordering::Acquire),
+        1
+    );
+    assert_eq!(
+        restored
+            .history_retention
+            .max_applied_commit_version
+            .load(Ordering::Acquire),
+        0
+    );
+
+    let directory = tempdir().unwrap();
+    let path = directory.path().join("metadata");
+    {
+        let store = HoltMetadataStore::open_file(&path).unwrap();
+        store
+            .commit_metadata(snapshot_pin_command(b"snapshot-1", 2))
+            .unwrap();
+        store
+            .commit_metadata(fork_binding_command(b"fork-1", 3))
+            .unwrap();
+    }
+    let reopened = HoltMetadataStore::open_file(path).unwrap();
+    assert_eq!(reopened.metadata_store_stats().active_snapshot_pin_total, 1);
+    assert_eq!(
+        reopened
+            .history_retention
+            .active_fork_bindings
+            .load(Ordering::Acquire),
+        1
+    );
+    assert_eq!(
+        reopened
+            .history_retention
+            .max_applied_commit_version
+            .load(Ordering::Acquire),
+        0
+    );
+
+    reopened
+        .commit_metadata(put_command(b"dir/a", b"post-open-write", b"value-a", 4))
+        .unwrap();
+    assert_eq!(
+        reopened
+            .history_retention
+            .max_applied_commit_version
+            .load(Ordering::Acquire),
+        4
+    );
+    assert_eq!(
+        reopened.commit_metadata(retention_put_command(
+            RecordFamily::Snapshot,
+            b"snapshot/2",
+            b"post-open-stale-pin",
+            3,
+        )),
+        Err(MetadataError::PredicateFailed)
+    );
+}
+
+#[test]
+fn checkpoint_image_round_trips_history_candidate_index() {
+    let store = HoltMetadataStore::open_memory().unwrap();
+    store
+        .commit_metadata(put_command(b"dir/a", b"req-a", b"value-a", 2))
+        .unwrap();
+    store
+        .commit_metadata(snapshot_pin_command(b"snapshot-1", 3))
+        .unwrap();
+    store
+        .commit_metadata(delete_command(b"dir/a", b"req-delete", 3, 4))
+        .unwrap();
+
+    let image = store.export_checkpoint_image().unwrap();
+    let restored = HoltMetadataStore::open_memory().unwrap();
+    restored.install_checkpoint_image(&image).unwrap();
+    let rows = restored
+        .scan(ScanRequest {
+            family: RecordFamily::Dentry,
+            prefix: b"dir/".to_vec(),
+            start_after: None,
+            version: version(2),
+            limit: 10,
+            purpose: ReadPurpose::Snapshot,
+        })
+        .unwrap();
+
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0].key, b"dir/a");
+    assert!(restored
+        .history_key_index_tree()
+        .unwrap()
+        .get(HISTORY_INDEX_COMPLETE_KEY)
+        .unwrap()
+        .is_some());
+}
+
+#[test]
+fn opening_legacy_store_backfills_missing_history_candidate_index() {
+    let directory = tempdir().unwrap();
+    let path = directory.path().join("metadata");
+    {
+        let store = HoltMetadataStore::open_file(&path).unwrap();
+        store
+            .commit_metadata(put_command(b"dir/a", b"req-a", b"value-a", 2))
+            .unwrap();
+        store
+            .commit_metadata(snapshot_pin_command(b"snapshot-1", 3))
+            .unwrap();
+        store
+            .commit_metadata(delete_command(b"dir/a", b"req-delete", 3, 4))
+            .unwrap();
+        let index = store.history_key_index_tree().unwrap();
+        let keys = index
+            .range()
+            .into_iter()
+            .filter_map(|entry| match entry.unwrap() {
+                RangeEntry::Key { key, .. } => Some(key),
+                _ => None,
+            })
+            .collect::<Vec<_>>();
+        for key in keys {
+            index.delete(&key).unwrap();
+        }
+        let history = store.history_tree().unwrap();
+        let (first_key, first_value) = history
+            .range()
+            .into_iter()
+            .find_map(|entry| match entry.unwrap() {
+                RangeEntry::Key { key, value, .. } => Some((key, value)),
+                _ => None,
+            })
+            .unwrap();
+        let first_index_key = history_index_key_from_record_key(&first_key).unwrap();
+        let (first_version, _) = decode_current_value(&first_value).unwrap();
+        index
+            .put(&first_index_key, &first_version.get().to_be_bytes())
+            .unwrap();
+        index.put(HISTORY_INDEX_PROGRESS_KEY, &first_key).unwrap();
+    }
+
+    let reopened = HoltMetadataStore::open_file(&path).unwrap();
+    let rows = reopened
+        .scan(ScanRequest {
+            family: RecordFamily::Dentry,
+            prefix: b"dir/".to_vec(),
+            start_after: None,
+            version: version(2),
+            limit: 10,
+            purpose: ReadPurpose::Snapshot,
+        })
+        .unwrap();
+
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0].key, b"dir/a");
+    assert!(reopened
+        .history_key_index_tree()
+        .unwrap()
+        .get(HISTORY_INDEX_COMPLETE_KEY)
+        .unwrap()
+        .is_some());
+    assert!(reopened
+        .history_key_index_tree()
+        .unwrap()
+        .get(HISTORY_INDEX_PROGRESS_KEY)
+        .unwrap()
+        .is_none());
+}
+
+#[test]
+fn file_backed_commit_is_wal_durable_before_ack() {
+    let directory = tempdir().unwrap();
+    let store = HoltMetadataStore::open_file(directory.path().join("metadata")).unwrap();
+
+    store
+        .commit_metadata(put_command(b"dir/durable", b"req-durable", b"value", 2))
+        .unwrap();
+
+    let journal = store.db.stats().journal.unwrap();
+    assert_eq!(journal.pending_work, 0);
+    assert_eq!(journal.flushed_work, journal.queued_work);
+    assert!(journal.syncs > 0);
 }
 
 #[test]
@@ -554,6 +1107,196 @@ fn deleted_key_is_hidden_latest_but_visible_to_old_version() {
         after_snapshot.history_lookup_total - before_snapshot.history_lookup_total,
         1,
         "snapshot reads must retain historical visibility"
+    );
+}
+
+#[test]
+fn snapshot_scan_includes_key_deleted_after_read_version() {
+    let store = HoltMetadataStore::open_memory().unwrap();
+    store
+        .commit_metadata(put_command(b"dir/a", b"req-1", b"value-a", 2))
+        .unwrap();
+    store
+        .commit_metadata(snapshot_pin_command(b"snapshot-1", 3))
+        .unwrap();
+    store
+        .commit_metadata(delete_command(b"dir/a", b"req-delete", 3, 4))
+        .unwrap();
+
+    let rows = store
+        .scan(ScanRequest {
+            family: RecordFamily::Dentry,
+            prefix: b"dir/".to_vec(),
+            start_after: None,
+            version: version(2),
+            limit: 10,
+            purpose: ReadPurpose::Snapshot,
+        })
+        .unwrap();
+
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0].key, b"dir/a");
+    assert_eq!(rows[0].value, Value(b"value-a".to_vec()));
+}
+
+#[test]
+fn snapshot_scan_delete_recreate_returns_one_historical_candidate() {
+    let store = HoltMetadataStore::open_memory().unwrap();
+    store
+        .commit_metadata(put_command(b"dir/a", b"req-1", b"value-a", 2))
+        .unwrap();
+    store
+        .commit_metadata(snapshot_pin_command(b"snapshot-1", 3))
+        .unwrap();
+    store
+        .commit_metadata(delete_command(b"dir/a", b"req-delete", 3, 4))
+        .unwrap();
+    store
+        .commit_metadata(put_command(b"dir/a", b"req-recreate", b"value-new", 5))
+        .unwrap();
+
+    let rows = store
+        .scan(ScanRequest {
+            family: RecordFamily::Dentry,
+            prefix: b"dir/".to_vec(),
+            start_after: None,
+            version: version(2),
+            limit: 10,
+            purpose: ReadPurpose::Snapshot,
+        })
+        .unwrap();
+
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0].key, b"dir/a");
+    assert_eq!(rows[0].value, Value(b"value-a".to_vec()));
+}
+
+#[test]
+fn snapshot_scan_applies_start_after_and_limit_to_visible_rows() {
+    let store = HoltMetadataStore::open_memory().unwrap();
+    for (key, request, value, commit) in [
+        (b"dir/a".as_slice(), b"req-a".as_slice(), b"a".as_slice(), 2),
+        (b"dir/b".as_slice(), b"req-b".as_slice(), b"b".as_slice(), 3),
+        (b"dir/c".as_slice(), b"req-c".as_slice(), b"c".as_slice(), 4),
+    ] {
+        store
+            .commit_metadata(put_command(key, request, value, commit))
+            .unwrap();
+    }
+    store
+        .commit_metadata(snapshot_pin_command(b"snapshot-1", 5))
+        .unwrap();
+    store
+        .commit_metadata(delete_command(b"dir/b", b"req-delete-b", 5, 6))
+        .unwrap();
+    store
+        .commit_metadata(delete_command(b"dir/c", b"req-delete-c", 6, 7))
+        .unwrap();
+
+    let before = store.metadata_store_stats();
+    let rows = store
+        .scan(ScanRequest {
+            family: RecordFamily::Dentry,
+            prefix: b"dir/".to_vec(),
+            start_after: Some(b"dir/a".to_vec()),
+            version: version(4),
+            limit: 1,
+            purpose: ReadPurpose::Snapshot,
+        })
+        .unwrap();
+
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0].key, b"dir/b");
+    let after = store.metadata_store_stats();
+    assert_eq!(
+        after.scan_key_visited_total - before.scan_key_visited_total,
+        1,
+        "streaming merge must stop when the visible page is full"
+    );
+}
+
+#[test]
+fn snapshot_delimited_scan_includes_deleted_historical_prefix() {
+    let store = HoltMetadataStore::open_memory().unwrap();
+    store
+        .commit_metadata(put_command(b"dir/removed/file", b"req-file", b"value", 2))
+        .unwrap();
+    store
+        .commit_metadata(snapshot_pin_command(b"snapshot-1", 3))
+        .unwrap();
+    store
+        .commit_metadata(delete_command(b"dir/removed/file", b"req-delete", 3, 4))
+        .unwrap();
+
+    let rows = store
+        .scan_delimited(DelimitedScanRequest {
+            family: RecordFamily::Dentry,
+            prefix: b"dir/".to_vec(),
+            start_after: None,
+            delimiter: b'/',
+            version: version(2),
+            limit: 10,
+            purpose: ReadPurpose::Snapshot,
+        })
+        .unwrap();
+
+    assert_eq!(
+        rows,
+        vec![DelimitedScanItem::CommonPrefix(b"dir/removed/".to_vec())]
+    );
+}
+
+#[test]
+fn snapshot_delimited_scan_pages_after_historical_common_prefix() {
+    let store = HoltMetadataStore::open_memory().unwrap();
+    for (key, request, commit) in [
+        (b"dir/a/file".as_slice(), b"req-a".as_slice(), 2),
+        (b"dir/b/file".as_slice(), b"req-b".as_slice(), 3),
+    ] {
+        store
+            .commit_metadata(put_command(key, request, b"value", commit))
+            .unwrap();
+    }
+    store
+        .commit_metadata(snapshot_pin_command(b"snapshot-1", 4))
+        .unwrap();
+    store
+        .commit_metadata(delete_command(b"dir/a/file", b"delete-a", 4, 5))
+        .unwrap();
+    store
+        .commit_metadata(delete_command(b"dir/b/file", b"delete-b", 5, 6))
+        .unwrap();
+
+    let first = store
+        .scan_delimited(DelimitedScanRequest {
+            family: RecordFamily::Dentry,
+            prefix: b"dir/".to_vec(),
+            start_after: None,
+            delimiter: b'/',
+            version: version(3),
+            limit: 1,
+            purpose: ReadPurpose::Snapshot,
+        })
+        .unwrap();
+    assert_eq!(
+        first,
+        vec![DelimitedScanItem::CommonPrefix(b"dir/a/".to_vec())]
+    );
+
+    let second = store
+        .scan_delimited(DelimitedScanRequest {
+            family: RecordFamily::Dentry,
+            prefix: b"dir/".to_vec(),
+            start_after: Some(b"dir/a/".to_vec()),
+            delimiter: b'/',
+            version: version(3),
+            limit: 1,
+            purpose: ReadPurpose::Snapshot,
+        })
+        .unwrap();
+    assert_eq!(
+        second,
+        vec![DelimitedScanItem::CommonPrefix(b"dir/b/".to_vec())]
     );
 }
 
@@ -741,6 +1484,7 @@ fn hot_path_skips_history_without_snapshot_retention() {
     let outcome = store
         .prune_history(HistoryPruneRequest {
             retain_from: None,
+            retention_epoch: store.history_retention_epoch().unwrap(),
             limit: 100,
         })
         .unwrap();
@@ -790,6 +1534,7 @@ fn prune_history_keeps_snapshot_floor_anchor_per_key() {
     let outcome = store
         .prune_history(HistoryPruneRequest {
             retain_from: Some(version(5)),
+            retention_epoch: store.history_retention_epoch().unwrap(),
             limit: 100,
         })
         .unwrap();
@@ -817,5 +1562,133 @@ fn prune_history_keeps_snapshot_floor_anchor_per_key() {
             )
             .unwrap(),
         None
+    );
+}
+
+#[test]
+fn pruning_last_history_record_removes_candidate_index_key() {
+    let store = HoltMetadataStore::open_memory().unwrap();
+    store
+        .commit_metadata(put_command(b"dir/a", b"req-a", b"value-a", 2))
+        .unwrap();
+    store
+        .commit_metadata(snapshot_pin_command(b"snapshot-1", 3))
+        .unwrap();
+    store
+        .commit_metadata(delete_command(b"dir/a", b"req-delete", 3, 4))
+        .unwrap();
+
+    let outcome = store
+        .prune_history(HistoryPruneRequest {
+            retain_from: None,
+            retention_epoch: store.history_retention_epoch().unwrap(),
+            limit: 100,
+        })
+        .unwrap();
+
+    assert_eq!(outcome.removed, 2);
+    assert!(store
+        .history_key_index_tree()
+        .unwrap()
+        .get(&history_index_key(RecordFamily::Dentry, b"dir/a"))
+        .unwrap()
+        .is_none());
+}
+
+#[test]
+fn stale_prune_plan_cannot_remove_history_added_by_concurrent_write() {
+    let store = HoltMetadataStore::open_memory().unwrap();
+    store
+        .commit_metadata(put_command(b"dir/a", b"req-a", b"value-a", 2))
+        .unwrap();
+    store
+        .commit_metadata(snapshot_pin_command(b"snapshot-1", 3))
+        .unwrap();
+    store
+        .commit_metadata(replace_command(
+            b"dir/a",
+            b"req-replace-b",
+            b"value-b",
+            3,
+            4,
+        ))
+        .unwrap();
+
+    let history = store.history_tree().unwrap();
+    let index = store.history_key_index_tree().unwrap();
+    let records = history
+        .range()
+        .into_iter()
+        .filter_map(|entry| match entry.unwrap() {
+            RangeEntry::Key { key, version, .. } => Some((key, version)),
+            _ => None,
+        })
+        .collect::<Vec<_>>();
+    let stale = store
+        .plan_history_record_deletion(&history, &index, &records)
+        .unwrap();
+
+    store
+        .commit_metadata(replace_command(
+            b"dir/a",
+            b"req-replace-c",
+            b"value-c",
+            4,
+            5,
+        ))
+        .unwrap();
+    assert_eq!(
+        store.apply_history_record_deletion(&stale),
+        Err(MetadataError::PredicateFailed)
+    );
+    assert_eq!(history.range().into_iter().count(), 2);
+
+    let retried = store
+        .prune_history(HistoryPruneRequest {
+            retain_from: None,
+            retention_epoch: store.history_retention_epoch().unwrap(),
+            limit: 100,
+        })
+        .unwrap();
+    assert_eq!(retried.removed, 2);
+    assert!(index
+        .get(&history_index_key(RecordFamily::Dentry, b"dir/a"))
+        .unwrap()
+        .is_none());
+}
+
+#[test]
+fn stale_retention_epoch_cannot_prune_history_needed_by_a_new_snapshot() {
+    let store = HoltMetadataStore::open_memory().unwrap();
+    store
+        .commit_metadata(put_command(b"dir/a", b"req-a", b"value-a", 2))
+        .unwrap();
+    let stale_epoch = store.history_retention_epoch().unwrap();
+
+    store
+        .commit_metadata(snapshot_pin_command(b"snapshot-new", 3))
+        .unwrap();
+    store
+        .commit_metadata(replace_command(b"dir/a", b"req-replace", b"value-b", 3, 4))
+        .unwrap();
+
+    assert_eq!(
+        store.prune_history(HistoryPruneRequest {
+            retain_from: None,
+            retention_epoch: stale_epoch,
+            limit: 100,
+        }),
+        Err(MetadataError::PredicateFailed)
+    );
+    assert_eq!(
+        store
+            .get(
+                RecordFamily::Dentry,
+                b"dir/a",
+                version(3),
+                ReadPurpose::Snapshot,
+            )
+            .unwrap(),
+        Some(Value(b"value-a".to_vec()))
     );
 }

--- a/crates/nokv-meta/src/layout/mod.rs
+++ b/crates/nokv-meta/src/layout/mod.rs
@@ -234,6 +234,23 @@ pub fn history_prefix(family: RecordFamily, user_key: &[u8]) -> Vec<u8> {
     out
 }
 
+/// Key in the derived history candidate index.
+///
+/// Unlike [`history_key`], this key deliberately omits the user-key length and
+/// commit version. The dedicated index tree already separates it from history
+/// records, so `[family_tag][user_key]` preserves the user's lexical ordering
+/// and permits efficient prefix scans for snapshot directory enumeration.
+pub fn history_index_key(family: RecordFamily, user_key: &[u8]) -> Vec<u8> {
+    history_index_prefix(family, user_key)
+}
+
+pub fn history_index_prefix(family: RecordFamily, user_key_prefix: &[u8]) -> Vec<u8> {
+    let mut out = Vec::with_capacity(1 + user_key_prefix.len());
+    out.push(family_tag(family));
+    out.extend_from_slice(user_key_prefix);
+    out
+}
+
 pub fn family_tag(family: RecordFamily) -> u8 {
     match family {
         RecordFamily::Mount => 1,
@@ -427,5 +444,18 @@ mod tests {
         let a = history_prefix(RecordFamily::Dentry, b"a");
         let aa = history_prefix(RecordFamily::Dentry, b"aa");
         assert!(!aa.starts_with(&a));
+    }
+
+    #[test]
+    fn history_index_key_preserves_family_local_user_prefix_order() {
+        let prefix = history_index_prefix(RecordFamily::Dentry, b"dir/");
+        let a = history_index_key(RecordFamily::Dentry, b"dir/a");
+        let b = history_index_key(RecordFamily::Dentry, b"dir/b");
+        let other = history_index_key(RecordFamily::Inode, b"dir/a");
+
+        assert!(a.starts_with(&prefix));
+        assert!(b.starts_with(&prefix));
+        assert!(a < b);
+        assert!(!other.starts_with(&prefix));
     }
 }

--- a/crates/nokv-meta/src/lib.rs
+++ b/crates/nokv-meta/src/lib.rs
@@ -50,5 +50,6 @@ pub use service::{
     ObjectTransferStats, OpenPathReadPlan, OpenPathReadPlanRequest, PendingObjectCleanupOutcome,
     PreparedArtifact, PublishArtifact, PublishArtifactRange, PublishArtifactSession,
     PublishArtifactStagedSession, ReadDirPlusPage, RecordCountProvenance, RenameReplaceResult,
-    SubtreeDelta, SubtreeDeltaKind, UpdateAttr, XattrSetMode, DEFAULT_SNAPSHOT_LEASE_MS,
+    SnapshotReapOutcome, SnapshotRenewOutcome, SubtreeDelta, SubtreeDeltaKind, UpdateAttr,
+    XattrSetMode, DEFAULT_SNAPSHOT_LEASE_MS,
 };

--- a/crates/nokv-meta/src/service.rs
+++ b/crates/nokv-meta/src/service.rs
@@ -14,6 +14,7 @@ mod command;
 mod fsck;
 mod gc;
 mod lifecycle;
+mod live_test_barrier;
 mod lock;
 mod log_archive;
 mod log_sync;
@@ -376,6 +377,7 @@ pub struct MetadataServiceStats {
 
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
 pub struct PendingObjectCleanupOutcome {
+    pub snapshot_reap: SnapshotReapOutcome,
     pub scanned: usize,
     pub blocked_by_snapshots: usize,
     pub blocked_by_read_leases: usize,
@@ -383,6 +385,20 @@ pub struct PendingObjectCleanupOutcome {
     pub deleted: usize,
     pub missing: usize,
     pub records_removed: usize,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum SnapshotRenewOutcome {
+    Renewed { pin: SnapshotPin, extended: bool },
+    Missing { snapshot_id: u64 },
+}
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct SnapshotReapOutcome {
+    pub scanned: usize,
+    pub expired_candidates: usize,
+    pub reaped: usize,
+    pub conflicted: usize,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -468,6 +484,7 @@ pub enum XattrSetMode {
 }
 
 #[derive(Debug)]
+#[non_exhaustive]
 pub enum MetadError {
     Model(ModelError),
     Metadata(MetadataError),
@@ -532,6 +549,24 @@ pub enum MetadError {
     /// point), NOT `EXDEV` — there is no copy+unlink fallback that would be
     /// correct here.
     GraftPoint,
+    SnapshotLeaseExpired {
+        snapshot_id: u64,
+        lease_expires_unix_ms: u64,
+        now_ms: u64,
+    },
+    SnapshotRootMismatch {
+        snapshot_id: u64,
+        expected_root: InodeId,
+        actual_root: Option<InodeId>,
+        actual_shard: u16,
+    },
+    SnapshotBindingChanged {
+        root_path: String,
+    },
+    SnapshotRenewContended {
+        snapshot_id: u64,
+        attempts: usize,
+    },
     /// The command was durably committed to the local engine, but archiving its
     /// logical-log segment failed, so durability could not be acknowledged.
     /// `committed` distinguishes "applied locally, not durable" from a plain
@@ -1517,6 +1552,42 @@ impl fmt::Display for MetadError {
             Self::GraftPoint => write!(
                 f,
                 "path is a cross-shard graft point; use unregister-graft"
+            ),
+            Self::SnapshotLeaseExpired {
+                snapshot_id,
+                lease_expires_unix_ms,
+                now_ms,
+            } => write!(
+                f,
+                "snapshot {snapshot_id} lease expired at {lease_expires_unix_ms}ms (now {now_ms}ms)"
+            ),
+            Self::SnapshotRootMismatch {
+                snapshot_id,
+                expected_root,
+                actual_root,
+                actual_shard,
+            } => match actual_root {
+                Some(actual_root) => write!(
+                    f,
+                    "snapshot {snapshot_id} belongs to root inode {} on shard {actual_shard}; request expected root inode {}",
+                    actual_root.get(),
+                    expected_root.get()
+                ),
+                None => write!(
+                    f,
+                    "snapshot {snapshot_id} belongs to shard {actual_shard}; request expected root inode {}",
+                    expected_root.get()
+                ),
+            },
+            Self::SnapshotBindingChanged { root_path } => {
+                write!(f, "snapshot root binding changed while resolving {root_path}")
+            }
+            Self::SnapshotRenewContended {
+                snapshot_id,
+                attempts,
+            } => write!(
+                f,
+                "snapshot {snapshot_id} renewal remained contended after {attempts} attempts"
             ),
             Self::SyncLogArchiveFailed { committed, message } => write!(
                 f,

--- a/crates/nokv-meta/src/service/clone.rs
+++ b/crates/nokv-meta/src/service/clone.rs
@@ -6,19 +6,6 @@ struct CloneFrame {
     dst_inode: InodeId,
 }
 
-/// How [`NoKvFs::materialize_subtree_at`] enumerates a directory at a read version.
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub(super) enum DirListing {
-    /// Plain current-tree dentry scan. Correct when nothing has been deleted since
-    /// the read version (clone of the current state).
-    Live,
-    /// Current-tree scan plus reconstruction of entries that were live at the read
-    /// version but deleted afterward. Needed to roll back to a prior snapshot, since
-    /// a delete hard-removes the dentry from the current tree and a current-tree scan
-    /// can no longer see it (point reads still find it via retained history).
-    Snapshot,
-}
-
 impl<M, O> NoKvFs<M, O>
 where
     M: MetadataStore,
@@ -52,9 +39,7 @@ where
         // shared base objects are GC-protected from the moment the fork exists.
         let pin = self.snapshot_subtree(src_root)?;
         let version = Version::new(pin.read_version)?;
-        // A clone copies the *current* state, where nothing has been deleted since
-        // the version it reads, so a plain dentry scan enumerates every child.
-        let dst_root = self.materialize_subtree_at(src_root, version, DirListing::Live)?;
+        let dst_root = self.materialize_subtree_at(src_root, version)?;
         Ok(CloneHandle {
             root: dst_root,
             snapshot_id: pin.snapshot_id,
@@ -80,16 +65,13 @@ where
     /// `read_version`), otherwise the source blocks the new manifests borrow could be
     /// reclaimed out from under it.
     ///
-    /// `listing` selects how each directory is enumerated at `read_version`.
-    /// [`DirListing::Live`] is a plain current-tree dentry scan; use it when nothing
-    /// could have been deleted since `read_version` (clone). [`DirListing::Snapshot`]
-    /// additionally reconstructs entries that existed at `read_version` but were
-    /// deleted afterward (rollback), which a current-tree scan alone cannot surface.
+    /// Snapshot-aware metadata scans merge current keys with the derived retained-
+    /// history key index, so deleted entries are enumerated without a whole-history
+    /// scan or a second point-read reconstruction pass.
     pub(super) fn materialize_subtree_at(
         &self,
         src_root: InodeId,
         read_version: Version,
-        listing: DirListing,
     ) -> Result<InodeId, MetadError> {
         let Some(src_attr) =
             self.get_attr_at_version_for_purpose(src_root, read_version, ReadPurpose::Snapshot)?
@@ -121,7 +103,7 @@ where
             dst_inode: dst_root,
         }];
         while let Some(frame) = queue.pop() {
-            let children = self.list_dir_at_version(frame.src_inode, read_version, listing)?;
+            let children = self.list_dir_at_version(frame.src_inode, read_version)?;
             if !children.is_empty() {
                 let mut sub_frames =
                     self.clone_children_into(frame.dst_inode, &children, read_version)?;
@@ -132,69 +114,13 @@ where
         Ok(dst_root)
     }
 
-    /// Enumerate the children of `dir` at `version` according to `listing`.
+    /// Enumerate the children of `dir` at `version` through snapshot-aware scan.
     fn list_dir_at_version(
         &self,
         dir: InodeId,
         version: Version,
-        listing: DirListing,
     ) -> Result<Vec<DentryWithAttr>, MetadError> {
-        let mut entries =
-            self.read_dir_plus_at_version_for_purpose(dir, version, ReadPurpose::Snapshot)?;
-        if listing == DirListing::Live {
-            return Ok(entries);
-        }
-        let mut present: HashSet<Vec<u8>> = entries
-            .iter()
-            .map(|entry| entry.dentry.name.as_bytes().to_vec())
-            .collect();
-        for name in self.deleted_child_names(dir)? {
-            if !present.insert(name.as_bytes().to_vec()) {
-                continue;
-            }
-            if let Some((entry, _)) =
-                self.lookup_plus_at_version_for_purpose(dir, &name, version, ReadPurpose::Snapshot)?
-            {
-                entries.push(entry);
-            }
-        }
-        Ok(entries)
-    }
-
-    /// Names that `dir` has ever parented according to the retained dentry history.
-    /// A delete hard-removes the dentry from the current tree, so an entry that was
-    /// live at a snapshot's read version but deleted afterward is invisible to a
-    /// current-tree scan; its identity survives only in history. The caller
-    /// re-validates each name with a point read at the target version, which both
-    /// confirms the entry was live then and rejects names created *after* the
-    /// snapshot (history is unfiltered by version here).
-    fn deleted_child_names(&self, dir: InodeId) -> Result<Vec<DentryName>, MetadError> {
-        let dir_prefix = dentry_prefix(self.mount, dir);
-        let mut names = Vec::new();
-        let mut seen = HashSet::new();
-        // History keys are `[family_tag][user_key_len: u32 BE][user_key][version]`.
-        for key in self.metadata.scan_keys(KeyScanRequest {
-            family: RecordFamily::History,
-            prefix: vec![dentry_family_tag()],
-            start_after: None,
-            limit: 0,
-            purpose: ReadPurpose::Snapshot,
-        })? {
-            let Some(user_key) = decode_dentry_history_user_key(&key) else {
-                continue;
-            };
-            let Some(name_bytes) = user_key.strip_prefix(dir_prefix.as_slice()) else {
-                continue;
-            };
-            if name_bytes.is_empty() || !seen.insert(name_bytes.to_vec()) {
-                continue;
-            }
-            let Ok(name) = DentryName::new(name_bytes.to_vec()) else {
-                continue;
-            };
-            names.push(name);
-        }
-        Ok(names)
+        self.read_dir_plus_at_version_for_purpose(dir, version, ReadPurpose::Snapshot)
     }
 
     /// Path variant of [`NoKvFs::clone_subtree`].
@@ -569,30 +495,6 @@ where
         }
         Ok(())
     }
-}
-
-fn dentry_family_tag() -> u8 {
-    crate::layout::family_tag(RecordFamily::Dentry)
-}
-
-/// Extract the original user key embedded in a dentry-family history key, which is
-/// laid out `[family_tag: 1][user_key_len: u32 BE][user_key][MAX-commit: u64]`.
-/// Returns `None` for keys that are not dentry history or are malformed.
-fn decode_dentry_history_user_key(key: &[u8]) -> Option<Vec<u8>> {
-    const TAG_LEN: usize = 1;
-    const LEN_LEN: usize = 4;
-    const VERSION_LEN: usize = 8;
-    if key.first().copied()? != dentry_family_tag() {
-        return None;
-    }
-    let len_bytes = key.get(TAG_LEN..TAG_LEN + LEN_LEN)?;
-    let user_key_len = u32::from_be_bytes(len_bytes.try_into().ok()?) as usize;
-    let user_key_start = TAG_LEN + LEN_LEN;
-    let user_key_end = user_key_start.checked_add(user_key_len)?;
-    if key.len() != user_key_end + VERSION_LEN {
-        return None;
-    }
-    Some(key[user_key_start..user_key_end].to_vec())
 }
 
 fn clone_command_kind(file_type: FileType) -> CommandKind {

--- a/crates/nokv-meta/src/service/gc.rs
+++ b/crates/nokv-meta/src/service/gc.rs
@@ -27,8 +27,8 @@ where
     ) -> Result<PendingObjectCleanupOutcome, MetadError> {
         // Reap expired snapshot pins first so the retention floor reflects only
         // live snapshots before deciding what is reclaimable.
-        self.reclaim_expired_snapshot_pins(limit)?;
-        let now_ms = current_time_ms();
+        let snapshot_reap = self.reclaim_expired_snapshot_pins(limit)?;
+        let now_ms = self.now_ms();
         let grace_ms = duration_millis_u64(read_lease_grace);
         let version = self.read_version()?;
         let rows = self.metadata.scan(ScanRequest {
@@ -40,11 +40,15 @@ where
             purpose: ReadPurpose::UserStrong,
         })?;
         if rows.is_empty() {
-            return Ok(PendingObjectCleanupOutcome::default());
+            return Ok(PendingObjectCleanupOutcome {
+                snapshot_reap,
+                ..PendingObjectCleanupOutcome::default()
+            });
         }
         let retention_floor = self.history_retention_floor()?;
 
         let mut outcome = PendingObjectCleanupOutcome {
+            snapshot_reap,
             scanned: rows.len(),
             blocked_by_snapshots: 0,
             blocked_by_read_leases: 0,
@@ -105,10 +109,24 @@ where
     }
 
     pub fn cleanup_history(&self, limit: usize) -> Result<HistoryPruneOutcome, MetadError> {
-        let retain_from = self.history_retention_floor()?;
-        self.metadata
-            .prune_history(HistoryPruneRequest { retain_from, limit })
-            .map_err(Into::into)
+        const RETENTION_RETRIES: usize = 8;
+        for attempt in 0..RETENTION_RETRIES {
+            let before = self.metadata.history_retention_epoch()?;
+            let retain_from = self.history_retention_floor()?;
+            let after = self.metadata.history_retention_epoch()?;
+            if before != after {
+                continue;
+            }
+            match self.metadata.prune_history(HistoryPruneRequest {
+                retain_from,
+                retention_epoch: after,
+                limit,
+            }) {
+                Err(MetadataError::PredicateFailed) if attempt + 1 < RETENTION_RETRIES => continue,
+                result => return result.map_err(Into::into),
+            }
+        }
+        Err(MetadError::Metadata(MetadataError::PredicateFailed))
     }
 
     /// Whether `object_key` was minted by this `(inode, generation)` and is thus
@@ -142,7 +160,7 @@ where
             limit: 0,
             purpose: ReadPurpose::UserStrong,
         })?;
-        let now_ms = current_time_ms();
+        let now_ms = self.now_ms();
         let mut floor: Option<Version> = None;
         for row in rows {
             let pin = decode_snapshot_pin(&row.value.0)
@@ -159,12 +177,17 @@ where
         Ok(floor)
     }
 
-    /// Delete pin records whose lease has expired, returning the number reaped.
+    /// Delete pin records whose lease has expired. Every delete is fenced by the
+    /// record version observed by the scan, so an old reaper pass cannot remove
+    /// a pin that changed after it was selected.
     /// Expired pins already stop holding the retention floor (see
     /// [`Self::history_retention_floor`]); this removes their records so they do
     /// not accumulate.
-    pub(super) fn reclaim_expired_snapshot_pins(&self, limit: usize) -> Result<usize, MetadError> {
-        let now_ms = current_time_ms();
+    pub fn reclaim_expired_snapshot_pins(
+        &self,
+        limit: usize,
+    ) -> Result<SnapshotReapOutcome, MetadError> {
+        let now_ms = self.now_ms();
         let rows = self.metadata.scan(ScanRequest {
             family: RecordFamily::Snapshot,
             prefix: snapshot_pin_prefix(self.mount),
@@ -173,20 +196,34 @@ where
             limit,
             purpose: ReadPurpose::UserStrong,
         })?;
+        let scanned = rows.len();
         let mut expired = Vec::new();
         for row in rows {
             let pin = decode_snapshot_pin(&row.value.0)
                 .map_err(|err| MetadError::Codec(err.to_string()))?;
             if now_ms >= pin.lease_expires_unix_ms {
-                expired.push(row.key);
+                expired.push((row.key, row.version, pin.snapshot_id));
             }
         }
+        let mut outcome = SnapshotReapOutcome {
+            scanned,
+            expired_candidates: expired.len(),
+            reaped: 0,
+            conflicted: 0,
+        };
         if expired.is_empty() {
-            return Ok(0);
+            return Ok(outcome);
         }
-        let removed = expired.len();
+        for (_, _, snapshot_id) in &expired {
+            live_test_barrier::snapshot(*snapshot_id, "reaper-scan")?;
+        }
+
+        // Common case: one atomic command removes the whole expired page. If a
+        // single candidate changed after the scan, the command is all-or-none;
+        // fall back to the same version-fenced delete per candidate so one hot
+        // pin cannot block unrelated expired pins.
         let commit_version = self.next_version()?;
-        self.commit_metadata(MetadataCommand {
+        let batch = MetadataCommand {
             request_id: request_id(
                 b"reclaim-expired-pins",
                 self.mount,
@@ -198,14 +235,105 @@ where
             commit_version,
             primary_family: RecordFamily::Snapshot,
             primary_key: snapshot_pin_prefix(self.mount),
-            predicates: Vec::new(),
+            predicates: expired
+                .iter()
+                .map(|(key, version, _)| PredicateRef {
+                    family: RecordFamily::Snapshot,
+                    key: key.clone(),
+                    predicate: Predicate::VersionEquals(*version),
+                })
+                .collect(),
             mutations: expired
-                .into_iter()
-                .map(|key| delete_mutation(RecordFamily::Snapshot, key))
+                .iter()
+                .map(|(key, _, _)| delete_mutation(RecordFamily::Snapshot, key.clone()))
                 .collect(),
             watch: Vec::new(),
-        })?;
-        Ok(removed)
+        };
+        match self.commit_metadata(batch) {
+            Ok(_) => {
+                outcome.reaped = expired.len();
+                return Ok(outcome);
+            }
+            Err(MetadError::Metadata(MetadataError::PredicateFailed)) => {}
+            Err(MetadError::SyncLogArchiveFailed {
+                committed: true, ..
+            }) => {
+                // Atomic apply completed. Reconcile rather than issuing a
+                // second delete under a different request id.
+                for (key, _, _) in &expired {
+                    if self
+                        .metadata
+                        .get(
+                            RecordFamily::Snapshot,
+                            key,
+                            self.read_version()?,
+                            ReadPurpose::UserStrong,
+                        )?
+                        .is_none()
+                    {
+                        outcome.reaped += 1;
+                    } else {
+                        outcome.conflicted += 1;
+                    }
+                }
+                return Ok(outcome);
+            }
+            Err(err) => return Err(err),
+        }
+
+        for (key, scanned_version, _) in expired {
+            let commit_version = self.next_version()?;
+            let command = MetadataCommand {
+                request_id: request_id(
+                    b"reclaim-expired-pin",
+                    self.mount,
+                    InodeId::root(),
+                    commit_version,
+                ),
+                kind: CommandKind::RetireSnapshot,
+                read_version: predecessor(commit_version)?,
+                commit_version,
+                primary_family: RecordFamily::Snapshot,
+                primary_key: key.clone(),
+                predicates: vec![PredicateRef {
+                    family: RecordFamily::Snapshot,
+                    key: key.clone(),
+                    predicate: Predicate::VersionEquals(scanned_version),
+                }],
+                mutations: vec![delete_mutation(RecordFamily::Snapshot, key.clone())],
+                watch: Vec::new(),
+            };
+            match self.commit_metadata(command) {
+                Ok(_) => outcome.reaped += 1,
+                Err(MetadError::Metadata(MetadataError::PredicateFailed)) => {
+                    outcome.conflicted += 1;
+                }
+                Err(MetadError::SyncLogArchiveFailed {
+                    committed: true, ..
+                }) => {
+                    if self
+                        .metadata
+                        .get(
+                            RecordFamily::Snapshot,
+                            &key,
+                            self.read_version()?,
+                            ReadPurpose::UserStrong,
+                        )?
+                        .is_none()
+                    {
+                        outcome.reaped += 1;
+                    } else {
+                        outcome.conflicted += 1;
+                    }
+                }
+                Err(err) => return Err(err),
+            }
+        }
+        debug_assert_eq!(
+            outcome.reaped + outcome.conflicted,
+            outcome.expired_candidates
+        );
+        Ok(outcome)
     }
 
     pub(super) fn chunk_manifest_delete_and_gc_mutations(

--- a/crates/nokv-meta/src/service/live_test_barrier.rs
+++ b/crates/nokv-meta/src/service/live_test_barrier.rs
@@ -1,0 +1,85 @@
+//! Explicit opt-in barriers for checked-in live acceptance tests.
+//!
+//! These hooks are inert unless the corresponding `NOKV_TEST_*` environment
+//! variable is set on the server process. They let the live harness exercise a
+//! precise distributed interleaving without weakening or changing the durable
+//! protocol used in normal deployments.
+
+use std::fs::OpenOptions;
+use std::io::Write as _;
+use std::path::PathBuf;
+use std::time::{Duration, Instant};
+
+use super::MetadError;
+
+const SNAPSHOT_BARRIER_DIR_ENV: &str = "NOKV_TEST_SNAPSHOT_BARRIER_DIR";
+const BARRIER_TIMEOUT_MS_ENV: &str = "NOKV_TEST_BARRIER_TIMEOUT_MS";
+const DEFAULT_BARRIER_TIMEOUT: Duration = Duration::from_secs(60);
+
+pub(super) fn snapshot(snapshot_id: u64, phase: &str) -> Result<(), MetadError> {
+    let Some(directory) = barrier_directory(SNAPSHOT_BARRIER_DIR_ENV)? else {
+        return Ok(());
+    };
+    wait(directory, format!("{snapshot_id}.{phase}"))
+}
+
+fn barrier_directory(variable: &str) -> Result<Option<PathBuf>, MetadError> {
+    let Some(raw) = std::env::var_os(variable) else {
+        return Ok(None);
+    };
+    let directory = PathBuf::from(raw);
+    if !directory.is_absolute() {
+        return Err(MetadError::Codec(format!(
+            "{variable} must be an absolute path"
+        )));
+    }
+    std::fs::create_dir_all(&directory).map_err(|err| {
+        MetadError::Codec(format!(
+            "failed to create live-test barrier directory {}: {err}",
+            directory.display()
+        ))
+    })?;
+    Ok(Some(directory))
+}
+
+fn wait(directory: PathBuf, stem: String) -> Result<(), MetadError> {
+    let arm = directory.join(format!("{stem}.arm"));
+    if !arm.exists() {
+        return Ok(());
+    }
+    let ready = directory.join(format!("{stem}.ready"));
+    let continue_marker = directory.join(format!("{stem}.continue"));
+    match OpenOptions::new().write(true).create_new(true).open(&ready) {
+        Ok(mut file) => file.write_all(b"ready\n").map_err(|err| {
+            MetadError::Codec(format!(
+                "failed to publish live-test barrier {}: {err}",
+                ready.display()
+            ))
+        })?,
+        Err(err) if err.kind() == std::io::ErrorKind::AlreadyExists => {}
+        Err(err) => {
+            return Err(MetadError::Codec(format!(
+                "failed to publish live-test barrier {}: {err}",
+                ready.display()
+            )))
+        }
+    }
+
+    let timeout = std::env::var(BARRIER_TIMEOUT_MS_ENV)
+        .ok()
+        .and_then(|raw| raw.parse::<u64>().ok())
+        .map(Duration::from_millis)
+        .unwrap_or(DEFAULT_BARRIER_TIMEOUT);
+    let deadline = Instant::now() + timeout;
+    while !continue_marker.exists() {
+        if Instant::now() >= deadline {
+            return Err(MetadError::Codec(format!(
+                "live-test barrier {} timed out after {} ms",
+                ready.display(),
+                timeout.as_millis()
+            )));
+        }
+        std::thread::sleep(Duration::from_millis(2));
+    }
+    Ok(())
+}

--- a/crates/nokv-meta/src/service/read.rs
+++ b/crates/nokv-meta/src/service/read.rs
@@ -212,6 +212,23 @@ where
         limit: usize,
         version: Version,
     ) -> Result<ReadDirPlusPage, MetadError> {
+        self.read_dir_plus_page_at_version_for_purpose(
+            parent,
+            after,
+            limit,
+            version,
+            ReadPurpose::UserStrong,
+        )
+    }
+
+    pub(super) fn read_dir_plus_page_at_version_for_purpose(
+        &self,
+        parent: InodeId,
+        after: Option<&DentryName>,
+        limit: usize,
+        version: Version,
+        purpose: ReadPurpose,
+    ) -> Result<ReadDirPlusPage, MetadError> {
         let requested = limit.max(1);
         let rows = self.metadata.scan(ScanRequest {
             family: RecordFamily::Dentry,
@@ -219,7 +236,7 @@ where
             start_after: after.map(|name| dentry_key(self.mount, parent, name)),
             version,
             limit: requested.saturating_add(1),
-            purpose: ReadPurpose::UserStrong,
+            purpose,
         })?;
         self.read_dir_plus_total.fetch_add(1, Ordering::Relaxed);
         let has_more = rows.len() > requested;

--- a/crates/nokv-meta/src/service/rollback.rs
+++ b/crates/nokv-meta/src/service/rollback.rs
@@ -1,4 +1,3 @@
-use super::clone::DirListing;
 use super::*;
 
 /// A top-level child of the rollback target captured before the atomic swap, so it
@@ -99,10 +98,9 @@ where
         }
 
         // 1. Reproduce the snapshot's subtree under a fresh detached root, sharing
-        //    the snapshot's blocks. `DirListing::Snapshot` reconstructs entries the
-        //    delta deleted, which a current-tree scan can no longer enumerate.
-        let restored_root =
-            self.materialize_subtree_at(target_root, snapshot_version, DirListing::Snapshot)?;
+        //    the snapshot's blocks. Snapshot-aware scans enumerate entries deleted
+        //    by the delta through the retained-history key index.
+        let restored_root = self.materialize_subtree_at(target_root, snapshot_version)?;
         let restored_keys = self.subtree_object_keys(restored_root)?;
 
         // 2. Capture both sides' top-level children, then graft atomically.

--- a/crates/nokv-meta/src/service/snapshot.rs
+++ b/crates/nokv-meta/src/service/snapshot.rs
@@ -3,50 +3,118 @@ use super::*;
 /// Default lease for a new snapshot pin: holders renew to keep it alive; an
 /// abandoned pin expires after this so a crashed client never blocks GC forever.
 pub const DEFAULT_SNAPSHOT_LEASE_MS: u64 = 3_600_000;
+const SNAPSHOT_MINT_MAX_ATTEMPTS: usize = 8;
+const SNAPSHOT_RENEW_MAX_ATTEMPTS: usize = 8;
+const SNAPSHOT_ID_SHARD_BITS: u32 = 16;
+const SNAPSHOT_ID_LOCAL_BITS: u32 = u64::BITS - SNAPSHOT_ID_SHARD_BITS;
+const SNAPSHOT_ID_LOCAL_MASK: u64 = (1_u64 << SNAPSHOT_ID_LOCAL_BITS) - 1;
+
+#[derive(Clone, Debug)]
+struct VersionedSnapshotPin {
+    pin: SnapshotPin,
+    version: Version,
+}
 
 impl<M, O> NoKvFs<M, O>
 where
     M: MetadataStore,
     O: ObjectStore,
 {
-    pub fn snapshot_subtree(&self, root: InodeId) -> Result<SnapshotPin, MetadError> {
+    pub(crate) fn snapshot_subtree(&self, root: InodeId) -> Result<SnapshotPin, MetadError> {
         self.snapshot_subtree_with_lease(root, DEFAULT_SNAPSHOT_LEASE_MS)
     }
 
-    pub fn snapshot_subtree_with_lease(
+    pub(crate) fn snapshot_subtree_with_lease(
         &self,
         root: InodeId,
         lease_ms: u64,
     ) -> Result<SnapshotPin, MetadError> {
-        let Some(attr) = self.get_attr_at_version_for_purpose(
-            root,
-            self.read_version()?,
-            ReadPurpose::WritePlanLocal,
-        )?
-        else {
-            return Err(MetadError::NotFound);
-        };
-        if attr.file_type != FileType::Directory {
-            return Err(MetadError::NotDirectory);
+        for attempt in 0..SNAPSHOT_MINT_MAX_ATTEMPTS {
+            let Some(attr) = self.get_attr_at_version_for_purpose(
+                root,
+                self.read_version()?,
+                ReadPurpose::WritePlanLocal,
+            )?
+            else {
+                return Err(MetadError::NotFound);
+            };
+            if attr.file_type != FileType::Directory {
+                return Err(MetadError::NotDirectory);
+            }
+            let created_version = self.next_version()?;
+            let read_version = predecessor(created_version)?;
+            let pin = SnapshotPin {
+                snapshot_id: self.snapshot_id_for_version(created_version)?,
+                root,
+                read_version: read_version.get(),
+                created_version: created_version.get(),
+                lease_expires_unix_ms: self.now_ms().saturating_add(lease_ms),
+            };
+            let key = snapshot_pin_key(self.mount, pin.snapshot_id);
+            match self.commit_metadata(MetadataCommand {
+                request_id: request_id(b"snapshot-subtree", self.mount, root, created_version),
+                kind: CommandKind::SnapshotSubtree,
+                read_version,
+                commit_version: created_version,
+                primary_family: RecordFamily::Snapshot,
+                primary_key: key.clone(),
+                predicates: vec![
+                    PredicateRef {
+                        family: RecordFamily::Inode,
+                        key: inode_key(self.mount, root),
+                        predicate: Predicate::Exists,
+                    },
+                    PredicateRef {
+                        family: RecordFamily::Snapshot,
+                        key: key.clone(),
+                        predicate: Predicate::NotExists,
+                    },
+                ],
+                mutations: vec![Mutation {
+                    family: RecordFamily::Snapshot,
+                    key,
+                    op: MutationOp::Put,
+                    value: Some(Value(encode_snapshot_pin(&pin))),
+                }],
+                watch: Vec::new(),
+            }) {
+                Ok(_) => return Ok(pin),
+                Err(MetadError::Metadata(MetadataError::PredicateFailed))
+                    if attempt + 1 < SNAPSHOT_MINT_MAX_ATTEMPTS =>
+                {
+                    continue;
+                }
+                Err(err) => return Err(err),
+            }
         }
-        let created_version = self.next_version()?;
-        let read_version = predecessor(created_version)?;
-        let pin = SnapshotPin {
-            snapshot_id: created_version.get(),
-            root,
-            read_version: read_version.get(),
-            created_version: created_version.get(),
-            lease_expires_unix_ms: current_time_ms().saturating_add(lease_ms),
-        };
-        let key = snapshot_pin_key(self.mount, pin.snapshot_id);
-        self.commit_metadata(MetadataCommand {
-            request_id: request_id(b"snapshot-subtree", self.mount, root, created_version),
-            kind: CommandKind::SnapshotSubtree,
-            read_version,
-            commit_version: created_version,
-            primary_family: RecordFamily::Snapshot,
-            primary_key: key.clone(),
-            predicates: vec![
+        unreachable!("snapshot mint retry loop always returns")
+    }
+
+    pub fn snapshot_subtree_path(&self, path: &str) -> Result<SnapshotPin, MetadError> {
+        self.snapshot_subtree_path_with_lease(path, DEFAULT_SNAPSHOT_LEASE_MS)
+    }
+
+    pub fn snapshot_subtree_path_with_lease(
+        &self,
+        path: &str,
+        lease_ms: u64,
+    ) -> Result<SnapshotPin, MetadError> {
+        for attempt in 0..SNAPSHOT_MINT_MAX_ATTEMPTS {
+            let binding_version = self.read_version()?;
+            let (root, mut predicates) =
+                self.resolve_snapshot_root_binding(path, binding_version)?;
+            let binding_predicates = predicates.clone();
+            let created_version = self.next_version()?;
+            let read_version = predecessor(created_version)?;
+            let pin = SnapshotPin {
+                snapshot_id: self.snapshot_id_for_version(created_version)?,
+                root,
+                read_version: read_version.get(),
+                created_version: created_version.get(),
+                lease_expires_unix_ms: self.now_ms().saturating_add(lease_ms),
+            };
+            let key = snapshot_pin_key(self.mount, pin.snapshot_id);
+            predicates.extend([
                 PredicateRef {
                     family: RecordFamily::Inode,
                     key: inode_key(self.mount, root),
@@ -57,24 +125,54 @@ where
                     key: key.clone(),
                     predicate: Predicate::NotExists,
                 },
-            ],
-            mutations: vec![Mutation {
-                family: RecordFamily::Snapshot,
-                key,
-                op: MutationOp::Put,
-                value: Some(Value(encode_snapshot_pin(&pin))),
-            }],
-            watch: Vec::new(),
-        })?;
-        Ok(pin)
+            ]);
+            match self.commit_metadata(MetadataCommand {
+                request_id: request_id(b"snapshot-subtree-path", self.mount, root, created_version),
+                kind: CommandKind::SnapshotSubtree,
+                read_version,
+                commit_version: created_version,
+                primary_family: RecordFamily::Snapshot,
+                primary_key: key.clone(),
+                predicates,
+                mutations: vec![Mutation {
+                    family: RecordFamily::Snapshot,
+                    key: key.clone(),
+                    op: MutationOp::Put,
+                    value: Some(Value(encode_snapshot_pin(&pin))),
+                }],
+                watch: Vec::new(),
+            }) {
+                Ok(_) => return Ok(pin),
+                Err(MetadError::SyncLogArchiveFailed {
+                    committed: true, ..
+                }) => {
+                    let durable = self.snapshot_pin(pin.snapshot_id)?;
+                    if durable.as_ref() == Some(&pin) {
+                        return Ok(pin);
+                    }
+                    return Err(MetadError::Codec(format!(
+                        "snapshot {} reported committed without its durable pin",
+                        pin.snapshot_id
+                    )));
+                }
+                Err(MetadError::Metadata(MetadataError::PredicateFailed)) => {
+                    if !self.snapshot_binding_predicates_match(&binding_predicates)? {
+                        return Err(MetadError::SnapshotBindingChanged {
+                            root_path: path.to_owned(),
+                        });
+                    }
+                    if attempt + 1 == SNAPSHOT_MINT_MAX_ATTEMPTS {
+                        return Err(MetadError::Metadata(MetadataError::PredicateFailed));
+                    }
+                }
+                Err(err) => return Err(err),
+            }
+        }
+        unreachable!("snapshot path mint retry loop always returns")
     }
 
-    pub fn snapshot_subtree_path(&self, path: &str) -> Result<SnapshotPin, MetadError> {
-        let root = self.resolve_directory_path(path)?;
-        self.snapshot_subtree(root)
-    }
-
-    pub fn retire_snapshot(&self, snapshot_id: u64) -> Result<bool, MetadError> {
+    #[cfg(test)]
+    pub(crate) fn retire_snapshot(&self, snapshot_id: u64) -> Result<bool, MetadError> {
         let key = snapshot_pin_key(self.mount, snapshot_id);
         if self.snapshot_pin(snapshot_id)?.is_none() {
             return Ok(false);
@@ -98,45 +196,233 @@ where
         Ok(true)
     }
 
-    /// Extend a pin's lease so it keeps protecting its snapshot. Extend-only: a
-    /// renew never shortens an existing lease (Iceberg / S3 Object Lock
-    /// semantics), so a short renew can't silently drop protection below what a
-    /// prior renew already granted. Shrinking protection is expressed by
-    /// `retire`, not by renew. Returns false if the pin no longer exists
-    /// (already retired, or reaped after expiry).
-    pub fn renew_snapshot(&self, snapshot_id: u64, lease_ms: u64) -> Result<bool, MetadError> {
-        let Some(mut pin) = self.snapshot_pin(snapshot_id)? else {
+    pub fn retire_snapshot_path(
+        &self,
+        root_path: &str,
+        snapshot_id: u64,
+    ) -> Result<bool, MetadError> {
+        let read_version = self.read_version()?;
+        let (expected_root, mut predicates) =
+            self.resolve_snapshot_root_binding(root_path, read_version)?;
+        self.ensure_snapshot_id_shard(snapshot_id, expected_root)?;
+        let Some(versioned) =
+            self.versioned_snapshot_pin_at(snapshot_id, read_version, ReadPurpose::UserStrong)?
+        else {
             return Ok(false);
         };
-        let new_expiry = current_time_ms().saturating_add(lease_ms);
-        pin.lease_expires_unix_ms = pin.lease_expires_unix_ms.max(new_expiry);
+        if versioned.pin.root != expected_root {
+            return Err(MetadError::SnapshotRootMismatch {
+                snapshot_id,
+                expected_root,
+                actual_root: Some(versioned.pin.root),
+                actual_shard: self.shard_index(),
+            });
+        }
         let key = snapshot_pin_key(self.mount, snapshot_id);
+        predicates.push(PredicateRef {
+            family: RecordFamily::Snapshot,
+            key: key.clone(),
+            predicate: Predicate::VersionEquals(versioned.version),
+        });
         let version = self.next_version()?;
-        self.commit_metadata(MetadataCommand {
-            request_id: request_id(b"renew-snapshot", self.mount, pin.root, version),
-            kind: CommandKind::RenewSnapshot,
+        match self.commit_metadata(MetadataCommand {
+            request_id: request_id(
+                b"retire-snapshot-path",
+                self.mount,
+                versioned.pin.root,
+                version,
+            ),
+            kind: CommandKind::RetireSnapshot,
             read_version: predecessor(version)?,
             commit_version: version,
             primary_family: RecordFamily::Snapshot,
             primary_key: key.clone(),
-            predicates: vec![PredicateRef {
-                family: RecordFamily::Snapshot,
-                key: key.clone(),
-                predicate: Predicate::Exists,
-            }],
-            mutations: vec![Mutation {
-                family: RecordFamily::Snapshot,
-                key,
-                op: MutationOp::Put,
-                value: Some(Value(encode_snapshot_pin(&pin))),
-            }],
+            predicates,
+            mutations: vec![delete_mutation(RecordFamily::Snapshot, key)],
             watch: Vec::new(),
-        })?;
-        Ok(true)
+        }) {
+            Ok(_) => Ok(true),
+            Err(MetadError::Metadata(MetadataError::PredicateFailed)) => {
+                Err(MetadError::SnapshotBindingChanged {
+                    root_path: root_path.to_owned(),
+                })
+            }
+            Err(err) => Err(err),
+        }
     }
 
-    pub fn snapshot_pin(&self, snapshot_id: u64) -> Result<Option<SnapshotPin>, MetadError> {
+    /// Extend a live pin without ever shortening a lease promised by another
+    /// successful renew. The pin record version read by this attempt is the CAS
+    /// fence; a conflict is retried from an authoritative read.
+    #[cfg(test)]
+    pub(crate) fn renew_snapshot(
+        &self,
+        snapshot_id: u64,
+        lease_ms: u64,
+    ) -> Result<SnapshotRenewOutcome, MetadError> {
+        self.renew_snapshot_bound(None, snapshot_id, lease_ms)
+    }
+
+    /// Root-bound form used by path clients. The absolute root path is resolved
+    /// on every retry and every component's dentry version joins the pin CAS, so
+    /// a concurrent rename/rebind cannot renew a snapshot through a stale name.
+    pub fn renew_snapshot_path(
+        &self,
+        root_path: &str,
+        snapshot_id: u64,
+        lease_ms: u64,
+    ) -> Result<SnapshotRenewOutcome, MetadError> {
+        self.renew_snapshot_bound(Some(root_path), snapshot_id, lease_ms)
+    }
+
+    fn renew_snapshot_bound(
+        &self,
+        root_path: Option<&str>,
+        snapshot_id: u64,
+        lease_ms: u64,
+    ) -> Result<SnapshotRenewOutcome, MetadError> {
+        let requested_expiry = self.now_ms().saturating_add(lease_ms);
+        let key = snapshot_pin_key(self.mount, snapshot_id);
+        for _attempt in 0..SNAPSHOT_RENEW_MAX_ATTEMPTS {
+            let read_version = self.read_version()?;
+            let (bound_root, mut binding_predicates) = match root_path {
+                Some(root_path) => {
+                    let (root, predicates) =
+                        self.resolve_snapshot_root_binding(root_path, read_version)?;
+                    self.ensure_snapshot_id_shard(snapshot_id, root)?;
+                    (Some(root), predicates)
+                }
+                None => (None, Vec::new()),
+            };
+            let Some(versioned) =
+                self.versioned_snapshot_pin_at(snapshot_id, read_version, ReadPurpose::UserStrong)?
+            else {
+                return Ok(SnapshotRenewOutcome::Missing { snapshot_id });
+            };
+            if let Some(actual_root) = bound_root {
+                if actual_root != versioned.pin.root {
+                    return Err(MetadError::SnapshotRootMismatch {
+                        snapshot_id,
+                        expected_root: actual_root,
+                        actual_root: Some(versioned.pin.root),
+                        actual_shard: self.shard_index(),
+                    });
+                }
+            }
+            let now_ms = self.now_ms();
+            if now_ms >= versioned.pin.lease_expires_unix_ms {
+                return Err(MetadError::SnapshotLeaseExpired {
+                    snapshot_id,
+                    lease_expires_unix_ms: versioned.pin.lease_expires_unix_ms,
+                    now_ms,
+                });
+            }
+            if versioned.pin.lease_expires_unix_ms >= requested_expiry {
+                return Ok(SnapshotRenewOutcome::Renewed {
+                    pin: versioned.pin,
+                    extended: false,
+                });
+            }
+
+            live_test_barrier::snapshot(snapshot_id, "renew-read")?;
+
+            let mut renewed = versioned.pin;
+            renewed.lease_expires_unix_ms = requested_expiry;
+            let binding_fence = binding_predicates.clone();
+            binding_predicates.push(PredicateRef {
+                family: RecordFamily::Snapshot,
+                key: key.clone(),
+                predicate: Predicate::VersionEquals(versioned.version),
+            });
+            let commit_version = self.next_version()?;
+            let command = MetadataCommand {
+                request_id: request_id(b"renew-snapshot", self.mount, renewed.root, commit_version),
+                kind: CommandKind::RenewSnapshot,
+                read_version: predecessor(commit_version)?,
+                commit_version,
+                primary_family: RecordFamily::Snapshot,
+                primary_key: key.clone(),
+                predicates: binding_predicates,
+                mutations: vec![Mutation {
+                    family: RecordFamily::Snapshot,
+                    key: key.clone(),
+                    op: MutationOp::Put,
+                    value: Some(Value(encode_snapshot_pin(&renewed))),
+                }],
+                watch: Vec::new(),
+            };
+            match self.commit_metadata(command) {
+                Ok(_) => {
+                    return Ok(SnapshotRenewOutcome::Renewed {
+                        pin: renewed,
+                        extended: true,
+                    });
+                }
+                Err(MetadError::Metadata(MetadataError::PredicateFailed)) => {
+                    if let Some(root_path) = root_path {
+                        if !self.snapshot_binding_predicates_match(&binding_fence)? {
+                            return Err(MetadError::SnapshotBindingChanged {
+                                root_path: root_path.to_owned(),
+                            });
+                        }
+                    }
+                    continue;
+                }
+                Err(MetadError::SyncLogArchiveFailed {
+                    committed: true,
+                    message,
+                }) => {
+                    let reconciled = self.snapshot_pin(snapshot_id)?;
+                    if let Some(pin) = reconciled {
+                        if pin.root == renewed.root && pin.lease_expires_unix_ms >= requested_expiry
+                        {
+                            return Ok(SnapshotRenewOutcome::Renewed {
+                                pin,
+                                extended: true,
+                            });
+                        }
+                    }
+                    return Err(MetadError::SyncLogArchiveFailed {
+                        committed: true,
+                        message,
+                    });
+                }
+                Err(err) => return Err(err),
+            }
+        }
+        Err(MetadError::SnapshotRenewContended {
+            snapshot_id,
+            attempts: SNAPSHOT_RENEW_MAX_ATTEMPTS,
+        })
+    }
+
+    pub(crate) fn snapshot_pin(&self, snapshot_id: u64) -> Result<Option<SnapshotPin>, MetadError> {
         self.snapshot_pin_for_purpose(snapshot_id, ReadPurpose::UserStrong)
+    }
+
+    pub fn snapshot_pin_path(
+        &self,
+        root_path: &str,
+        snapshot_id: u64,
+    ) -> Result<Option<SnapshotPin>, MetadError> {
+        let binding_version = self.read_version()?;
+        let (actual_root, _) = self.resolve_snapshot_root_binding(root_path, binding_version)?;
+        self.ensure_snapshot_id_shard(snapshot_id, actual_root)?;
+        let Some(pin) = self
+            .versioned_snapshot_pin_at(snapshot_id, binding_version, ReadPurpose::UserStrong)?
+            .map(|versioned| versioned.pin)
+        else {
+            return Ok(None);
+        };
+        if actual_root != pin.root {
+            return Err(MetadError::SnapshotRootMismatch {
+                snapshot_id,
+                expected_root: actual_root,
+                actual_root: Some(pin.root),
+                actual_shard: self.shard_index(),
+            });
+        }
+        Ok(Some(pin))
     }
 
     fn snapshot_pin_for_purpose(
@@ -144,68 +430,225 @@ where
         snapshot_id: u64,
         purpose: ReadPurpose,
     ) -> Result<Option<SnapshotPin>, MetadError> {
-        let value = self.metadata.get(
+        Ok(self
+            .versioned_snapshot_pin_at(snapshot_id, self.read_version()?, purpose)?
+            .map(|versioned| versioned.pin))
+    }
+
+    fn versioned_snapshot_pin_at(
+        &self,
+        snapshot_id: u64,
+        version: Version,
+        purpose: ReadPurpose,
+    ) -> Result<Option<VersionedSnapshotPin>, MetadError> {
+        let item = self.metadata.get_versioned(
             RecordFamily::Snapshot,
             &snapshot_pin_key(self.mount, snapshot_id),
-            self.read_version()?,
+            version,
             purpose,
         )?;
-        value
-            .map(|value| {
-                decode_snapshot_pin(&value.0).map_err(|err| MetadError::Codec(err.to_string()))
+        item.map(|item| {
+            let pin = decode_snapshot_pin(&item.value.0)
+                .map_err(|err| MetadError::Codec(err.to_string()))?;
+            Ok(VersionedSnapshotPin {
+                pin,
+                version: item.version,
             })
-            .transpose()
+        })
+        .transpose()
+    }
+
+    fn resolve_snapshot_root_binding(
+        &self,
+        root_path: &str,
+        version: Version,
+    ) -> Result<(InodeId, Vec<PredicateRef>), MetadError> {
+        let components = parse_absolute_path(root_path)?;
+        let mut current = InodeId::root();
+        let mut predicates = Vec::with_capacity(components.len());
+        for name in components {
+            let Some((entry, dentry_version)) = self.lookup_plus_at_version_for_purpose(
+                current,
+                &name,
+                version,
+                ReadPurpose::UserStrong,
+            )?
+            else {
+                return Err(MetadError::NotFound);
+            };
+            if entry.attr.file_type != FileType::Directory {
+                return Err(MetadError::NotDirectory);
+            }
+            predicates.push(PredicateRef {
+                family: RecordFamily::Dentry,
+                key: dentry_key(self.mount, current, &name),
+                predicate: Predicate::VersionEquals(dentry_version),
+            });
+            current = entry.attr.inode;
+        }
+        Ok((current, predicates))
+    }
+
+    fn snapshot_binding_predicates_match(
+        &self,
+        predicates: &[PredicateRef],
+    ) -> Result<bool, MetadError> {
+        let version = self.read_version()?;
+        for predicate in predicates {
+            let Predicate::VersionEquals(expected) = predicate.predicate else {
+                continue;
+            };
+            let current = self.metadata.get_versioned(
+                predicate.family,
+                &predicate.key,
+                version,
+                ReadPurpose::UserStrong,
+            )?;
+            if current.as_ref().map(|item| item.version) != Some(expected) {
+                return Ok(false);
+            }
+        }
+        Ok(true)
+    }
+
+    fn live_snapshot_pin_bound_to_path(
+        &self,
+        root_path: &str,
+        snapshot_id: u64,
+        purpose: ReadPurpose,
+    ) -> Result<SnapshotPin, MetadError> {
+        let binding_version = self.read_version()?;
+        let (actual_root, _) = self.resolve_snapshot_root_binding(root_path, binding_version)?;
+        self.ensure_snapshot_id_shard(snapshot_id, actual_root)?;
+        let pin = self
+            .versioned_snapshot_pin_at(snapshot_id, binding_version, purpose)?
+            .map(|versioned| versioned.pin)
+            .ok_or(MetadError::NotFound)?;
+        if actual_root != pin.root {
+            return Err(MetadError::SnapshotRootMismatch {
+                snapshot_id,
+                expected_root: actual_root,
+                actual_root: Some(pin.root),
+                actual_shard: self.shard_index(),
+            });
+        }
+        self.ensure_snapshot_pin_live(&pin)?;
+        Ok(pin)
+    }
+
+    fn snapshot_id_for_version(&self, version: Version) -> Result<u64, MetadError> {
+        let local = version.get();
+        if local > SNAPSHOT_ID_LOCAL_MASK {
+            return Err(MetadError::Codec(
+                "snapshot id local sequence exhausted its 48-bit shard namespace".to_owned(),
+            ));
+        }
+        Ok((u64::from(self.shard_index()) << SNAPSHOT_ID_LOCAL_BITS) | local)
+    }
+
+    fn ensure_snapshot_id_shard(
+        &self,
+        snapshot_id: u64,
+        expected_root: InodeId,
+    ) -> Result<(), MetadError> {
+        let actual_shard = (snapshot_id >> SNAPSHOT_ID_LOCAL_BITS) as u16;
+        if actual_shard != self.shard_index() {
+            return Err(MetadError::SnapshotRootMismatch {
+                snapshot_id,
+                expected_root,
+                actual_root: None,
+                actual_shard,
+            });
+        }
+        Ok(())
+    }
+
+    fn ensure_snapshot_pin_live(&self, pin: &SnapshotPin) -> Result<(), MetadError> {
+        let now_ms = self.now_ms();
+        if now_ms >= pin.lease_expires_unix_ms {
+            return Err(MetadError::SnapshotLeaseExpired {
+                snapshot_id: pin.snapshot_id,
+                lease_expires_unix_ms: pin.lease_expires_unix_ms,
+                now_ms,
+            });
+        }
+        Ok(())
     }
 
     pub fn get_attr_at_snapshot(
         &self,
+        root_path: &str,
         snapshot_id: u64,
-        inode: InodeId,
+        components: &[DentryName],
     ) -> Result<Option<InodeAttr>, MetadError> {
-        let version = self.snapshot_read_version(snapshot_id)?;
-        self.get_attr_at_version_for_purpose(inode, version, ReadPurpose::Snapshot)
+        let pin =
+            self.live_snapshot_pin_bound_to_path(root_path, snapshot_id, ReadPurpose::Snapshot)?;
+        let version = Version::new(pin.read_version)?;
+        if components.is_empty() {
+            return self.get_attr_at_version_for_purpose(pin.root, version, ReadPurpose::Snapshot);
+        }
+        self.snapshot_entry_from_components(pin.root, components, version)
+            .map(|entry| entry.map(|entry| entry.attr))
     }
 
     pub fn lookup_plus_at_snapshot(
         &self,
+        root_path: &str,
         snapshot_id: u64,
-        parent: InodeId,
+        parent_components: &[DentryName],
         name: &DentryName,
     ) -> Result<Option<DentryWithAttr>, MetadError> {
-        let version = self.snapshot_read_version(snapshot_id)?;
+        let pin =
+            self.live_snapshot_pin_bound_to_path(root_path, snapshot_id, ReadPurpose::Snapshot)?;
+        let version = Version::new(pin.read_version)?;
+        let parent = self.resolve_components_as_directory_from_at_version_for_purpose(
+            pin.root,
+            parent_components,
+            version,
+            ReadPurpose::Snapshot,
+        )?;
         self.lookup_plus_at_version_for_purpose(parent, name, version, ReadPurpose::Snapshot)
             .map(|entry| entry.map(|(entry, _)| entry))
     }
 
     pub fn read_dir_plus_at_snapshot(
         &self,
+        root_path: &str,
         snapshot_id: u64,
-        parent: InodeId,
+        components: &[DentryName],
     ) -> Result<Vec<DentryWithAttr>, MetadError> {
-        let version = self.snapshot_read_version(snapshot_id)?;
+        let pin =
+            self.live_snapshot_pin_bound_to_path(root_path, snapshot_id, ReadPurpose::Snapshot)?;
+        let version = Version::new(pin.read_version)?;
+        let parent = self.resolve_components_as_directory_from_at_version_for_purpose(
+            pin.root,
+            components,
+            version,
+            ReadPurpose::Snapshot,
+        )?;
         self.read_dir_plus_at_version_for_purpose(parent, version, ReadPurpose::Snapshot)
     }
 
     pub fn stat_path_at_snapshot(
         &self,
+        root_path: &str,
         snapshot_id: u64,
         path: &str,
     ) -> Result<Option<PathMetadata>, MetadError> {
-        let pin = self
-            .snapshot_pin_for_purpose(snapshot_id, ReadPurpose::Snapshot)?
-            .ok_or(MetadError::NotFound)?;
+        let pin =
+            self.live_snapshot_pin_bound_to_path(root_path, snapshot_id, ReadPurpose::Snapshot)?;
         let version = Version::new(pin.read_version)?;
         self.stat_path_from_at_version_for_purpose(pin.root, path, version, ReadPurpose::Snapshot)
     }
 
     pub fn read_dir_plus_path_at_snapshot(
         &self,
+        root_path: &str,
         snapshot_id: u64,
         path: &str,
     ) -> Result<Vec<DentryWithAttr>, MetadError> {
-        let pin = self
-            .snapshot_pin_for_purpose(snapshot_id, ReadPurpose::Snapshot)?
-            .ok_or(MetadError::NotFound)?;
+        let pin =
+            self.live_snapshot_pin_bound_to_path(root_path, snapshot_id, ReadPurpose::Snapshot)?;
         let version = Version::new(pin.read_version)?;
         let parent = self.resolve_components_as_directory_from_at_version_for_purpose(
             pin.root,
@@ -216,38 +659,58 @@ where
         self.read_dir_plus_at_version_for_purpose(parent, version, ReadPurpose::Snapshot)
     }
 
+    pub fn read_dir_plus_path_at_snapshot_page(
+        &self,
+        root_path: &str,
+        snapshot_id: u64,
+        path: &str,
+        after: Option<&DentryName>,
+        limit: usize,
+    ) -> Result<ReadDirPlusPage, MetadError> {
+        let pin =
+            self.live_snapshot_pin_bound_to_path(root_path, snapshot_id, ReadPurpose::Snapshot)?;
+        let version = Version::new(pin.read_version)?;
+        let parent = self.resolve_components_as_directory_from_at_version_for_purpose(
+            pin.root,
+            &parse_absolute_path(path)?,
+            version,
+            ReadPurpose::Snapshot,
+        )?;
+        self.read_dir_plus_page_at_version_for_purpose(
+            parent,
+            after,
+            limit,
+            version,
+            ReadPurpose::Snapshot,
+        )
+    }
+
     pub fn read_file_at_snapshot(
         &self,
+        root_path: &str,
         snapshot_id: u64,
-        inode: InodeId,
+        components: &[DentryName],
         offset: u64,
         len: usize,
     ) -> Result<Vec<u8>, MetadError> {
+        let pin =
+            self.live_snapshot_pin_bound_to_path(root_path, snapshot_id, ReadPurpose::Snapshot)?;
         if len == 0 {
             return Ok(Vec::new());
         }
-        let version = self.snapshot_read_version(snapshot_id)?;
-        let Some(attr) =
-            self.get_attr_at_version_for_purpose(inode, version, ReadPurpose::Snapshot)?
-        else {
-            return Err(MetadError::NotFound);
-        };
-        if attr.file_type != FileType::File {
+        let version = Version::new(pin.read_version)?;
+        let entry = self
+            .snapshot_entry_from_components(pin.root, components, version)?
+            .ok_or(MetadError::NotFound)?;
+        if entry.attr.file_type != FileType::File {
             return Err(MetadError::NotFile);
         }
-        if offset >= attr.size {
+        if offset >= entry.attr.size {
             return Ok(Vec::new());
         }
-        let body = self
-            .body_descriptor_at_version_for_purpose(
-                inode,
-                attr.generation,
-                version,
-                ReadPurpose::Snapshot,
-            )?
-            .ok_or(MetadError::MissingBodyDescriptor)?;
+        let body = entry.body.ok_or(MetadError::MissingBodyDescriptor)?;
         self.read_file_at_version_for_purpose(
-            inode,
+            entry.attr.inode,
             &body,
             offset,
             len,
@@ -258,28 +721,22 @@ where
 
     pub fn read_symlink_at_snapshot(
         &self,
+        root_path: &str,
         snapshot_id: u64,
-        inode: InodeId,
+        components: &[DentryName],
     ) -> Result<Vec<u8>, MetadError> {
-        let version = self.snapshot_read_version(snapshot_id)?;
-        let Some(attr) =
-            self.get_attr_at_version_for_purpose(inode, version, ReadPurpose::Snapshot)?
-        else {
-            return Err(MetadError::NotFound);
-        };
-        if attr.file_type != FileType::Symlink {
+        let pin =
+            self.live_snapshot_pin_bound_to_path(root_path, snapshot_id, ReadPurpose::Snapshot)?;
+        let version = Version::new(pin.read_version)?;
+        let entry = self
+            .snapshot_entry_from_components(pin.root, components, version)?
+            .ok_or(MetadError::NotFound)?;
+        if entry.attr.file_type != FileType::Symlink {
             return Err(MetadError::NotFile);
         }
-        let body = self
-            .body_descriptor_at_version_for_purpose(
-                inode,
-                attr.generation,
-                version,
-                ReadPurpose::Snapshot,
-            )?
-            .ok_or(MetadError::MissingBodyDescriptor)?;
+        let body = entry.body.ok_or(MetadError::MissingBodyDescriptor)?;
         self.read_file_at_version_for_purpose(
-            inode,
+            entry.attr.inode,
             &body,
             0,
             body.size as usize,
@@ -288,19 +745,38 @@ where
         )
     }
 
+    fn snapshot_entry_from_components(
+        &self,
+        root: InodeId,
+        components: &[DentryName],
+        version: Version,
+    ) -> Result<Option<DentryWithAttr>, MetadError> {
+        let Some((name, parents)) = components.split_last() else {
+            return Ok(None);
+        };
+        let parent = self.resolve_components_as_directory_from_at_version_for_purpose(
+            root,
+            parents,
+            version,
+            ReadPurpose::Snapshot,
+        )?;
+        self.lookup_plus_at_version_for_purpose(parent, name, version, ReadPurpose::Snapshot)
+            .map(|entry| entry.map(|(entry, _)| entry))
+    }
+
     pub fn read_file_path_at_snapshot(
         &self,
+        root_path: &str,
         snapshot_id: u64,
         path: &str,
         offset: u64,
         len: usize,
     ) -> Result<Vec<u8>, MetadError> {
+        let pin =
+            self.live_snapshot_pin_bound_to_path(root_path, snapshot_id, ReadPurpose::Snapshot)?;
         if len == 0 {
             return Ok(Vec::new());
         }
-        let pin = self
-            .snapshot_pin_for_purpose(snapshot_id, ReadPurpose::Snapshot)?
-            .ok_or(MetadError::NotFound)?;
         let version = Version::new(pin.read_version)?;
         let entry = self
             .lookup_path_from_at_version_for_purpose(
@@ -328,39 +804,14 @@ where
         )
     }
 
-    pub fn read_artifact_at_snapshot(
-        &self,
-        snapshot_id: u64,
-        parent: InodeId,
-        name: &DentryName,
-    ) -> Result<Vec<u8>, MetadError> {
-        let version = self.snapshot_read_version(snapshot_id)?;
-        let entry = self
-            .lookup_plus_at_version_for_purpose(parent, name, version, ReadPurpose::Snapshot)?
-            .map(|(entry, _)| entry)
-            .ok_or(MetadError::NotFound)?;
-        if entry.attr.file_type != FileType::File {
-            return Err(MetadError::NotFile);
-        }
-        let body = entry.body.ok_or(MetadError::MissingBodyDescriptor)?;
-        self.read_file_at_version_for_purpose(
-            entry.attr.inode,
-            &body,
-            0,
-            body.size as usize,
-            version,
-            ReadPurpose::Snapshot,
-        )
-    }
-
     pub fn read_artifact_path_at_snapshot(
         &self,
+        root_path: &str,
         snapshot_id: u64,
         path: &str,
     ) -> Result<Vec<u8>, MetadError> {
-        let pin = self
-            .snapshot_pin_for_purpose(snapshot_id, ReadPurpose::Snapshot)?
-            .ok_or(MetadError::NotFound)?;
+        let pin =
+            self.live_snapshot_pin_bound_to_path(root_path, snapshot_id, ReadPurpose::Snapshot)?;
         let version = Version::new(pin.read_version)?;
         let entry = self
             .lookup_path_from_at_version_for_purpose(
@@ -383,12 +834,5 @@ where
             version,
             ReadPurpose::Snapshot,
         )
-    }
-
-    pub(super) fn snapshot_read_version(&self, snapshot_id: u64) -> Result<Version, MetadError> {
-        let pin = self
-            .snapshot_pin_for_purpose(snapshot_id, ReadPurpose::Snapshot)?
-            .ok_or(MetadError::NotFound)?;
-        Version::new(pin.read_version).map_err(Into::into)
     }
 }

--- a/crates/nokv-meta/src/service_tests.rs
+++ b/crates/nokv-meta/src/service_tests.rs
@@ -4,7 +4,174 @@ use crate::holtstore::HoltMetadataStore;
 use crate::{MetadataLogEntry, MetadataLogSegment, METADATA_LOG_ZERO_DIGEST};
 use nokv_object::{MemoryObjectStore, ObjectBytes};
 use nokv_types::{AdvisoryLockKind, AdvisoryLockRequest};
-use std::sync::Arc;
+use std::sync::{Arc, Barrier};
+
+#[derive(Clone)]
+struct SnapshotCommitBarrierStore {
+    inner: HoltMetadataStore,
+    kind: CommandKind,
+    remaining: Arc<AtomicU64>,
+    entered: Arc<Barrier>,
+    release: Arc<Barrier>,
+}
+
+impl SnapshotCommitBarrierStore {
+    fn new(kind: CommandKind, blocked_commits: u64, parties: usize) -> Self {
+        Self {
+            inner: HoltMetadataStore::open_memory().unwrap(),
+            kind,
+            remaining: Arc::new(AtomicU64::new(blocked_commits)),
+            entered: Arc::new(Barrier::new(parties)),
+            release: Arc::new(Barrier::new(parties)),
+        }
+    }
+
+    fn wait_until_blocked(&self) {
+        self.entered.wait();
+    }
+
+    fn release_blocked(&self) {
+        self.release.wait();
+    }
+}
+
+impl MetadataStore for SnapshotCommitBarrierStore {
+    fn get_versioned(
+        &self,
+        family: RecordFamily,
+        key: &[u8],
+        version: Version,
+        purpose: ReadPurpose,
+    ) -> Result<Option<ReadItem>, MetadataError> {
+        self.inner.get_versioned(family, key, version, purpose)
+    }
+
+    fn scan(&self, request: ScanRequest) -> Result<Vec<ScanItem>, MetadataError> {
+        self.inner.scan(request)
+    }
+
+    fn commit_metadata(&self, command: MetadataCommand) -> Result<CommitResult, MetadataError> {
+        if command.kind == self.kind
+            && self
+                .remaining
+                .fetch_update(Ordering::SeqCst, Ordering::SeqCst, |remaining| {
+                    remaining.checked_sub(1)
+                })
+                .is_ok()
+        {
+            self.entered.wait();
+            self.release.wait();
+        }
+        self.inner.commit_metadata(command)
+    }
+
+    fn commit_independent_batch(
+        &self,
+        commands: &[MetadataCommand],
+    ) -> Vec<Result<CommitResult, MetadataError>> {
+        self.inner.commit_independent_batch(commands)
+    }
+
+    fn committed_request_result(
+        &self,
+        request_id: &[u8],
+    ) -> Result<Option<CommitResult>, MetadataError> {
+        self.inner.committed_request_result(request_id)
+    }
+
+    fn history_retention_epoch(&self) -> Result<u64, MetadataError> {
+        self.inner.history_retention_epoch()
+    }
+
+    fn prune_history(
+        &self,
+        request: HistoryPruneRequest,
+    ) -> Result<HistoryPruneOutcome, MetadataError> {
+        self.inner.prune_history(request)
+    }
+}
+
+impl MetadataStoreStatsProvider for SnapshotCommitBarrierStore {
+    fn metadata_store_stats(&self) -> MetadataStoreStats {
+        self.inner.metadata_store_stats()
+    }
+}
+
+#[derive(Clone)]
+struct SnapshotPredicateOnceStore {
+    inner: HoltMetadataStore,
+    remaining_failures: Arc<AtomicU64>,
+}
+
+impl SnapshotPredicateOnceStore {
+    fn new() -> Self {
+        Self {
+            inner: HoltMetadataStore::open_memory().unwrap(),
+            remaining_failures: Arc::new(AtomicU64::new(1)),
+        }
+    }
+}
+
+impl MetadataStore for SnapshotPredicateOnceStore {
+    fn get_versioned(
+        &self,
+        family: RecordFamily,
+        key: &[u8],
+        version: Version,
+        purpose: ReadPurpose,
+    ) -> Result<Option<ReadItem>, MetadataError> {
+        self.inner.get_versioned(family, key, version, purpose)
+    }
+
+    fn scan(&self, request: ScanRequest) -> Result<Vec<ScanItem>, MetadataError> {
+        self.inner.scan(request)
+    }
+
+    fn commit_metadata(&self, command: MetadataCommand) -> Result<CommitResult, MetadataError> {
+        if command.kind == CommandKind::SnapshotSubtree
+            && self
+                .remaining_failures
+                .fetch_update(Ordering::SeqCst, Ordering::SeqCst, |remaining| {
+                    remaining.checked_sub(1)
+                })
+                .is_ok()
+        {
+            return Err(MetadataError::PredicateFailed);
+        }
+        self.inner.commit_metadata(command)
+    }
+
+    fn commit_independent_batch(
+        &self,
+        commands: &[MetadataCommand],
+    ) -> Vec<Result<CommitResult, MetadataError>> {
+        self.inner.commit_independent_batch(commands)
+    }
+
+    fn committed_request_result(
+        &self,
+        request_id: &[u8],
+    ) -> Result<Option<CommitResult>, MetadataError> {
+        self.inner.committed_request_result(request_id)
+    }
+
+    fn history_retention_epoch(&self) -> Result<u64, MetadataError> {
+        self.inner.history_retention_epoch()
+    }
+
+    fn prune_history(
+        &self,
+        request: HistoryPruneRequest,
+    ) -> Result<HistoryPruneOutcome, MetadataError> {
+        self.inner.prune_history(request)
+    }
+}
+
+impl MetadataStoreStatsProvider for SnapshotPredicateOnceStore {
+    fn metadata_store_stats(&self) -> MetadataStoreStats {
+        self.inner.metadata_store_stats()
+    }
+}
 
 #[derive(Clone)]
 struct PurposeTrackingStore {
@@ -111,6 +278,10 @@ impl MetadataStore for PurposeTrackingStore {
         request_id: &[u8],
     ) -> Result<Option<CommitResult>, MetadataError> {
         self.inner.committed_request_result(request_id)
+    }
+
+    fn history_retention_epoch(&self) -> Result<u64, MetadataError> {
+        self.inner.history_retention_epoch()
     }
 
     fn prune_history(
@@ -369,17 +540,17 @@ fn write_planning_reads_are_marked_local_while_user_reads_stay_strong() {
     assert!(after_snapshot.write_plan_gets > after_remove.write_plan_gets);
 
     assert!(service
-        .get_attr_at_snapshot(snapshot.snapshot_id, dir.attr.inode)
+        .get_attr_at_snapshot("/runs", snapshot.snapshot_id, &[])
         .unwrap()
         .is_some());
     assert!(service
-        .read_dir_plus_at_snapshot(snapshot.snapshot_id, dir.attr.inode)
+        .read_dir_plus_at_snapshot("/runs", snapshot.snapshot_id, &[])
         .unwrap()
         .is_empty());
     let after_snapshot_reads = metadata.counts();
-    assert_eq!(
-        after_snapshot_reads.user_strong_gets,
-        after_snapshot.user_strong_gets
+    assert!(
+        after_snapshot_reads.user_strong_gets > after_snapshot.user_strong_gets,
+        "root-path binding is resolved with strong reads before snapshot-purpose reads"
     );
     assert!(after_snapshot_reads.snapshot_gets > after_snapshot.snapshot_gets);
     assert!(after_snapshot_reads.snapshot_scans > after_snapshot.snapshot_scans);
@@ -1815,7 +1986,7 @@ fn advisory_locks_detect_conflicts_and_support_partial_unlock() {
 fn snapshot_preserves_symlink_target() {
     let service = service();
     let name = DentryName::new(b"latest".to_vec()).unwrap();
-    let created = service
+    service
         .create_symlink(
             InodeId::root(),
             name.clone(),
@@ -1830,7 +2001,7 @@ fn snapshot_preserves_symlink_target() {
     service
         .create_symlink(
             InodeId::root(),
-            name,
+            name.clone(),
             b"runs/new".to_vec(),
             0o777,
             1000,
@@ -1840,7 +2011,7 @@ fn snapshot_preserves_symlink_target() {
 
     assert_eq!(
         service
-            .read_symlink_at_snapshot(snapshot.snapshot_id, created.attr.inode)
+            .read_symlink_at_snapshot("/", snapshot.snapshot_id, std::slice::from_ref(&name))
             .unwrap(),
         b"runs/old"
     );
@@ -2073,7 +2244,7 @@ fn history_writes_are_snapshot_retention_driven() {
     let snapshot = service.snapshot_subtree(InodeId::root()).unwrap();
     assert_eq!(metadata.metadata_store_stats().active_snapshot_pin_total, 1);
     let snapshot_attr = service
-        .get_attr_at_snapshot(snapshot.snapshot_id, InodeId::root())
+        .get_attr_at_snapshot("/", snapshot.snapshot_id, &[])
         .unwrap()
         .unwrap();
     let before_retained = metadata.metadata_store_stats();
@@ -2091,7 +2262,7 @@ fn history_writes_are_snapshot_retention_driven() {
     );
     assert_eq!(
         service
-            .get_attr_at_snapshot(snapshot.snapshot_id, InodeId::root())
+            .get_attr_at_snapshot("/", snapshot.snapshot_id, &[])
             .unwrap()
             .unwrap(),
         snapshot_attr
@@ -3377,7 +3548,7 @@ fn chain_collapse_gc_is_snapshot_safe() {
     // floor blocks reclamation of everything enqueued after the snapshot.
     assert_eq!(
         service
-            .read_file_at_snapshot(pin.snapshot_id, inode, 0, 4)
+            .read_file_at_snapshot("/", pin.snapshot_id, std::slice::from_ref(&name), 0, 4)
             .unwrap(),
         b"AAAA"
     );
@@ -3390,7 +3561,7 @@ fn chain_collapse_gc_is_snapshot_safe() {
     // Snapshot read still works after the (blocked) GC pass.
     assert_eq!(
         service
-            .read_file_at_snapshot(pin.snapshot_id, inode, 0, 4)
+            .read_file_at_snapshot("/", pin.snapshot_id, std::slice::from_ref(&name), 0, 4)
             .unwrap(),
         b"AAAA"
     );
@@ -3677,7 +3848,7 @@ fn snapshot_after_replace_does_not_block_old_object_cleanup() {
 
     assert_eq!(
         service
-            .read_artifact_at_snapshot(snapshot.snapshot_id, InodeId::root(), &name)
+            .read_artifact_path_at_snapshot("/", snapshot.snapshot_id, "/checkpoint.bin")
             .unwrap(),
         b"new-body"
     );
@@ -3722,25 +3893,25 @@ fn snapshot_preserves_old_artifact_and_blocks_object_gc_until_retired() {
 
     assert_eq!(
         service
-            .read_artifact_at_snapshot(snapshot.snapshot_id, InodeId::root(), &name)
+            .read_artifact_path_at_snapshot("/", snapshot.snapshot_id, "/checkpoint.bin")
             .unwrap(),
         b"old"
     );
     assert_eq!(
         service
-            .get_attr_at_snapshot(snapshot.snapshot_id, first.attr.inode)
+            .get_attr_at_snapshot("/", snapshot.snapshot_id, std::slice::from_ref(&name))
             .unwrap(),
         Some(first.attr.clone())
     );
     assert_eq!(
         service
-            .read_file_at_snapshot(snapshot.snapshot_id, first.attr.inode, 0, 3)
+            .read_file_at_snapshot("/", snapshot.snapshot_id, std::slice::from_ref(&name), 0, 3,)
             .unwrap(),
         b"old"
     );
     assert_eq!(
         service
-            .read_dir_plus_at_snapshot(snapshot.snapshot_id, InodeId::root())
+            .read_dir_plus_at_snapshot("/", snapshot.snapshot_id, &[])
             .unwrap(),
         vec![first.clone()]
     );
@@ -3822,32 +3993,94 @@ fn snapshot_path_reads_are_rooted_at_snapshot_subtree_and_support_ranges() {
         .unwrap();
 
     let root = service
-        .stat_path_at_snapshot(snapshot.snapshot_id, "/")
+        .stat_path_at_snapshot("/scope", snapshot.snapshot_id, "/")
         .unwrap()
         .unwrap();
     assert_eq!(root.attr.inode, scope.attr.inode);
     assert_eq!(
         service
-            .read_dir_plus_path_at_snapshot(snapshot.snapshot_id, "/")
+            .read_dir_plus_path_at_snapshot("/scope", snapshot.snapshot_id, "/")
             .unwrap(),
         vec![nested.clone()]
     );
     let file = service
-        .stat_path_at_snapshot(snapshot.snapshot_id, "/nested/model.bin")
+        .stat_path_at_snapshot("/scope", snapshot.snapshot_id, "/nested/model.bin")
         .unwrap()
         .unwrap();
     assert_eq!(file.attr.generation, inside_old.attr.generation);
     assert_eq!(file.body, inside_old.body);
     assert_eq!(
         service
-            .read_file_path_at_snapshot(snapshot.snapshot_id, "/nested/model.bin", 7, 3)
+            .read_file_path_at_snapshot("/scope", snapshot.snapshot_id, "/nested/model.bin", 7, 3,)
             .unwrap(),
         b"old"
     );
     assert!(matches!(
-        service.read_file_path_at_snapshot(snapshot.snapshot_id, "/outside/model.bin", 0, 7),
+        service.read_file_path_at_snapshot(
+            "/scope",
+            snapshot.snapshot_id,
+            "/outside/model.bin",
+            0,
+            7,
+        ),
         Err(MetadError::NotFound)
     ));
+}
+
+#[test]
+fn snapshot_path_list_pages_include_entries_deleted_after_snapshot() {
+    let service = service();
+    for name in [
+        b"a.txt".as_slice(),
+        b"b.txt".as_slice(),
+        b"c.txt".as_slice(),
+    ] {
+        service
+            .create_file(
+                InodeId::root(),
+                DentryName::new(name.to_vec()).unwrap(),
+                0o644,
+                1000,
+                1000,
+            )
+            .unwrap();
+    }
+    let snapshot = service.snapshot_subtree(InodeId::root()).unwrap();
+    service
+        .rename(
+            InodeId::root(),
+            &DentryName::new(b"b.txt".to_vec()).unwrap(),
+            InodeId::root(),
+            DentryName::new(b"z.txt".to_vec()).unwrap(),
+        )
+        .unwrap();
+    service
+        .remove_file(
+            InodeId::root(),
+            &DentryName::new(b"c.txt".to_vec()).unwrap(),
+        )
+        .unwrap();
+
+    let first = service
+        .read_dir_plus_path_at_snapshot_page("/", snapshot.snapshot_id, "/", None, 2)
+        .unwrap();
+    assert_eq!(
+        first
+            .entries
+            .iter()
+            .map(|entry| entry.dentry.name.as_bytes())
+            .collect::<Vec<_>>(),
+        vec![b"a.txt".as_slice(), b"b.txt".as_slice()]
+    );
+    let cursor = first.next_cursor.unwrap();
+    assert_eq!(cursor.as_bytes(), b"b.txt");
+
+    let second = service
+        .read_dir_plus_path_at_snapshot_page("/", snapshot.snapshot_id, "/", Some(&cursor), 2)
+        .unwrap();
+    assert_eq!(second.entries.len(), 1);
+    assert_eq!(second.entries[0].dentry.name.as_bytes(), b"c.txt");
+    assert!(second.next_cursor.is_none());
 }
 
 #[test]
@@ -3870,7 +4103,7 @@ fn history_cleanup_keeps_snapshot_reads_until_snapshot_retired() {
     assert!(retained.retained_by_snapshots > 0);
     assert_eq!(
         service
-            .read_artifact_at_snapshot(snapshot.snapshot_id, InodeId::root(), &name)
+            .read_artifact_path_at_snapshot("/", snapshot.snapshot_id, "/checkpoint.bin")
             .unwrap(),
         b"old"
     );
@@ -5588,50 +5821,406 @@ fn live_snapshot_pin_blocks_object_gc_until_retired() {
 }
 
 #[test]
-fn renew_snapshot_restores_protection_for_an_expired_lease() {
-    let (service, objects) = service_with_objects();
-    // Pin starts expired, but is renewed before any GC pass reaps it.
-    let (pin, block) = snapshot_then_free_block(&service, 0);
-    assert!(service.renew_snapshot(pin.snapshot_id, 3_600_000).unwrap());
+fn renew_snapshot_rejects_expiry_at_the_deadline() {
+    let (service, _objects) = service_with_objects();
+    service.set_clock_override_ms(1_000);
+    service.create_dir_path("/runs", 0o755, 1000, 1000).unwrap();
+    let runs = service.resolve_directory_path("/runs").unwrap();
+    let pin = service.snapshot_subtree_with_lease(runs, 500).unwrap();
 
-    let blocked = service.cleanup_pending_objects(100).unwrap();
-    assert_eq!(blocked.blocked_by_snapshots, 1);
-    assert!(objects.head(&block).unwrap().is_some());
+    service.set_clock_override_ms(1_500);
+    assert!(matches!(
+        service.renew_snapshot(pin.snapshot_id, 3_600_000),
+        Err(MetadError::SnapshotLeaseExpired {
+            snapshot_id,
+            lease_expires_unix_ms: 1_500,
+            now_ms: 1_500,
+        }) if snapshot_id == pin.snapshot_id
+    ));
 
-    // Renewing a pin that no longer exists is a no-op.
-    assert!(!service
-        .renew_snapshot(pin.snapshot_id + 9_999, 1_000)
-        .unwrap());
+    assert_eq!(
+        service
+            .renew_snapshot(pin.snapshot_id + 9_999, 1_000)
+            .unwrap(),
+        SnapshotRenewOutcome::Missing {
+            snapshot_id: pin.snapshot_id + 9_999,
+        }
+    );
 }
 
 #[test]
 fn renew_snapshot_is_extend_only_and_never_shortens_protection() {
     let (service, _objects) = service_with_objects();
+    service.set_clock_override_ms(1_000);
     service.create_dir_path("/runs", 0o755, 1000, 1000).unwrap();
     let runs = service.resolve_directory_path("/runs").unwrap();
-    let pin = service.snapshot_subtree_with_lease(runs, 0).unwrap();
+    let pin = service.snapshot_subtree_with_lease(runs, 1_000).unwrap();
 
     // Grant a long lease.
-    assert!(service.renew_snapshot(pin.snapshot_id, 3_600_000).unwrap());
-    let long = service.snapshot_pin(pin.snapshot_id).unwrap().unwrap();
+    let SnapshotRenewOutcome::Renewed {
+        pin: long,
+        extended: true,
+    } = service.renew_snapshot(pin.snapshot_id, 3_600_000).unwrap()
+    else {
+        panic!("expected an extended live pin")
+    };
 
     // A shorter renew must NOT shorten the protection already granted: renew is
     // extend-only (Iceberg / S3 Object Lock semantics). Shrinking protection is
     // expressed by `retire`, never by a shorter renew silently dropping it.
-    assert!(service.renew_snapshot(pin.snapshot_id, 1_000).unwrap());
-    let after_short = service.snapshot_pin(pin.snapshot_id).unwrap().unwrap();
+    let SnapshotRenewOutcome::Renewed {
+        pin: after_short,
+        extended: false,
+    } = service.renew_snapshot(pin.snapshot_id, 1_000).unwrap()
+    else {
+        panic!("expected an unchanged live pin")
+    };
     assert_eq!(
         after_short.lease_expires_unix_ms, long.lease_expires_unix_ms,
         "a shorter renew must never shorten protection"
     );
 
     // A longer renew still extends protection.
-    assert!(service.renew_snapshot(pin.snapshot_id, 7_200_000).unwrap());
-    let after_long = service.snapshot_pin(pin.snapshot_id).unwrap().unwrap();
+    let SnapshotRenewOutcome::Renewed {
+        pin: after_long,
+        extended: true,
+    } = service.renew_snapshot(pin.snapshot_id, 7_200_000).unwrap()
+    else {
+        panic!("expected an extended live pin")
+    };
     assert!(
         after_long.lease_expires_unix_ms > long.lease_expires_unix_ms,
         "a longer renew extends protection"
     );
+}
+
+#[test]
+fn concurrent_snapshot_renewals_preserve_the_longest_successful_lease() {
+    let store = SnapshotCommitBarrierStore::new(CommandKind::RenewSnapshot, 2, 2);
+    let objects = MemoryObjectStore::new();
+    let service = Arc::new(NoKvFs::new(MountId::new(1).unwrap(), store, objects));
+    service.bootstrap_root(0o755, 1000, 1000).unwrap();
+    service.set_clock_override_ms(1_000);
+    service.create_dir_path("/runs", 0o755, 1000, 1000).unwrap();
+    let root = service.resolve_directory_path("/runs").unwrap();
+    let pin = service.snapshot_subtree_with_lease(root, 1_000).unwrap();
+
+    let short_service = Arc::clone(&service);
+    let short = std::thread::spawn(move || short_service.renew_snapshot(pin.snapshot_id, 5_000));
+    let long_service = Arc::clone(&service);
+    let long = std::thread::spawn(move || long_service.renew_snapshot(pin.snapshot_id, 10_000));
+
+    let short = short.join().unwrap().unwrap();
+    let long = long.join().unwrap().unwrap();
+    assert!(matches!(short, SnapshotRenewOutcome::Renewed { .. }));
+    assert!(matches!(long, SnapshotRenewOutcome::Renewed { .. }));
+    assert_eq!(
+        service
+            .snapshot_pin(pin.snapshot_id)
+            .unwrap()
+            .unwrap()
+            .lease_expires_unix_ms,
+        11_000
+    );
+}
+
+#[test]
+fn sixteen_concurrent_snapshot_renewals_converge_on_the_longest_lease() {
+    const WRITERS: usize = 16;
+    let store =
+        SnapshotCommitBarrierStore::new(CommandKind::RenewSnapshot, WRITERS as u64, WRITERS);
+    let service = Arc::new(NoKvFs::new(
+        MountId::new(1).unwrap(),
+        store,
+        MemoryObjectStore::new(),
+    ));
+    service.bootstrap_root(0o755, 1000, 1000).unwrap();
+    service.set_clock_override_ms(1_000);
+    service.create_dir_path("/runs", 0o755, 1000, 1000).unwrap();
+    let root = service.resolve_directory_path("/runs").unwrap();
+    let pin = service.snapshot_subtree_with_lease(root, 1_000).unwrap();
+
+    let mut writers = Vec::new();
+    for index in 0..WRITERS {
+        let service = Arc::clone(&service);
+        let lease_ms = 2_000 + index as u64 * 1_000;
+        writers.push(std::thread::spawn(move || {
+            service.renew_snapshot(pin.snapshot_id, lease_ms)
+        }));
+    }
+    for writer in writers {
+        assert!(matches!(
+            writer.join().unwrap().unwrap(),
+            SnapshotRenewOutcome::Renewed { .. }
+        ));
+    }
+    assert_eq!(
+        service
+            .snapshot_pin(pin.snapshot_id)
+            .unwrap()
+            .unwrap()
+            .lease_expires_unix_ms,
+        18_000
+    );
+}
+
+#[test]
+fn stale_reaper_scan_cannot_delete_a_newer_pin_version() {
+    let store = SnapshotCommitBarrierStore::new(CommandKind::RetireSnapshot, 1, 2);
+    let objects = MemoryObjectStore::new();
+    let service = Arc::new(NoKvFs::new(
+        MountId::new(1).unwrap(),
+        store.clone(),
+        objects,
+    ));
+    service.bootstrap_root(0o755, 1000, 1000).unwrap();
+    service.set_clock_override_ms(1_000);
+    service.create_dir_path("/runs", 0o755, 1000, 1000).unwrap();
+    let root = service.resolve_directory_path("/runs").unwrap();
+    let pin = service.snapshot_subtree_with_lease(root, 500).unwrap();
+
+    service.set_clock_override_ms(1_500);
+    let reaper_service = Arc::clone(&service);
+    let reaper = std::thread::spawn(move || reaper_service.reclaim_expired_snapshot_pins(100));
+    store.wait_until_blocked();
+
+    // A deterministic clock rewind models a stale reaper candidate whose record
+    // was replaced before its delete applied. The version fence, not wall time,
+    // is the invariant under test.
+    service.set_clock_override_ms(1_400);
+    assert!(matches!(
+        service.renew_snapshot(pin.snapshot_id, 10_000).unwrap(),
+        SnapshotRenewOutcome::Renewed { extended: true, .. }
+    ));
+    store.release_blocked();
+
+    let outcome = reaper.join().unwrap().unwrap();
+    assert_eq!(outcome.expired_candidates, 1);
+    assert_eq!(outcome.reaped, 0);
+    assert_eq!(outcome.conflicted, 1);
+    assert!(service.snapshot_pin(pin.snapshot_id).unwrap().is_some());
+}
+
+#[test]
+fn one_reaper_conflict_does_not_block_other_expired_pins() {
+    let store = SnapshotCommitBarrierStore::new(CommandKind::RetireSnapshot, 1, 2);
+    let service = Arc::new(NoKvFs::new(
+        MountId::new(1).unwrap(),
+        store.clone(),
+        MemoryObjectStore::new(),
+    ));
+    service.bootstrap_root(0o755, 1000, 1000).unwrap();
+    service.set_clock_override_ms(1_000);
+    service.create_dir_path("/a", 0o755, 1000, 1000).unwrap();
+    service.create_dir_path("/b", 0o755, 1000, 1000).unwrap();
+    let a = service.resolve_directory_path("/a").unwrap();
+    let b = service.resolve_directory_path("/b").unwrap();
+    let renewed = service.snapshot_subtree_with_lease(a, 500).unwrap();
+    let expired = service.snapshot_subtree_with_lease(b, 500).unwrap();
+
+    service.set_clock_override_ms(1_500);
+    let reaper_service = Arc::clone(&service);
+    let reaper = std::thread::spawn(move || reaper_service.reclaim_expired_snapshot_pins(100));
+    store.wait_until_blocked();
+    service.set_clock_override_ms(1_400);
+    assert!(matches!(
+        service.renew_snapshot(renewed.snapshot_id, 10_000).unwrap(),
+        SnapshotRenewOutcome::Renewed { extended: true, .. }
+    ));
+    store.release_blocked();
+
+    let outcome = reaper.join().unwrap().unwrap();
+    assert_eq!(outcome.expired_candidates, 2);
+    assert_eq!(outcome.reaped, 1);
+    assert_eq!(outcome.conflicted, 1);
+    assert!(service.snapshot_pin(renewed.snapshot_id).unwrap().is_some());
+    assert!(service.snapshot_pin(expired.snapshot_id).unwrap().is_none());
+}
+
+#[test]
+fn uncontended_reaper_page_uses_one_atomic_commit() {
+    let (service, _objects) = service_with_objects();
+    service.set_clock_override_ms(1_000);
+    service.create_dir_path("/a", 0o755, 1000, 1000).unwrap();
+    service.create_dir_path("/b", 0o755, 1000, 1000).unwrap();
+    let a = service.resolve_directory_path("/a").unwrap();
+    let b = service.resolve_directory_path("/b").unwrap();
+    service.snapshot_subtree_with_lease(a, 500).unwrap();
+    service.snapshot_subtree_with_lease(b, 500).unwrap();
+    service.set_clock_override_ms(1_500);
+
+    let before = service.metadata_store_stats().commit_total;
+    let outcome = service.reclaim_expired_snapshot_pins(100).unwrap();
+    let commits = service.metadata_store_stats().commit_total - before;
+    assert_eq!(outcome.expired_candidates, 2);
+    assert_eq!(outcome.reaped, 2);
+    assert_eq!(outcome.conflicted, 0);
+    assert_eq!(commits, 1);
+}
+
+#[test]
+fn snapshot_path_operations_reject_a_different_root() {
+    let (service, _objects) = service_with_objects();
+    service.set_clock_override_ms(1_000);
+    service.create_dir_path("/a", 0o755, 1000, 1000).unwrap();
+    service.create_dir_path("/b", 0o755, 1000, 1000).unwrap();
+    let root = service.resolve_directory_path("/a").unwrap();
+    let pin = service.snapshot_subtree_with_lease(root, 10_000).unwrap();
+
+    assert!(matches!(
+        service.stat_path_at_snapshot("/b", pin.snapshot_id, "/"),
+        Err(MetadError::SnapshotRootMismatch {
+            snapshot_id,
+            expected_root,
+            actual_root,
+            ..
+        }) if snapshot_id == pin.snapshot_id && expected_root != root && actual_root == Some(root)
+    ));
+    assert!(matches!(
+        service.renew_snapshot_path("/b", pin.snapshot_id, 20_000),
+        Err(MetadError::SnapshotRootMismatch { .. })
+    ));
+
+    service.set_clock_override_ms(pin.lease_expires_unix_ms);
+    assert!(matches!(
+        service.stat_path_at_snapshot("/a", pin.snapshot_id, "/"),
+        Err(MetadError::SnapshotLeaseExpired {
+            snapshot_id,
+            lease_expires_unix_ms,
+            now_ms,
+        }) if snapshot_id == pin.snapshot_id
+            && lease_expires_unix_ms == pin.lease_expires_unix_ms
+            && now_ms == pin.lease_expires_unix_ms
+    ));
+}
+
+#[test]
+fn snapshot_component_reads_are_root_bound_even_when_empty_or_zero_length() {
+    let (service, _objects) = service_with_objects();
+    service.set_clock_override_ms(1_000);
+    service.create_dir_path("/a", 0o755, 1000, 1000).unwrap();
+    service.create_dir_path("/b", 0o755, 1000, 1000).unwrap();
+    service
+        .create_file_path("/a/inside", 0o644, 1000, 1000)
+        .unwrap();
+    service
+        .create_file_path("/b/outside", 0o644, 1000, 1000)
+        .unwrap();
+    let pin = service
+        .snapshot_subtree_path_with_lease("/a", 10_000)
+        .unwrap();
+    let inside = DentryName::new("inside").unwrap();
+    let outside = DentryName::new("outside").unwrap();
+
+    assert!(service
+        .get_attr_at_snapshot("/a", pin.snapshot_id, std::slice::from_ref(&inside))
+        .unwrap()
+        .is_some());
+    assert!(service
+        .get_attr_at_snapshot("/a", pin.snapshot_id, std::slice::from_ref(&outside))
+        .unwrap()
+        .is_none());
+    assert!(matches!(
+        service.get_attr_at_snapshot("/b", pin.snapshot_id, &[]),
+        Err(MetadError::SnapshotRootMismatch { .. })
+    ));
+    assert!(matches!(
+        service.read_file_at_snapshot("/b", pin.snapshot_id, std::slice::from_ref(&outside), 0, 0,),
+        Err(MetadError::SnapshotRootMismatch { .. })
+    ));
+}
+
+#[test]
+fn snapshot_ids_are_shard_qualified_and_foreign_ids_fail_as_root_mismatch() {
+    let source = service().with_shard_index(1);
+    source
+        .create_dir_path("/source", 0o755, 1000, 1000)
+        .unwrap();
+    let pin = source.snapshot_subtree_path("/source").unwrap();
+    assert_eq!(pin.snapshot_id >> 48, 1);
+
+    let destination = service().with_shard_index(2);
+    destination
+        .create_dir_path("/destination", 0o755, 1000, 1000)
+        .unwrap();
+    assert!(matches!(
+        destination.stat_path_at_snapshot("/destination", pin.snapshot_id, "/"),
+        Err(MetadError::SnapshotRootMismatch {
+            snapshot_id,
+            actual_root: None,
+            actual_shard: 1,
+            ..
+        }) if snapshot_id == pin.snapshot_id
+    ));
+}
+
+#[test]
+fn snapshot_renew_reports_a_concurrent_root_rebind() {
+    let store = SnapshotCommitBarrierStore::new(CommandKind::RenewSnapshot, 1, 2);
+    let service = Arc::new(NoKvFs::new(
+        MountId::new(1).unwrap(),
+        store.clone(),
+        MemoryObjectStore::new(),
+    ));
+    service.bootstrap_root(0o755, 1000, 1000).unwrap();
+    service.set_clock_override_ms(1_000);
+    service.create_dir_path("/a", 0o755, 1000, 1000).unwrap();
+    let root = service.resolve_directory_path("/a").unwrap();
+    let pin = service.snapshot_subtree_with_lease(root, 10_000).unwrap();
+
+    let renew_service = Arc::clone(&service);
+    let renew = std::thread::spawn(move || {
+        renew_service.renew_snapshot_path("/a", pin.snapshot_id, 20_000)
+    });
+    store.wait_until_blocked();
+    service.rename_path("/a", "/moved").unwrap();
+    store.release_blocked();
+
+    assert!(matches!(
+        renew.join().unwrap(),
+        Err(MetadError::SnapshotBindingChanged { root_path }) if root_path == "/a"
+    ));
+}
+
+#[test]
+fn snapshot_mint_rejects_a_concurrent_root_rebind() {
+    let store = SnapshotCommitBarrierStore::new(CommandKind::SnapshotSubtree, 1, 2);
+    let service = Arc::new(NoKvFs::new(
+        MountId::new(1).unwrap(),
+        store.clone(),
+        MemoryObjectStore::new(),
+    ));
+    service.bootstrap_root(0o755, 1000, 1000).unwrap();
+    service.set_clock_override_ms(1_000);
+    service.create_dir_path("/a", 0o755, 1000, 1000).unwrap();
+
+    let mint_service = Arc::clone(&service);
+    let mint =
+        std::thread::spawn(move || mint_service.snapshot_subtree_path_with_lease("/a", 10_000));
+    store.wait_until_blocked();
+    service.rename_path("/a", "/moved").unwrap();
+    store.release_blocked();
+
+    assert!(matches!(
+        mint.join().unwrap(),
+        Err(MetadError::SnapshotBindingChanged { root_path }) if root_path == "/a"
+    ));
+    assert_eq!(service.metadata_store_stats().active_snapshot_pin_total, 0);
+}
+
+#[test]
+fn snapshot_mint_retries_a_stable_binding_after_a_planning_conflict() {
+    let store = SnapshotPredicateOnceStore::new();
+    let service = NoKvFs::new(MountId::new(1).unwrap(), store, MemoryObjectStore::new());
+    service.bootstrap_root(0o755, 1000, 1000).unwrap();
+    service.create_dir_path("/a", 0o755, 1000, 1000).unwrap();
+
+    let pin = service
+        .snapshot_subtree_path_with_lease("/a", 10_000)
+        .unwrap();
+
+    assert_eq!(service.metadata_store_stats().active_snapshot_pin_total, 1);
+    assert_eq!(service.snapshot_pin(pin.snapshot_id).unwrap(), Some(pin));
 }
 
 #[test]

--- a/crates/nokv-protocol/src/lib.rs
+++ b/crates/nokv-protocol/src/lib.rs
@@ -45,8 +45,9 @@ pub enum MetadataRpcRequest {
         inode: u64,
     },
     GetAttrAtSnapshot {
+        root_path: String,
         snapshot_id: u64,
-        inode: u64,
+        path_components: Vec<String>,
     },
     LookupPlus {
         parent: u64,
@@ -57,8 +58,9 @@ pub enum MetadataRpcRequest {
         name: String,
     },
     LookupPlusAtSnapshot {
+        root_path: String,
         snapshot_id: u64,
-        parent: u64,
+        parent_components: Vec<String>,
         name: String,
     },
     LookupPath {
@@ -76,8 +78,9 @@ pub enum MetadataRpcRequest {
         limit: usize,
     },
     ReadDirPlusAtSnapshot {
+        root_path: String,
         snapshot_id: u64,
-        parent: u64,
+        path_components: Vec<String>,
     },
     ReadDirPlusPath {
         path: String,
@@ -270,14 +273,13 @@ pub enum MetadataRpcRequest {
         source: String,
         destination: String,
     },
-    SnapshotSubtree {
-        root: u64,
-    },
     SnapshotPin {
+        root_path: String,
         snapshot_id: u64,
     },
     SnapshotSubtreePath {
-        path: String,
+        root_path: String,
+        lease_ms: u64,
     },
     CloneSubtreePath {
         src_path: String,
@@ -292,22 +294,33 @@ pub enum MetadataRpcRequest {
         snapshot_id: u64,
     },
     StatPathAtSnapshot {
+        root_path: String,
         snapshot_id: u64,
         path: String,
     },
     ReadDirPlusPathAtSnapshot {
+        root_path: String,
         snapshot_id: u64,
         path: String,
     },
+    ReadDirPlusPathAtSnapshotPage {
+        root_path: String,
+        snapshot_id: u64,
+        path: String,
+        after_name_hex: Option<String>,
+        limit: usize,
+    },
     ReadFilePathAtSnapshot {
+        root_path: String,
         snapshot_id: u64,
         path: String,
         offset: u64,
         len: u64,
     },
     ReadFileAtSnapshot {
+        root_path: String,
         snapshot_id: u64,
-        inode: u64,
+        path_components: Vec<String>,
         offset: u64,
         len: u64,
     },
@@ -315,13 +328,16 @@ pub enum MetadataRpcRequest {
         inode: u64,
     },
     ReadSymlinkAtSnapshot {
+        root_path: String,
         snapshot_id: u64,
-        inode: u64,
+        path_components: Vec<String>,
     },
     RetireSnapshot {
+        root_path: String,
         snapshot_id: u64,
     },
     RenewSnapshot {
+        root_path: String,
         snapshot_id: u64,
         lease_ms: u64,
     },
@@ -341,6 +357,7 @@ pub enum MetadataRpcRequest {
         len: u64,
     },
     ReadArtifactPathAtSnapshot {
+        root_path: String,
         snapshot_id: u64,
         path: String,
     },
@@ -452,6 +469,24 @@ pub enum WireMetadataError {
     /// The target dentry is a cross-shard graft point; remove/rename of it must
     /// go through the graft lifecycle. The client maps this to `EBUSY`.
     GraftPoint,
+    SnapshotLeaseExpired {
+        snapshot_id: u64,
+        lease_expires_unix_ms: u64,
+        now_ms: u64,
+    },
+    SnapshotRootMismatch {
+        snapshot_id: u64,
+        expected_root: u64,
+        actual_root: Option<u64>,
+        actual_shard: u16,
+    },
+    SnapshotBindingChanged {
+        root_path: String,
+    },
+    SnapshotRenewContended {
+        snapshot_id: u64,
+        attempts: usize,
+    },
     SyncLogArchiveFailed {
         committed: bool,
         message: String,
@@ -532,12 +567,13 @@ pub enum MetadataRpcResult {
     },
     SnapshotPin {
         snapshot: Option<WireSnapshotPin>,
+        server_now_ms: u64,
     },
     RetiredSnapshot {
         retired: bool,
     },
     RenewedSnapshot {
-        renewed: bool,
+        outcome: WireSnapshotRenewOutcome,
     },
     OpenPathReadPlan {
         metadata: WirePathMetadata,
@@ -1157,6 +1193,18 @@ pub struct WireSnapshotPin {
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(tag = "state", rename_all = "snake_case")]
+pub enum WireSnapshotRenewOutcome {
+    Renewed {
+        pin: WireSnapshotPin,
+        extended: bool,
+    },
+    Missing {
+        snapshot_id: u64,
+    },
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
 pub struct WireReadLease {
     pub inode: u64,
     pub generation: u64,
@@ -1580,9 +1628,9 @@ pub enum RoutingKey<'a> {
     Default,
 }
 
-/// The routing dimension a request carries. For variants that bundle both a
-/// `snapshot_id` and an inode/path, key on the inode/path (the snapshot id is
-/// shard-local and not a routing key on its own).
+/// The routing dimension a request carries. Every snapshot operation routes on
+/// its absolute `root_path`; the snapshot id is shard-local and never serves as
+/// a routing key on its own.
 pub fn request_routing_key(request: &MetadataRpcRequest) -> RoutingKey<'_> {
     match request {
         // Path-addressed operations route by longest-prefix match.
@@ -1594,17 +1642,28 @@ pub fn request_routing_key(request: &MetadataRpcRequest) -> RoutingKey<'_> {
         | MetadataRpcRequest::CreateFilePath { path, .. }
         | MetadataRpcRequest::RemoveFilePath { path }
         | MetadataRpcRequest::RemoveEmptyDirPath { path }
-        | MetadataRpcRequest::SnapshotSubtreePath { path }
+        | MetadataRpcRequest::SnapshotSubtreePath {
+            root_path: path, ..
+        }
         | MetadataRpcRequest::ReadIndexedPathPage { path, .. }
         | MetadataRpcRequest::ReadDirPlusPathPage { path, .. }
         | MetadataRpcRequest::ReadPage { path, .. }
         | MetadataRpcRequest::ListPage { path, .. }
-        | MetadataRpcRequest::StatPathAtSnapshot { path, .. }
-        | MetadataRpcRequest::ReadDirPlusPathAtSnapshot { path, .. }
-        | MetadataRpcRequest::ReadFilePathAtSnapshot { path, .. }
-        | MetadataRpcRequest::ReadArtifactPathAtSnapshot { path, .. }
         | MetadataRpcRequest::OpenPathReadPlan { path, .. }
         | MetadataRpcRequest::PrepareArtifactPath { path, .. } => RoutingKey::Path(path),
+        MetadataRpcRequest::SnapshotPin { root_path, .. }
+        | MetadataRpcRequest::GetAttrAtSnapshot { root_path, .. }
+        | MetadataRpcRequest::LookupPlusAtSnapshot { root_path, .. }
+        | MetadataRpcRequest::ReadDirPlusAtSnapshot { root_path, .. }
+        | MetadataRpcRequest::StatPathAtSnapshot { root_path, .. }
+        | MetadataRpcRequest::ReadDirPlusPathAtSnapshot { root_path, .. }
+        | MetadataRpcRequest::ReadDirPlusPathAtSnapshotPage { root_path, .. }
+        | MetadataRpcRequest::ReadFilePathAtSnapshot { root_path, .. }
+        | MetadataRpcRequest::ReadFileAtSnapshot { root_path, .. }
+        | MetadataRpcRequest::ReadSymlinkAtSnapshot { root_path, .. }
+        | MetadataRpcRequest::ReadArtifactPathAtSnapshot { root_path, .. }
+        | MetadataRpcRequest::RetireSnapshot { root_path, .. }
+        | MetadataRpcRequest::RenewSnapshot { root_path, .. } => RoutingKey::Path(root_path),
         MetadataRpcRequest::CreateFilesInDirPath { parent_path, .. } => {
             RoutingKey::Path(parent_path)
         }
@@ -1631,7 +1690,6 @@ pub fn request_routing_key(request: &MetadataRpcRequest) -> RoutingKey<'_> {
 
         // Inode/parent-addressed operations route on the encoded shard index.
         MetadataRpcRequest::GetAttr { inode }
-        | MetadataRpcRequest::GetAttrAtSnapshot { inode, .. }
         | MetadataRpcRequest::SetXattr { inode, .. }
         | MetadataRpcRequest::GetXattr { inode, .. }
         | MetadataRpcRequest::ListXattr { inode }
@@ -1639,15 +1697,11 @@ pub fn request_routing_key(request: &MetadataRpcRequest) -> RoutingKey<'_> {
         | MetadataRpcRequest::GetAdvisoryLock { inode, .. }
         | MetadataRpcRequest::SetAdvisoryLock { inode, .. }
         | MetadataRpcRequest::ReadBodyPlan { inode, .. }
-        | MetadataRpcRequest::ReadSymlink { inode }
-        | MetadataRpcRequest::ReadSymlinkAtSnapshot { inode, .. }
-        | MetadataRpcRequest::ReadFileAtSnapshot { inode, .. } => RoutingKey::Inode(*inode),
+        | MetadataRpcRequest::ReadSymlink { inode } => RoutingKey::Inode(*inode),
         MetadataRpcRequest::LookupPlus { parent, .. }
         | MetadataRpcRequest::CurrentDentryVersion { parent, .. }
-        | MetadataRpcRequest::LookupPlusAtSnapshot { parent, .. }
         | MetadataRpcRequest::ReadDirPlus { parent }
         | MetadataRpcRequest::ReadDirPlusPage { parent, .. }
-        | MetadataRpcRequest::ReadDirPlusAtSnapshot { parent, .. }
         | MetadataRpcRequest::CreateDir { parent, .. }
         | MetadataRpcRequest::CreateGraft { parent, .. }
         | MetadataRpcRequest::RemoveGraft { parent, .. }
@@ -1662,7 +1716,6 @@ pub fn request_routing_key(request: &MetadataRpcRequest) -> RoutingKey<'_> {
         MetadataRpcRequest::Link { new_parent, .. } => RoutingKey::Inode(*new_parent),
         MetadataRpcRequest::Rename { parent, .. } => RoutingKey::Inode(*parent),
         MetadataRpcRequest::RenameReplace { parent, .. } => RoutingKey::Inode(*parent),
-        MetadataRpcRequest::SnapshotSubtree { root } => RoutingKey::Inode(*root),
         MetadataRpcRequest::PublishPreparedArtifact { prepared, .. } => {
             RoutingKey::Inode(prepared.parent)
         }
@@ -1673,10 +1726,7 @@ pub fn request_routing_key(request: &MetadataRpcRequest) -> RoutingKey<'_> {
         // No addressable key: target the default/root shard.
         MetadataRpcRequest::Batch { .. }
         | MetadataRpcRequest::BootstrapRoot { .. }
-        | MetadataRpcRequest::UpdateRootAttrs { .. }
-        | MetadataRpcRequest::SnapshotPin { .. }
-        | MetadataRpcRequest::RetireSnapshot { .. }
-        | MetadataRpcRequest::RenewSnapshot { .. } => RoutingKey::Default,
+        | MetadataRpcRequest::UpdateRootAttrs { .. } => RoutingKey::Default,
     }
 }
 
@@ -1893,6 +1943,50 @@ mod tests {
     }
 
     #[test]
+    fn snapshot_path_requests_route_on_the_absolute_root_binding() {
+        let stat = MetadataRpcRequest::StatPathAtSnapshot {
+            root_path: "/agents/scout/wb".to_owned(),
+            snapshot_id: 7,
+            path: "/outputs/result.txt".to_owned(),
+        };
+        assert!(matches!(
+            request_routing_key(&stat),
+            RoutingKey::Path("/agents/scout/wb")
+        ));
+
+        let renew = MetadataRpcRequest::RenewSnapshot {
+            root_path: "/agents/scout/wb".to_owned(),
+            snapshot_id: 7,
+            lease_ms: 60_000,
+        };
+        assert!(matches!(
+            request_routing_key(&renew),
+            RoutingKey::Path("/agents/scout/wb")
+        ));
+
+        let retire = MetadataRpcRequest::RetireSnapshot {
+            root_path: "/agents/scout/wb".to_owned(),
+            snapshot_id: 7,
+        };
+        assert!(matches!(
+            request_routing_key(&retire),
+            RoutingKey::Path("/agents/scout/wb")
+        ));
+
+        let inode_free_read = MetadataRpcRequest::ReadFileAtSnapshot {
+            root_path: "/agents/scout/wb".to_owned(),
+            snapshot_id: 7,
+            path_components: vec!["outputs".to_owned(), "result.txt".to_owned()],
+            offset: 0,
+            len: 16,
+        };
+        assert!(matches!(
+            request_routing_key(&inode_free_read),
+            RoutingKey::Path("/agents/scout/wb")
+        ));
+    }
+
+    #[test]
     fn binary_codec_round_trips_clone_and_diff_requests() {
         let clone = MetadataRpcRequest::CloneSubtreePath {
             src_path: "/base".to_owned(),
@@ -1912,10 +2006,29 @@ mod tests {
     #[test]
     fn binary_codec_round_trips_snapshot_and_rollback_requests() {
         let snapshot = MetadataRpcRequest::SnapshotSubtreePath {
-            path: "/base".to_owned(),
+            root_path: "/base".to_owned(),
+            lease_ms: 60_000,
         };
         let encoded = encode_request(&snapshot).unwrap();
         assert_eq!(decode_request(&encoded).unwrap(), snapshot);
+
+        let snapshot_page = MetadataRpcRequest::ReadDirPlusPathAtSnapshotPage {
+            root_path: "/base".to_owned(),
+            snapshot_id: 7,
+            path: "/outputs".to_owned(),
+            after_name_hex: Some("612e747874".to_owned()),
+            limit: 100,
+        };
+        let encoded = encode_request(&snapshot_page).unwrap();
+        assert_eq!(decode_request(&encoded).unwrap(), snapshot_page);
+
+        let component_read = MetadataRpcRequest::GetAttrAtSnapshot {
+            root_path: "/base".to_owned(),
+            snapshot_id: 7,
+            path_components: vec!["outputs".to_owned(), "result.txt".to_owned()],
+        };
+        let encoded = encode_request(&component_read).unwrap();
+        assert_eq!(decode_request(&encoded).unwrap(), component_read);
 
         let rollback = MetadataRpcRequest::RollbackSubtreePath {
             target_path: "/base".to_owned(),

--- a/crates/nokv-python/src/lib.rs
+++ b/crates/nokv-python/src/lib.rs
@@ -1121,49 +1121,84 @@ impl PythonNoKvClient {
     fn snapshot_pin<'py>(
         &self,
         py: Python<'py>,
+        root_path: &str,
         snapshot_id: u64,
     ) -> PyResult<Option<Bound<'py, PyDict>>> {
         let pin = py
-            .detach(|| self.inner.metadata().snapshot_pin(snapshot_id))
+            .detach(|| self.inner.metadata().snapshot_pin(root_path, snapshot_id))
             .map_err(runtime_error)?;
         pin.map(|pin| snapshot_pin_to_py(py, &pin)).transpose()
     }
 
-    fn retire_snapshot(&self, py: Python<'_>, snapshot_id: u64) -> PyResult<bool> {
-        py.detach(|| self.inner.metadata().retire_snapshot(snapshot_id))
-            .map_err(runtime_error)
+    fn retire_snapshot(&self, py: Python<'_>, root_path: &str, snapshot_id: u64) -> PyResult<bool> {
+        py.detach(|| {
+            self.inner
+                .metadata()
+                .retire_snapshot(root_path, snapshot_id)
+        })
+        .map_err(runtime_error)
     }
 
-    fn renew_snapshot(&self, py: Python<'_>, snapshot_id: u64, lease_ms: u64) -> PyResult<bool> {
-        py.detach(|| self.inner.metadata().renew_snapshot(snapshot_id, lease_ms))
-            .map_err(runtime_error)
+    fn renew_snapshot<'py>(
+        &self,
+        py: Python<'py>,
+        root_path: &str,
+        snapshot_id: u64,
+        lease_ms: u64,
+    ) -> PyResult<Bound<'py, PyDict>> {
+        let outcome = py
+            .detach(|| {
+                self.inner
+                    .metadata()
+                    .renew_snapshot(root_path, snapshot_id, lease_ms)
+            })
+            .map_err(runtime_error)?;
+        let result = PyDict::new(py);
+        match outcome {
+            nokv_meta::SnapshotRenewOutcome::Renewed { pin, extended } => {
+                result.set_item("state", "renewed")?;
+                result.set_item("extended", extended)?;
+                result.set_item("pin", snapshot_pin_to_py(py, &pin)?)?;
+            }
+            nokv_meta::SnapshotRenewOutcome::Missing { snapshot_id } => {
+                result.set_item("state", "missing")?;
+                result.set_item("snapshot_id", snapshot_id)?;
+            }
+        }
+        Ok(result)
     }
 
     /// Read a whole file. With `snapshot_id` set, read it as of that subtree
     /// snapshot (reproducible reads against a pinned dataset version) — resolved
     /// through the snapshot's namespace via the path-based snapshot read.
-    #[pyo3(signature = (path, snapshot_id = None))]
+    #[pyo3(signature = (path, snapshot_id = None, snapshot_root_path = None))]
     fn cat<'py>(
         &self,
         py: Python<'py>,
         path: &str,
         snapshot_id: Option<u64>,
+        snapshot_root_path: Option<&str>,
     ) -> PyResult<Bound<'py, PyBytes>> {
         let bytes = py
             .detach(|| -> Result<Vec<u8>, nokv_client::ClientError> {
                 match snapshot_id {
                     Some(id) => {
+                        let root_path = snapshot_root_path.ok_or_else(|| {
+                            nokv_client::ClientError::Protocol(
+                                "snapshot_root_path is required with snapshot_id".to_owned(),
+                            )
+                        })?;
                         let metadata = self
                             .inner
                             .metadata()
-                            .stat_path_at_snapshot(id, path)?
+                            .stat_path_at_snapshot(root_path, id, path)?
                             .ok_or_else(|| nokv_client::ClientError::NotFound(path.to_owned()))?;
                         let size = usize::try_from(metadata.attr.size).map_err(|_| {
                             nokv_client::ClientError::Protocol(
                                 "artifact size exceeds usize".to_owned(),
                             )
                         })?;
-                        self.inner.read_snapshot(id, path, 0, size)
+                        self.inner.read_snapshot(root_path, id, path, 0, size)
                     }
                     None => self.inner.cat(path),
                 }

--- a/crates/nokv-server/src/metadata.rs
+++ b/crates/nokv-server/src/metadata.rs
@@ -101,6 +101,12 @@ impl MetadataStore for ServerMetadataStore {
         }
     }
 
+    fn history_retention_epoch(&self) -> Result<u64, MetadataError> {
+        match self {
+            Self::Direct(store) => store.history_retention_epoch(),
+        }
+    }
+
     fn prune_history(
         &self,
         request: HistoryPruneRequest,

--- a/crates/nokv-server/src/rpc/mod.rs
+++ b/crates/nokv-server/src/rpc/mod.rs
@@ -113,10 +113,15 @@ fn execute(server: &Server, request: MetadataRpcRequest) -> Result<MetadataRpcRe
                     .map(nokv_protocol::WireInodeAttr::from_inode_attr),
             })
         }
-        MetadataRpcRequest::GetAttrAtSnapshot { snapshot_id, inode } => {
-            let attr = slot
-                .service()
-                .get_attr_at_snapshot(snapshot_id, inode_id(inode)?)?;
+        MetadataRpcRequest::GetAttrAtSnapshot {
+            root_path,
+            snapshot_id,
+            path_components,
+        } => {
+            let path_components = dentry_components(path_components)?;
+            let attr =
+                slot.service()
+                    .get_attr_at_snapshot(&root_path, snapshot_id, &path_components)?;
             Ok(MetadataRpcResult::InodeAttr {
                 attr: attr
                     .as_ref()
@@ -138,13 +143,16 @@ fn execute(server: &Server, request: MetadataRpcRequest) -> Result<MetadataRpcRe
             Ok(MetadataRpcResult::DentryVersion { version })
         }
         MetadataRpcRequest::LookupPlusAtSnapshot {
+            root_path,
             snapshot_id,
-            parent,
+            parent_components,
             name,
         } => {
+            let parent_components = dentry_components(parent_components)?;
             let entry = slot.service().lookup_plus_at_snapshot(
+                &root_path,
                 snapshot_id,
-                inode_id(parent)?,
+                &parent_components,
                 &dentry_name(name)?,
             )?;
             Ok(MetadataRpcResult::Dentry {
@@ -188,12 +196,16 @@ fn execute(server: &Server, request: MetadataRpcRequest) -> Result<MetadataRpcRe
             })
         }
         MetadataRpcRequest::ReadDirPlusAtSnapshot {
+            root_path,
             snapshot_id,
-            parent,
+            path_components,
         } => {
-            let entries = slot
-                .service()
-                .read_dir_plus_at_snapshot(snapshot_id, inode_id(parent)?)?;
+            let path_components = dentry_components(path_components)?;
+            let entries = slot.service().read_dir_plus_at_snapshot(
+                &root_path,
+                snapshot_id,
+                &path_components,
+            )?;
             Ok(MetadataRpcResult::Dentries {
                 entries: entries.iter().map(wire_dentry).collect(),
             })
@@ -649,22 +661,25 @@ fn execute(server: &Server, request: MetadataRpcRequest) -> Result<MetadataRpcRe
                     .map(|entry| Box::new(wire_dentry(entry))),
             })
         }
-        MetadataRpcRequest::SnapshotSubtree { root } => {
-            let snapshot = slot.service().snapshot_subtree(inode_id(root)?)?;
-            Ok(MetadataRpcResult::Snapshot {
-                snapshot: nokv_protocol::WireSnapshotPin::from_snapshot_pin(&snapshot),
-            })
-        }
-        MetadataRpcRequest::SnapshotPin { snapshot_id } => {
-            let snapshot = slot.service().snapshot_pin(snapshot_id)?;
+        MetadataRpcRequest::SnapshotPin {
+            root_path,
+            snapshot_id,
+        } => {
+            let snapshot = slot.service().snapshot_pin_path(&root_path, snapshot_id)?;
             Ok(MetadataRpcResult::SnapshotPin {
                 snapshot: snapshot
                     .as_ref()
                     .map(nokv_protocol::WireSnapshotPin::from_snapshot_pin),
+                server_now_ms: slot.service().now_ms(),
             })
         }
-        MetadataRpcRequest::SnapshotSubtreePath { path } => {
-            let snapshot = slot.service().snapshot_subtree_path(&path)?;
+        MetadataRpcRequest::SnapshotSubtreePath {
+            root_path,
+            lease_ms,
+        } => {
+            let snapshot = slot
+                .service()
+                .snapshot_subtree_path_with_lease(&root_path, lease_ms)?;
             Ok(MetadataRpcResult::Snapshot {
                 snapshot: nokv_protocol::WireSnapshotPin::from_snapshot_pin(&snapshot),
             })
@@ -692,30 +707,83 @@ fn execute(server: &Server, request: MetadataRpcRequest) -> Result<MetadataRpcRe
                 .rollback_subtree_path(&target_path, snapshot_id)?;
             Ok(MetadataRpcResult::Unit)
         }
-        MetadataRpcRequest::StatPathAtSnapshot { snapshot_id, path } => {
-            let metadata = slot.service().stat_path_at_snapshot(snapshot_id, &path)?;
+        MetadataRpcRequest::StatPathAtSnapshot {
+            root_path,
+            snapshot_id,
+            path,
+        } => {
+            let metadata = slot
+                .service()
+                .stat_path_at_snapshot(&root_path, snapshot_id, &path)?;
             Ok(MetadataRpcResult::PathMetadata {
                 metadata: metadata.as_ref().map(WirePathMetadata::from_path_metadata),
             })
         }
-        MetadataRpcRequest::ReadDirPlusPathAtSnapshot { snapshot_id, path } => {
-            let entries = slot
-                .service()
-                .read_dir_plus_path_at_snapshot(snapshot_id, &path)?;
+        MetadataRpcRequest::ReadDirPlusPathAtSnapshot {
+            root_path,
+            snapshot_id,
+            path,
+        } => {
+            let entries =
+                slot.service()
+                    .read_dir_plus_path_at_snapshot(&root_path, snapshot_id, &path)?;
             Ok(MetadataRpcResult::Dentries {
                 entries: entries.iter().map(wire_dentry).collect(),
             })
         }
-        MetadataRpcRequest::RetireSnapshot { snapshot_id } => {
-            let retired = slot.service().retire_snapshot(snapshot_id)?;
+        MetadataRpcRequest::ReadDirPlusPathAtSnapshotPage {
+            root_path,
+            snapshot_id,
+            path,
+            after_name_hex,
+            limit,
+        } => {
+            let after = after_name_hex
+                .as_deref()
+                .map(decode_name_cursor)
+                .transpose()
+                .map_err(protocol_error)?;
+            let page = slot.service().read_dir_plus_path_at_snapshot_page(
+                &root_path,
+                snapshot_id,
+                &path,
+                after.as_ref(),
+                limit,
+            )?;
+            Ok(MetadataRpcResult::DentriesPage {
+                entries: page.entries.iter().map(wire_dentry).collect(),
+                next_name_hex: page.next_cursor.as_ref().map(encode_name_cursor),
+            })
+        }
+        MetadataRpcRequest::RetireSnapshot {
+            root_path,
+            snapshot_id,
+        } => {
+            let retired = slot
+                .service()
+                .retire_snapshot_path(&root_path, snapshot_id)?;
             Ok(MetadataRpcResult::RetiredSnapshot { retired })
         }
         MetadataRpcRequest::RenewSnapshot {
+            root_path,
             snapshot_id,
             lease_ms,
         } => {
-            let renewed = slot.service().renew_snapshot(snapshot_id, lease_ms)?;
-            Ok(MetadataRpcResult::RenewedSnapshot { renewed })
+            let outcome = slot
+                .service()
+                .renew_snapshot_path(&root_path, snapshot_id, lease_ms)?;
+            let outcome = match outcome {
+                nokv_meta::SnapshotRenewOutcome::Renewed { pin, extended } => {
+                    nokv_protocol::WireSnapshotRenewOutcome::Renewed {
+                        pin: nokv_protocol::WireSnapshotPin::from_snapshot_pin(&pin),
+                        extended,
+                    }
+                }
+                nokv_meta::SnapshotRenewOutcome::Missing { snapshot_id } => {
+                    nokv_protocol::WireSnapshotRenewOutcome::Missing { snapshot_id }
+                }
+            };
+            Ok(MetadataRpcResult::RenewedSnapshot { outcome })
         }
         MetadataRpcRequest::OpenPathReadPlan {
             path,
@@ -766,13 +834,18 @@ fn execute(server: &Server, request: MetadataRpcRequest) -> Result<MetadataRpcRe
                 plan: wire_body_read_plan(&plan),
             })
         }
-        MetadataRpcRequest::ReadArtifactPathAtSnapshot { snapshot_id, path } => {
-            let bytes = slot
-                .service()
-                .read_artifact_path_at_snapshot(snapshot_id, &path)?;
+        MetadataRpcRequest::ReadArtifactPathAtSnapshot {
+            root_path,
+            snapshot_id,
+            path,
+        } => {
+            let bytes =
+                slot.service()
+                    .read_artifact_path_at_snapshot(&root_path, snapshot_id, &path)?;
             Ok(MetadataRpcResult::FileBytes { bytes })
         }
         MetadataRpcRequest::ReadFilePathAtSnapshot {
+            root_path,
             snapshot_id,
             path,
             offset,
@@ -783,35 +856,52 @@ fn execute(server: &Server, request: MetadataRpcRequest) -> Result<MetadataRpcRe
                     "snapshot read length exceeds platform limit".to_owned(),
                 ))
             })?;
-            let bytes =
-                slot.service()
-                    .read_file_path_at_snapshot(snapshot_id, &path, offset, len)?;
+            let bytes = slot.service().read_file_path_at_snapshot(
+                &root_path,
+                snapshot_id,
+                &path,
+                offset,
+                len,
+            )?;
             Ok(MetadataRpcResult::FileBytes { bytes })
         }
         MetadataRpcRequest::ReadFileAtSnapshot {
+            root_path,
             snapshot_id,
-            inode,
+            path_components,
             offset,
             len,
         } => {
+            let path_components = dentry_components(path_components)?;
             let len = usize::try_from(len).map_err(|_| {
                 ServerError::Metadata(MetadError::Codec(
                     "snapshot read length exceeds platform limit".to_owned(),
                 ))
             })?;
-            let bytes =
-                slot.service()
-                    .read_file_at_snapshot(snapshot_id, inode_id(inode)?, offset, len)?;
+            let bytes = slot.service().read_file_at_snapshot(
+                &root_path,
+                snapshot_id,
+                &path_components,
+                offset,
+                len,
+            )?;
             Ok(MetadataRpcResult::FileBytes { bytes })
         }
         MetadataRpcRequest::ReadSymlink { inode } => {
             let bytes = slot.service().read_symlink(inode_id(inode)?)?;
             Ok(MetadataRpcResult::FileBytes { bytes })
         }
-        MetadataRpcRequest::ReadSymlinkAtSnapshot { snapshot_id, inode } => {
-            let bytes = slot
-                .service()
-                .read_symlink_at_snapshot(snapshot_id, inode_id(inode)?)?;
+        MetadataRpcRequest::ReadSymlinkAtSnapshot {
+            root_path,
+            snapshot_id,
+            path_components,
+        } => {
+            let path_components = dentry_components(path_components)?;
+            let bytes = slot.service().read_symlink_at_snapshot(
+                &root_path,
+                snapshot_id,
+                &path_components,
+            )?;
             Ok(MetadataRpcResult::FileBytes { bytes })
         }
         MetadataRpcRequest::PrepareArtifact {
@@ -943,6 +1033,10 @@ fn open_path_read_plan_request(
     })
 }
 
+fn dentry_components(components: Vec<String>) -> Result<Vec<nokv_types::DentryName>, MetadError> {
+    components.into_iter().map(dentry_name).collect()
+}
+
 fn refreshes_metadata_view(request: &MetadataRpcRequest) -> bool {
     match request {
         MetadataRpcRequest::Batch { requests } => requests.iter().any(refreshes_metadata_view),
@@ -967,6 +1061,7 @@ fn refreshes_metadata_view(request: &MetadataRpcRequest) -> bool {
         | MetadataRpcRequest::ReadPage { .. }
         | MetadataRpcRequest::StatPathAtSnapshot { .. }
         | MetadataRpcRequest::ReadDirPlusPathAtSnapshot { .. }
+        | MetadataRpcRequest::ReadDirPlusPathAtSnapshotPage { .. }
         | MetadataRpcRequest::ReadFileAtSnapshot { .. }
         | MetadataRpcRequest::ReadFilePathAtSnapshot { .. }
         | MetadataRpcRequest::ReadSymlink { .. }
@@ -1005,7 +1100,6 @@ fn refreshes_metadata_view(request: &MetadataRpcRequest) -> bool {
         | MetadataRpcRequest::RenamePath { .. }
         | MetadataRpcRequest::RenameReplace { .. }
         | MetadataRpcRequest::RenameReplacePath { .. }
-        | MetadataRpcRequest::SnapshotSubtree { .. }
         | MetadataRpcRequest::SnapshotSubtreePath { .. }
         | MetadataRpcRequest::CloneSubtreePath { .. }
         | MetadataRpcRequest::RollbackSubtreePath { .. }

--- a/crates/nokv-server/src/rpc/tests.rs
+++ b/crates/nokv-server/src/rpc/tests.rs
@@ -349,16 +349,32 @@ fn rpc_supports_remote_fuse_inode_operations() {
     assert_eq!(special.attr.file_type, "char_device");
     assert_eq!(special.attr.rdev, 0x1234);
 
-    let snapshot = request_envelope(&server, MetadataRpcRequest::SnapshotSubtree { root: 1 });
+    let snapshot = request_envelope(
+        &server,
+        MetadataRpcRequest::SnapshotSubtreePath {
+            root_path: "/".to_owned(),
+            lease_ms: nokv_meta::DEFAULT_SNAPSHOT_LEASE_MS,
+        },
+    );
     let snapshot_id = match snapshot.result.unwrap() {
         MetadataRpcResult::Snapshot { snapshot } => snapshot.snapshot_id,
         other => panic!("unexpected snapshot result: {other:?}"),
     };
-    let pin = request_envelope(&server, MetadataRpcRequest::SnapshotPin { snapshot_id });
+    let pin = request_envelope(
+        &server,
+        MetadataRpcRequest::SnapshotPin {
+            root_path: "/".to_owned(),
+            snapshot_id,
+        },
+    );
     match pin.result.unwrap() {
         MetadataRpcResult::SnapshotPin {
             snapshot: Some(snapshot),
-        } => assert_eq!(snapshot.snapshot_id, snapshot_id),
+            server_now_ms,
+        } => {
+            assert_eq!(snapshot.snapshot_id, snapshot_id);
+            assert!(server_now_ms > 0);
+        }
         other => panic!("unexpected snapshot pin result: {other:?}"),
     }
 }
@@ -1401,10 +1417,16 @@ fn framed_rpc_client_reuses_peer_connection() {
 
     let client = FramedRpcClient::new(addr);
     let first = client
-        .call(&MetadataRpcRequest::RetireSnapshot { snapshot_id: 1 })
+        .call(&MetadataRpcRequest::RetireSnapshot {
+            root_path: "/".to_owned(),
+            snapshot_id: 1,
+        })
         .unwrap();
     let second = client
-        .call(&MetadataRpcRequest::RetireSnapshot { snapshot_id: 2 })
+        .call(&MetadataRpcRequest::RetireSnapshot {
+            root_path: "/".to_owned(),
+            snapshot_id: 2,
+        })
         .unwrap();
     assert!(first.ok);
     assert!(second.ok);
@@ -1830,7 +1852,8 @@ fn rpc_snapshot_then_rollback_restores_namespace_to_snapshot() {
     let snapshot = request_envelope(
         &server,
         MetadataRpcRequest::SnapshotSubtreePath {
-            path: "/base".to_owned(),
+            root_path: "/base".to_owned(),
+            lease_ms: nokv_meta::DEFAULT_SNAPSHOT_LEASE_MS,
         },
     );
     assert!(snapshot.ok, "unexpected snapshot error: {snapshot:?}");
@@ -2193,6 +2216,109 @@ mod multi_shard {
             DEFAULT_SHARD_INDEX,
             "a bare-inode request for a shard-0 inode routes to shard 0"
         );
+    }
+
+    #[test]
+    fn snapshot_path_lifecycle_routes_to_the_root_owning_shard() {
+        let (server, _control, _dir) = two_shard_server();
+        let dataset = create_dir_path(&server, "/dataset");
+        create_file_path(&server, "/dataset/checkpoint.bin");
+
+        let snapshot = request_envelope(
+            &server,
+            MetadataRpcRequest::SnapshotSubtreePath {
+                root_path: "/dataset".to_owned(),
+                lease_ms: 60_000,
+            },
+        );
+        let snapshot = match snapshot.result.unwrap() {
+            MetadataRpcResult::Snapshot { snapshot } => snapshot,
+            other => panic!("unexpected snapshot result: {other:?}"),
+        };
+        assert_eq!(
+            InodeId::new(snapshot.root).unwrap().shard_index(),
+            DATASET_INDEX
+        );
+
+        let renewed = request_envelope(
+            &server,
+            MetadataRpcRequest::RenewSnapshot {
+                root_path: "/dataset".to_owned(),
+                snapshot_id: snapshot.snapshot_id,
+                lease_ms: 120_000,
+            },
+        );
+        assert!(matches!(
+            renewed.result.unwrap(),
+            MetadataRpcResult::RenewedSnapshot {
+                outcome: nokv_protocol::WireSnapshotRenewOutcome::Renewed { .. }
+            }
+        ));
+
+        let stat = request_envelope(
+            &server,
+            MetadataRpcRequest::StatPathAtSnapshot {
+                root_path: "/dataset".to_owned(),
+                snapshot_id: snapshot.snapshot_id,
+                path: "/".to_owned(),
+            },
+        );
+        let stat = match stat.result.unwrap() {
+            MetadataRpcResult::PathMetadata {
+                metadata: Some(metadata),
+            } => metadata,
+            other => panic!("unexpected snapshot stat result: {other:?}"),
+        };
+        assert_eq!(stat.attr.inode, dataset.inode);
+    }
+
+    #[test]
+    fn swapped_snapshot_ids_across_shards_are_typed_root_mismatches() {
+        let (server, _control, _dir) = two_shard_server();
+        create_dir_path(&server, "/dataset");
+        create_dir_path(&server, "/other");
+
+        let mint = |root_path: &str| {
+            let envelope = request_envelope(
+                &server,
+                MetadataRpcRequest::SnapshotSubtreePath {
+                    root_path: root_path.to_owned(),
+                    lease_ms: 60_000,
+                },
+            );
+            match envelope.result.unwrap() {
+                MetadataRpcResult::Snapshot { snapshot } => snapshot,
+                other => panic!("unexpected snapshot result: {other:?}"),
+            }
+        };
+        let dataset = mint("/dataset");
+        let other = mint("/other");
+        assert_eq!(dataset.snapshot_id >> 48, u64::from(DATASET_INDEX));
+        assert_eq!(other.snapshot_id >> 48, u64::from(DEFAULT_SHARD_INDEX));
+
+        for (root_path, snapshot_id, foreign_shard) in [
+            ("/other", dataset.snapshot_id, DATASET_INDEX),
+            ("/dataset", other.snapshot_id, DEFAULT_SHARD_INDEX),
+        ] {
+            let envelope = request_envelope(
+                &server,
+                MetadataRpcRequest::StatPathAtSnapshot {
+                    root_path: root_path.to_owned(),
+                    snapshot_id,
+                    path: "/".to_owned(),
+                },
+            );
+            assert!(!envelope.ok);
+            assert!(matches!(
+                envelope.error_kind,
+                Some(WireMetadataError::SnapshotRootMismatch {
+                    snapshot_id: actual_id,
+                    actual_root: None,
+                    actual_shard,
+                    ..
+                }) if actual_id == snapshot_id && actual_shard == foreign_shard
+            ));
+        }
     }
 
     /// Per-shard MVCC independence: the two shards mint inodes from disjoint

--- a/crates/nokv-server/src/rpc/wire.rs
+++ b/crates/nokv-server/src/rpc/wire.rs
@@ -134,6 +134,38 @@ fn wire_metad_error(err: &MetadError) -> WireMetadataError {
             dest_shard: *dest_shard,
         },
         MetadError::GraftPoint => WireMetadataError::GraftPoint,
+        MetadError::SnapshotLeaseExpired {
+            snapshot_id,
+            lease_expires_unix_ms,
+            now_ms,
+        } => WireMetadataError::SnapshotLeaseExpired {
+            snapshot_id: *snapshot_id,
+            lease_expires_unix_ms: *lease_expires_unix_ms,
+            now_ms: *now_ms,
+        },
+        MetadError::SnapshotRootMismatch {
+            snapshot_id,
+            expected_root,
+            actual_root,
+            actual_shard,
+        } => WireMetadataError::SnapshotRootMismatch {
+            snapshot_id: *snapshot_id,
+            expected_root: expected_root.get(),
+            actual_root: actual_root.map(InodeId::get),
+            actual_shard: *actual_shard,
+        },
+        MetadError::SnapshotBindingChanged { root_path } => {
+            WireMetadataError::SnapshotBindingChanged {
+                root_path: root_path.clone(),
+            }
+        }
+        MetadError::SnapshotRenewContended {
+            snapshot_id,
+            attempts,
+        } => WireMetadataError::SnapshotRenewContended {
+            snapshot_id: *snapshot_id,
+            attempts: *attempts,
+        },
         other => WireMetadataError::Metadata {
             message: other.to_string(),
         },

--- a/crates/nokv-server/src/server.rs
+++ b/crates/nokv-server/src/server.rs
@@ -631,12 +631,17 @@ impl Server {
             object.deleted += object_outcome.deleted;
             object.missing += object_outcome.missing;
             object.records_removed += object_outcome.records_removed;
+            object.snapshot_reap.scanned += object_outcome.snapshot_reap.scanned;
+            object.snapshot_reap.expired_candidates +=
+                object_outcome.snapshot_reap.expired_candidates;
+            object.snapshot_reap.reaped += object_outcome.snapshot_reap.reaped;
+            object.snapshot_reap.conflicted += object_outcome.snapshot_reap.conflicted;
             history.scanned += history_outcome.scanned;
             history.removed += history_outcome.removed;
             history.retained_by_snapshots += history_outcome.retained_by_snapshots;
         }
         Ok(format!(
-            r#"{{"object_gc":{{"scanned":{},"blocked_by_snapshots":{},"blocked_by_read_leases":{},"attempted":{},"deleted":{},"missing":{},"records_removed":{}}},"history_gc":{{"scanned":{},"removed":{},"retained_by_snapshots":{}}}}}
+            r#"{{"object_gc":{{"scanned":{},"blocked_by_snapshots":{},"blocked_by_read_leases":{},"attempted":{},"deleted":{},"missing":{},"records_removed":{},"snapshot_reap":{{"scanned":{},"expired_candidates":{},"reaped":{},"conflicted":{}}}}},"history_gc":{{"scanned":{},"removed":{},"retained_by_snapshots":{}}}}}
 "#,
             object.scanned,
             object.blocked_by_snapshots,
@@ -645,6 +650,10 @@ impl Server {
             object.deleted,
             object.missing,
             object.records_removed,
+            object.snapshot_reap.scanned,
+            object.snapshot_reap.expired_candidates,
+            object.snapshot_reap.reaped,
+            object.snapshot_reap.conflicted,
             history.scanned,
             history.removed,
             history.retained_by_snapshots,
@@ -1233,10 +1242,15 @@ fn restore_shard_owner_recovery_refs(
 }
 
 fn object_gc_json(state: &ObjectGcWorkerState) -> String {
+    let reap = state.snapshot_reap;
     format!(
-        "{{\"iterations\":{},\"last_error\":{}}}",
+        "{{\"iterations\":{},\"last_error\":{},\"snapshot_reap\":{{\"scanned\":{},\"expired_candidates\":{},\"reaped\":{},\"conflicted\":{}}}}}",
         state.iterations,
-        json_string_or_null(state.last_error.as_deref())
+        json_string_or_null(state.last_error.as_deref()),
+        reap.scanned,
+        reap.expired_candidates,
+        reap.reaped,
+        reap.conflicted,
     )
 }
 
@@ -1513,6 +1527,25 @@ pub(crate) mod tests {
         let body = server.run_manual_gc(128).unwrap();
         assert!(body.contains("\"object_gc\""));
         assert!(body.contains("\"history_gc\""));
+    }
+
+    #[test]
+    fn object_gc_health_keeps_cumulative_reaper_conflicts() {
+        let state = ObjectGcWorkerState {
+            iterations: 9,
+            last_outcome: Some(nokv_meta::PendingObjectCleanupOutcome::default()),
+            snapshot_reap: nokv_meta::SnapshotReapOutcome {
+                scanned: 12,
+                expired_candidates: 3,
+                reaped: 2,
+                conflicted: 1,
+            },
+            last_error: None,
+        };
+
+        let json = object_gc_json(&state);
+        assert!(json.contains("\"iterations\":9"));
+        assert!(json.contains("\"conflicted\":1"));
     }
 
     #[test]

--- a/crates/nokv/src/bin/nokv.rs
+++ b/crates/nokv/src/bin/nokv.rs
@@ -119,6 +119,7 @@ enum Command {
         options: MountCliOptions,
     },
     MountSnapshot {
+        root_path: String,
         snapshot_id: u64,
         mountpoint: PathBuf,
         options: MountCliOptions,
@@ -133,6 +134,7 @@ enum Command {
     Fsck,
     Snapshot {
         path: String,
+        lease_ms: u64,
     },
     Clone {
         src: String,
@@ -147,13 +149,16 @@ enum Command {
         snapshot_id: u64,
     },
     CatSnapshot {
+        root_path: String,
         snapshot_id: u64,
         path: String,
     },
     RetireSnapshot {
+        root_path: String,
         snapshot_id: u64,
     },
     RenewSnapshot {
+        root_path: String,
         snapshot_id: u64,
         lease_ms: u64,
     },
@@ -485,6 +490,7 @@ fn run(args: Vec<String>) -> Result<(), CliError> {
             mount.join().map_err(from_io)?;
         }
         Command::MountSnapshot {
+            root_path,
             snapshot_id,
             mountpoint,
             options,
@@ -492,7 +498,7 @@ fn run(args: Vec<String>) -> Result<(), CliError> {
             let metadata = open_mount_metadata(&config)?;
             let objects = config.object.open().map_err(from_object)?;
             let snapshot = metadata
-                .snapshot_pin(snapshot_id)
+                .snapshot_pin(&root_path, snapshot_id)
                 .map_err(from_client)?
                 .ok_or_else(|| CliError::Client(format!("snapshot {snapshot_id} not found")))?;
             let mount = nokv_fuse::spawn_mount_client(
@@ -535,15 +541,15 @@ fn run(args: Vec<String>) -> Result<(), CliError> {
             let body = control_get(&config, "/fsck")?;
             print!("{body}");
         }
-        Command::Snapshot { path } => {
+        Command::Snapshot { path, lease_ms } => {
             let client = open_client(&config)?;
             let snapshot = client
                 .metadata()
-                .snapshot_subtree_path(&path)
+                .snapshot_subtree_path_with_lease(&path, lease_ms)
                 .map_err(from_client)?;
             println!(
-                "snapshot {} id={} version={}",
-                path, snapshot.snapshot_id, snapshot.read_version
+                "snapshot {} id={} version={} lease_expires_unix_ms={}",
+                path, snapshot.snapshot_id, snapshot.read_version, snapshot.lease_expires_unix_ms
             );
         }
         Command::Clone { src, dst } => {
@@ -584,32 +590,40 @@ fn run(args: Vec<String>) -> Result<(), CliError> {
                 .map_err(from_client)?;
             println!("rolled back {} to snapshot {}", path, snapshot_id);
         }
-        Command::CatSnapshot { snapshot_id, path } => {
+        Command::CatSnapshot {
+            root_path,
+            snapshot_id,
+            path,
+        } => {
             let client = open_client(&config)?;
             let bytes = client
-                .cat_snapshot(snapshot_id, &path)
+                .cat_snapshot(&root_path, snapshot_id, &path)
                 .map_err(from_client)?;
             io::stdout().write_all(&bytes).map_err(from_io)?;
         }
-        Command::RetireSnapshot { snapshot_id } => {
+        Command::RetireSnapshot {
+            root_path,
+            snapshot_id,
+        } => {
             let client = open_client(&config)?;
             let retired = client
                 .metadata()
-                .retire_snapshot(snapshot_id)
+                .retire_snapshot(&root_path, snapshot_id)
                 .map_err(from_client)?;
             println!("retired_snapshot id={} retired={}", snapshot_id, retired);
         }
         Command::RenewSnapshot {
+            root_path,
             snapshot_id,
             lease_ms,
         } => {
             let client = open_client(&config)?;
             let renewed = client
                 .metadata()
-                .renew_snapshot(snapshot_id, lease_ms)
+                .renew_snapshot(&root_path, snapshot_id, lease_ms)
                 .map_err(from_client)?;
             println!(
-                "renewed_snapshot id={} renewed={} lease_ms={}",
+                "renewed_snapshot id={} outcome={:?} lease_ms={}",
                 snapshot_id, renewed, lease_ms
             );
         }
@@ -1321,12 +1335,15 @@ fn parse_command(args: &[String]) -> Result<Command, CliError> {
             })
         }
         "mount-snapshot" => {
-            if args.len() < 3 {
-                return Err(CliError::MissingArgument("snapshot id and mountpoint"));
+            if args.len() < 4 {
+                return Err(CliError::MissingArgument(
+                    "snapshot root path, id, and mountpoint",
+                ));
             }
-            let (options, mountpoint) = parse_mount_args(args, 2, false)?;
+            let (options, mountpoint) = parse_mount_args(args, 3, false)?;
             Ok(Command::MountSnapshot {
-                snapshot_id: parse_u64(&args[1], "snapshot_id")?,
+                root_path: args[1].clone(),
+                snapshot_id: parse_u64(&args[2], "snapshot_id")?,
                 mountpoint,
                 options,
             })
@@ -1345,9 +1362,17 @@ fn parse_command(args: &[String]) -> Result<Command, CliError> {
             }),
             _ => Err(CliError::TooManyArguments),
         },
-        "snapshot" => exact_args(args, 2).map(|()| Command::Snapshot {
-            path: args[1].clone(),
-        }),
+        "snapshot" => match args.len() {
+            2 => Ok(Command::Snapshot {
+                path: args[1].clone(),
+                lease_ms: nokv_meta::DEFAULT_SNAPSHOT_LEASE_MS,
+            }),
+            3 => Ok(Command::Snapshot {
+                path: args[1].clone(),
+                lease_ms: parse_u64(&args[2], "lease_ms")?,
+            }),
+            _ => Err(CliError::TooManyArguments),
+        },
         "clone" => exact_args(args, 3).map(|()| Command::Clone {
             src: args[1].clone(),
             dst: args[2].clone(),
@@ -1364,26 +1389,30 @@ fn parse_command(args: &[String]) -> Result<Command, CliError> {
             })
         }
         "cat-snapshot" => {
-            exact_args(args, 3)?;
+            exact_args(args, 4)?;
             Ok(Command::CatSnapshot {
-                snapshot_id: parse_u64(&args[1], "snapshot_id")?,
-                path: args[2].clone(),
+                root_path: args[1].clone(),
+                snapshot_id: parse_u64(&args[2], "snapshot_id")?,
+                path: args[3].clone(),
             })
         }
         "retire-snapshot" => {
-            exact_args(args, 2)?;
+            exact_args(args, 3)?;
             Ok(Command::RetireSnapshot {
-                snapshot_id: parse_u64(&args[1], "snapshot_id")?,
+                root_path: args[1].clone(),
+                snapshot_id: parse_u64(&args[2], "snapshot_id")?,
             })
         }
         "renew-snapshot" => match args.len() {
-            2 => Ok(Command::RenewSnapshot {
-                snapshot_id: parse_u64(&args[1], "snapshot_id")?,
+            3 => Ok(Command::RenewSnapshot {
+                root_path: args[1].clone(),
+                snapshot_id: parse_u64(&args[2], "snapshot_id")?,
                 lease_ms: nokv_meta::DEFAULT_SNAPSHOT_LEASE_MS,
             }),
-            3 => Ok(Command::RenewSnapshot {
-                snapshot_id: parse_u64(&args[1], "snapshot_id")?,
-                lease_ms: parse_u64(&args[2], "lease_ms")?,
+            4 => Ok(Command::RenewSnapshot {
+                root_path: args[1].clone(),
+                snapshot_id: parse_u64(&args[2], "snapshot_id")?,
+                lease_ms: parse_u64(&args[3], "lease_ms")?,
             }),
             _ => Err(CliError::TooManyArguments),
         },
@@ -1685,9 +1714,9 @@ fn exact_args(args: &[String], expected: usize) -> Result<(), CliError> {
                 Some("register-graft") | Some("unregister-graft") => "prefix",
                 Some("put-artifact") => "path and source",
                 Some("snapshot") => "path",
-                Some("cat-snapshot") => "snapshot id and path",
-                Some("retire-snapshot") => "snapshot id",
-                Some("mount-snapshot") => "snapshot id and mountpoint",
+                Some("cat-snapshot") => "snapshot root path, id, and relative path",
+                Some("retire-snapshot") => "snapshot root path and id",
+                Some("mount-snapshot") => "snapshot root path, id, and mountpoint",
                 Some("rename") | Some("rename-replace") => "source and destination",
                 Some("clone") => "source and destination paths",
                 Some("diff") => "two paths",
@@ -1986,7 +2015,14 @@ where
                                                             nokv_agent::execute_agent_tool(
                                                                 &client, &call.name, &args,
                                                             )
-                                                            .map_err(|err| err.to_string())
+                                                            .map_err(|err| {
+                                                                json!({
+                                                                    "code": "AgentToolError",
+                                                                    "message": err.to_string(),
+                                                                    "retryable": false,
+                                                                    "details": {},
+                                                                })
+                                                            })
                                                         }
                                                         McpProfile::Workbench => {
                                                             workbench_mcp::execute_tool(
@@ -1997,7 +2033,7 @@ where
                                                                 &call.name,
                                                                 &args,
                                                             )
-                                                            .map_err(|err| err.to_string())
+                                                            .map_err(|err| err.as_value())
                                                         }
                                                     };
                                                     match tool_result {
@@ -2006,8 +2042,9 @@ where
                                                             "structuredContent": val,
                                                         })),
                                                         Err(err) => Ok(json!({
-                                                            "content": [{ "type": "text", "text": err.to_string() }],
-                                                            "isError": true
+                                                            "content": [{ "type": "text", "text": serde_json::to_string_pretty(&err).unwrap_or_default() }],
+                                                            "structuredContent": err,
+                                                            "isError": true,
                                                         })),
                                                     }
                                                 }
@@ -2061,20 +2098,20 @@ Usage:\n\
   nokv [--server-bind ADDR] [--object-backend s3|rustfs] [--mount ID] rename SOURCE DESTINATION\n\
   nokv [--server-bind ADDR] [--object-backend s3|rustfs] [--mount ID] rename-replace SOURCE DESTINATION\n\
   nokv [--server-bind ADDR] [--object-backend s3|rustfs] [--mount ID] mount [--read-only] [--no-kernel-cache] [--direct-io] [--entry-ttl-ms MS] [--attr-ttl-ms MS] [--writeback-cache] MOUNTPOINT\n\
-  nokv [--server-bind ADDR] [--object-backend s3|rustfs] [--mount ID] mount-snapshot SNAPSHOT_ID [--no-kernel-cache] [--direct-io] [--entry-ttl-ms MS] [--attr-ttl-ms MS] [--writeback-cache] MOUNTPOINT\n\
+  nokv [--server-bind ADDR] [--object-backend s3|rustfs] [--mount ID] mount-snapshot ROOT_PATH SNAPSHOT_ID [--no-kernel-cache] [--direct-io] [--entry-ttl-ms MS] [--attr-ttl-ms MS] [--writeback-cache] MOUNTPOINT\n\
   nokv [--meta PATH] [--object-backend s3|rustfs] [--mount ID] [--control-backend etcd] serve\n\
   nokv [--server-bind ADDR] [--object-backend s3|rustfs] [--mount ID] mcp [--profile agent|workbench] [--workbench-root PATH] [--workbench-max-bytes BYTES]\n\
   nokv [--server-bind ADDR] [--object-backend s3|rustfs] [--mount ID] backup\n\
   nokv [--meta PATH] [--object-backend s3|rustfs] [--mount ID] restore\n\
   nokv [--server-bind ADDR] [--object-backend s3|rustfs] [--mount ID] fsck\n\
   nokv [--server-bind ADDR] [--object-backend s3|rustfs] [--mount ID] gc [LIMIT]\n\
-  nokv [--server-bind ADDR] [--object-backend s3|rustfs] [--mount ID] snapshot PATH\n\
+  nokv [--server-bind ADDR] [--object-backend s3|rustfs] [--mount ID] snapshot PATH [LEASE_MS]\n\
   nokv [--server-bind ADDR] [--object-backend s3|rustfs] [--mount ID] clone SRC_PATH DST_PATH\n\
   nokv [--server-bind ADDR] [--object-backend s3|rustfs] [--mount ID] diff PATH_A PATH_B\n\
   nokv [--server-bind ADDR] [--object-backend s3|rustfs] [--mount ID] rollback PATH SNAPSHOT_ID\n\
-  nokv [--server-bind ADDR] [--object-backend s3|rustfs] [--mount ID] cat-snapshot SNAPSHOT_ID PATH\n\
-  nokv [--server-bind ADDR] [--object-backend s3|rustfs] [--mount ID] retire-snapshot SNAPSHOT_ID\n\
-  nokv [--server-bind ADDR] [--object-backend s3|rustfs] [--mount ID] renew-snapshot SNAPSHOT_ID [LEASE_MS]\n\
+  nokv [--server-bind ADDR] [--object-backend s3|rustfs] [--mount ID] cat-snapshot ROOT_PATH SNAPSHOT_ID RELATIVE_PATH\n\
+  nokv [--server-bind ADDR] [--object-backend s3|rustfs] [--mount ID] retire-snapshot ROOT_PATH SNAPSHOT_ID\n\
+  nokv [--server-bind ADDR] [--object-backend s3|rustfs] [--mount ID] renew-snapshot ROOT_PATH SNAPSHOT_ID [LEASE_MS]\n\
 \n\
 Object backends:\n\
   --object-backend s3|rustfs\n\
@@ -2725,6 +2762,7 @@ mod tests {
         );
         let (_config, command) = parse(vec![
             s("mount-snapshot"),
+            s("/runs"),
             s("42"),
             s("--direct-io"),
             s("/tmp/nokv-ro"),
@@ -2733,6 +2771,7 @@ mod tests {
         assert_eq!(
             command,
             Command::MountSnapshot {
+                root_path: s("/runs"),
                 snapshot_id: 42,
                 mountpoint: PathBuf::from("/tmp/nokv-ro"),
                 options: MountCliOptions {
@@ -2742,7 +2781,12 @@ mod tests {
             }
         );
         assert!(matches!(
-            parse(vec![s("mount-snapshot"), s("bad"), s("/tmp/nokv-ro")]),
+            parse(vec![
+                s("mount-snapshot"),
+                s("/runs"),
+                s("bad"),
+                s("/tmp/nokv-ro")
+            ]),
             Err(CliError::InvalidNumber {
                 field: "snapshot_id",
                 ..
@@ -2885,23 +2929,56 @@ mod tests {
     fn parse_snapshot_commands() {
         assert_eq!(
             parse(vec![s("snapshot"), s("/runs")]).unwrap().1,
-            Command::Snapshot { path: s("/runs") }
-        );
-        assert_eq!(
-            parse(vec![s("cat-snapshot"), s("42"), s("/runs/checkpoint")])
-                .unwrap()
-                .1,
-            Command::CatSnapshot {
-                snapshot_id: 42,
-                path: s("/runs/checkpoint")
+            Command::Snapshot {
+                path: s("/runs"),
+                lease_ms: nokv_meta::DEFAULT_SNAPSHOT_LEASE_MS,
             }
         );
         assert_eq!(
-            parse(vec![s("retire-snapshot"), s("42")]).unwrap().1,
-            Command::RetireSnapshot { snapshot_id: 42 }
+            parse(vec![s("snapshot"), s("/runs"), s("200")]).unwrap().1,
+            Command::Snapshot {
+                path: s("/runs"),
+                lease_ms: 200,
+            }
         );
         assert!(matches!(
-            parse(vec![s("cat-snapshot"), s("bad"), s("/runs/checkpoint")]),
+            parse(vec![s("snapshot"), s("/runs"), s("invalid")]),
+            Err(CliError::InvalidNumber {
+                field: "lease_ms",
+                ..
+            })
+        ));
+        assert_eq!(
+            parse(vec![
+                s("cat-snapshot"),
+                s("/runs"),
+                s("42"),
+                s("/checkpoint")
+            ])
+            .unwrap()
+            .1,
+            Command::CatSnapshot {
+                root_path: s("/runs"),
+                snapshot_id: 42,
+                path: s("/checkpoint")
+            }
+        );
+        assert_eq!(
+            parse(vec![s("retire-snapshot"), s("/runs"), s("42")])
+                .unwrap()
+                .1,
+            Command::RetireSnapshot {
+                root_path: s("/runs"),
+                snapshot_id: 42,
+            }
+        );
+        assert!(matches!(
+            parse(vec![
+                s("cat-snapshot"),
+                s("/runs"),
+                s("bad"),
+                s("/checkpoint")
+            ]),
             Err(CliError::InvalidNumber {
                 field: "snapshot_id",
                 ..
@@ -5086,6 +5163,105 @@ mod tests {
     }
 
     #[test]
+    fn workbench_mcp_snapshot_list_collapses_renew_events() {
+        let id = "ckpt-dedup-010";
+        let mut requests = commit_snapshot_prelude(id);
+        requests.push(workbench_tool_call(
+            4,
+            "workbench_snapshot",
+            serde_json::json!({"id": id, "name": "handoff", "ttl_days": 1}),
+        ));
+        requests.push(workbench_tool_call(
+            5,
+            "workbench_snapshot_renew",
+            serde_json::json!({"id": id, "name": "handoff", "ttl_days": 5}),
+        ));
+        requests.push(workbench_tool_call(
+            6,
+            "workbench_snapshot_renew",
+            serde_json::json!({"id": id, "name": "handoff", "ttl_days": 30}),
+        ));
+        requests.push(workbench_tool_call(
+            7,
+            "workbench_snapshot_list",
+            serde_json::json!({"id": id}),
+        ));
+        let responses = run_shared_workbench_mcp_requests(requests);
+        for (index, response) in responses.iter().enumerate() {
+            assert_ne!(
+                response["result"]["isError"], true,
+                "response {index}: {response}"
+            );
+        }
+        let sid = responses[3]["result"]["structuredContent"]["snapshot_id"]
+            .as_u64()
+            .unwrap();
+        let list = &responses[6]["result"]["structuredContent"];
+        assert_eq!(list["checkpoint_count"], 1, "list: {list}");
+        let checkpoint = &list["checkpoints"][0];
+        assert_eq!(checkpoint["snapshot_id"], sid, "checkpoint: {checkpoint}");
+        assert_eq!(checkpoint["name"], "handoff", "checkpoint: {checkpoint}");
+        assert_eq!(checkpoint["renew_count"], 2, "checkpoint: {checkpoint}");
+        assert_eq!(checkpoint["state"], "alive", "checkpoint: {checkpoint}");
+        assert!(
+            checkpoint["server_now_ms"].as_u64().unwrap()
+                < checkpoint["live_lease_expires_unix_ms"].as_u64().unwrap(),
+            "checkpoint: {checkpoint}"
+        );
+        assert_eq!(
+            checkpoint["lease_expires_at"], checkpoint["live_lease_expires_unix_ms"],
+            "checkpoint: {checkpoint}"
+        );
+    }
+
+    #[test]
+    fn workbench_mcp_rejects_foreign_snapshot_ids_with_typed_errors() {
+        let source_id = "ckpt-owner-source-012";
+        let target_id = "ckpt-owner-target-012";
+        let mut source_requests = commit_snapshot_prelude(source_id);
+        source_requests.push(workbench_tool_call(
+            4,
+            "workbench_snapshot",
+            serde_json::json!({"id": source_id, "name": "owned", "ttl_days": 7}),
+        ));
+        let source = run_shared_workbench_mcp_requests(source_requests);
+        let snapshot_id = source[3]["result"]["structuredContent"]["snapshot_id"]
+            .as_u64()
+            .unwrap();
+
+        let responses = run_shared_workbench_mcp_requests(vec![
+            workbench_tool_call(1, "workbench_create", serde_json::json!({"id": target_id})),
+            workbench_tool_call(
+                2,
+                "workbench_read",
+                serde_json::json!({
+                    "id": target_id,
+                    "section": "outputs",
+                    "path": "result.txt",
+                    "at_snapshot": snapshot_id,
+                }),
+            ),
+            workbench_tool_call(
+                3,
+                "workbench_snapshot_renew",
+                serde_json::json!({
+                    "id": target_id,
+                    "snapshot_id": snapshot_id,
+                    "ttl_days": 30,
+                }),
+            ),
+        ]);
+        assert_ne!(responses[0]["result"]["isError"], true);
+        for response in &responses[1..] {
+            assert_eq!(response["result"]["isError"], true, "response: {response}");
+            let error = &response["result"]["structuredContent"];
+            assert_eq!(error["code"], "SnapshotRootMismatch", "error: {error}");
+            assert_eq!(error["retryable"], false, "error: {error}");
+            assert_eq!(error["details"]["snapshot_id"], snapshot_id);
+        }
+    }
+
+    #[test]
     fn workbench_mcp_snapshot_renew_reports_reaped_snapshot() {
         let id = "ckpt-reaped-007";
         let mut requests = commit_snapshot_prelude(id);
@@ -5236,6 +5412,68 @@ mod tests {
         let frozen = &responses[1]["result"]["structuredContent"];
         assert_eq!(frozen["record_count"], 2);
         assert_eq!(frozen["items"][0]["value"]["text"], "one");
+    }
+
+    #[test]
+    fn workbench_mcp_at_snapshot_list_pages_with_opaque_cursor() {
+        let id = "ckpt-list-page-010";
+        let mut requests = vec![workbench_tool_call(
+            1,
+            "workbench_create",
+            serde_json::json!({"id": id}),
+        )];
+        for (request_id, name) in [(2, "a.txt"), (3, "b.txt"), (4, "c.txt")] {
+            requests.push(workbench_tool_call(
+                request_id,
+                "workbench_put_file",
+                serde_json::json!({
+                    "id": id, "section": "outputs", "path": name, "text": name
+                }),
+            ));
+        }
+        requests.push(workbench_tool_call(
+            5,
+            "workbench_commit",
+            serde_json::json!({"id": id, "manifest": {"task": id}}),
+        ));
+        requests.push(workbench_tool_call(
+            6,
+            "workbench_snapshot",
+            serde_json::json!({"id": id, "name": "page"}),
+        ));
+        requests.push(workbench_tool_call(
+            7,
+            "workbench_list",
+            serde_json::json!({
+                "id": id, "section": "outputs", "at_snapshot": "page", "limit": 2
+            }),
+        ));
+        let first = run_shared_workbench_mcp_requests(requests);
+        let first_page = &first[6]["result"]["structuredContent"];
+        assert_ne!(first[6]["result"]["isError"], true, "{first_page}");
+        assert_eq!(first_page["entries"].as_array().unwrap().len(), 2);
+        assert_eq!(first_page["entries"][0]["name"], "a.txt");
+        assert_eq!(first_page["entries"][1]["name"], "b.txt");
+        assert_eq!(first_page["truncated"], true);
+        let cursor = first_page["next_cursor"].as_str().unwrap();
+
+        let second = run_shared_workbench_mcp_requests(vec![workbench_tool_call(
+            8,
+            "workbench_list",
+            serde_json::json!({
+                "id": id,
+                "section": "outputs",
+                "at_snapshot": "page",
+                "limit": 2,
+                "cursor": cursor
+            }),
+        )]);
+        let second_page = &second[0]["result"]["structuredContent"];
+        assert_ne!(second[0]["result"]["isError"], true, "{second_page}");
+        assert_eq!(second_page["entries"].as_array().unwrap().len(), 1);
+        assert_eq!(second_page["entries"][0]["name"], "c.txt");
+        assert_eq!(second_page["truncated"], false);
+        assert!(second_page["next_cursor"].is_null());
     }
 
     #[test]

--- a/crates/nokv/src/bin/nokv/workbench_mcp.rs
+++ b/crates/nokv/src/bin/nokv/workbench_mcp.rs
@@ -4,8 +4,10 @@ use std::time::{SystemTime, UNIX_EPOCH};
 use base64::Engine;
 use nokv_agent::AgentToolDefinition;
 use nokv_client::{
-    is_artifact_write_conflict, is_metadata_not_found, ArtifactMetadata, NoKvFsClient,
+    decode_name_cursor, encode_name_cursor, is_artifact_write_conflict, is_metadata_not_found,
+    ArtifactMetadata, ClientError, NoKvFsClient,
 };
+use nokv_meta::MetadError;
 use nokv_object::ObjectStore;
 use nokv_types::{FileType, PathMetadata};
 use serde_json::{json, Value};
@@ -84,14 +86,43 @@ pub struct WorkbenchMcpOptions {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct WorkbenchToolError {
+    code: &'static str,
     message: String,
+    retryable: bool,
+    details: Value,
 }
 
 impl WorkbenchToolError {
     fn new(message: impl Into<String>) -> Self {
         Self {
+            code: "WorkbenchToolError",
             message: message.into(),
+            retryable: false,
+            details: json!({}),
         }
+    }
+
+    fn typed(
+        code: &'static str,
+        message: impl Into<String>,
+        retryable: bool,
+        details: Value,
+    ) -> Self {
+        Self {
+            code,
+            message: message.into(),
+            retryable,
+            details,
+        }
+    }
+
+    pub fn as_value(&self) -> Value {
+        json!({
+            "code": self.code,
+            "message": self.message,
+            "retryable": self.retryable,
+            "details": self.details,
+        })
     }
 }
 
@@ -1333,28 +1364,16 @@ where
         )));
     }
     let path = workbench_path(options, &id);
-    // Mint at the default 1h lease, then extend to the requested ttl and read
-    // the pin back so lease_expires_at is the server's authoritative deadline,
-    // never a client-computed guess (three low-frequency RPCs, no new op).
+    let lease_ms = ttl_days.saturating_mul(MS_PER_DAY);
+    // The requested lease is part of the mint RPC, so the returned pin is the
+    // authoritative checkpoint and creation costs one metadata round trip.
     let snapshot = client
         .metadata()
-        .snapshot_subtree_path(&path)
+        .snapshot_subtree_path_with_lease(&path, lease_ms)
         .map_err(client_error)?;
     let snapshot_id = snapshot.snapshot_id;
-    let lease_ms = ttl_days.saturating_mul(MS_PER_DAY);
-    client
-        .metadata()
-        .renew_snapshot(snapshot_id, lease_ms)
-        .map_err(client_error)?;
-    let pin = client
-        .metadata()
-        .snapshot_pin(snapshot_id)
-        .map_err(client_error)?;
-    let lease_expires_unix_ms = pin.as_ref().map(|pin| pin.lease_expires_unix_ms);
-    let read_version = pin
-        .as_ref()
-        .map(|pin| pin.read_version)
-        .unwrap_or(snapshot.read_version);
+    let lease_expires_unix_ms = Some(snapshot.lease_expires_unix_ms);
+    let read_version = snapshot.read_version;
     let created_at = unix_ms();
     let registry_entry = json!({
         "name": name,
@@ -1402,21 +1421,26 @@ where
     let (ttl_days, _ttl_defaulted) = resolve_ttl_days(args)?;
     let snapshot_id = resolve_renew_target(client, options, &id, args)?;
     let lease_ms = ttl_days.saturating_mul(MS_PER_DAY);
-    let renewed = client
+    let path = workbench_path(options, &id);
+    let outcome = client
         .metadata()
-        .renew_snapshot(snapshot_id, lease_ms)
+        .renew_snapshot(&path, snapshot_id, lease_ms)
         .map_err(client_error)?;
-    if !renewed {
-        return Err(WorkbenchToolError::new(format!(
-            "snapshot {snapshot_id} was reaped after lease expiry; re-mint from current state"
-        )));
-    }
-    let pin = client
-        .metadata()
-        .snapshot_pin(snapshot_id)
-        .map_err(client_error)?;
-    let lease_expires_unix_ms = pin.as_ref().map(|pin| pin.lease_expires_unix_ms);
-    let read_version = pin.as_ref().map(|pin| pin.read_version);
+    let (pin, extended) = match outcome {
+        nokv_meta::SnapshotRenewOutcome::Renewed { pin, extended } => (pin, extended),
+        nokv_meta::SnapshotRenewOutcome::Missing { .. } => {
+            return Err(WorkbenchToolError::typed(
+                "SnapshotNotFound",
+                format!(
+                    "snapshot {snapshot_id} was reaped after lease expiry; re-mint from current state"
+                ),
+                false,
+                json!({"snapshot_id": snapshot_id}),
+            ));
+        }
+    };
+    let lease_expires_unix_ms = Some(pin.lease_expires_unix_ms);
+    let read_version = Some(pin.read_version);
     // Carry the name forward from the mint record so the renew row stays joinable
     // with the checkpoint it extends.
     let name = registry_name_for_snapshot(client, options, &id, snapshot_id)?;
@@ -1441,12 +1465,24 @@ where
         "snapshot_id": snapshot_id,
         "name": name,
         "renewed": true,
+        "extended": extended,
         "ttl_days": ttl_days,
         "read_version": read_version,
         "lease_expires_at": lease_expires_unix_ms,
         "lease_expires_unix_ms": lease_expires_unix_ms,
         "registry": registry,
     }))
+}
+
+#[derive(Default)]
+struct CheckpointGroup {
+    name: Value,
+    created_at: Value,
+    read_version: Value,
+    has_mint: bool,
+    registered_lease: Value,
+    renew_count: u64,
+    last_renewed_at: Value,
 }
 
 fn list_snapshots_workbench<O>(
@@ -1459,40 +1495,61 @@ where
 {
     let id = required_workbench_id(args)?;
     let entries = read_checkpoint_registry(client, options, &id)?;
-    let now = unix_ms();
-    let mut checkpoints = Vec::with_capacity(entries.len());
+    let root_path = workbench_path(options, &id);
+    let mut order = Vec::new();
+    let mut groups: std::collections::HashMap<u64, CheckpointGroup> =
+        std::collections::HashMap::new();
     for entry in &entries {
-        let snapshot_id = entry.get("snapshot_id").and_then(Value::as_u64);
-        let (state, live_lease) = match snapshot_id {
-            Some(snapshot_id) => {
-                match client
-                    .metadata()
-                    .snapshot_pin(snapshot_id)
-                    .map_err(client_error)?
-                {
-                    None => ("reaped", None),
-                    Some(pin) => {
-                        if now >= pin.lease_expires_unix_ms {
-                            ("expired (reap pending)", Some(pin.lease_expires_unix_ms))
-                        } else {
-                            ("alive", Some(pin.lease_expires_unix_ms))
-                        }
-                    }
-                }
+        let Some(snapshot_id) = entry.get("snapshot_id").and_then(Value::as_u64) else {
+            continue;
+        };
+        let group = groups.entry(snapshot_id).or_insert_with(|| {
+            order.push(snapshot_id);
+            CheckpointGroup::default()
+        });
+        if let Some(lease) = entry.get("lease_expires_unix_ms") {
+            group.registered_lease = lease.clone();
+        }
+        if entry.get("reason").and_then(Value::as_str) == Some("renew") {
+            group.renew_count += 1;
+            group.last_renewed_at = entry.get("created_at").cloned().unwrap_or(Value::Null);
+        } else {
+            group.has_mint = true;
+            group.name = entry.get("name").cloned().unwrap_or(Value::Null);
+            group.created_at = entry.get("created_at").cloned().unwrap_or(Value::Null);
+            group.read_version = entry.get("read_version").cloned().unwrap_or(Value::Null);
+        }
+        if group.read_version.is_null() {
+            group.read_version = entry.get("read_version").cloned().unwrap_or(Value::Null);
+        }
+    }
+
+    let mut checkpoints = Vec::with_capacity(order.len());
+    for snapshot_id in order {
+        let group = &groups[&snapshot_id];
+        let status = client
+            .metadata()
+            .snapshot_pin_status(&root_path, snapshot_id)
+            .map_err(client_error)?;
+        let (state, live_lease) = match status.pin {
+            None => ("reaped", None),
+            Some(pin) if status.server_now_ms >= pin.lease_expires_unix_ms => {
+                ("expired", Some(pin.lease_expires_unix_ms))
             }
-            None => ("unknown", None),
+            Some(pin) => ("alive", Some(pin.lease_expires_unix_ms)),
         };
         checkpoints.push(json!({
-            "name": entry.get("name").cloned().unwrap_or(Value::Null),
+            "name": group.name.clone(),
             "snapshot_id": snapshot_id,
-            "read_version": entry.get("read_version").cloned().unwrap_or(Value::Null),
-            "reason": entry.get("reason").cloned().unwrap_or(Value::Null),
-            "created_at": entry.get("created_at").cloned().unwrap_or(Value::Null),
-            "registered_lease_expires_unix_ms": entry
-                .get("lease_expires_unix_ms")
-                .cloned()
-                .unwrap_or(Value::Null),
+            "read_version": group.read_version.clone(),
+            "reason": if group.has_mint { "mint" } else { "renew" },
+            "created_at": group.created_at.clone(),
+            "renew_count": group.renew_count,
+            "last_renewed_at": group.last_renewed_at.clone(),
+            "registered_lease_expires_unix_ms": group.registered_lease.clone(),
             "live_lease_expires_unix_ms": live_lease,
+            "lease_expires_at": live_lease,
+            "server_now_ms": status.server_now_ms,
             "state": state,
         }));
     }
@@ -1525,7 +1582,6 @@ where
         ));
     }
     let snapshot_id = resolve_at_snapshot(client, options, id, at_snapshot)?;
-    ensure_snapshot_live(client, snapshot_id)?;
     let scope = path_scope(options, id, target)?;
     // Subtree-snapshot reads address paths relative to the snapshot root (the
     // workbench directory), so strip the workbench prefix; the absolute `target`
@@ -1533,7 +1589,7 @@ where
     let snap_path = snapshot_relative_path(options, id, target)?;
     match read_tool {
         "stat" => at_snapshot_stat(client, options, id, snapshot_id, &scope, &snap_path),
-        "ls" => at_snapshot_list(client, options, id, snapshot_id, &scope, target, &snap_path),
+        "ls" => at_snapshot_list(client, options, id, snapshot_id, &scope, target, args),
         "read" => at_snapshot_read(client, options, id, snapshot_id, &scope, &snap_path, args),
         other => Err(WorkbenchToolError::new(format!(
             "at_snapshot is not supported for {other}"
@@ -1573,8 +1629,8 @@ where
 {
     let metadata = client
         .metadata()
-        .stat_path_at_snapshot(snapshot_id, snap_path)
-        .map_err(client_error)?
+        .stat_path_at_snapshot(&workbench_path(options, id), snapshot_id, snap_path)
+        .map_err(|err| snapshot_client_error(snapshot_id, err))?
         .ok_or_else(|| {
             WorkbenchToolError::new(format!(
                 "path not found at snapshot {snapshot_id}: {}",
@@ -1600,15 +1656,36 @@ fn at_snapshot_list<O>(
     snapshot_id: u64,
     scope: &WorkbenchPathScope,
     target: &str,
-    snap_path: &str,
+    args: &Value,
 ) -> Result<Value, WorkbenchToolError>
 where
     O: ObjectStore + Send + Sync + 'static,
 {
-    let dentries = client
+    let limit = optional_usize(args, "limit")?.unwrap_or(MAX_WORKBENCH_LIST_LIMIT);
+    if limit == 0 || limit > MAX_WORKBENCH_LIST_LIMIT {
+        return Err(WorkbenchToolError::new(format!(
+            "limit must be between 1 and {MAX_WORKBENCH_LIST_LIMIT}"
+        )));
+    }
+    let cursor = optional_string(args, "cursor")?;
+    let after = cursor
+        .map(decode_name_cursor)
+        .transpose()
+        .map_err(|err| WorkbenchToolError::new(format!("invalid snapshot list cursor: {err}")))?;
+    let snap_path = snapshot_relative_path(options, id, target)?;
+    let page = client
         .metadata()
-        .list_path_at_snapshot(snapshot_id, snap_path)
-        .map_err(client_error)?;
+        .list_path_at_snapshot_page(
+            &workbench_path(options, id),
+            snapshot_id,
+            &snap_path,
+            after.as_ref(),
+            limit,
+        )
+        .map_err(|err| snapshot_client_error(snapshot_id, err))?;
+    let next_cursor = page.next_cursor.as_ref().map(encode_name_cursor);
+    let truncated = next_cursor.is_some();
+    let dentries = page.entries;
     let base = target.trim_end_matches('/');
     let mut entries = Vec::with_capacity(dentries.len());
     for dentry in &dentries {
@@ -1636,8 +1713,8 @@ where
         "path": scope.path.clone(),
         "entry_count": entries.len(),
         "entries": entries,
-        "next_cursor": Value::Null,
-        "truncated": false,
+        "next_cursor": next_cursor,
+        "truncated": truncated,
     }))
 }
 
@@ -1655,8 +1732,8 @@ where
 {
     let metadata = client
         .metadata()
-        .stat_path_at_snapshot(snapshot_id, snap_path)
-        .map_err(client_error)?
+        .stat_path_at_snapshot(&workbench_path(options, id), snapshot_id, snap_path)
+        .map_err(|err| snapshot_client_error(snapshot_id, err))?
         .ok_or_else(|| {
             WorkbenchToolError::new(format!(
                 "path not found at snapshot {snapshot_id}: {}",
@@ -1701,8 +1778,14 @@ where
             len = options.max_bytes as u64;
         }
         let raw = client
-            .read_snapshot(snapshot_id, snap_path, offset, len as usize)
-            .map_err(client_error)?;
+            .read_snapshot(
+                &workbench_path(options, id),
+                snapshot_id,
+                snap_path,
+                offset,
+                len as usize,
+            )
+            .map_err(|err| snapshot_client_error(snapshot_id, err))?;
         let returned = raw.len() as u64;
         out.insert("format".to_owned(), json!("bytes"));
         out.insert("record_type".to_owned(), Value::Null);
@@ -1730,8 +1813,14 @@ where
         )));
     }
     let raw = client
-        .read_snapshot(snapshot_id, snap_path, 0, size as usize)
-        .map_err(client_error)?;
+        .read_snapshot(
+            &workbench_path(options, id),
+            snapshot_id,
+            snap_path,
+            0,
+            size as usize,
+        )
+        .map_err(|err| snapshot_client_error(snapshot_id, err))?;
     let text = String::from_utf8(raw).map_err(|_| {
         WorkbenchToolError::new(format!(
             "at_snapshot read of {} is not UTF-8 text; structured record reads at a snapshot are not yet supported, use format=bytes",
@@ -2019,37 +2108,6 @@ where
         (Some(_), Some(_)) | (None, None) => Err(WorkbenchToolError::new(
             "provide exactly one of snapshot_id or name",
         )),
-    }
-}
-
-/// Loud liveness check before any at-snapshot read. A missing pin (reaped) and
-/// an expired-but-unreaped pin both fail with an explicit message naming the
-/// state, so a caller never silently reads a half-dead snapshot.
-fn ensure_snapshot_live<O>(
-    client: &NoKvFsClient<O>,
-    snapshot_id: u64,
-) -> Result<(), WorkbenchToolError>
-where
-    O: ObjectStore + Send + Sync + 'static,
-{
-    match client
-        .metadata()
-        .snapshot_pin(snapshot_id)
-        .map_err(client_error)?
-    {
-        None => Err(WorkbenchToolError::new(format!(
-            "snapshot {snapshot_id} not found; snapshots are reaped after lease expiry"
-        ))),
-        Some(pin) => {
-            let now = unix_ms();
-            if now >= pin.lease_expires_unix_ms {
-                return Err(WorkbenchToolError::new(format!(
-                    "snapshot {snapshot_id} lease expired at {}; renew within the reap window or re-mint",
-                    pin.lease_expires_unix_ms
-                )));
-            }
-            Ok(())
-        }
     }
 }
 
@@ -2745,8 +2803,69 @@ fn optional_usize(args: &Value, name: &'static str) -> Result<Option<usize>, Wor
     }
 }
 
-fn client_error(err: impl fmt::Display) -> WorkbenchToolError {
-    WorkbenchToolError::new(err.to_string())
+fn client_error(err: ClientError) -> WorkbenchToolError {
+    match &err {
+        ClientError::Metadata(MetadError::SnapshotLeaseExpired {
+            snapshot_id,
+            lease_expires_unix_ms,
+            now_ms,
+        }) => WorkbenchToolError::typed(
+            "SnapshotLeaseExpired",
+            err.to_string(),
+            false,
+            json!({
+                "snapshot_id": snapshot_id,
+                "lease_expires_unix_ms": lease_expires_unix_ms,
+                "now_ms": now_ms,
+            }),
+        ),
+        ClientError::Metadata(MetadError::SnapshotRootMismatch {
+            snapshot_id,
+            expected_root,
+            actual_root,
+            actual_shard,
+        }) => WorkbenchToolError::typed(
+            "SnapshotRootMismatch",
+            err.to_string(),
+            false,
+            json!({
+                "snapshot_id": snapshot_id,
+                "expected_root": expected_root.get(),
+                "actual_root": actual_root.map(|root| root.get()),
+                "actual_shard": actual_shard,
+            }),
+        ),
+        ClientError::Metadata(MetadError::SnapshotBindingChanged { root_path }) => {
+            WorkbenchToolError::typed(
+                "SnapshotBindingChanged",
+                err.to_string(),
+                true,
+                json!({"root_path": root_path}),
+            )
+        }
+        ClientError::Metadata(MetadError::SnapshotRenewContended {
+            snapshot_id,
+            attempts,
+        }) => WorkbenchToolError::typed(
+            "SnapshotRenewContended",
+            err.to_string(),
+            true,
+            json!({"snapshot_id": snapshot_id, "attempts": attempts}),
+        ),
+        _ => WorkbenchToolError::typed("NoKvClientError", err.to_string(), false, json!({})),
+    }
+}
+
+fn snapshot_client_error(snapshot_id: u64, err: ClientError) -> WorkbenchToolError {
+    if matches!(&err, ClientError::Metadata(MetadError::NotFound)) {
+        return WorkbenchToolError::typed(
+            "SnapshotNotFound",
+            format!("snapshot {snapshot_id} not found; it may have been reaped after lease expiry"),
+            false,
+            json!({"snapshot_id": snapshot_id}),
+        );
+    }
+    client_error(err)
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary

- make snapshot renew extend-only and linearizable, with strict terminal expiry
- make reaper deletion conditional on the scanned pin version
- bind every snapshot lifecycle/read RPC to an absolute root path and return typed errors
- add retained-history indexing, migration, and snapshot-aware pagination
- keep ordinary current scans on the existing hot path

## Stack and scope

This is the first layer of a stacked delivery.

The existing inode-addressed MetadataClient snapshot calls are temporarily fail-closed in this layer so the breaking root-bound protocol can compile before the separate FUSE adapter is merged. The next stacked PR removes those five bridge methods completely. There is no root-unbound compatibility RPC or server path.

The only FUSE source change here is a future-proof fail-closed error fallback required by the non-exhaustive cross-crate error enum. Snapshot mount path reconstruction is not in this PR.

Excluded: restore-to-fork, operator rollback changes, mutation fencing, SubtreeReplaced, FUSE invalidation changes, and FUSE object-GC recovery.

## Validation

- cargo test --workspace --all-targets --no-run
- cargo test -p nokv-meta snapshot: 40 passed
- cargo test -p nokv-client snapshot: 6 passed including snapshot_lease integration
- cargo test -p nokv-server: 68 passed
- cargo fmt --all -- --check
- git diff --check

The complete stack is additionally covered by the checked-in full RustFS and LingTai live E2E in the Workbench restore PR.