### PR TITLE
test: initialize Python before formatting errors

### DIFF
--- a/crates/nokv-python/src/client.rs
+++ b/crates/nokv-python/src/client.rs
@@ -993,6 +993,7 @@ mod tests {
 
     #[test]
     fn public_list_cursor_requires_the_previous_page_read_version() {
+        Python::initialize();
         let error = validate_list_page_fence(Some(b"page-2"), None).unwrap_err();
         assert!(error
             .to_string()


### PR DESCRIPTION
## What changed

- initialize PyO3 explicitly in the list cursor validation unit test before formatting a `PyErr`

## Why

The test constructed and formatted `PyValueError` without initializing Python. Because other tests happened to initialize the interpreter, the result depended on parallel test order and failed in GitHub Actions when this test ran first.

This changes test setup only. Python SDK behavior, Agent interfaces, and the Workbench contract are unchanged.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`
- isolated failing test in a fresh process
- `cargo test -p nokv-python --lib` (18 passed)
- LingTai Workbench contract tests (8 passed)
- LingTai first-client tests (6 passed)
- `git diff --check`
