### PR TITLE
Harden directional similar-run contracts

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -13,6 +13,19 @@ permissions:
   contents: read
 
 jobs:
+  directional-similar-runs:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Set up Python
+        uses: actions/setup-python@v7
+        with:
+          python-version: "3.9"
+
+      - name: Check the experimental directional-search contract
+        run: make experimental-test
+
   lingtai-first-client:
     runs-on: ubuntu-latest
     steps:

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 
 NOKV_MANIFEST := Cargo.toml
 
-.PHONY: help build test fmt lint workbench-test verify clean
+.PHONY: help build test fmt lint workbench-test experimental-test verify clean
 
 help:
 	@echo "NoKV development commands:"
@@ -13,7 +13,8 @@ help:
 	@echo "  make fmt         - Format the Rust workspace"
 	@echo "  make lint        - Run cargo clippy"
 	@echo "  make workbench-test - Run Workbench contract and LingTai first-client tests"
-	@echo "  make verify      - Run Rust and Workbench validation"
+	@echo "  make experimental-test - Run opt-in experimental helper tests"
+	@echo "  make verify      - Run Rust, Workbench, and experimental validation"
 	@echo "  make clean       - Remove build artifacts"
 
 build:
@@ -32,12 +33,17 @@ workbench-test:
 	python3 scripts/lingtai-workbench/workbench_contract_test.py
 	python3 scripts/lingtai-workbench/live_first_client_test.py
 
+experimental-test:
+	python3 -m unittest discover \
+		-s experimental/directional-similar-runs/tests -v
+
 verify:
 	cargo fmt --manifest-path $(NOKV_MANIFEST) --all -- --check
 	cargo clippy --manifest-path $(NOKV_MANIFEST) --workspace --all-targets -- -D warnings
 	cargo test --manifest-path $(NOKV_MANIFEST) --workspace
 	python3 scripts/lingtai-workbench/workbench_contract_test.py
 	python3 scripts/lingtai-workbench/live_first_client_test.py
+	$(MAKE) experimental-test
 	git diff --check
 
 clean:

--- a/experimental/directional-similar-runs/README.md
+++ b/experimental/directional-similar-runs/README.md
@@ -1,44 +1,86 @@
 # Experimental directional similar-run search
 
 **Experimental, opt-in, and offline only.** This directory is a disposable
-analysis helper. It is not part of NoKV's storage, namespace, snapshot/restore,
-agent-tool, or default-search paths, and it does not build or persist an index.
-It reads caller-provided JSON records into an in-memory index and prints derived
-results without rewriting the source records.
+analysis helper. It is not part of NoKV storage, metadata, Workbench tools, or
+default search, and it does not build or persist an index. It uses only the
+Python standard library and never rewrites the source dataset.
 
-## Why this location and language
+## Versioned dataset contract
 
-The frozen NoKV repository is a Rust workspace with no existing `examples/` or
-`experimental/` tree. A standalone directory using only Python's standard
-library is the smallest honest placement for an opt-in analysis prototype: the
-repository already contains small Python analysis tools under `scripts/`, while
-this directory remains outside the workspace crates and their default build,
-storage, and runtime behavior. No database, daemon, LLM call, or new dependency
-is needed.
+The input is one `directional-similar-runs/v1` object:
 
-## Record contract
+```json
+{
+  "schema": "directional-similar-runs/v1",
+  "feature_space": {
+    "id": "latency-profile-v1",
+    "features": [
+      {"name": "latency", "scale": 0.25, "unit": "seconds"},
+      {"name": "tokens", "scale": 1000, "unit": "count"}
+    ]
+  },
+  "runs": [
+    {
+      "run_id": "run-1",
+      "before": [1.0, 1000],
+      "after": [1.5, 3000],
+      "provenance": {"source": "frozen/runs.json", "reference": "run-1"},
+      "outcome": {"label": "optional-and-not-indexed"}
+    }
+  ]
+}
+```
 
-Input is a JSON array. Every record contains:
+- `feature_space.id` is a non-empty caller-owned label. Every fingerprint and
+  result also carries the full descriptor plus a recomputed, domain-separated
+  SHA-256 commitment over the ID and ordered `(name, float.hex(scale), unit)`
+  definitions, so the same label cannot hide incompatible scales.
+- Each feature has a unique non-empty `name`, a strictly positive finite
+  `scale`, and a descriptive non-empty `unit`.
+- Each run has a unique stable `run_id`, finite `before` and `after` vectors
+  matching the feature-space dimension, and provenance with a non-empty
+  `source`. Nested provenance is preserved in output.
+- Optional `outcome` data is checked for JSON compatibility, then discarded;
+  it cannot affect a fingerprint or ranking.
+- Identity text must be valid UTF-8 with no leading or trailing whitespace.
+  Unknown schema fields and nested metadata deeper than 64 levels are rejected.
 
-- `run_id`: a non-empty stable string, unique within the input;
-- `features`: non-empty unique feature names in a meaningful, ordered list;
-- `before` and `after`: finite numeric vectors with the same dimension as each
-  other and as `features`;
-- `provenance`: an object with a non-empty `source` reference. Extra provenance
-  fields are preserved in output.
+This is intentionally a breaking contract. Legacy bare arrays and missing
+scales are rejected instead of silently assuming `scale = 1.0`.
 
-An optional `outcome` field is accepted as metadata, but it is deliberately not
-used in delta, magnitude, direction, cosine, ranking, or the output's identity.
-Changing only an outcome label therefore cannot change a fingerprint or ranking.
-All records must use exactly the same feature names in exactly the same order.
+The feature-space commitment has a frozen binary preimage. It starts with the
+ASCII domain `directional-similar-runs.feature-space.v1` plus one NUL byte,
+then encodes the feature-space ID as `u64` big-endian byte length plus UTF-8,
+the feature count as `u64` big-endian, and each ordered feature's name,
+`float.hex(scale)`, and unit with the same length-prefixed UTF-8 encoding. The
+published value is `sha256:` plus the lowercase digest. Changing this encoding
+requires a new schema and commitment domain.
 
-For each record the tool computes `delta = after - before`, keeps its Euclidean
-`magnitude` separate, and normalizes a nonzero delta into a unit `direction`.
-Zero deltas are explicit (`magnitude: 0.0`, `direction: null`): they are not
-compared, because cosine similarity is undefined for a zero vector. A zero
-query returns no ranked results. Search excludes the query itself by default;
-`--include-self` is an explicit diagnostic override. Results sort by descending
-cosine similarity, then ascending `run_id`, so ties do not depend on input order.
+## Direction and ranking
+
+For each feature `i`, the tool computes:
+
+```text
+raw_delta[i]    = after[i] - before[i]
+scaled_delta[i] = raw_delta[i] / scale[i]
+direction       = scaled_delta / hypot(scaled_delta)
+```
+
+Changing a raw unit together with its scale therefore preserves the direction
+and cosine ranking. `unit` documents the raw values but does not enter the
+calculation. Non-finite raw deltas, scaled deltas, or magnitudes are rejected.
+If scaling would underflow a nonzero raw component to `0.0`, the record is
+rejected instead of being silently treated as a zero direction.
+
+A zero scaled delta is explicit (`scaled_magnitude: 0.0`, `direction: null`)
+and is not ranked because cosine similarity is undefined. Search excludes the
+query by default, skips zero-direction candidates, and orders ties by ascending
+`run_id` after descending cosine similarity.
+
+The index recursively copies and freezes nested provenance and does not expose
+its internal runs. `fingerprint()` and `search()` return new disposable
+dict/list trees on every call, so caller or source-record mutation cannot alter
+later results.
 
 ## Usage
 
@@ -46,39 +88,44 @@ From this directory:
 
 ```bash
 python3 directional_similar_runs.py \
-  --records examples/runs.json \
+  --dataset examples/runs.json \
   --query-run-id toy-east \
   --top-k 3
 ```
 
-The JSON output includes the query fingerprint and each candidate's cosine,
-delta, magnitude, normalized direction, feature order, and copied provenance.
-The example labels and vectors are synthetic illustrations, not NoKV workload
-results or a claim about a Transformer mechanism.
+Output uses `directional-similar-runs/result/v1` and includes
+the exact `feature_space`, its `feature_space_commitment`, `raw_delta`,
+`scaled_delta`, `scaled_magnitude`, normalized direction, cosine, and copied
+provenance.
 
