### PR TITLE
fix(fuse): persist object GC claims in publish journal

### DIFF
--- a/crates/nokv-fuse/src/backend.rs
+++ b/crates/nokv-fuse/src/backend.rs
@@ -56,6 +56,9 @@ pub(crate) struct PreparedRecordFields {
     pub replace: bool,
     pub dentry_version: Option<u64>,
     pub old_generation: Option<u64>,
+    /// Durable object-GC claim captured before staging. Async publish journals
+    /// must persist the real claim so crash recovery never fabricates a token.
+    pub object_gc_claim_version: u64,
 }
 
 /// One writeback-cache block to re-stage during async-publish mount recovery,
@@ -810,6 +813,7 @@ where
             replace: prepared.replace,
             dentry_version: prepared.dentry_version,
             old_generation: prepared.old_generation,
+            object_gc_claim_version: prepared.object_gc_claim_version,
         }
     }
 
@@ -1359,6 +1363,7 @@ where
             dentry_version: fields.dentry_version,
             old_generation: fields.old_generation,
         })
+        .with_object_gc_claim_version(fields.object_gc_claim_version)
     }
 
     fn purge_cache_orphans(
@@ -1492,7 +1497,8 @@ mod tests {
             replace: true,
             dentry_version: Some(1),
             old_generation: None,
-        });
+        })
+        .with_object_gc_claim_version(2);
 
         let pending = backend
             .stage_prepared_artifact_shared_ranges_async(
@@ -1557,7 +1563,8 @@ mod tests {
             replace: true,
             dentry_version: Some(1),
             old_generation: None,
-        });
+        })
+        .with_object_gc_claim_version(2);
 
         let pending = backend
             .stage_prepared_artifact_shared_ranges_async(
@@ -1620,7 +1627,8 @@ mod tests {
             replace: true,
             dentry_version: Some(1),
             old_generation: None,
-        });
+        })
+        .with_object_gc_claim_version(2);
 
         let err = backend
             .stage_prepared_artifact_shared_ranges_async(

--- a/crates/nokv-fuse/src/filesystem.rs
+++ b/crates/nokv-fuse/src/filesystem.rs
@@ -2557,6 +2557,7 @@ mod tests {
                 replace: false,
                 dentry_version: None,
                 old_generation: None,
+                object_gc_claim_version: 1,
             }
         }
 

--- a/crates/nokv-fuse/src/filesystem/handle.rs
+++ b/crates/nokv-fuse/src/filesystem/handle.rs
@@ -1439,6 +1439,7 @@ where
             replace: fields.replace,
             dentry_version: fields.dentry_version.unwrap_or(0),
             old_generation: fields.old_generation.unwrap_or(0),
+            object_gc_claim_version: fields.object_gc_claim_version,
             size: staged.size,
             mode: staged.mode,
             uid: staged.uid,

--- a/crates/nokv-fuse/src/filesystem/publish_journal.rs
+++ b/crates/nokv-fuse/src/filesystem/publish_journal.rs
@@ -11,6 +11,7 @@
 //! A crash mid-append leaves a truncated tail; `replay` stops at the first frame
 //! whose header or payload is incomplete, or whose sha256 does not match — so a
 //! torn or corrupt tail is silently dropped without losing earlier records.
+//! A complete record with an unsupported schema version instead fails closed.
 
 use std::collections::HashSet;
 use std::fs::{self, File, OpenOptions};
@@ -22,7 +23,11 @@ use sha2::{Digest, Sha256};
 
 const KIND_PUBLISH: u8 = 1;
 const KIND_TOMBSTONE: u8 = 2;
-const RECORD_VERSION: u8 = 1;
+// Version 2 adds the durable object-GC claim required to reconstruct a
+// prepared artifact after restart. Older records cannot be replayed safely
+// once metadata publish requires this claim, so replay rejects them instead of
+// silently treating them as a torn tail.
+const RECORD_VERSION: u8 = 2;
 const FRAME_HEADER_LEN: usize = 1 + 4 + 32;
 const TOMBSTONE_PAYLOAD_LEN: usize = 16;
 pub(crate) const JOURNAL_FILE_NAME: &str = "publish.journal";
