### PR TITLE
fix(fuse): bind snapshot mounts to root paths

### DIFF
--- a/crates/nokv-client/src/service.rs
+++ b/crates/nokv-client/src/service.rs
@@ -56,13 +56,6 @@ use crate::wire::*;
 const DEFAULT_RPC_TIMEOUT: Duration = Duration::from_secs(10);
 const MAX_BATCH_RPC_REQUESTS: usize = 128;
 
-fn snapshot_inode_api_disabled() -> ClientError {
-    ClientError::Protocol(
-        "inode-addressed snapshot reads are disabled; use a root-bound snapshot path API"
-            .to_owned(),
-    )
-}
-
 /// Bound for re-resolve+retry in fleet mode: enough attempts to ride out a
 /// single owner handoff (old owner -> control update -> new owner) without
 /// retrying forever against a permanently-missing shard.
@@ -313,17 +306,7 @@ impl MetadataClient {
         }
     }
 
-    /// Temporary fail-closed bridge for the stacked FUSE snapshot adapter.
-    /// The root-bound adapter removes this inode-addressed API.
     pub fn get_attr_at_snapshot(
-        &self,
-        _snapshot_id: u64,
-        _inode: InodeId,
-    ) -> Result<Option<InodeAttr>, ClientError> {
-        Err(snapshot_inode_api_disabled())
-    }
-
-    pub fn get_attr_at_snapshot_rooted(
         &self,
         root_path: &str,
         snapshot_id: u64,
@@ -371,18 +354,7 @@ impl MetadataClient {
         }
     }
 
-    /// Temporary fail-closed bridge for the stacked FUSE snapshot adapter.
-    /// The root-bound adapter removes this inode-addressed API.
     pub fn lookup_plus_at_snapshot(
-        &self,
-        _snapshot_id: u64,
-        _parent: InodeId,
-        _name: DentryName,
-    ) -> Result<Option<DentryWithAttr>, ClientError> {
-        Err(snapshot_inode_api_disabled())
-    }
-
-    pub fn lookup_plus_at_snapshot_rooted(
         &self,
         root_path: &str,
         snapshot_id: u64,
@@ -431,17 +403,7 @@ impl MetadataClient {
         }
     }
 
-    /// Temporary fail-closed bridge for the stacked FUSE snapshot adapter.
-    /// The root-bound adapter removes this inode-addressed API.
     pub fn read_dir_plus_at_snapshot(
-        &self,
-        _snapshot_id: u64,
-        _inode: InodeId,
-    ) -> Result<Vec<DentryWithAttr>, ClientError> {
-        Err(snapshot_inode_api_disabled())
-    }
-
-    pub fn read_dir_plus_at_snapshot_rooted(
         &self,
         root_path: &str,
         snapshot_id: u64,
@@ -1906,19 +1868,7 @@ impl MetadataClient {
         }
     }
 
-    /// Temporary fail-closed bridge for the stacked FUSE snapshot adapter.
-    /// The root-bound adapter removes this inode-addressed API.
     pub fn read_file_at_snapshot(
-        &self,
-        _snapshot_id: u64,
-        _inode: InodeId,
-        _offset: u64,
-        _len: usize,
-    ) -> Result<Vec<u8>, ClientError> {
-        Err(snapshot_inode_api_disabled())
-    }
-
-    pub fn read_file_at_snapshot_rooted(
         &self,
         root_path: &str,
         snapshot_id: u64,
@@ -1947,17 +1897,7 @@ impl MetadataClient {
         }
     }
 