-As a library in another offline analysis script:
+As a library:
 
 ```python
-from directional_similar_runs import DirectionalIndex, load_records
+from directional_similar_runs import DirectionalIndex, load_dataset
 
-index = DirectionalIndex(load_records("examples/runs.json"))
-results = index.search("toy-east", top_k=3)  # self excluded by default
+index = DirectionalIndex(load_dataset("examples/runs.json"))
+fingerprint = index.fingerprint("toy-east")
+results = index.search("toy-east", top_k=3)
 ```
 
-Run the deterministic focused suite:
+The supported public Python symbols are `DirectionalIndex`,
+`DirectionalSearchError`, `INPUT_SCHEMA`, `RESULT_SCHEMA`, and `load_dataset`.
+This cutover removes the previous `load_records`, `RunVector`, `SimilarRun`,
+`.runs`, and `.get()` surfaces; no compatibility alias is retained. Callers use
+`fingerprint(run_id)` when they need one validated run's derived values.
+
+Run the focused suite from the repository root:
 
 ```bash
-python3 -m unittest discover -s tests -v
+make experimental-test
 ```
 
 ## Boundary and next validation
 
 This helper was inspired by a small experiment by Runyuan in which reproducible
-directional/low-dimensional structure appeared in one task-specific setting.
-It does **not** establish a NoKV benefit, a general Transformer
-mechanism, outcome/damage prediction, Kakeya causation, or a multiscale-specific
-advantage. Real NoKV workload validation with frozen source records, held-out
-runs, provenance, baselines, and workload-level correctness/cost measures is
-required before any core/index integration could be considered. Until then,
-this remains a local prototype and disposable derived artifact, not canonical
-history or an authoritative result store.
+directional or low-dimensional structure appeared in one task-specific
+setting. It does **not** establish a NoKV benefit, a general Transformer
+mechanism, outcome prediction, Kakeya causation, or a multiscale-specific
+advantage. Any future NoKV integration requires frozen real workloads,
+held-out runs, provenance, baselines, and workload-level correctness and cost
+evidence. Until then this remains a disposable offline analysis prototype.

--- a/experimental/directional-similar-runs/directional_similar_runs.py
+++ b/experimental/directional-similar-runs/directional_similar_runs.py
@@ -2,172 +2,255 @@
 # SPDX-License-Identifier: Apache-2.0
 """Opt-in, offline directional similar-run search.
 
-This module deliberately has no NoKV storage or runtime integration.  It builds
-an in-memory index from caller-provided records and returns disposable result
-dictionaries.  Outcome labels are retained on the in-memory record only as
-metadata; they are never read while constructing fingerprints or scores.
+This module deliberately has no NoKV storage or runtime integration. It builds
+an immutable in-memory index from one versioned feature space and returns fresh,
+disposable JSON-compatible result dictionaries.
 """
 
 from __future__ import annotations
 
 import argparse
-import copy
+import hashlib
 import json
 import math
 from dataclasses import dataclass
 from numbers import Real
-from typing import Any, Iterable, Mapping, Optional, Sequence
+from types import MappingProxyType
+from typing import Any, Mapping, Optional, Sequence
+
+
+INPUT_SCHEMA = "directional-similar-runs/v1"
+RESULT_SCHEMA = "directional-similar-runs/result/v1"
+_MAX_METADATA_DEPTH = 64
+
+__all__ = [
+    "DirectionalIndex",
+    "DirectionalSearchError",
+    "INPUT_SCHEMA",
+    "RESULT_SCHEMA",
+    "load_dataset",
+]
 
 
 class DirectionalSearchError(ValueError):
-    """Raised when run records or a search request violate the contract."""
+    """Raised when a dataset or search request violates the contract."""
 
 
-_MISSING = object()
-
-
-def _finite_vector(value: Any, field: str, record_number: int) -> tuple[float, ...]:
-    if not isinstance(value, (list, tuple)) or not value:
-        raise DirectionalSearchError(
-            f"record {record_number}: {field} must be a non-empty numeric vector"
-        )
-
-    result: list[float] = []
-    for position, item in enumerate(value):
-        if isinstance(item, bool) or not isinstance(item, Real):
-            raise DirectionalSearchError(
-                f"record {record_number}: {field}[{position}] must be numeric"
-            )
-        try:
-            number = float(item)
-        except (TypeError, ValueError, OverflowError) as exc:
-            raise DirectionalSearchError(
-                f"record {record_number}: {field}[{position}] must be finite"
-            ) from exc
-        if not math.isfinite(number):
-            raise DirectionalSearchError(
-                f"record {record_number}: {field}[{position}] must be finite"
-            )
-        result.append(number)
-    return tuple(result)
-
-
-def _feature_names(value: Any, record_number: int) -> tuple[str, ...]:
-    if not isinstance(value, (list, tuple)) or not value:
-        raise DirectionalSearchError(
-            f"record {record_number}: features must be a non-empty ordered list"
-        )
-    if any(not isinstance(name, str) or not name.strip() for name in value):
-        raise DirectionalSearchError(
-            f"record {record_number}: feature names must be non-empty strings"
-        )
-    result = tuple(value)
-    if len(set(result)) != len(result):
-        raise DirectionalSearchError(
-            f"record {record_number}: feature names must be unique"
-        )
-    return result
-
-
-def _run_id(value: Any, record_number: int) -> str:
+def _required_text(value: Any, field: str) -> str:
     if not isinstance(value, str) or not value.strip():
+        raise DirectionalSearchError(f"{field} must be a non-empty string")
+    if value != value.strip():
         raise DirectionalSearchError(
-            f"record {record_number}: run_id must be a non-empty string"
+            f"{field} must not contain leading or trailing whitespace"
         )
+    try:
+        value.encode("utf-8")
+    except UnicodeEncodeError as exc:
+        raise DirectionalSearchError(f"{field} must be valid UTF-8 text") from exc
     return value
 
 
-def _provenance(value: Any, record_number: int) -> Mapping[str, Any]:
+def _sequence(value: Any, field: str) -> Sequence[Any]:
+    if not isinstance(value, (list, tuple)) or not value:
+        raise DirectionalSearchError(f"{field} must be a non-empty ordered list")
+    return value
+
+
+def _finite_number(value: Any, field: str) -> float:
+    if isinstance(value, bool) or not isinstance(value, Real):
+        raise DirectionalSearchError(f"{field} must be numeric")
+    try:
+        number = float(value)
+    except (TypeError, ValueError, OverflowError) as exc:
+        raise DirectionalSearchError(f"{field} must be finite") from exc
+    if not math.isfinite(number):
+        raise DirectionalSearchError(f"{field} must be finite")
+    return number
+
+
+def _finite_vector(value: Any, field: str, record_number: int) -> tuple[float, ...]:
+    vector = _sequence(value, f"record {record_number}: {field}")
+    return tuple(
+        _finite_number(item, f"record {record_number}: {field}[{position}]")
+        for position, item in enumerate(vector)
+    )
+
+
+def _reject_unknown_keys(value: Mapping[str, Any], allowed: set[str], field: str) -> None:
+    unknown = sorted(
+        repr(key) for key in value if not isinstance(key, str) or key not in allowed
+    )
+    if unknown:
+        raise DirectionalSearchError(f"{field} contains unknown fields: {unknown!r}")
+
+
+def _freeze_json(
+    value: Any,
+    field: str,
+    active: Optional[set[int]] = None,
+    depth: int = 0,
+) -> Any:
+    """Recursively copy and freeze one JSON-compatible value."""
+
+    if active is None:
+        active = set()
+    if depth > _MAX_METADATA_DEPTH:
+        raise DirectionalSearchError(
+            f"{field} exceeds the maximum JSON depth of {_MAX_METADATA_DEPTH}"
+        )
+    if value is None or isinstance(value, (str, bool, int)):
+        return value
+    if isinstance(value, float):
+        if not math.isfinite(value):
+            raise DirectionalSearchError(f"{field} must contain only finite JSON numbers")
+        return value
+    if isinstance(value, Mapping):
+        identity = id(value)
+        if identity in active:
+            raise DirectionalSearchError(f"{field} must be acyclic JSON")
+        active.add(identity)
+        try:
+            frozen: dict[str, Any] = {}
+            for key, item in value.items():
+                if not isinstance(key, str):
+                    raise DirectionalSearchError(f"{field} object keys must be strings")
+                frozen[key] = _freeze_json(item, f"{field}.{key}", active, depth + 1)
+            return MappingProxyType(frozen)
+        finally:
+            active.remove(identity)
+    if isinstance(value, (list, tuple)):
+        identity = id(value)
+        if identity in active:
+            raise DirectionalSearchError(f"{field} must be acyclic JSON")
+        active.add(identity)
+        try:
+            return tuple(
+                _freeze_json(item, f"{field}[{position}]", active, depth + 1)
+                for position, item in enumerate(value)
+            )
+        finally:
+            active.remove(identity)
+    raise DirectionalSearchError(f"{field} must be JSON-compatible")
+
+
+def _thaw_json(value: Any) -> Any:
+    """Return a new JSON-compatible mutable value from frozen internal state."""
+
+    if isinstance(value, Mapping):
+        return {key: _thaw_json(item) for key, item in value.items()}
+    if isinstance(value, tuple):
+        return [_thaw_json(item) for item in value]
+    return value
+
+
+@dataclass(frozen=True)
+class _FeatureSpec:
+    name: str
+    scale: float
+    unit: str
+
+
+@dataclass(frozen=True)
+class _RunVector:
+    run_id: str
+    raw_delta: tuple[float, ...]
+    scaled_delta: tuple[float, ...]
+    scaled_magnitude: float
+    direction: Optional[tuple[float, ...]]
+    provenance: Mapping[str, Any]
+
+
+def _hash_text(hasher: Any, value: str) -> None:
+    encoded = value.encode("utf-8")
+    hasher.update(len(encoded).to_bytes(8, "big"))
+    hasher.update(encoded)
+
+
+def _feature_space_commitment(
+    feature_space_id: str, features: tuple[_FeatureSpec, ...]
+) -> str:
+    hasher = hashlib.sha256()
+    hasher.update(b"directional-similar-runs.feature-space.v1\0")
+    _hash_text(hasher, feature_space_id)
+    hasher.update(len(features).to_bytes(8, "big"))
+    for feature in features:
+        _hash_text(hasher, feature.name)
+        _hash_text(hasher, feature.scale.hex())
+        _hash_text(hasher, feature.unit)
+    return f"sha256:{hasher.hexdigest()}"
+
+
+def _feature_space(value: Any) -> tuple[str, tuple[_FeatureSpec, ...]]:
     if not isinstance(value, Mapping):