@@ -56,6 +61,7 @@ pub(crate) struct PendingPublishRecord {
     pub replace: bool,
     pub dentry_version: u64,
     pub old_generation: u64,
+    pub object_gc_claim_version: u64,
     pub size: u64,
     pub mode: u32,
     pub uid: u32,
@@ -87,6 +93,12 @@ impl PublishJournal {
     /// Append + fsync a pending-publish record. This is the durability anchor:
     /// the caller may ack the write only after this returns.
     pub fn append_publish(&self, record: &PendingPublishRecord) -> io::Result<()> {
+        if record.object_gc_claim_version == 0 {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "publish journal record has no object GC claim version",
+            ));
+        }
         self.append_frame(KIND_PUBLISH, &encode_record(record))
     }
 
@@ -115,11 +127,26 @@ impl PublishJournal {
         while let Some((kind, payload)) = reader.next_frame() {
             match kind {
                 KIND_PUBLISH => {
-                    if let Some(record) = decode_record(payload) {
-                        records.push(record);
-                    } else {
-                        break; // unparsable record => treat the rest as torn
+                    if let Some(version) = payload.first().copied() {
+                        if version != RECORD_VERSION {
+                            return Err(io::Error::new(
+                                io::ErrorKind::InvalidData,
+                                format!(
+                                    "unsupported publish journal record version {version}; expected {RECORD_VERSION}"
+                                ),
+                            ));
+                        }
                     }
+                    let Some(record) = decode_record(payload) else {
+                        break; // unparsable record => treat the rest as torn
+                    };
+                    if record.object_gc_claim_version == 0 {
+                        return Err(io::Error::new(
+                            io::ErrorKind::InvalidData,
+                            "publish journal record has no object GC claim version",
+                        ));
+                    }
+                    records.push(record);
                 }
                 KIND_TOMBSTONE => {
                     if payload.len() != TOMBSTONE_PAYLOAD_LEN {
@@ -225,6 +252,7 @@ fn encode_record(record: &PendingPublishRecord) -> Vec<u8> {
     out.push(u8::from(record.replace));
     put_u64(&mut out, record.dentry_version);
     put_u64(&mut out, record.old_generation);
+    put_u64(&mut out, record.object_gc_claim_version);
     put_u64(&mut out, record.size);
     put_u32(&mut out, record.mode);
     put_u32(&mut out, record.uid);
@@ -255,6 +283,7 @@ fn decode_record(payload: &[u8]) -> Option<PendingPublishRecord> {
     let replace = r.u8()? != 0;
     let dentry_version = r.u64()?;
     let old_generation = r.u64()?;
+    let object_gc_claim_version = r.u64()?;
     let size = r.u64()?;
     let mode = r.u32()?;
     let uid = r.u32()?;
@@ -286,6 +315,7 @@ fn decode_record(payload: &[u8]) -> Option<PendingPublishRecord> {
         replace,
         dentry_version,
         old_generation,
+        object_gc_claim_version,
         size,
         mode,
         uid,
@@ -387,6 +417,7 @@ mod tests {
             replace: generation > 1,
             dentry_version: 7,
             old_generation: generation.saturating_sub(1),
+            object_gc_claim_version: 17,
             size: 4096,
             mode: 0o644,
             uid: 1000,
@@ -406,6 +437,52 @@ mod tests {
         let record = sample_record(42, 10);
         let decoded = decode_record(&encode_record(&record)).unwrap();
         assert_eq!(decoded, record);
+    }
+
+    #[test]
+    fn replay_fails_closed_for_legacy_record_without_object_gc_claim() {
+        let dir = tempfile::tempdir().unwrap();
+        let journal = PublishJournal::open(dir.path()).unwrap();
+        let mut payload = encode_record(&sample_record(42, 10));
+        payload[0] = 1;
+        journal.append_frame(KIND_PUBLISH, &payload).unwrap();
+
+        let error = journal.replay().unwrap_err();
+        assert_eq!(error.kind(), io::ErrorKind::InvalidData);
+        assert!(error
+            .to_string()
+            .contains("unsupported publish journal record version 1"));
+    }
+
+    #[test]
+    fn append_rejects_zero_object_gc_claim() {
+        let dir = tempfile::tempdir().unwrap();
+        let journal = PublishJournal::open(dir.path()).unwrap();
+        let mut record = sample_record(42, 10);
+        record.object_gc_claim_version = 0;
+
+        let error = journal.append_publish(&record).unwrap_err();
+        assert_eq!(error.kind(), io::ErrorKind::InvalidInput);
+        assert!(error
+            .to_string()
+            .contains("publish journal record has no object GC claim version"));
+    }
+
+    #[test]
+    fn replay_rejects_zero_object_gc_claim() {
+        let dir = tempfile::tempdir().unwrap();
+        let journal = PublishJournal::open(dir.path()).unwrap();
+        let mut record = sample_record(42, 10);
+        record.object_gc_claim_version = 0;
+        journal
+            .append_frame(KIND_PUBLISH, &encode_record(&record))
+            .unwrap();
+
+        let error = journal.replay().unwrap_err();
+        assert_eq!(error.kind(), io::ErrorKind::InvalidData);
+        assert!(error
+            .to_string()
+            .contains("publish journal record has no object GC claim version"));
     }
 
     #[test]

--- a/crates/nokv-fuse/src/filesystem/publisher.rs
+++ b/crates/nokv-fuse/src/filesystem/publisher.rs
@@ -479,6 +479,7 @@ fn reconstruct_pending<B: FuseBackend>(
         replace: record.replace,
         dentry_version: (record.dentry_version != 0).then_some(record.dentry_version),
         old_generation: (record.old_generation != 0).then_some(record.old_generation),
+        object_gc_claim_version: record.object_gc_claim_version,
     };
     let prepared = backend.prepared_from_record_fields(parent, name.clone(), inode, fields);
     let blocks = record
@@ -537,7 +538,10 @@ mod tests {
 
     use super::super::publish_journal::{CacheFileRef, PendingPublishRecord, PublishJournal};
     use super::super::write_session::{PendingBufferedRange, PendingBufferedUpload};
-    use super::{PendingPublish, PendingPublishTracker, PublisherWorker, WritebackPublisher};
+    use super::{
+        reconstruct_pending, PendingPublish, PendingPublishTracker, PublisherWorker,
+        WritebackPublisher,
+    };
 
     fn unsupported<T>() -> FuseBackendResult<T> {
         Err(FuseBackendError::Metadata(MetadError::Codec(
@@ -559,6 +563,7 @@ mod tests {
         generation: u64,
         replace: bool,
         dentry_version: Option<u64>,
+        object_gc_claim_version: u64,
     }
 
     #[derive(Default)]
@@ -615,6 +620,7 @@ mod tests {
                 replace: prepared.replace,
                 dentry_version: prepared.dentry_version,
                 old_generation: None,
+                object_gc_claim_version: prepared.object_gc_claim_version,
             }
         }
 
@@ -1009,6 +1015,7 @@ mod tests {
                 generation: fields.generation,
                 replace: fields.replace,
                 dentry_version: fields.dentry_version,
+                object_gc_claim_version: fields.object_gc_claim_version,
             }
         }
 
@@ -1076,6 +1083,7 @@ mod tests {
             replace: false,
             dentry_version: 0,
             old_generation: 0,
+            object_gc_claim_version: 2,
             size: 4096,
             mode: 0o644,
             uid: 0,
@@ -1097,6 +1105,7 @@ mod tests {
                 generation,
                 replace: false,
                 dentry_version: None,
+                object_gc_claim_version: 2,
             },
             parent: inode(1),
             name: name(b"file.bin"),
@@ -1109,6 +1118,17 @@ mod tests {
             gid: 0,
             uploads: vec![ready_upload(ino, generation)],
         }
+    }
+
+    #[test]
+    fn recovery_reconstructs_the_persisted_object_gc_claim() {
+        let backend = MockBackend::default();
+        let mut record = sample_record(5, 2);
+        record.object_gc_claim_version = 19;
+
+        let pending = reconstruct_pending(&backend, &record).unwrap();
+
+        assert_eq!(pending.prepared.object_gc_claim_version, 19);
     }
 
     fn wait_until<F: Fn() -> bool>(predicate: F) -> bool {


### PR DESCRIPTION
## Summary

- persist the exact object-GC claim version in each asynchronous FUSE publish journal record
- reject zero claim versions when appending or replaying records
- fail closed for legacy journal records that cannot prove their object-reference claim
- reconstruct recovery state with the persisted claim instead of inventing a current token

## Stack and scope

Depends on #403 and is intentionally separate from the Workbench restore delivery.

This is a narrow publish-journal correctness PR. It changes five nokv-fuse files only.

It does not add operator rollback, mutation fencing, SubtreeReplaced invalidation, remote watch support, or a general automatic object-GC refresh and re-upload loop. Broader restage policy remains deferred.

## Validation

- cargo test -p nokv-fuse: 73 passed
- cargo clippy -p nokv-fuse --all-targets -- -D warnings
- cargo test --workspace --all-targets --no-run
- cargo fmt --all -- --check
- git diff --check

The added deterministic tests cover zero-token rejection, legacy-record fail-closed behavior, and exact claim reconstruction during recovery.