-    /// Temporary fail-closed bridge for the stacked FUSE snapshot adapter.
-    /// The root-bound adapter removes this inode-addressed API.
     pub fn read_symlink_at_snapshot(
-        &self,
-        _snapshot_id: u64,
-        _inode: InodeId,
-    ) -> Result<Vec<u8>, ClientError> {
-        Err(snapshot_inode_api_disabled())
-    }
-
-    pub fn read_symlink_at_snapshot_rooted(
         &self,
         root_path: &str,
         snapshot_id: u64,

--- a/crates/nokv-fuse/src/backend.rs
+++ b/crates/nokv-fuse/src/backend.rs
@@ -2,7 +2,9 @@ use std::fmt;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
 
-use nokv_client::{ClientError, ClientPreparedArtifact, MetadataClient};
+use nokv_client::{
+    ClientError, ClientPreparedArtifact, ClientPreparedArtifactRecovery, MetadataClient,
+};
 use nokv_meta::{
     DentryWithAttr, MetadError, PublishArtifactStagedSession, ReadDirPlusPage, RenameReplaceResult,
     UpdateAttr, XattrSetMode,
@@ -94,7 +96,7 @@ pub(crate) trait FuseBackend: Send + Sync + 'static {
     fn get_attr_at_snapshot(
         &self,
         snapshot_id: u64,
-        inode: InodeId,
+        path_components: &[DentryName],
     ) -> FuseBackendResult<Option<InodeAttr>>;
     fn lookup_plus(
         &self,
@@ -113,7 +115,7 @@ pub(crate) trait FuseBackend: Send + Sync + 'static {
     fn lookup_plus_at_snapshot(
         &self,
         snapshot_id: u64,
-        parent: InodeId,
+        parent_components: &[DentryName],
         name: &DentryName,
     ) -> FuseBackendResult<Option<DentryWithAttr>>;
     fn read_dir_plus_page(
@@ -125,7 +127,7 @@ pub(crate) trait FuseBackend: Send + Sync + 'static {
     fn read_dir_plus_at_snapshot(
         &self,
         snapshot_id: u64,
-        inode: InodeId,
+        path_components: &[DentryName],
     ) -> FuseBackendResult<Vec<DentryWithAttr>>;
     fn rename(
         &self,
@@ -159,7 +161,7 @@ pub(crate) trait FuseBackend: Send + Sync + 'static {
     fn read_file_at_snapshot(
         &self,
         snapshot_id: u64,
-        inode: InodeId,
+        path_components: &[DentryName],
         offset: u64,
         len: usize,
     ) -> FuseBackendResult<Vec<u8>>;
@@ -167,7 +169,7 @@ pub(crate) trait FuseBackend: Send + Sync + 'static {
     fn read_symlink_at_snapshot(
         &self,
         snapshot_id: u64,
-        inode: InodeId,
+        path_components: &[DentryName],
     ) -> FuseBackendResult<Vec<u8>>;
     fn update_root_attrs(&self, changes: UpdateAttr) -> FuseBackendResult<InodeAttr>;
     fn update_attrs(
@@ -312,6 +314,7 @@ pub(crate) trait FuseBackend: Send + Sync + 'static {
 pub(crate) struct ClientFuseBackend<O> {
     metadata: MetadataClient,
     objects: Arc<O>,
+    snapshot_root_path: Option<String>,
     /// User-configured re-read block cache (`None` with `--no-block-cache`). Kept
     /// distinct from `read_cache` so cache-hit stats reflect the configured cache,
     /// not the read-ahead staging buffer.
@@ -407,6 +410,20 @@ where
         objects: O,
         options: &FuseOptions,
     ) -> FuseBackendResult<Self> {
+        let snapshot_root_path = match options.view {
+            crate::filesystem::FuseView::Live => None,
+            crate::filesystem::FuseView::Snapshot { .. } => {
+                let path = options.snapshot_root_path.as_ref().ok_or_else(|| {
+                    FuseBackendError::Metadata(MetadError::InvalidPath(
+                        "snapshot FUSE view requires an absolute snapshot_root_path".to_owned(),
+                    ))
+                })?;
+                nokv_types::parse_absolute_path(path).map_err(|err| {
+                    FuseBackendError::Metadata(MetadError::InvalidPath(err.to_string()))
+                })?;
+                Some(path.clone())
+            }
+        };
         let objects = Arc::new(objects);
         let block_cache = options.block_cache.clone().open()?;
         // The prefetcher stages read-ahead blocks into a cache that foreground
@@ -465,6 +482,7 @@ where
         Ok(Self {
             metadata,
             objects,
+            snapshot_root_path,
             block_cache,
             read_cache,
             read_plan_cache: ReadPlanCacheShards::new(
@@ -487,6 +505,14 @@ where
             writeback_cache,
             writeback_uploader,
             upload_workers: writeback.upload_workers_per_request.max(1),
+        })
+    }
+
+    fn snapshot_root_path(&self) -> FuseBackendResult<&str> {
+        self.snapshot_root_path.as_deref().ok_or_else(|| {
+            FuseBackendError::Metadata(MetadError::InvalidPath(
+                "snapshot operation requires a bound snapshot root path".to_owned(),
+            ))
         })
     }
 
@@ -815,10 +841,10 @@ where
     fn get_attr_at_snapshot(
         &self,
         snapshot_id: u64,
-        inode: InodeId,
+        path_components: &[DentryName],
     ) -> FuseBackendResult<Option<InodeAttr>> {
         self.metadata
-            .get_attr_at_snapshot(snapshot_id, inode)
+            .get_attr_at_snapshot(self.snapshot_root_path()?, snapshot_id, path_components)
             .map_err(Into::into)
     }
 
@@ -845,11 +871,16 @@ where
     fn lookup_plus_at_snapshot(
         &self,
         snapshot_id: u64,
-        parent: InodeId,
+        parent_components: &[DentryName],
         name: &DentryName,
     ) -> FuseBackendResult<Option<DentryWithAttr>> {
         self.metadata
-            .lookup_plus_at_snapshot(snapshot_id, parent, name.clone())
+            .lookup_plus_at_snapshot(
+                self.snapshot_root_path()?,
+                snapshot_id,
+                parent_components,
+                name.clone(),
+            )
             .map_err(Into::into)
     }
 
@@ -872,10 +903,10 @@ where
     fn read_dir_plus_at_snapshot(
         &self,
         snapshot_id: u64,
-        inode: InodeId,
+        path_components: &[DentryName],
     ) -> FuseBackendResult<Vec<DentryWithAttr>> {
         self.metadata
-            .read_dir_plus_at_snapshot(snapshot_id, inode)
+            .read_dir_plus_at_snapshot(self.snapshot_root_path()?, snapshot_id, path_components)
             .map_err(Into::into)
     }
 
@@ -971,12 +1002,18 @@ where
     fn read_file_at_snapshot(
         &self,
         snapshot_id: u64,
-        inode: InodeId,
+        path_components: &[DentryName],
         offset: u64,
         len: usize,
     ) -> FuseBackendResult<Vec<u8>> {
         self.metadata
-            .read_file_at_snapshot(snapshot_id, inode, offset, len)
+            .read_file_at_snapshot(
+                self.snapshot_root_path()?,
+                snapshot_id,
+                path_components,
+                offset,
+                len,
+            )
             .map_err(Into::into)
     }
 
@@ -987,10 +1024,10 @@ where
     fn read_symlink_at_snapshot(
         &self,
         snapshot_id: u64,
-        inode: InodeId,
+        path_components: &[DentryName],
     ) -> FuseBackendResult<Vec<u8>> {
         self.metadata
-            .read_symlink_at_snapshot(snapshot_id, inode)
+            .read_symlink_at_snapshot(self.snapshot_root_path()?, snapshot_id, path_components)
             .map_err(Into::into)
     }
 
@@ -1309,7 +1346,7 @@ where
         inode: InodeId,
         fields: PreparedRecordFields,
     ) -> Self::Prepared {
-        ClientPreparedArtifact {
+        ClientPreparedArtifact::from_recovery(ClientPreparedArtifactRecovery {
             mount: fields.mount,
             parent,
             name,
@@ -1321,7 +1358,7 @@ where
             replace: fields.replace,
             dentry_version: fields.dentry_version,
             old_generation: fields.old_generation,
-        }
+        })
     }
 
     fn purge_cache_orphans(
@@ -1443,7 +1480,7 @@ mod tests {
             },
         )
         .unwrap();
-        let prepared = ClientPreparedArtifact {
+        let prepared = ClientPreparedArtifact::from_recovery(ClientPreparedArtifactRecovery {
             mount: 1,
             parent: InodeId::new(1).unwrap(),
             name: DentryName::new("checkpoint.bin").unwrap(),
@@ -1455,7 +1492,7 @@ mod tests {
             replace: true,
             dentry_version: Some(1),
             old_generation: None,
-        };
+        });
 
         let pending = backend
             .stage_prepared_artifact_shared_ranges_async(
@@ -1508,7 +1545,7 @@ mod tests {
             },
         )
         .unwrap();
-        let prepared = ClientPreparedArtifact {
+        let prepared = ClientPreparedArtifact::from_recovery(ClientPreparedArtifactRecovery {
             mount: 1,
             parent: InodeId::new(1).unwrap(),
             name: DentryName::new("checkpoint.bin").unwrap(),
@@ -1520,7 +1557,7 @@ mod tests {
             replace: true,
             dentry_version: Some(1),
             old_generation: None,
-        };
+        });
 
         let pending = backend
             .stage_prepared_artifact_shared_ranges_async(
@@ -1571,7 +1608,7 @@ mod tests {
             },
         )
         .unwrap();
-        let prepared = ClientPreparedArtifact {
+        let prepared = ClientPreparedArtifact::from_recovery(ClientPreparedArtifactRecovery {
             mount: 1,
             parent: InodeId::new(1).unwrap(),
             name: DentryName::new("checkpoint.bin").unwrap(),
@@ -1583,7 +1620,7 @@ mod tests {
             replace: true,
             dentry_version: Some(1),
             old_generation: None,
-        };
+        });
 
         let err = backend
             .stage_prepared_artifact_shared_ranges_async(

--- a/crates/nokv-fuse/src/filesystem.rs
+++ b/crates/nokv-fuse/src/filesystem.rs
@@ -1647,6 +1647,38 @@ mod tests {
     }
 
     #[test]
+    fn snapshot_inode_cache_reconstructs_only_root_relative_components() {
+        let root = InodeId::new(42).unwrap();
+        let options = FuseOptions {
+            view: FuseView::Snapshot {
+                snapshot_id: 7,
+                root,
+            },
+            snapshot_root_path: Some("/workbenches/source".to_owned()),
+            ..FuseOptions::default()
+        };
+        let fuse = NoKvFuse::from_backend(UnsupportedTestBackend::default(), options);
+        let directory = InodeId::new(43).unwrap();
+        let file = InodeId::new(44).unwrap();
+        fuse.remember_parent(directory, root);
+        fuse.remember_name(directory, &DentryName::new("nested").unwrap());
+        fuse.remember_parent(file, directory);
+        fuse.remember_name(file, &DentryName::new("checkpoint.bin").unwrap());
+
+        let components = fuse.snapshot_path_components(file).unwrap();
+        assert_eq!(
+            components
+                .iter()
+                .map(|component| component.as_bytes())
+                .collect::<Vec<_>>(),
+            vec![b"nested".as_slice(), b"checkpoint.bin".as_slice()]
+        );
+        assert!(fuse
+            .snapshot_path_components(InodeId::new(99).unwrap())
+            .is_err());
+    }
+
+    #[test]
     fn statfs_snapshot_reports_nonzero_capacity_and_name_limit() {
         let fuse =
             NoKvFuse::from_backend(UnsupportedTestBackend::default(), FuseOptions::default());
@@ -2554,7 +2586,7 @@ mod tests {
         fn get_attr_at_snapshot(
             &self,
             _snapshot_id: u64,
-            _inode: InodeId,
+            _path_components: &[DentryName],
         ) -> FuseBackendResult<Option<InodeAttr>> {
             unsupported()
         }
@@ -2578,7 +2610,7 @@ mod tests {
         fn lookup_plus_at_snapshot(
             &self,
             _snapshot_id: u64,
-            _parent: InodeId,
+            _parent_components: &[DentryName],
             _name: &DentryName,
         ) -> FuseBackendResult<Option<DentryWithAttr>> {
             unsupported()
@@ -2596,7 +2628,7 @@ mod tests {
         fn read_dir_plus_at_snapshot(
             &self,
             _snapshot_id: u64,
-            _inode: InodeId,
+            _path_components: &[DentryName],
         ) -> FuseBackendResult<Vec<DentryWithAttr>> {
             unsupported()
         }
@@ -2691,7 +2723,7 @@ mod tests {
         fn read_file_at_snapshot(
             &self,
             _snapshot_id: u64,
-            _inode: InodeId,
+            _path_components: &[DentryName],
             _offset: u64,
             _len: usize,
         ) -> FuseBackendResult<Vec<u8>> {
@@ -2705,7 +2737,7 @@ mod tests {
         fn read_symlink_at_snapshot(
             &self,
             _snapshot_id: u64,
-            _inode: InodeId,
+            _path_components: &[DentryName],
         ) -> FuseBackendResult<Vec<u8>> {
             unsupported()
         }

--- a/crates/nokv-fuse/src/filesystem/errors.rs
+++ b/crates/nokv-fuse/src/filesystem/errors.rs
@@ -60,6 +60,12 @@ fn metadata_errno(err: &MetadError) -> Errno {
         // is a live mount point), not EXDEV — there is no copy+unlink fallback
         // that would correctly tear down the graft.
         MetadError::GraftPoint => Errno::EBUSY,
+        MetadError::SnapshotLeaseExpired { .. } | MetadError::SnapshotRootMismatch { .. } => {
+            Errno::ESTALE
+        }
+        MetadError::SnapshotBindingChanged { .. } | MetadError::SnapshotRenewContended { .. } => {
+            Errno::EAGAIN
+        }
         MetadError::LockConflict(_) => Errno::EAGAIN,
         // See the note above: surface the underlying metadata/object/allocator
         // failure before it collapses into an opaque `EIO`.
@@ -76,8 +82,9 @@ fn metadata_errno(err: &MetadError) -> Errno {
             eprintln!("nokv-fuse: metadata operation failed -> EIO: {err:?}");
             Errno::EIO
         }
-        // Cross-crate metadata errors fail closed until their feature-specific
-        // FUSE adapter defines an intentional POSIX mapping.
+        // MetadError is intentionally non-exhaustive across crate boundaries.
+        // Feature-specific errors stay fail-closed until their own FUSE change
+        // defines the correct POSIX mapping.
         _ => {
             eprintln!("nokv-fuse: unsupported metadata error -> EIO: {err:?}");
             Errno::EIO

--- a/crates/nokv-fuse/src/filesystem/handle.rs
+++ b/crates/nokv-fuse/src/filesystem/handle.rs
@@ -9,7 +9,7 @@ use fuser::{
     ReplyDirectory, ReplyDirectoryPlus,
 };
 use nokv_meta::{
-    DentryWithAttr, PublishArtifactStagedSession, ReadDirPlusPage, RenameReplaceResult,
+    DentryWithAttr, MetadError, PublishArtifactStagedSession, ReadDirPlusPage, RenameReplaceResult,
 };
 use nokv_object::{
     chunk_manifests_from_stored_chunks, manifest_digest_uri, DirtyChunkExtent, FileReadPipeline,
@@ -175,6 +175,49 @@ where
         }
     }
 
+    pub(super) fn snapshot_path_components(
+        &self,
+        inode: InodeId,
+    ) -> Result<Vec<DentryName>, FuseBackendError> {
+        let root = self.options.view.root();
+        if inode == root {
+            return Ok(Vec::new());
+        }
+        let parents = self.parents.read().map_err(|err| {
+            FuseBackendError::Metadata(MetadError::Codec(format!(
+                "snapshot parent cache lock poisoned: {err}"
+            )))
+        })?;
+        let names = self.names.read().map_err(|err| {
+            FuseBackendError::Metadata(MetadError::Codec(format!(
+                "snapshot name cache lock poisoned: {err}"
+            )))
+        })?;
+        let mut current = inode.get();
+        let mut reversed = Vec::new();
+        let mut seen = HashSet::new();
+        while current != root.get() {
+            if !seen.insert(current) {
+                return Err(FuseBackendError::Metadata(MetadError::Codec(
+                    "snapshot inode path cache contains a parent cycle".to_owned(),
+                )));
+            }
+            let parent = parents
+                .get(&current)
+                .copied()
+                .ok_or(FuseBackendError::Metadata(MetadError::NotFound))?;
+            let name = names
+                .get(&current)
+                .ok_or(FuseBackendError::Metadata(MetadError::NotFound))?;
+            reversed.push(DentryName::new(name.clone()).map_err(|err| {
+                FuseBackendError::Metadata(MetadError::InvalidPath(err.to_string()))
+            })?);
+            current = parent;
+        }
+        reversed.reverse();
+        Ok(reversed)
+    }
+
     pub(super) fn statfs_snapshot(&self) -> FuseStatfs {
         let blocks = STATFS_TOTAL_BYTES / u64::from(STATFS_BLOCK_SIZE);
         FuseStatfs {
@@ -314,7 +357,8 @@ where
         match self.options.view {
             FuseView::Live => self.backend.get_attr(inode),
             FuseView::Snapshot { snapshot_id, .. } => {
-                self.backend.get_attr_at_snapshot(snapshot_id, inode)
+                let components = self.snapshot_path_components(inode)?;
+                self.backend.get_attr_at_snapshot(snapshot_id, &components)
             }
         }
     }
@@ -343,8 +387,9 @@ where
         match self.options.view {
             FuseView::Live => self.backend.lookup_plus(parent, name),
             FuseView::Snapshot { snapshot_id, .. } => {
+                let parent_components = self.snapshot_path_components(parent)?;
                 self.backend
-                    .lookup_plus_at_snapshot(snapshot_id, parent, name)
+                    .lookup_plus_at_snapshot(snapshot_id, &parent_components, name)
             }
         }
     }
@@ -359,7 +404,10 @@ where
             FuseView::Live => self.backend.read_dir_plus_page(inode, after, limit),
             FuseView::Snapshot { snapshot_id, .. } => {
                 let requested = limit.max(1);
-                let rows = self.backend.read_dir_plus_at_snapshot(snapshot_id, inode)?;
+                let components = self.snapshot_path_components(inode)?;
+                let rows = self
+                    .backend
+                    .read_dir_plus_at_snapshot(snapshot_id, &components)?;
                 let mut entries = rows
                     .into_iter()
                     .filter(|entry| {
@@ -411,8 +459,9 @@ where
         match self.options.view {
             FuseView::Live => self.backend.read_file(inode, offset, len),
             FuseView::Snapshot { snapshot_id, .. } => {
+                let components = self.snapshot_path_components(inode)?;
                 self.backend
-                    .read_file_at_snapshot(snapshot_id, inode, offset, len)
+                    .read_file_at_snapshot(snapshot_id, &components, offset, len)
             }
         }
     }
@@ -430,8 +479,9 @@ where
                 .backend
                 .read_file_with_known_attr_pipeline(attr, offset, len, pipeline, read_plans),
             FuseView::Snapshot { snapshot_id, .. } => {
+                let components = self.snapshot_path_components(attr.inode)?;
                 self.backend
-                    .read_file_at_snapshot(snapshot_id, attr.inode, offset, len)
+                    .read_file_at_snapshot(snapshot_id, &components, offset, len)
             }
         }
     }
@@ -445,8 +495,9 @@ where
         match self.options.view {
             FuseView::Live => self.backend.read_file_with_known_attr(attr, offset, len),
             FuseView::Snapshot { snapshot_id, .. } => {
+                let components = self.snapshot_path_components(attr.inode)?;
                 self.backend
-                    .read_file_at_snapshot(snapshot_id, attr.inode, offset, len)
+                    .read_file_at_snapshot(snapshot_id, &components, offset, len)
             }
         }
     }
@@ -455,7 +506,9 @@ where
         match self.options.view {
             FuseView::Live => self.backend.read_symlink(inode),
             FuseView::Snapshot { snapshot_id, .. } => {
-                self.backend.read_symlink_at_snapshot(snapshot_id, inode)
+                let components = self.snapshot_path_components(inode)?;
+                self.backend
+                    .read_symlink_at_snapshot(snapshot_id, &components)
             }
         }
     }

--- a/crates/nokv-fuse/src/filesystem/options.rs
+++ b/crates/nokv-fuse/src/filesystem/options.rs
@@ -34,6 +34,10 @@ pub struct FuseOptions {
     pub read_pipeline: FileReadPipelineOptions,
     pub writeback: FuseWritebackOptions,
     pub view: FuseView,
+    /// Absolute live namespace path that owns `view` when mounting a snapshot.
+    /// Required for `FuseView::Snapshot`; snapshot RPCs route and bind through
+    /// this path while all targets remain snapshot-root-relative.
+    pub snapshot_root_path: Option<String>,
     pub access: FuseAccessMode,
     pub invalidation: FuseInvalidationOptions,
     pub stats_bind: Option<SocketAddr>,
@@ -183,6 +187,7 @@ impl Default for FuseOptions {
             read_pipeline: FileReadPipelineOptions::default(),
             writeback: FuseWritebackOptions::default(),
             view: FuseView::Live,
+            snapshot_root_path: None,
             access: FuseAccessMode::ReadWrite,
             invalidation: FuseInvalidationOptions::default(),
             stats_bind: None,

--- a/crates/nokv-fuse/src/filesystem/publisher.rs
+++ b/crates/nokv-fuse/src/filesystem/publisher.rs
@@ -731,7 +731,7 @@ mod tests {
         fn get_attr_at_snapshot(
             &self,
             _snapshot_id: u64,
-            _inode: InodeId,
+            _path_components: &[DentryName],
         ) -> FuseBackendResult<Option<InodeAttr>> {
             unsupported()
         }
@@ -745,7 +745,7 @@ mod tests {
         fn lookup_plus_at_snapshot(
             &self,
             _snapshot_id: u64,
-            _parent: InodeId,
+            _parent_components: &[DentryName],
             _name: &DentryName,
         ) -> FuseBackendResult<Option<DentryWithAttr>> {
             unsupported()
@@ -761,7 +761,7 @@ mod tests {
         fn read_dir_plus_at_snapshot(
             &self,
             _snapshot_id: u64,
-            _inode: InodeId,
+            _path_components: &[DentryName],
         ) -> FuseBackendResult<Vec<DentryWithAttr>> {
             unsupported()
         }
@@ -812,7 +812,7 @@ mod tests {
         fn read_file_at_snapshot(
             &self,
             _snapshot_id: u64,
-            _inode: InodeId,
+            _path_components: &[DentryName],
             _offset: u64,
             _len: usize,
         ) -> FuseBackendResult<Vec<u8>> {
@@ -824,7 +824,7 @@ mod tests {
         fn read_symlink_at_snapshot(
             &self,
             _snapshot_id: u64,
-            _inode: InodeId,
+            _path_components: &[DentryName],
         ) -> FuseBackendResult<Vec<u8>> {
             unsupported()
         }

--- a/crates/nokv/src/bin/nokv.rs
+++ b/crates/nokv/src/bin/nokv.rs
@@ -511,6 +511,7 @@ fn run(args: Vec<String>) -> Result<(), CliError> {
                         snapshot_id,
                         root: snapshot.root,
                     },
+                    snapshot_root_path: Some(root_path),
                     ..options.fuse_options(nokv_fuse::FuseAccessMode::ReadOnly)
                 },
             )


### PR DESCRIPTION
## Summary

- bind snapshot FUSE mounts to the absolute snapshot root path
- reconstruct snapshot-root-relative path components from the mount inode cache
- route snapshot attr, lookup, list, file read, and symlink read through root-bound client RPCs
- map snapshot stale and retryable errors intentionally at the POSIX boundary
- keep prepared-artifact recovery construction isolated behind a stable DTO

## Stack and scope

Depends on #401 and removes every temporary fail-closed inode snapshot bridge introduced there.

This PR is limited to the small snapshot-mount protocol adapter: six nokv-fuse files, MetadataClient bridge cleanup, and mount-snapshot CLI wiring.

It does not add or change:

- watch-driven FUSE invalidation
- SubtreeReplaced handling
- operator rollback or write fencing
- FUSE writeback fencing
- object-GC restage or replay behavior
- FUSE invalidation metrics

## Validation

- cargo test -p nokv-fuse: 69 passed
- cargo clippy -p nokv-fuse --all-targets -- -D warnings
- cargo test --workspace --all-targets --no-run
- cargo fmt --all -- --check
- git diff --check