-        raise DirectionalSearchError(
-            f"record {record_number}: provenance must be an object with a source"
-        )
-    source = value.get("source")
-    if not isinstance(source, str) or not source.strip():
-        raise DirectionalSearchError(
-            f"record {record_number}: provenance.source must be a non-empty string"
-        )
-    return copy.deepcopy(value)
+        raise DirectionalSearchError("feature_space must be an object")
+    _reject_unknown_keys(value, {"id", "features"}, "feature_space")
+    feature_space_id = _required_text(value.get("id"), "feature_space.id")
+    raw_features = _sequence(value.get("features"), "feature_space.features")
+
+    features: list[_FeatureSpec] = []
+    names: set[str] = set()
+    for position, raw_feature in enumerate(raw_features):
+        field = f"feature_space.features[{position}]"
+        if not isinstance(raw_feature, Mapping):
+            raise DirectionalSearchError(f"{field} must be an object")
+        _reject_unknown_keys(raw_feature, {"name", "scale", "unit"}, field)
+        name = _required_text(raw_feature.get("name"), f"{field}.name")
+        if name in names:
+            raise DirectionalSearchError(f"duplicate feature name: {name}")
+        names.add(name)
+        scale = _finite_number(raw_feature.get("scale"), f"{field}.scale")
+        if scale <= 0.0:
+            raise DirectionalSearchError(f"{field}.scale must be greater than zero")
+        unit = _required_text(raw_feature.get("unit"), f"{field}.unit")
+        features.append(_FeatureSpec(name=name, scale=scale, unit=unit))
+    return feature_space_id, tuple(features)
 
 
-@dataclass(frozen=True)
-class RunVector:
-    """Validated, immutable-in-use representation of one source run."""
-
-    run_id: str
-    features: tuple[str, ...]
-    before: tuple[float, ...]
-    after: tuple[float, ...]
-    delta: tuple[float, ...]
-    magnitude: float
-    direction: Optional[tuple[float, ...]]
-    provenance: Mapping[str, Any]
-    outcome: Any = _MISSING
-
-    def fingerprint(self) -> Optional[tuple[float, ...]]:
-        """Return the unit delta direction, or ``None`` for a zero delta."""
-
-        return self.direction
-
-
-@dataclass(frozen=True)
-class SimilarRun:
-    """A ranked result with source provenance and no source-record mutation."""
-
-    run_id: str
-    cosine_similarity: float
-    features: tuple[str, ...]
-    delta: tuple[float, ...]
-    magnitude: float
-    direction: Optional[tuple[float, ...]]
-    provenance: Mapping[str, Any]
-
-    def as_dict(self) -> dict[str, Any]:
-        """Return a JSON-compatible copy of this disposable result."""
-
-        return {
-            "run_id": self.run_id,
-            "cosine_similarity": self.cosine_similarity,
-            "features": list(self.features),
-            "delta": list(self.delta),
-            "magnitude": self.magnitude,
-            "direction": None if self.direction is None else list(self.direction),
-            "provenance": copy.deepcopy(self.provenance),
-        }
+def _provenance(value: Any, record_number: int) -> Mapping[str, Any]:
+    field = f"record {record_number}: provenance"
+    if not isinstance(value, Mapping):
+        raise DirectionalSearchError(f"{field} must be an object with a source")
+    _required_text(value.get("source"), f"{field}.source")
+    frozen = _freeze_json(value, field)
+    if not isinstance(frozen, Mapping):
+        raise AssertionError("mapping provenance freezes to a mapping")
+    return frozen
 
 
 class DirectionalIndex:
-    """An in-memory, rebuildable index for directional similar-run search.
+    """Immutable in-memory index for one explicit scaled feature space.
 
