### PR TITLE
feat: add an offline directional similar-run prototype

### DIFF
--- a/experimental/directional-similar-runs/README.md
+++ b/experimental/directional-similar-runs/README.md
@@ -1,0 +1,84 @@
+# Experimental directional similar-run search
+
+**Experimental, opt-in, and offline only.** This directory is a disposable
+analysis helper. It is not part of NoKV's storage, namespace, snapshot/restore,
+agent-tool, or default-search paths, and it does not build or persist an index.
+It reads caller-provided JSON records into an in-memory index and prints derived
+results without rewriting the source records.
+
+## Why this location and language
+
+The frozen NoKV repository is a Rust workspace with no existing `examples/` or
+`experimental/` tree. A standalone directory using only Python's standard
+library is the smallest honest placement for an opt-in analysis prototype: the
+repository already contains small Python analysis tools under `scripts/`, while
+this directory remains outside the workspace crates and their default build,
+storage, and runtime behavior. No database, daemon, LLM call, or new dependency
+is needed.
+
+## Record contract
+
+Input is a JSON array. Every record contains:
+
+- `run_id`: a non-empty stable string, unique within the input;
+- `features`: non-empty unique feature names in a meaningful, ordered list;
+- `before` and `after`: finite numeric vectors with the same dimension as each
+  other and as `features`;
+- `provenance`: an object with a non-empty `source` reference. Extra provenance
+  fields are preserved in output.
+
+An optional `outcome` field is accepted as metadata, but it is deliberately not
+used in delta, magnitude, direction, cosine, ranking, or the output's identity.
+Changing only an outcome label therefore cannot change a fingerprint or ranking.
+All records must use exactly the same feature names in exactly the same order.
+
+For each record the tool computes `delta = after - before`, keeps its Euclidean
+`magnitude` separate, and normalizes a nonzero delta into a unit `direction`.
+Zero deltas are explicit (`magnitude: 0.0`, `direction: null`): they are not
+compared, because cosine similarity is undefined for a zero vector. A zero
+query returns no ranked results. Search excludes the query itself by default;
+`--include-self` is an explicit diagnostic override. Results sort by descending
+cosine similarity, then ascending `run_id`, so ties do not depend on input order.
+
+## Usage
+
+From this directory:
+
+```bash
+python3 directional_similar_runs.py \
+  --records examples/runs.json \
+  --query-run-id toy-east \
+  --top-k 3
+```
+
+The JSON output includes the query fingerprint and each candidate's cosine,
+delta, magnitude, normalized direction, feature order, and copied provenance.
+The example labels and vectors are synthetic illustrations, not NoKV workload
+results or a claim about a Transformer mechanism.
+
+As a library in another offline analysis script:
+
+```python
+from directional_similar_runs import DirectionalIndex, load_records
+
+index = DirectionalIndex(load_records("examples/runs.json"))
+results = index.search("toy-east", top_k=3)  # self excluded by default
+```
+
+Run the deterministic focused suite:
+
+```bash
+python3 -m unittest discover -s tests -v
+```
+
+## Boundary and next validation
+
+This helper was inspired by a small experiment by Runyuan in which reproducible
+directional/low-dimensional structure appeared in one task-specific setting.
+It does **not** establish a NoKV benefit, a general Transformer
+mechanism, outcome/damage prediction, Kakeya causation, or a multiscale-specific
+advantage. Real NoKV workload validation with frozen source records, held-out
+runs, provenance, baselines, and workload-level correctness/cost measures is
+required before any core/index integration could be considered. Until then,
+this remains a local prototype and disposable derived artifact, not canonical
+history or an authoritative result store.

--- a/experimental/directional-similar-runs/directional_similar_runs.py
+++ b/experimental/directional-similar-runs/directional_similar_runs.py
@@ -1,0 +1,342 @@
+# Copyright 2024-2026 The NoKV Authors.
+# SPDX-License-Identifier: Apache-2.0
+"""Opt-in, offline directional similar-run search.
+
+This module deliberately has no NoKV storage or runtime integration.  It builds
+an in-memory index from caller-provided records and returns disposable result
+dictionaries.  Outcome labels are retained on the in-memory record only as
+metadata; they are never read while constructing fingerprints or scores.
+"""
+
+from __future__ import annotations
+
+import argparse
+import copy
+import json
+import math
+from dataclasses import dataclass
+from numbers import Real
+from typing import Any, Iterable, Mapping, Optional, Sequence
+
+
+class DirectionalSearchError(ValueError):
+    """Raised when run records or a search request violate the contract."""
+
+
+_MISSING = object()
+
+
+def _finite_vector(value: Any, field: str, record_number: int) -> tuple[float, ...]:
+    if not isinstance(value, (list, tuple)) or not value:
+        raise DirectionalSearchError(
+            f"record {record_number}: {field} must be a non-empty numeric vector"
+        )
+
+    result: list[float] = []
+    for position, item in enumerate(value):
+        if isinstance(item, bool) or not isinstance(item, Real):
+            raise DirectionalSearchError(
+                f"record {record_number}: {field}[{position}] must be numeric"
+            )
+        try:
+            number = float(item)
+        except (TypeError, ValueError, OverflowError) as exc:
+            raise DirectionalSearchError(
+                f"record {record_number}: {field}[{position}] must be finite"
+            ) from exc
+        if not math.isfinite(number):
+            raise DirectionalSearchError(
+                f"record {record_number}: {field}[{position}] must be finite"
+            )
+        result.append(number)
+    return tuple(result)
+
+
+def _feature_names(value: Any, record_number: int) -> tuple[str, ...]:
+    if not isinstance(value, (list, tuple)) or not value:
+        raise DirectionalSearchError(
+            f"record {record_number}: features must be a non-empty ordered list"
+        )
+    if any(not isinstance(name, str) or not name.strip() for name in value):
+        raise DirectionalSearchError(
+            f"record {record_number}: feature names must be non-empty strings"
+        )
+    result = tuple(value)
+    if len(set(result)) != len(result):
+        raise DirectionalSearchError(
+            f"record {record_number}: feature names must be unique"
+        )
+    return result
+
+
+def _run_id(value: Any, record_number: int) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise DirectionalSearchError(
+            f"record {record_number}: run_id must be a non-empty string"
+        )
+    return value
+
+
+def _provenance(value: Any, record_number: int) -> Mapping[str, Any]:
+    if not isinstance(value, Mapping):
+        raise DirectionalSearchError(
+            f"record {record_number}: provenance must be an object with a source"
+        )
+    source = value.get("source")
+    if not isinstance(source, str) or not source.strip():
+        raise DirectionalSearchError(
+            f"record {record_number}: provenance.source must be a non-empty string"
+        )
+    return copy.deepcopy(value)
+
+
+@dataclass(frozen=True)
+class RunVector:
+    """Validated, immutable-in-use representation of one source run."""
+
+    run_id: str
+    features: tuple[str, ...]
+    before: tuple[float, ...]
+    after: tuple[float, ...]
+    delta: tuple[float, ...]
+    magnitude: float
+    direction: Optional[tuple[float, ...]]
+    provenance: Mapping[str, Any]
+    outcome: Any = _MISSING
+
+    def fingerprint(self) -> Optional[tuple[float, ...]]:
+        """Return the unit delta direction, or ``None`` for a zero delta."""
+
+        return self.direction
+
+
+@dataclass(frozen=True)
+class SimilarRun:
+    """A ranked result with source provenance and no source-record mutation."""
+
+    run_id: str
+    cosine_similarity: float
+    features: tuple[str, ...]
+    delta: tuple[float, ...]
+    magnitude: float
+    direction: Optional[tuple[float, ...]]
+    provenance: Mapping[str, Any]
+
+    def as_dict(self) -> dict[str, Any]:
+        """Return a JSON-compatible copy of this disposable result."""
+
+        return {
+            "run_id": self.run_id,
+            "cosine_similarity": self.cosine_similarity,
+            "features": list(self.features),
+            "delta": list(self.delta),
+            "magnitude": self.magnitude,
+            "direction": None if self.direction is None else list(self.direction),
+            "provenance": copy.deepcopy(self.provenance),
+        }
+
+
+class DirectionalIndex:
+    """An in-memory, rebuildable index for directional similar-run search.
+
+    Every record must use the same feature names in the same order.  The index
+    owns no source files and stores no persistent sidecar.  A zero-delta run is
+    represented with magnitude ``0.0`` and ``direction=None``; it is not ranked
+    because cosine similarity is undefined for a zero vector.
+    """
+
+    def __init__(self, records: Iterable[Mapping[str, Any]]) -> None:
+        if isinstance(records, (str, bytes, Mapping)):
+            raise DirectionalSearchError("records must be an iterable of record objects")
+        try:
+            materialized = list(records)
+        except TypeError as exc:
+            raise DirectionalSearchError(
+                "records must be an iterable of record objects"
+            ) from exc
+        if not materialized:
+            raise DirectionalSearchError("records must not be empty")
+
+        self._runs: dict[str, RunVector] = {}
+        expected_features: Optional[tuple[str, ...]] = None
+        for record_number, record in enumerate(materialized, start=1):
+            if not isinstance(record, Mapping):
+                raise DirectionalSearchError(
+                    f"record {record_number}: must be an object"
+                )
+            run_id = _run_id(record.get("run_id"), record_number)
+            if run_id in self._runs:
+                raise DirectionalSearchError(f"duplicate run_id: {run_id}")
+            features = _feature_names(record.get("features"), record_number)
+            before = _finite_vector(record.get("before"), "before", record_number)
+            after = _finite_vector(record.get("after"), "after", record_number)
+            if len(before) != len(after):
+                raise DirectionalSearchError(
+                    f"record {record_number}: before and after dimensions differ"
+                )
+            if len(features) != len(before):
+                raise DirectionalSearchError(
+                    f"record {record_number}: features and vector dimensions differ"
+                )
+            if expected_features is None:
+                expected_features = features
+            elif features != expected_features:
+                raise DirectionalSearchError(
+                    "feature semantics/order differ: "
+                    f"expected {expected_features!r}, got {features!r}"
+                )
+
+            delta = tuple(
+                after_value - before_value
+                for before_value, after_value in zip(before, after)
+            )
+            if any(not math.isfinite(value) for value in delta):
+                raise DirectionalSearchError(
+                    f"record {record_number}: delta must remain finite"
+                )
+            magnitude = math.hypot(*delta)
+            if not math.isfinite(magnitude):
+                raise DirectionalSearchError(
+                    f"record {record_number}: delta magnitude must remain finite"
+                )
+            direction: Optional[tuple[float, ...]]
+            if magnitude == 0.0:
+                direction = None
+            else:
+                direction = tuple(value / magnitude for value in delta)
+
+            self._runs[run_id] = RunVector(
+                run_id=run_id,
+                features=features,
+                before=before,
+                after=after,
+                delta=delta,
+                magnitude=magnitude,
+                direction=direction,
+                provenance=_provenance(record.get("provenance"), record_number),
+                outcome=copy.deepcopy(record["outcome"])
+                if "outcome" in record
+                else _MISSING,
+            )
+
+    @property
+    def runs(self) -> tuple[RunVector, ...]:
+        """Return validated runs in source iteration order."""
+
+        return tuple(self._runs.values())
+
+    def get(self, run_id: str) -> RunVector:
+        """Return one run or raise a contract error for an unknown ID."""
+
+        try:
+            return self._runs[run_id]
+        except KeyError:
+            raise DirectionalSearchError(f"unknown run_id: {run_id}") from None
+
+    def fingerprint(self, run_id: str) -> dict[str, Any]:
+        """Return delta, magnitude, and normalized direction for one run."""
+
+        run = self.get(run_id)
+        return {
+            "delta": list(run.delta),
+            "magnitude": run.magnitude,
+            "direction": None if run.direction is None else list(run.direction),
+        }
+
+    def search(
+        self, query_run_id: str, top_k: int, *, exclude_self: bool = True
+    ) -> list[dict[str, Any]]:
+        """Return deterministic top-k nonzero runs ranked by cosine similarity.
+
+        ``exclude_self`` defaults to true and can be set false explicitly for
+        diagnostics.  A zero-direction query returns an empty list because no
+        cosine ranking is defined; zero-direction candidates are skipped.
+        Ties are ordered by ascending stable ``run_id``.
+        """
+
+        if isinstance(top_k, bool) or not isinstance(top_k, int) or top_k < 0:
+            raise DirectionalSearchError("top_k must be a non-negative integer")
+        if not isinstance(exclude_self, bool):
+            raise DirectionalSearchError("exclude_self must be a boolean")
+
+        query = self.get(query_run_id)
+        if top_k == 0 or query.direction is None:
+            return []
+
+        ranked: list[SimilarRun] = []
+        for candidate in self._runs.values():
+            if exclude_self and candidate.run_id == query.run_id:
+                continue
+            if candidate.direction is None:
+                continue
+            similarity = math.fsum(
+                query_component * candidate_component
+                for query_component, candidate_component in zip(
+                    query.direction, candidate.direction
+                )
+            )
+            # Unit-vector rounding can produce a value infinitesimally outside
+            # the cosine range.  Clamp only that arithmetic artifact.
+            similarity = max(-1.0, min(1.0, similarity))
+            ranked.append(
+                SimilarRun(
+                    run_id=candidate.run_id,
+                    cosine_similarity=similarity,
+                    features=candidate.features,
+                    delta=candidate.delta,
+                    magnitude=candidate.magnitude,
+                    direction=candidate.direction,
+                    provenance=candidate.provenance,
+                )
+            )
+
+        ranked.sort(key=lambda result: (-result.cosine_similarity, result.run_id))
+        return [result.as_dict() for result in ranked[:top_k]]
+
+
+def load_records(path: str) -> list[Mapping[str, Any]]:
+    """Load a JSON array of run records without modifying the source file."""
+
+    with open(path, "r", encoding="utf-8") as source:
+        payload = json.load(source)
+    if not isinstance(payload, list):
+        raise DirectionalSearchError("input must be a JSON array of run records")
+    return payload
+
+
+def _cli() -> int:
+    parser = argparse.ArgumentParser(
+        description="Experimental offline directional similar-run search"
+    )
+    parser.add_argument("--records", required=True, help="JSON array of run records")
+    parser.add_argument("--query-run-id", required=True, help="stable query run ID")
+    parser.add_argument("--top-k", type=int, default=5)
+    parser.add_argument(
+        "--include-self",
+        action="store_true",
+        help="include the query run in results (self-exclusion is default)",
+    )
+    args = parser.parse_args()
+
+    try:
+        index = DirectionalIndex(load_records(args.records))
+        query = index.get(args.query_run_id)
+        output = {
+            "query_run_id": query.run_id,
+            "query_fingerprint": index.fingerprint(query.run_id),
+            "top_k": args.top_k,
+            "exclude_self": not args.include_self,
+            "results": index.search(
+                query.run_id,
+                args.top_k,
+                exclude_self=not args.include_self,
+            ),
+        }
+    except (OSError, json.JSONDecodeError, DirectionalSearchError) as exc:
+        parser.error(str(exc))
+    print(json.dumps(output, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(_cli())

--- a/experimental/directional-similar-runs/examples/runs.json
+++ b/experimental/directional-similar-runs/examples/runs.json
@@ -1,0 +1,57 @@
+[
+  {
+    "run_id": "toy-east",
+    "features": ["direction_x", "direction_y", "position_x"],
+    "before": [0, 0, 0],
+    "after": [1, 0, 0],
+    "provenance": {
+      "source": "examples/runs.json",
+      "reference": "toy-east"
+    },
+    "outcome": {"label": "illustrative-only"}
+  },
+  {
+    "run_id": "toy-east-scaled",
+    "features": ["direction_x", "direction_y", "position_x"],
+    "before": [0, 0, 0],
+    "after": [2, 0, 0],
+    "provenance": {
+      "source": "examples/runs.json",
+      "reference": "toy-east-scaled"
+    },
+    "outcome": {"label": "illustrative-only"}
+  },
+  {
+    "run_id": "toy-west",
+    "features": ["direction_x", "direction_y", "position_x"],
+    "before": [0, 0, 0],
+    "after": [-1, 0, 0],
+    "provenance": {
+      "source": "examples/runs.json",
+      "reference": "toy-west"
+    },
+    "outcome": {"label": "illustrative-only"}
+  },
+  {
+    "run_id": "toy-north",
+    "features": ["direction_x", "direction_y", "position_x"],
+    "before": [0, 0, 0],
+    "after": [0, 1, 0],
+    "provenance": {
+      "source": "examples/runs.json",
+      "reference": "toy-north"
+    },
+    "outcome": {"label": "illustrative-only"}
+  },
+  {
+    "run_id": "toy-unchanged",
+    "features": ["direction_x", "direction_y", "position_x"],
+    "before": [3, 3, 3],
+    "after": [3, 3, 3],
+    "provenance": {
+      "source": "examples/runs.json",
+      "reference": "toy-unchanged"
+    },
+    "outcome": {"label": "illustrative-only"}
+  }
+]

--- a/experimental/directional-similar-runs/tests/test_directional_similar_runs.py
+++ b/experimental/directional-similar-runs/tests/test_directional_similar_runs.py
@@ -1,0 +1,182 @@
+# Copyright 2024-2026 The NoKV Authors.
+# SPDX-License-Identifier: Apache-2.0
+
+import json
+import pathlib
+import subprocess
+import sys
+import unittest
+
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+from directional_similar_runs import DirectionalIndex, DirectionalSearchError  # noqa: E402
+
+
+FEATURES = ["direction_x", "direction_y"]
+
+
+def record(run_id, after, *, before=None, features=None, provenance=None, outcome=None):
+    return {
+        "run_id": run_id,
+        "features": FEATURES if features is None else features,
+        "before": [0, 0] if before is None else before,
+        "after": after,
+        "provenance": {
+            "source": "tests/fixture.json",
+            "reference": run_id,
+        }
+        if provenance is None
+        else provenance,
+        "outcome": {"label": outcome} if outcome is not None else None,
+    }
+
+
+class DirectionalIndexTests(unittest.TestCase):
+    def test_same_direction_under_scale_is_near_one(self):
+        index = DirectionalIndex(
+            [record("query", [1, 2]), record("scaled", [10, 20])]
+        )
+        result = index.search("query", top_k=1)[0]
+        self.assertAlmostEqual(result["cosine_similarity"], 1.0, places=12)
+        self.assertEqual(index.fingerprint("query")["delta"], [1.0, 2.0])
+        self.assertAlmostEqual(index.get("scaled").magnitude, (500**0.5), places=12)
+
+    def test_opposite_and_orthogonal_directions_rank_correctly(self):
+        index = DirectionalIndex(
+            [
+                record("query", [1, 0]),
+                record("same", [2, 0]),
+                record("orthogonal", [0, 3]),
+                record("opposite", [-4, 0]),
+            ]
+        )
+        results = index.search("query", top_k=3)
+        self.assertEqual(
+            [result["run_id"] for result in results],
+            ["same", "orthogonal", "opposite"],
+        )
+        self.assertAlmostEqual(results[0]["cosine_similarity"], 1.0, places=12)
+        self.assertAlmostEqual(results[1]["cosine_similarity"], 0.0, places=12)
+        self.assertAlmostEqual(results[2]["cosine_similarity"], -1.0, places=12)
+
+    def test_zero_delta_is_explicit_and_never_divides_or_ranks(self):
+        index = DirectionalIndex(
+            [
+                record("flat", [4, -2], before=[4, -2]),
+                record("moving", [1, 0]),
+            ]
+        )
+        self.assertEqual(index.get("flat").magnitude, 0.0)
+        self.assertIsNone(index.get("flat").direction)
+        self.assertEqual(index.fingerprint("flat")["direction"], None)
+        self.assertEqual(index.search("flat", top_k=5), [])
+        self.assertEqual([r["run_id"] for r in index.search("moving", top_k=5)], [])
+
+    def test_before_after_dimension_mismatch_is_rejected(self):
+        with self.assertRaisesRegex(DirectionalSearchError, "dimensions differ"):
+            DirectionalIndex([record("bad", [1], before=[0, 0])])
+
+    def test_feature_vector_dimension_mismatch_is_rejected(self):
+        with self.assertRaisesRegex(DirectionalSearchError, "features and vector"):
+            DirectionalIndex([record("bad", [1, 2], features=["x"])])
+
+    def test_feature_semantics_and_order_must_match(self):
+        with self.assertRaisesRegex(DirectionalSearchError, "feature semantics/order"):
+            DirectionalIndex(
+                [
+                    record("first", [1, 0]),
+                    record("second", [1, 0], features=["direction_y", "direction_x"]),
+                ]
+            )
+
+    def test_nan_and_infinity_are_rejected(self):
+        for bad in (float("nan"), float("inf"), float("-inf")):
+            with self.subTest(bad=bad):
+                with self.assertRaisesRegex(DirectionalSearchError, "finite"):
+                    DirectionalIndex([record("bad", [bad, 0])])
+
+    def test_duplicate_run_ids_are_rejected(self):
+        with self.assertRaisesRegex(DirectionalSearchError, "duplicate run_id"):
+            DirectionalIndex([record("same", [1, 0]), record("same", [0, 1])])
+
+    def test_ties_are_deterministic_and_independent_of_input_order(self):
+        query = record("query", [1, 0])
+        first = DirectionalIndex(
+            [query, record("zeta", [1, 1]), record("alpha", [1, 1])]
+        )
+        second = DirectionalIndex(
+            [query, record("alpha", [1, 1]), record("zeta", [1, 1])]
+        )
+        self.assertEqual(
+            [r["run_id"] for r in first.search("query", top_k=2)], ["alpha", "zeta"]
+        )
+        self.assertEqual(first.search("query", top_k=2), second.search("query", top_k=2))
+
+    def test_outcome_label_cannot_leak_into_fingerprint_or_ranking(self):
+        records_a = [
+            record("query", [1, 0], outcome="one"),
+            record("candidate", [1, 1], outcome="good"),
+        ]
+        records_b = [
+            record("query", [1, 0], outcome="completely-different"),
+            record("candidate", [1, 1], outcome={"unexpected": "shape"}),
+        ]
+        index_a = DirectionalIndex(records_a)
+        index_b = DirectionalIndex(records_b)
+        self.assertEqual(index_a.fingerprint("candidate"), index_b.fingerprint("candidate"))
+        self.assertEqual(index_a.search("query", top_k=1), index_b.search("query", top_k=1))
+
+    def test_top_k_and_explicit_self_exclusion(self):
+        index = DirectionalIndex(
+            [record("query", [1, 0]), record("zz-other", [1, 0]), record("third", [0, 1])]
+        )
+        self.assertEqual([r["run_id"] for r in index.search("query", top_k=1)], ["zz-other"])
+        self.assertEqual(
+            [r["run_id"] for r in index.search("query", top_k=1, exclude_self=False)],
+            ["query"],
+        )
+        self.assertEqual(index.search("query", top_k=0), [])
+
+    def test_provenance_is_preserved_in_results(self):
+        provenance = {
+            "source": "frozen/raw.jsonl",
+            "reference": {"offset": 17, "digest": "abc"},
+            "producer": "offline-fixture",
+        }
+        index = DirectionalIndex(
+            [record("query", [1, 0]), record("candidate", [1, 0], provenance=provenance)]
+        )
+        result = index.search("query", top_k=1)[0]
+        self.assertEqual(result["provenance"], provenance)
+        result["provenance"]["reference"]["offset"] = 999
+        self.assertEqual(index.get("candidate").provenance, provenance)
+
+    def test_cli_reads_example_and_emits_disposable_results(self):
+        example = ROOT / "examples" / "runs.json"
+        completed = subprocess.run(
+            [
+                sys.executable,
+                str(ROOT / "directional_similar_runs.py"),
+                "--records",
+                str(example),
+                "--query-run-id",
+                "toy-east",
+                "--top-k",
+                "2",
+            ],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        output = json.loads(completed.stdout)
+        self.assertTrue(output["exclude_self"])
+        self.assertEqual([r["run_id"] for r in output["results"]], ["toy-east-scaled", "toy-north"])
+        self.assertEqual(
+            output["results"][0]["provenance"]["reference"], "toy-east-scaled"
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Related Issue

No linked issue.

I understand that this repository normally prefers non-trivial feature proposals to begin with an issue or discussion. This PR is only an isolated experimental helper, so I am offering the small concrete artifact for consideration. If an issue-first route would be better, or if this direction does not fit the project, please feel completely free to close or redirect it.

## Summary

- Adds an opt-in, offline, standard-library Python prototype for ranking past runs by the cosine similarity of normalized `after - before` directions.
- The idea was inspired by a small task-specific experiment by Runyuan. I hope this prototype may provide a little help or a useful discussion artifact for NoKV.
- Keeps magnitude separate from direction, excludes the query itself by default, handles zero deltas explicitly, preserves provenance, and does not use outcome labels while building fingerprints or rankings.
- Uses synthetic examples only. It does **not** claim a demonstrated NoKV benefit, a production index design, or a general mechanism.

## Scope

- [x] This PR changes one logical boundary only: a standalone helper under `experimental/`.
- [x] No unrelated refactor, benchmark, metadata model, Holt layout, object-store, or docs change is mixed in.
- [ ] The linked issue describes the user-visible problem, design decision, or maintenance task this PR resolves. (There is no linked issue; the reason is explained above.)
- [x] No breaking change is introduced.
- [x] No compatibility shim, deprecated alias, or forwarding wrapper is added.

## Code Contract

- [x] No existing crate, package boundary, runtime path, storage path, or default search behavior is changed.
- [x] The helper uses only the Python standard library and is isolated from the Rust workspace.
- [x] Names and file placement are specific to this experimental helper and documented in its local README.
- [x] No new cross-package error, metric, persisted metadata, or compatibility surface is introduced.

## Validation

- `python3 -m unittest discover -s tests -v` — 13 tests passed.
- `python3 directional_similar_runs.py --records examples/runs.json --query-run-id toy-east --top-k 3` — passed; deterministic result order was `toy-east-scaled`, `toy-north`, `toy-west`.
- `python3 -m json.tool examples/runs.json` — passed.
- `git diff --check` — passed.
- The full repository `make` gate was not run. This helper is outside the Cargo workspace, and the available macOS checkout does not have the FUSE development dependency required by the full workspace. I am not claiming a full workspace pass.

## Contributor Sign-off

- [x] Every commit in this PR includes a DCO `Signed-off-by` trailer.