-    Every record must use the same feature names in the same order.  The index
-    owns no source files and stores no persistent sidecar.  A zero-delta run is
-    represented with magnitude ``0.0`` and ``direction=None``; it is not ranked
-    because cosine similarity is undefined for a zero vector.
+    ``scaled_delta[i] = (after[i] - before[i]) / scale[i]``. A nonzero
+    scaled delta is L2-normalized into the direction used for cosine ranking.
+    A zero scaled delta has no direction and is never ranked.
     """
 
-    def __init__(self, records: Iterable[Mapping[str, Any]]) -> None:
-        if isinstance(records, (str, bytes, Mapping)):
-            raise DirectionalSearchError("records must be an iterable of record objects")
-        try:
-            materialized = list(records)
-        except TypeError as exc:
+    def __init__(self, dataset: Mapping[str, Any]) -> None:
+        if not isinstance(dataset, Mapping):
             raise DirectionalSearchError(
-                "records must be an iterable of record objects"
-            ) from exc
-        if not materialized:
-            raise DirectionalSearchError("records must not be empty")
+                "input must be a versioned dataset object, not a legacy run array"
+            )
+        _reject_unknown_keys(dataset, {"schema", "feature_space", "runs"}, "input")
+        schema = dataset.get("schema")
+        if schema != INPUT_SCHEMA:
+            raise DirectionalSearchError(
+                f"unsupported schema {schema!r}; expected {INPUT_SCHEMA!r}"
+            )
+        feature_space_id, features = _feature_space(dataset.get("feature_space"))
+        raw_runs = _sequence(dataset.get("runs"), "runs")
 
-        self._runs: dict[str, RunVector] = {}
-        expected_features: Optional[tuple[str, ...]] = None
-        for record_number, record in enumerate(materialized, start=1):
+        runs: dict[str, _RunVector] = {}
+        for record_number, record in enumerate(raw_runs, start=1):
             if not isinstance(record, Mapping):
-                raise DirectionalSearchError(
-                    f"record {record_number}: must be an object"
-                )
-            run_id = _run_id(record.get("run_id"), record_number)
-            if run_id in self._runs:
+                raise DirectionalSearchError(f"record {record_number}: must be an object")
+            _reject_unknown_keys(
+                record,
+                {"run_id", "before", "after", "provenance", "outcome"},
+                f"record {record_number}",
+            )
+            run_id = _required_text(record.get("run_id"), f"record {record_number}: run_id")
+            if run_id in runs:
                 raise DirectionalSearchError(f"duplicate run_id: {run_id}")
-            features = _feature_names(record.get("features"), record_number)
             before = _finite_vector(record.get("before"), "before", record_number)
             after = _finite_vector(record.get("after"), "after", record_number)
             if len(before) != len(after):
@@ -176,94 +259,109 @@ class DirectionalIndex:
                 )
             if len(features) != len(before):
                 raise DirectionalSearchError(
-                    f"record {record_number}: features and vector dimensions differ"
-                )
-            if expected_features is None:
-                expected_features = features
-            elif features != expected_features:
-                raise DirectionalSearchError(
-                    "feature semantics/order differ: "
-                    f"expected {expected_features!r}, got {features!r}"
+                    f"record {record_number}: feature space and vector dimensions differ"
                 )
 
-            delta = tuple(
+            raw_delta = tuple(
                 after_value - before_value
                 for before_value, after_value in zip(before, after)
             )
-            if any(not math.isfinite(value) for value in delta):
+            if any(not math.isfinite(value) for value in raw_delta):
                 raise DirectionalSearchError(
-                    f"record {record_number}: delta must remain finite"
+                    f"record {record_number}: raw delta must remain finite"
                 )
-            magnitude = math.hypot(*delta)
-            if not math.isfinite(magnitude):
+            scaled_delta = tuple(
+                value / feature.scale for value, feature in zip(raw_delta, features)
+            )
+            if any(not math.isfinite(value) for value in scaled_delta):
                 raise DirectionalSearchError(
-                    f"record {record_number}: delta magnitude must remain finite"
+                    f"record {record_number}: scaled delta must remain finite"
                 )
-            direction: Optional[tuple[float, ...]]
-            if magnitude == 0.0:
-                direction = None
-            else:
-                direction = tuple(value / magnitude for value in delta)
+            if any(
+                raw_value != 0.0 and scaled_value == 0.0
+                for raw_value, scaled_value in zip(raw_delta, scaled_delta)
+            ):
+                raise DirectionalSearchError(
+                    f"record {record_number}: scaled delta must not underflow to zero"
+                )
+            scaled_magnitude = math.hypot(*scaled_delta)
+            if not math.isfinite(scaled_magnitude):
+                raise DirectionalSearchError(
+                    f"record {record_number}: scaled magnitude must remain finite"
+                )
+            direction = (
+                None
+                if scaled_magnitude == 0.0
+                else tuple(value / scaled_magnitude for value in scaled_delta)
+            )
+            provenance = _provenance(record.get("provenance"), record_number)
+            if "outcome" in record:
+                _freeze_json(record["outcome"], f"record {record_number}: outcome")
 
-            self._runs[run_id] = RunVector(
+            runs[run_id] = _RunVector(
                 run_id=run_id,
-                features=features,
-                before=before,
-                after=after,
-                delta=delta,
-                magnitude=magnitude,
+                raw_delta=raw_delta,
+                scaled_delta=scaled_delta,
+                scaled_magnitude=scaled_magnitude,
                 direction=direction,
-                provenance=_provenance(record.get("provenance"), record_number),
-                outcome=copy.deepcopy(record["outcome"])
-                if "outcome" in record
-                else _MISSING,
+                provenance=provenance,
             )
 
-    @property
-    def runs(self) -> tuple[RunVector, ...]:
-        """Return validated runs in source iteration order."""
+        self._feature_space_id = feature_space_id
+        self._features = features
+        self._feature_space_commitment = _feature_space_commitment(
+            feature_space_id, features
+        )
+        self._runs: Mapping[str, _RunVector] = MappingProxyType(runs)
 
-        return tuple(self._runs.values())
+    def _feature_space_output(self) -> dict[str, Any]:
+        return {
+            "id": self._feature_space_id,
+            "features": [
+                {
+                    "name": feature.name,
+                    "scale": feature.scale,
+                    "unit": feature.unit,
+                }
+                for feature in self._features
+            ],
+        }
 
-    def get(self, run_id: str) -> RunVector:
-        """Return one run or raise a contract error for an unknown ID."""
-
+    def _get(self, run_id: str) -> _RunVector:
+        run_id = _required_text(run_id, "run_id")
         try:
             return self._runs[run_id]
         except KeyError:
             raise DirectionalSearchError(f"unknown run_id: {run_id}") from None
 
     def fingerprint(self, run_id: str) -> dict[str, Any]:
-        """Return delta, magnitude, and normalized direction for one run."""
+        """Return a fresh scaled directional fingerprint for one run."""
 
-        run = self.get(run_id)
+        run = self._get(run_id)
         return {
-            "delta": list(run.delta),
-            "magnitude": run.magnitude,
+            "feature_space": self._feature_space_output(),
+            "feature_space_commitment": self._feature_space_commitment,
+            "raw_delta": list(run.raw_delta),
+            "scaled_delta": list(run.scaled_delta),
+            "scaled_magnitude": run.scaled_magnitude,
             "direction": None if run.direction is None else list(run.direction),
         }
 
     def search(
         self, query_run_id: str, top_k: int, *, exclude_self: bool = True
     ) -> list[dict[str, Any]]:
-        """Return deterministic top-k nonzero runs ranked by cosine similarity.
-
-        ``exclude_self`` defaults to true and can be set false explicitly for
-        diagnostics.  A zero-direction query returns an empty list because no
-        cosine ranking is defined; zero-direction candidates are skipped.
-        Ties are ordered by ascending stable ``run_id``.
-        """
+        """Return fresh deterministic top-k results ranked by scaled cosine."""
 
         if isinstance(top_k, bool) or not isinstance(top_k, int) or top_k < 0:
             raise DirectionalSearchError("top_k must be a non-negative integer")
         if not isinstance(exclude_self, bool):
             raise DirectionalSearchError("exclude_self must be a boolean")
 
-        query = self.get(query_run_id)
+        query = self._get(query_run_id)
         if top_k == 0 or query.direction is None:
             return []
 
-        ranked: list[SimilarRun] = []
+        ranked: list[tuple[float, str, _RunVector]] = []
         for candidate in self._runs.values():
             if exclude_self and candidate.run_id == query.run_id:
                 continue
@@ -275,32 +373,46 @@ class DirectionalIndex:
                     query.direction, candidate.direction
                 )
             )
-            # Unit-vector rounding can produce a value infinitesimally outside
-            # the cosine range.  Clamp only that arithmetic artifact.
             similarity = max(-1.0, min(1.0, similarity))
-            ranked.append(
-                SimilarRun(
-                    run_id=candidate.run_id,
-                    cosine_similarity=similarity,
-                    features=candidate.features,
-                    delta=candidate.delta,
-                    magnitude=candidate.magnitude,
-                    direction=candidate.direction,
-                    provenance=candidate.provenance,
-                )
+            ranked.append((-similarity, candidate.run_id, candidate))
+
+        ranked.sort(key=lambda item: (item[0], item[1]))
+        results: list[dict[str, Any]] = []
+        for negative_similarity, _, candidate in ranked[:top_k]:
+            results.append(
+                {
+                    "run_id": candidate.run_id,
+                    "cosine_similarity": -negative_similarity,
+                    "feature_space": self._feature_space_output(),
+                    "feature_space_commitment": self._feature_space_commitment,
+                    "raw_delta": list(candidate.raw_delta),
+                    "scaled_delta": list(candidate.scaled_delta),
+                    "scaled_magnitude": candidate.scaled_magnitude,
+                    "direction": (
+                        None
+                        if candidate.direction is None
+                        else list(candidate.direction)
+                    ),
+                    "provenance": _thaw_json(candidate.provenance),
+                }
             )
-
-        ranked.sort(key=lambda result: (-result.cosine_similarity, result.run_id))
-        return [result.as_dict() for result in ranked[:top_k]]
+        return results
 
 
-def load_records(path: str) -> list[Mapping[str, Any]]:
-    """Load a JSON array of run records without modifying the source file."""
+def load_dataset(path: str) -> Mapping[str, Any]:
+    """Load one versioned JSON dataset without modifying the source file."""
 
-    with open(path, "r", encoding="utf-8") as source:
-        payload = json.load(source)
-    if not isinstance(payload, list):
-        raise DirectionalSearchError("input must be a JSON array of run records")
+    try:
+        with open(path, "r", encoding="utf-8") as source:
+            payload = json.load(source)
+    except UnicodeError as exc:
+        raise DirectionalSearchError("input must be valid UTF-8 JSON") from exc
+    except RecursionError as exc:
+        raise DirectionalSearchError("input JSON exceeds the parser depth limit") from exc
+    if not isinstance(payload, Mapping):
+        raise DirectionalSearchError(
+            "input must be a versioned dataset object, not a legacy run array"
+        )
     return payload
 
 
@@ -308,7 +420,7 @@ def _cli() -> int:
     parser = argparse.ArgumentParser(
         description="Experimental offline directional similar-run search"
     )
-    parser.add_argument("--records", required=True, help="JSON array of run records")
+    parser.add_argument("--dataset", required=True, help="versioned JSON dataset")
     parser.add_argument("--query-run-id", required=True, help="stable query run ID")
     parser.add_argument("--top-k", type=int, default=5)
     parser.add_argument(
@@ -319,15 +431,20 @@ def _cli() -> int:
     args = parser.parse_args()
 
     try:
-        index = DirectionalIndex(load_records(args.records))
-        query = index.get(args.query_run_id)
+        index = DirectionalIndex(load_dataset(args.dataset))
+        query_fingerprint = index.fingerprint(args.query_run_id)
         output = {
-            "query_run_id": query.run_id,
-            "query_fingerprint": index.fingerprint(query.run_id),
+            "schema": RESULT_SCHEMA,
+            "feature_space": query_fingerprint["feature_space"],
+            "feature_space_commitment": query_fingerprint[
+                "feature_space_commitment"
+            ],
+            "query_run_id": args.query_run_id,
+            "query_fingerprint": query_fingerprint,
             "top_k": args.top_k,
             "exclude_self": not args.include_self,
             "results": index.search(
-                query.run_id,
+                args.query_run_id,
                 args.top_k,
                 exclude_self=not args.include_self,
             ),

--- a/experimental/directional-similar-runs/examples/runs.json
+++ b/experimental/directional-similar-runs/examples/runs.json
@@ -1,57 +1,75 @@
-[
-  {
-    "run_id": "toy-east",
-    "features": ["direction_x", "direction_y", "position_x"],
-    "before": [0, 0, 0],
-    "after": [1, 0, 0],
-    "provenance": {
-      "source": "examples/runs.json",
-      "reference": "toy-east"
-    },
-    "outcome": {"label": "illustrative-only"}
+{
+  "schema": "directional-similar-runs/v1",
+  "feature_space": {
+    "id": "toy-direction-v1",
+    "features": [
+      {
+        "name": "direction_x",
+        "scale": 1.0,
+        "unit": "normalized"
+      },
+      {
+        "name": "direction_y",
+        "scale": 1.0,
+        "unit": "normalized"
+      },
+      {
+        "name": "position_x",
+        "scale": 1.0,
+        "unit": "normalized"
+      }
+    ]
   },
-  {
-    "run_id": "toy-east-scaled",
-    "features": ["direction_x", "direction_y", "position_x"],
-    "before": [0, 0, 0],
-    "after": [2, 0, 0],
-    "provenance": {
-      "source": "examples/runs.json",
-      "reference": "toy-east-scaled"
+  "runs": [
+    {
+      "run_id": "toy-east",
+      "before": [0, 0, 0],
+      "after": [1, 0, 0],
+      "provenance": {
+        "source": "examples/runs.json",
+        "reference": "toy-east"
+      },
+      "outcome": {"label": "illustrative-only"}
     },
-    "outcome": {"label": "illustrative-only"}
-  },
-  {
-    "run_id": "toy-west",
-    "features": ["direction_x", "direction_y", "position_x"],
-    "before": [0, 0, 0],
-    "after": [-1, 0, 0],
-    "provenance": {
-      "source": "examples/runs.json",
-      "reference": "toy-west"
+    {
+      "run_id": "toy-east-scaled",
+      "before": [0, 0, 0],
+      "after": [2, 0, 0],
+      "provenance": {
+        "source": "examples/runs.json",
+        "reference": "toy-east-scaled"
+      },
+      "outcome": {"label": "illustrative-only"}
     },
-    "outcome": {"label": "illustrative-only"}
-  },
-  {
-    "run_id": "toy-north",
-    "features": ["direction_x", "direction_y", "position_x"],
-    "before": [0, 0, 0],
-    "after": [0, 1, 0],
-    "provenance": {
-      "source": "examples/runs.json",
-      "reference": "toy-north"
+    {
+      "run_id": "toy-west",
+      "before": [0, 0, 0],
+      "after": [-1, 0, 0],
+      "provenance": {
+        "source": "examples/runs.json",
+        "reference": "toy-west"
+      },
+      "outcome": {"label": "illustrative-only"}
     },
-    "outcome": {"label": "illustrative-only"}
-  },
-  {
-    "run_id": "toy-unchanged",
-    "features": ["direction_x", "direction_y", "position_x"],
-    "before": [3, 3, 3],
-    "after": [3, 3, 3],
-    "provenance": {
-      "source": "examples/runs.json",
-      "reference": "toy-unchanged"
+    {
+      "run_id": "toy-north",
+      "before": [0, 0, 0],
+      "after": [0, 1, 0],
+      "provenance": {
+        "source": "examples/runs.json",
+        "reference": "toy-north"
+      },
+      "outcome": {"label": "illustrative-only"}
     },
-    "outcome": {"label": "illustrative-only"}
-  }
-]
+    {
+      "run_id": "toy-unchanged",
+      "before": [3, 3, 3],
+      "after": [3, 3, 3],
+      "provenance": {
+        "source": "examples/runs.json",
+        "reference": "toy-unchanged"
+      },
+      "outcome": {"label": "illustrative-only"}
+    }
+  ]
+}

--- a/experimental/directional-similar-runs/tests/test_directional_similar_runs.py
+++ b/experimental/directional-similar-runs/tests/test_directional_similar_runs.py
@@ -1,26 +1,37 @@
 # Copyright 2024-2026 The NoKV Authors.
 # SPDX-License-Identifier: Apache-2.0
 
+import copy
 import json
 import pathlib
 import subprocess
 import sys
+import tempfile
 import unittest
 
 
 ROOT = pathlib.Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT))
 
-from directional_similar_runs import DirectionalIndex, DirectionalSearchError  # noqa: E402
+import directional_similar_runs as directional_module  # noqa: E402
+from directional_similar_runs import (  # noqa: E402
+    DirectionalIndex,
+    DirectionalSearchError,
+    INPUT_SCHEMA,
+    RESULT_SCHEMA,
+)
 
 
-FEATURES = ["direction_x", "direction_y"]
+FEATURES = [
+    {"name": "direction_x", "scale": 1.0, "unit": "normalized"},
+    {"name": "direction_y", "scale": 1.0, "unit": "normalized"},
+]
+_UNSET = object()
 
 
-def record(run_id, after, *, before=None, features=None, provenance=None, outcome=None):
-    return {
+def record(run_id, after, *, before=None, provenance=None, outcome=_UNSET):
+    value = {
         "run_id": run_id,
-        "features": FEATURES if features is None else features,
         "before": [0, 0] if before is None else before,
         "after": after,
         "provenance": {
@@ -29,28 +40,129 @@ def record(run_id, after, *, before=None, features=None, provenance=None, outcom
         }
         if provenance is None
         else provenance,
-        "outcome": {"label": outcome} if outcome is not None else None,
+    }
+    if outcome is not _UNSET:
+        value["outcome"] = outcome
+    return value
+
+
+def dataset(*runs, feature_space_id="test-direction-v1", features=None, schema=INPUT_SCHEMA):
+    return {
+        "schema": schema,
+        "feature_space": {
+            "id": feature_space_id,
+            "features": copy.deepcopy(FEATURES if features is None else features),
+        },
+        "runs": list(runs),
     }
 
 
+def nested_provenance(depth):
+    value = "leaf"
+    for _ in range(depth):
+        value = {"next": value}
+    return {"source": "tests/fixture.json", "nested": value}
+
+
 class DirectionalIndexTests(unittest.TestCase):
-    def test_same_direction_under_scale_is_near_one(self):
+    def test_same_scaled_direction_is_near_one(self):
         index = DirectionalIndex(
-            [record("query", [1, 2]), record("scaled", [10, 20])]
+            dataset(record("query", [1, 2]), record("scaled", [10, 20]))
         )
         result = index.search("query", top_k=1)[0]
         self.assertAlmostEqual(result["cosine_similarity"], 1.0, places=12)
-        self.assertEqual(index.fingerprint("query")["delta"], [1.0, 2.0])
-        self.assertAlmostEqual(index.get("scaled").magnitude, (500**0.5), places=12)
+        fingerprint = index.fingerprint("scaled")
+        self.assertEqual(fingerprint["raw_delta"], [10.0, 20.0])
+        self.assertEqual(fingerprint["scaled_delta"], [10.0, 20.0])
+        self.assertAlmostEqual(
+            fingerprint["scaled_magnitude"], (500**0.5), places=12
+        )
+
+    def test_unit_conversion_with_matching_scales_preserves_direction_and_ranking(self):
+        seconds = dataset(
+            record("query", [2, 4]),
+            record("same", [4, 8]),
+            record("orthogonal", [0, 4]),
+            features=[
+                {"name": "latency", "scale": 2, "unit": "seconds"},
+                {"name": "duration", "scale": 4, "unit": "seconds"},
+            ],
+        )
+        milliseconds = dataset(
+            record("query", [2000, 4000]),
+            record("same", [4000, 8000]),
+            record("orthogonal", [0, 4000]),
+            features=[
+                {"name": "latency", "scale": 2000, "unit": "milliseconds"},
+                {"name": "duration", "scale": 4000, "unit": "milliseconds"},
+            ],
+        )
+        seconds_index = DirectionalIndex(seconds)
+        milliseconds_index = DirectionalIndex(milliseconds)
+
+        self.assertEqual(
+            seconds_index.fingerprint("query")["scaled_delta"],
+            milliseconds_index.fingerprint("query")["scaled_delta"],
+        )
+        self.assertEqual(
+            seconds_index.fingerprint("query")["direction"],
+            milliseconds_index.fingerprint("query")["direction"],
+        )
+        self.assertNotEqual(
+            seconds_index.fingerprint("query")["feature_space_commitment"],
+            milliseconds_index.fingerprint("query")["feature_space_commitment"],
+        )
+        self.assertEqual(
+            [result["run_id"] for result in seconds_index.search("query", 2)],
+            [result["run_id"] for result in milliseconds_index.search("query", 2)],
+        )
+        self.assertEqual(
+            [result["cosine_similarity"] for result in seconds_index.search("query", 2)],
+            [
+                result["cosine_similarity"]
+                for result in milliseconds_index.search("query", 2)
+            ],
+        )
+
+    def test_scale_values_change_ranking(self):
+        runs = [
+            record("query", [1, 1]),
+            record("x-axis", [1, 0]),
+            record("y-axis", [0, 1]),
+        ]
+        x_weighted = DirectionalIndex(
+            dataset(
+                *runs,
+                features=[
+                    {"name": "x", "scale": 1, "unit": "raw"},
+                    {"name": "y", "scale": 10, "unit": "raw"},
+                ],
+            )
+        )
+        y_weighted = DirectionalIndex(
+            dataset(
+                *runs,
+                features=[
+                    {"name": "x", "scale": 10, "unit": "raw"},
+                    {"name": "y", "scale": 1, "unit": "raw"},
+                ],
+            )
+        )
+        self.assertEqual(x_weighted.search("query", 1)[0]["run_id"], "x-axis")
+        self.assertEqual(y_weighted.search("query", 1)[0]["run_id"], "y-axis")
+        self.assertNotEqual(
+            x_weighted.fingerprint("query")["feature_space_commitment"],
+            y_weighted.fingerprint("query")["feature_space_commitment"],
+        )
 
     def test_opposite_and_orthogonal_directions_rank_correctly(self):
         index = DirectionalIndex(
-            [
+            dataset(
                 record("query", [1, 0]),
                 record("same", [2, 0]),
                 record("orthogonal", [0, 3]),
                 record("opposite", [-4, 0]),
-            ]
+            )
         )
         results = index.search("query", top_k=3)
         self.assertEqual(
@@ -61,105 +173,290 @@ class DirectionalIndexTests(unittest.TestCase):
         self.assertAlmostEqual(results[1]["cosine_similarity"], 0.0, places=12)
         self.assertAlmostEqual(results[2]["cosine_similarity"], -1.0, places=12)
 
-    def test_zero_delta_is_explicit_and_never_divides_or_ranks(self):
+    def test_zero_delta_is_explicit_and_never_ranks(self):
         index = DirectionalIndex(
-            [
+            dataset(
                 record("flat", [4, -2], before=[4, -2]),
                 record("moving", [1, 0]),
-            ]
-        )
-        self.assertEqual(index.get("flat").magnitude, 0.0)
-        self.assertIsNone(index.get("flat").direction)
-        self.assertEqual(index.fingerprint("flat")["direction"], None)
-        self.assertEqual(index.search("flat", top_k=5), [])
-        self.assertEqual([r["run_id"] for r in index.search("moving", top_k=5)], [])
-
-    def test_before_after_dimension_mismatch_is_rejected(self):
-        with self.assertRaisesRegex(DirectionalSearchError, "dimensions differ"):
-            DirectionalIndex([record("bad", [1], before=[0, 0])])
-
-    def test_feature_vector_dimension_mismatch_is_rejected(self):
-        with self.assertRaisesRegex(DirectionalSearchError, "features and vector"):
-            DirectionalIndex([record("bad", [1, 2], features=["x"])])
-
-    def test_feature_semantics_and_order_must_match(self):
-        with self.assertRaisesRegex(DirectionalSearchError, "feature semantics/order"):
-            DirectionalIndex(
-                [
-                    record("first", [1, 0]),
-                    record("second", [1, 0], features=["direction_y", "direction_x"]),
-                ]
             )
+        )
+        fingerprint = index.fingerprint("flat")
+        self.assertEqual(fingerprint["raw_delta"], [0.0, 0.0])
+        self.assertEqual(fingerprint["scaled_delta"], [0.0, 0.0])
+        self.assertEqual(fingerprint["scaled_magnitude"], 0.0)
+        self.assertIsNone(fingerprint["direction"])
+        self.assertEqual(index.search("flat", top_k=5), [])
+        self.assertEqual(index.search("moving", top_k=5), [])
 
-    def test_nan_and_infinity_are_rejected(self):
+    def test_legacy_array_unknown_schema_and_empty_feature_space_id_are_rejected(self):
+        with self.assertRaisesRegex(DirectionalSearchError, "legacy run array"):
+            DirectionalIndex([record("legacy", [1, 0])])
+        with self.assertRaisesRegex(DirectionalSearchError, "unsupported schema"):
+            DirectionalIndex(dataset(record("bad", [1, 0]), schema="unknown/v1"))
+        with self.assertRaisesRegex(DirectionalSearchError, "feature_space.id"):
+            DirectionalIndex(dataset(record("bad", [1, 0]), feature_space_id=""))
+
+    def test_invalid_feature_scales_are_rejected(self):
+        invalid_scales = [(_UNSET, "numeric"), (True, "numeric"), (0, "greater"), (-1, "greater")]
+        invalid_scales.extend(
+            [(float("nan"), "finite"), (float("inf"), "finite")]
+        )
+        for scale, message in invalid_scales:
+            with self.subTest(scale=scale):
+                feature = {"name": "x", "unit": "raw"}
+                if scale is not _UNSET:
+                    feature["scale"] = scale
+                with self.assertRaisesRegex(DirectionalSearchError, message):
+                    DirectionalIndex(
+                        dataset(record("bad", [1]), features=[feature])
+                    )
+
+    def test_duplicate_features_and_vector_dimension_mismatch_are_rejected(self):
+        duplicate_features = [
+            {"name": "x", "scale": 1, "unit": "raw"},
+            {"name": "x", "scale": 2, "unit": "raw"},
+        ]
+        with self.assertRaisesRegex(DirectionalSearchError, "duplicate feature"):
+            DirectionalIndex(
+                dataset(record("bad", [1, 2]), features=duplicate_features)
+            )
+        with self.assertRaisesRegex(DirectionalSearchError, "feature space and vector"):
+            DirectionalIndex(dataset(record("bad", [1], before=[0])))
+        with self.assertRaisesRegex(DirectionalSearchError, "dimensions differ"):
+            DirectionalIndex(dataset(record("bad", [1], before=[0, 0])))
+
+    def test_nonfinite_vectors_and_derived_values_are_rejected(self):
         for bad in (float("nan"), float("inf"), float("-inf")):
             with self.subTest(bad=bad):
                 with self.assertRaisesRegex(DirectionalSearchError, "finite"):
-                    DirectionalIndex([record("bad", [bad, 0])])
+                    DirectionalIndex(dataset(record("bad", [bad, 0])))
+
+        with self.assertRaisesRegex(DirectionalSearchError, "raw delta"):
+            DirectionalIndex(
+                dataset(record("bad", [1e308, 0], before=[-1e308, 0]))
+            )
+        with self.assertRaisesRegex(DirectionalSearchError, "scaled delta"):
+            DirectionalIndex(
+                dataset(
+                    record("bad", [1e308], before=[0]),
+                    features=[{"name": "x", "scale": 1e-308, "unit": "raw"}],
+                )
+            )
+        with self.assertRaisesRegex(DirectionalSearchError, "scaled magnitude"):
+            DirectionalIndex(
+                dataset(
+                    record("bad", [1.7e308, 1.7e308]),
+                    features=[
+                        {"name": "x", "scale": 1, "unit": "raw"},
+                        {"name": "y", "scale": 1, "unit": "raw"},
+                    ],
+                )
+            )
+        with self.assertRaisesRegex(DirectionalSearchError, "underflow"):
+            DirectionalIndex(
+                dataset(
+                    record("bad", [5e-324], before=[0]),
+                    features=[{"name": "x", "scale": 1e308, "unit": "raw"}],
+                )
+            )
 
     def test_duplicate_run_ids_are_rejected(self):
         with self.assertRaisesRegex(DirectionalSearchError, "duplicate run_id"):
-            DirectionalIndex([record("same", [1, 0]), record("same", [0, 1])])
+            DirectionalIndex(
+                dataset(record("same", [1, 0]), record("same", [0, 1]))
+            )
 
     def test_ties_are_deterministic_and_independent_of_input_order(self):
         query = record("query", [1, 0])
         first = DirectionalIndex(
-            [query, record("zeta", [1, 1]), record("alpha", [1, 1])]
+            dataset(query, record("zeta", [1, 1]), record("alpha", [1, 1]))
         )
         second = DirectionalIndex(
-            [query, record("alpha", [1, 1]), record("zeta", [1, 1])]
+            dataset(query, record("alpha", [1, 1]), record("zeta", [1, 1]))
         )
         self.assertEqual(
-            [r["run_id"] for r in first.search("query", top_k=2)], ["alpha", "zeta"]
+            [result["run_id"] for result in first.search("query", top_k=2)],
+            ["alpha", "zeta"],
         )
-        self.assertEqual(first.search("query", top_k=2), second.search("query", top_k=2))
+        self.assertEqual(first.search("query", 2), second.search("query", 2))
 
-    def test_outcome_label_cannot_leak_into_fingerprint_or_ranking(self):
+    def test_outcome_is_validated_but_not_stored_or_scored(self):
         records_a = [
-            record("query", [1, 0], outcome="one"),
-            record("candidate", [1, 1], outcome="good"),
+            record("query", [1, 0], outcome={"label": "one"}),
+            record("candidate", [1, 1], outcome={"label": "good"}),
         ]
         records_b = [
-            record("query", [1, 0], outcome="completely-different"),
-            record("candidate", [1, 1], outcome={"unexpected": "shape"}),
+            record("query", [1, 0], outcome={"label": "different"}),
+            record("candidate", [1, 1], outcome=["another", "shape"]),
         ]
-        index_a = DirectionalIndex(records_a)
-        index_b = DirectionalIndex(records_b)
-        self.assertEqual(index_a.fingerprint("candidate"), index_b.fingerprint("candidate"))
-        self.assertEqual(index_a.search("query", top_k=1), index_b.search("query", top_k=1))
-
-    def test_top_k_and_explicit_self_exclusion(self):
-        index = DirectionalIndex(
-            [record("query", [1, 0]), record("zz-other", [1, 0]), record("third", [0, 1])]
-        )
-        self.assertEqual([r["run_id"] for r in index.search("query", top_k=1)], ["zz-other"])
+        index_a = DirectionalIndex(dataset(*records_a))
+        index_b = DirectionalIndex(dataset(*records_b))
         self.assertEqual(
-            [r["run_id"] for r in index.search("query", top_k=1, exclude_self=False)],
-            ["query"],
+            index_a.fingerprint("candidate"), index_b.fingerprint("candidate")
         )
-        self.assertEqual(index.search("query", top_k=0), [])
+        self.assertEqual(index_a.search("query", 1), index_b.search("query", 1))
+        with self.assertRaisesRegex(DirectionalSearchError, "JSON-compatible"):
+            DirectionalIndex(
+                dataset(record("bad", [1, 0], outcome=object()))
+            )
 
-    def test_provenance_is_preserved_in_results(self):
+    def test_non_string_keys_and_cyclic_metadata_are_rejected_cleanly(self):
+        invalid = dataset(record("bad", [1, 0]))
+        invalid[1] = "not a JSON object key"
+        with self.assertRaisesRegex(DirectionalSearchError, "unknown fields"):
+            DirectionalIndex(invalid)
+
+        cyclic = {"source": "tests/fixture.json"}
+        cyclic["cycle"] = cyclic
+        with self.assertRaisesRegex(DirectionalSearchError, "acyclic JSON"):
+            DirectionalIndex(
+                dataset(record("bad", [1, 0], provenance=cyclic))
+            )
+
+    def test_metadata_depth_is_bounded_with_a_contract_error(self):
+        at_limit = nested_provenance(directional_module._MAX_METADATA_DEPTH - 1)
+        DirectionalIndex(dataset(record("ok", [1, 0], provenance=at_limit)))
+
+        over_limit = nested_provenance(directional_module._MAX_METADATA_DEPTH)
+        with self.assertRaisesRegex(DirectionalSearchError, "maximum JSON depth"):
+            DirectionalIndex(
+                dataset(record("bad", [1, 0], provenance=over_limit))
+            )
+
+    def test_identity_text_rejects_boundary_whitespace_and_lone_surrogates(self):
+        invalid_values = []
+
+        invalid_id = dataset(record("run", [1, 0]))
+        invalid_id["feature_space"]["id"] = " space"
+        invalid_values.append(invalid_id)
+
+        invalid_name = dataset(record("run", [1, 0]))
+        invalid_name["feature_space"]["features"][0]["name"] = "x "
+        invalid_values.append(invalid_name)
+
+        invalid_unit = dataset(record("run", [1, 0]))
+        invalid_unit["feature_space"]["features"][0]["unit"] = " raw"
+        invalid_values.append(invalid_unit)
+
+        invalid_run = dataset(record(" run", [1, 0]))
+        invalid_values.append(invalid_run)
+
+        invalid_source = dataset(record("run", [1, 0]))
+        invalid_source["runs"][0]["provenance"]["source"] = "source "
+        invalid_values.append(invalid_source)
+
+        for invalid in invalid_values:
+            with self.subTest(invalid=invalid):
+                with self.assertRaisesRegex(DirectionalSearchError, "whitespace"):
+                    DirectionalIndex(invalid)
+
+        lone_surrogate = dataset(record("run", [1, 0]))
+        lone_surrogate["feature_space"]["id"] = "\ud800"
+        with self.assertRaisesRegex(DirectionalSearchError, "UTF-8"):
+            DirectionalIndex(lone_surrogate)
+
+    def test_public_api_has_no_legacy_mutable_accessors(self):
+        self.assertEqual(
+            set(directional_module.__all__),
+            {
+                "DirectionalIndex",
+                "DirectionalSearchError",
+                "INPUT_SCHEMA",
+                "RESULT_SCHEMA",
+                "load_dataset",
+            },
+        )
+        index = DirectionalIndex(dataset(record("run", [1, 0])))
+        self.assertFalse(hasattr(index, "get"))
+        self.assertFalse(hasattr(index, "runs"))
+        self.assertFalse(hasattr(directional_module, "load_records"))
+        self.assertFalse(hasattr(directional_module, "RunVector"))
+        self.assertFalse(hasattr(directional_module, "SimilarRun"))
+
+    def test_top_k_self_exclusion_and_unknown_run_validation(self):
+        index = DirectionalIndex(
+            dataset(
+                record("query", [1, 0]),
+                record("zz-other", [1, 0]),
+                record("third", [0, 1]),
+            )
+        )
+        self.assertEqual(index.search("query", 1)[0]["run_id"], "zz-other")
+        self.assertEqual(
+            index.search("query", 1, exclude_self=False)[0]["run_id"], "query"
+        )
+        self.assertEqual(index.search("query", 0), [])
+        with self.assertRaisesRegex(DirectionalSearchError, "unknown run_id"):
+            index.fingerprint("missing")
+        with self.assertRaisesRegex(DirectionalSearchError, "run_id"):
+            index.fingerprint([])
+        with self.assertRaisesRegex(DirectionalSearchError, "top_k"):
+            index.search("query", True)
+
+    def test_input_and_result_mutation_cannot_change_index_state(self):
         provenance = {
             "source": "frozen/raw.jsonl",
-            "reference": {"offset": 17, "digest": "abc"},
-            "producer": "offline-fixture",
+            "reference": {"offset": 17, "tags": ["a", "b"]},
         }
-        index = DirectionalIndex(
-            [record("query", [1, 0]), record("candidate", [1, 0], provenance=provenance)]
+        source = dataset(
+            record("query", [1, 0]),
+            record("candidate", [1, 0], provenance=provenance),
         )
-        result = index.search("query", top_k=1)[0]
-        self.assertEqual(result["provenance"], provenance)
-        result["provenance"]["reference"]["offset"] = 999
-        self.assertEqual(index.get("candidate").provenance, provenance)
+        index = DirectionalIndex(source)
+        provenance["reference"]["offset"] = 999
+        provenance["reference"]["tags"].append("mutated")
+        source["feature_space"]["id"] = "mutated-space"
+        source["runs"][1]["after"][0] = -1
 
-    def test_cli_reads_example_and_emits_disposable_results(self):
+        first_result = index.search("query", 1)
+        first_fingerprint = index.fingerprint("candidate")
+        self.assertEqual(first_result[0]["provenance"]["reference"]["offset"], 17)
+        self.assertEqual(first_result[0]["provenance"]["reference"]["tags"], ["a", "b"])
+        self.assertEqual(
+            first_result[0]["feature_space"]["id"], "test-direction-v1"
+        )
+        self.assertEqual(first_fingerprint["raw_delta"], [1.0, 0.0])
+
+        first_result[0]["provenance"]["reference"]["offset"] = 404
+        first_result[0]["raw_delta"][0] = 404
+        first_fingerprint["scaled_delta"][0] = 404
+        first_fingerprint["feature_space"]["features"][0]["scale"] = 404
+        self.assertEqual(index.search("query", 1)[0]["raw_delta"], [1.0, 0.0])
+        self.assertEqual(
+            index.search("query", 1)[0]["provenance"]["reference"]["offset"],
+            17,
+        )
+        self.assertEqual(index.fingerprint("candidate")["scaled_delta"], [1.0, 0.0])
+        self.assertEqual(
+            index.fingerprint("candidate")["feature_space"]["features"][0]["scale"],
+            1.0,
+        )
+
+    def test_fingerprint_and_results_identify_the_feature_space(self):
+        index = DirectionalIndex(
+            dataset(
+                record("query", [1, 0]),
+                record("candidate", [1, 0]),
+                feature_space_id="frozen-space-2026-08",
+            )
+        )
+        fingerprint = index.fingerprint("query")
+        self.assertEqual(fingerprint["feature_space"]["id"], "frozen-space-2026-08")
+        self.assertRegex(fingerprint["feature_space_commitment"], r"^sha256:[0-9a-f]{64}$")
+        result = index.search("query", 1)[0]
+        self.assertEqual(result["feature_space"], fingerprint["feature_space"])
+        self.assertEqual(
+            result["feature_space_commitment"],
+            fingerprint["feature_space_commitment"],
+        )
+
+    def test_cli_reads_versioned_example_and_emits_disposable_results(self):
         example = ROOT / "examples" / "runs.json"
         completed = subprocess.run(
             [
                 sys.executable,
                 str(ROOT / "directional_similar_runs.py"),
-                "--records",
+                "--dataset",
                 str(example),
                 "--query-run-id",
                 "toy-east",
@@ -171,11 +468,74 @@ class DirectionalIndexTests(unittest.TestCase):
             text=True,
         )
         output = json.loads(completed.stdout)
-        self.assertTrue(output["exclude_self"])
-        self.assertEqual([r["run_id"] for r in output["results"]], ["toy-east-scaled", "toy-north"])
-        self.assertEqual(
-            output["results"][0]["provenance"]["reference"], "toy-east-scaled"
+        expected_commitment = (
+            "sha256:e3200e1254056d8148e98ef460fc4fe1c2ef6e9af3152873abd25604f96beb60"
         )
+        self.assertEqual(output["schema"], RESULT_SCHEMA)
+        self.assertEqual(output["feature_space"]["id"], "toy-direction-v1")
+        self.assertEqual(output["feature_space_commitment"], expected_commitment)
+        self.assertEqual(
+            output["query_fingerprint"]["feature_space_commitment"],
+            expected_commitment,
+        )
+        self.assertEqual(
+            output["query_fingerprint"]["feature_space"], output["feature_space"]
+        )
+        self.assertTrue(output["exclude_self"])
+        self.assertEqual(
+            [result["run_id"] for result in output["results"]],
+            ["toy-east-scaled", "toy-north"],
+        )
+        self.assertEqual(
+            output["results"][0]["provenance"]["reference"],
+            "toy-east-scaled",
+        )
+        for result in output["results"]:
+            self.assertEqual(result["feature_space"], output["feature_space"])
+            self.assertEqual(
+                result["feature_space_commitment"], expected_commitment
+            )
+
+    def test_cli_rejects_the_legacy_array_with_exit_two(self):
+        with tempfile.TemporaryDirectory() as directory:
+            legacy = pathlib.Path(directory) / "legacy.json"
+            legacy.write_text(json.dumps([record("legacy", [1, 0])]), encoding="utf-8")
+            completed = subprocess.run(
+                [
+                    sys.executable,
+                    str(ROOT / "directional_similar_runs.py"),
+                    "--dataset",
+                    str(legacy),
+                    "--query-run-id",
+                    "legacy",
+                ],
+                check=False,
+                capture_output=True,
+                text=True,
+            )
+        self.assertEqual(completed.returncode, 2)
+        self.assertIn("versioned dataset object", completed.stderr)
+
+    def test_cli_rejects_non_utf8_input_without_a_traceback(self):
+        with tempfile.TemporaryDirectory() as directory:
+            invalid = pathlib.Path(directory) / "invalid.json"
+            invalid.write_bytes(b"\xff\xfe")
+            completed = subprocess.run(
+                [
+                    sys.executable,
+                    str(ROOT / "directional_similar_runs.py"),
+                    "--dataset",
+                    str(invalid),
+                    "--query-run-id",
+                    "run",
+                ],
+                check=False,
+                capture_output=True,
+                text=True,
+            )
+        self.assertEqual(completed.returncode, 2)
+        self.assertIn("valid UTF-8 JSON", completed.stderr)
+        self.assertNotIn("Traceback", completed.stderr)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- replace the implicit bare-array input with a versioned feature-space schema that requires positive finite per-feature scales
- compute raw and scaled deltas explicitly, bind fingerprints and results to an exact domain-separated feature-space commitment, and reject derived overflow, underflow, and zero directions
- make indexed provenance deeply immutable, remove the legacy mutable helper surface, and return controlled CLI contract errors without tracebacks
- add the experimental Python suite to `make verify` and an independent Python 3.9 GitHub Actions job

## Why

PR #422 added the initial directional similar-run experiment, but its vectors implicitly treated every feature component as commensurate, nested provenance could still alias mutable caller state, and the experiment was not exercised by CI. That made rankings ambiguous across units and allowed post-index mutation to change observable state.

This follow-up establishes an explicit breaking v1 contract. It intentionally does not retain a legacy parser or compatibility shim.

## Breaking changes

- `--records` becomes `--dataset`
- bare run arrays are rejected
- every dataset must provide an exact ordered feature-space descriptor with scale and unit
- legacy public helper types and mutable accessors are removed

## Validation

- `make experimental-test` — 22 passed
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace` — 423 passed
- Workbench contract tests — 8 passed
- LingTai first-client tests — 6 passed
- `git diff --check`

The commit includes the required DCO `Signed-off-by` trailer.