### PR TITLE
feat(publication): operator reconciliation for quarantined publish operations

### DIFF
--- a/crates/nokv-meta/src/workspace/mod.rs
+++ b/crates/nokv-meta/src/workspace/mod.rs
@@ -99,10 +99,12 @@ pub use publication::{
     advance_manifest_rolling_digest, advance_staged_object_rolling_digest, dependency_owner_digest,
     manifest_rows_digest, seal_publish_operation, staged_object_ledger_digest, BeginPublishRequest,
     CleanupPublishBatchRequest, FinalizePublishOutcome, FinalizePublishRequest,
-    HeartbeatPublishRequest, ManifestRowInput, MarkObjectsUploadedBatchRequest, PublicationContext,
-    PublicationError, PublicationService, PublishCommandOutcome, PublishedArtifact,
-    StageManifestBatchRequest, StageObjectsBatchRequest, StagedObjectUpdate,
-    TakeOverOrphanedPublishRequest, TransitionPublishRequest, MAX_PUBLICATION_BATCH_ROWS,
+    FinishReconcileQuarantinedPublishRequest, HeartbeatPublishRequest, ManifestRowInput,
+    MarkObjectsUploadedBatchRequest, PublicationContext, PublicationError, PublicationService,
+    PublishCommandOutcome, PublishedArtifact, QuarantineReconcileResolution,
+    ReconcileQuarantinedPublishBatchRequest, StageManifestBatchRequest, StageObjectsBatchRequest,
+    StagedObjectUpdate, TakeOverOrphanedPublishRequest, TransitionPublishRequest,
+    MAX_PUBLICATION_BATCH_ROWS,
 };
 pub use publication_records::{
     ArtifactRevisionClaimRecord, ArtifactRevisionRecord, GcCandidateRecord, PathEntry,

--- a/crates/nokv-meta/src/workspace/publication.rs
+++ b/crates/nokv-meta/src/workspace/publication.rs
@@ -41,8 +41,9 @@ use super::publication_records::{
 };
 use super::publish_operation_records::{
     ArtifactManifestRow, ManifestPosition, PublishAuthority, PublishClaim, PublishOperationRecord,
-    PublishRecordError, PublishResult, PublishTerminalError, PublishTransition, StagedObjectRecord,
-    MAX_DEPENDENCY_COUNT, MAX_MANIFEST_ROWS, MAX_STAGED_OBJECTS,
+    PublishRecordError, PublishResult, PublishTerminalError, PublishTerminalErrorKind,
+    PublishTransition, StagedObjectRecord, MAX_DEPENDENCY_COUNT, MAX_MANIFEST_ROWS,
+    MAX_STAGED_OBJECTS,
 };
 use super::query_records::{
     secondary_index_key, ChangeEventKind, ChangeEventRecord, QueryRecordError,
@@ -160,6 +161,49 @@ pub struct CleanupPublishBatchRequest {
     /// Contiguous rows starting at `cleanup_staged_object_cursor`. Each next
     /// state is durable proof that provider cleanup completed.
     pub staged_object_updates: Vec<StagedObjectUpdate>,
+}
+
+/// Operator verdict about the provider-side state of one quarantined publish.
+///
+/// The operator verifies at the provider before calling; the metadata command
+/// enforces the machine-checkable half of each verdict atomically against the
+/// authoritative `ArtifactRevision` row so a wrong verdict fails loudly.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum QuarantineReconcileResolution {
+    /// Every staged provider key was verified absent and the artifact revision
+    /// was never published. Reconciliation releases the revision identity for
+    /// a fresh begin.
+    RevisionUnpublished,
+    /// The artifact revision is already published, so the staged provider
+    /// keys are the published revision's live objects and must not be touched.
+    /// Only this operation's private bookkeeping rows are removed.
+    RevisionPublished,
+}
+
+/// Bounded removal of one quarantined operation's durable staging rows.
+///
+/// The operation stays `Quarantined` while batches run, so an abandoned
+/// reconciliation keeps the fail-closed default and remains resumable.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ReconcileQuarantinedPublishBatchRequest {
+    pub context: PublicationContext,
+    pub expected_operation: PublishOperationRecord,
+    pub resolution: QuarantineReconcileResolution,
+    /// Exact durable staged rows starting at `cleanup_staged_object_cursor`.
+    /// Empty once the staged cursor is sealed and manifest pages remain.
+    pub staged_object_rows: Vec<StagedObjectRecord>,
+}
+
+/// Atomic operator resolution of one fully-swept quarantined operation.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct FinishReconcileQuarantinedPublishRequest {
+    pub context: PublicationContext,
+    pub expected_operation: PublishOperationRecord,
+    pub resolution: QuarantineReconcileResolution,
+    /// Operator-supplied audit reason retained in the terminal error.
+    pub reason: String,
+    /// Digest of the operator's provider verification transcript.
+    pub operator_evidence_digest: [u8; SHA256_BYTES],
 }
 
 /// Caller-visible metadata projected into both the revision and path records.
@@ -335,6 +379,13 @@ pub enum PublicationError {
     RevisionClaimHeld {
         revision: ArtifactRevisionId,
         operation_id: OperationId,
+    },
+    ReconcileResolutionMismatch {
+        resolution: QuarantineReconcileResolution,
+        revision_published: bool,
+    },
+    ReconcileManifestRowsRemain {
+        remaining: u32,
     },
     RevisionNotFound {
         revision: ArtifactRevisionId,
@@ -580,6 +631,20 @@ impl fmt::Display for PublicationError {
                 "artifact revision {:02x?} is claimed by in-flight publish operation {:02x?}",
                 revision.as_bytes(),
                 operation_id.as_bytes()
+            ),
+            Self::ReconcileResolutionMismatch {
+                resolution,
+                revision_published,
+            } => write!(
+                formatter,
+                "operator resolution {resolution:?} contradicts the authoritative revision state \
+                 (published: {revision_published})"
+            ),
+            Self::ReconcileManifestRowsRemain { remaining } => write!(
+                formatter,
+                "quarantined operation still owns {remaining} manifest rows under a published \
+                 revision; those rows are the published manifest and reconciliation refuses to \
+                 touch them"
             ),
             Self::RevisionNotFound { revision } => {
                 write!(
@@ -1225,6 +1290,44 @@ fn finalization_takeover_absence_proof(
     hasher.update(context.read_version.get().to_be_bytes());
     hash_bytes(&mut hasher, finalizing_payload)?;
     Ok(hasher.finalize().into())
+}
+
+fn reconcile_resolution_label(resolution: QuarantineReconcileResolution) -> &'static str {
+    match resolution {
+        QuarantineReconcileResolution::RevisionUnpublished => "revision-unpublished",
+        QuarantineReconcileResolution::RevisionPublished => "revision-published",
+    }
+}
+
+fn reconcile_terminal_message(resolution: QuarantineReconcileResolution, reason: &str) -> String {
+    format!(
+        "operator reconciliation ({}): {reason}",
+        reconcile_resolution_label(resolution)
+    )
+}
+
+/// Deterministic audit chain binding the operator verdict, the operator's
+/// provider verification transcript, and the original quarantine evidence.
+fn reconcile_evidence_digest(
+    resolution: QuarantineReconcileResolution,
+    original_evidence_digest: Option<[u8; SHA256_BYTES]>,
+    operator_evidence_digest: [u8; SHA256_BYTES],
+) -> [u8; SHA256_BYTES] {
+    let mut hasher = Sha256::new();
+    hasher.update(b"nokv.publish.reconcile-evidence.v1\0");
+    hasher.update([match resolution {
+        QuarantineReconcileResolution::RevisionUnpublished => 1,
+        QuarantineReconcileResolution::RevisionPublished => 2,
+    }]);
+    match original_evidence_digest {
+        None => hasher.update([0]),
+        Some(digest) => {
+            hasher.update([1]);
+            hasher.update(digest);
+        }
+    }
+    hasher.update(operator_evidence_digest);
+    hasher.finalize().into()
 }
 
 fn decode_operation_outcome(
@@ -2257,6 +2360,292 @@ impl PublicationService<'_> {
         decode_operation_outcome(result, next_operation.operation_id)
     }
 
+    /// Remove one bounded page of a quarantined operation's durable staging
+    /// rows under an explicit operator verdict. Staged-object rows are removed
+    /// first, exactly like aborted cleanup; manifest pages follow. The phase
+    /// stays `Quarantined` so an abandoned reconciliation remains fail-closed
+    /// and resumable, and every batch re-pins the verdict's revision predicate.
+    pub fn reconcile_quarantined_publish_batch(
+        &self,
+        request: ReconcileQuarantinedPublishBatchRequest,
+    ) -> Result<PublishCommandOutcome, PublicationError> {
+        validate_operation_seals(&request.expected_operation)?;
+        require_operation_phase(&request.expected_operation, PublishPhase::Quarantined)?;
+
+        let mut next_operation = request.expected_operation.clone();
+        let mut plan = CommandPlan::default();
+        self.predicate_reconcile_revision_state(
+            request.context,
+            &next_operation,
+            request.resolution,
+            &mut plan,
+        )?;
+        if next_operation.cleanup_staged_object_cursor < next_operation.staged_object_cursor {
+            validate_batch_size("reconcile staged objects", request.staged_object_rows.len())?;
+            let next_cursor = checked_batch_cursor(
+                "reconcile staged objects",
+                next_operation.cleanup_staged_object_cursor,
+                request.staged_object_rows.len(),
+                next_operation.staged_object_cursor,
+            )?;
+            for (offset, expected) in request.staged_object_rows.iter().enumerate() {
+                expected.validate()?;
+                let sequence = next_operation
+                    .cleanup_staged_object_cursor
+                    .checked_add(u32::try_from(offset).map_err(|_| {
+                        PublicationError::BatchTooLarge {
+                            batch: "reconcile staged objects",
+                            count: request.staged_object_rows.len(),
+                            max: MAX_PUBLICATION_BATCH_ROWS,
+                        }
+                    })?)
+                    .ok_or(PublicationError::BatchExceedsPlannedCount {
+                        batch: "reconcile staged objects",
+                        cursor: next_operation.cleanup_staged_object_cursor,
+                        count: request.staged_object_rows.len(),
+                        planned: next_operation.staged_object_cursor,
+                    })?;
+                if expected.object_sequence != sequence {
+                    return Err(PublicationError::StagedObjectSequenceMismatch {
+                        expected: sequence,
+                        actual: expected.object_sequence,
+                    });
+                }
+                if expected.artifact_revision_id != next_operation.artifact_revision_id {
+                    return Err(PublicationError::StagedObjectRevisionMismatch);
+                }
+                plan.delete(
+                    MetadataFamily::StagedObject,
+                    staged_object_key(
+                        request.context.root_id,
+                        next_operation.operation_id,
+                        u64::from(sequence),
+                    ),
+                    expected.encode()?,
+                )?;
+            }
+            next_operation.cleanup_staged_object_cursor = next_cursor;
+        } else {
+            if !request.staged_object_rows.is_empty() {
+                return Err(PublicationError::BatchExceedsPlannedCount {
+                    batch: "reconcile staged objects",
+                    cursor: next_operation.cleanup_staged_object_cursor,
+                    count: request.staged_object_rows.len(),
+                    planned: next_operation.staged_object_cursor,
+                });
+            }
+            let remaining = next_operation
+                .manifest_cursor
+                .checked_sub(next_operation.cleanup_manifest_cursor)
+                .expect("operation validation orders manifest cleanup cursors");
+            if remaining == 0 {
+                return Err(PublicationError::EmptyBatch {
+                    batch: "reconcile manifest",
+                });
+            }
+            // Under a published revision the manifest prefix holds the
+            // published revision's live manifest. This operation legally never
+            // retains un-swept manifest rows in that case, so a remainder
+            // means the invariant derivation is wrong somewhere: stop loudly
+            // instead of deleting published data.
+            if matches!(
+                request.resolution,
+                QuarantineReconcileResolution::RevisionPublished
+            ) {
+                return Err(PublicationError::ReconcileManifestRowsRemain { remaining });
+            }
+            let limit = usize::try_from(remaining)
+                .unwrap_or(usize::MAX)
+                .min(MAX_PUBLICATION_BATCH_ROWS);
+            let prefix = artifact_manifest_prefix(
+                request.context.root_id,
+                next_operation.artifact_revision_id,
+            );
+            let rows = self.store.scan_prefix_at(
+                request.context.root_id,
+                request.context.placement_generation,
+                request.context.owner_epoch,
+                MetadataFamily::ArtifactManifest,
+                &prefix,
+                request.context.read_version,
+                None,
+                limit,
+            )?;
+            if rows.is_empty() {
+                return Err(PublicationError::ManifestCountMismatch {
+                    expected: next_operation.manifest_cursor,
+                    actual: usize::try_from(next_operation.cleanup_manifest_cursor)
+                        .unwrap_or(usize::MAX),
+                });
+            }
+            for row in &rows {
+                plan.delete(
+                    MetadataFamily::ArtifactManifest,
+                    row.key.clone(),
+                    row.value.clone(),
+                )?;
+            }
+            next_operation.cleanup_manifest_cursor = next_operation
+                .cleanup_manifest_cursor
+                .checked_add(u32::try_from(rows.len()).map_err(|_| {
+                    PublicationError::BatchTooLarge {
+                        batch: "reconcile manifest",
+                        count: rows.len(),
+                        max: MAX_PUBLICATION_BATCH_ROWS,
+                    }
+                })?)
+                .ok_or(PublicationError::BatchExceedsPlannedCount {
+                    batch: "reconcile manifest",
+                    cursor: next_operation.cleanup_manifest_cursor,
+                    count: rows.len(),
+                    planned: next_operation.manifest_cursor,
+                })?;
+        }
+
+        let expected_payload = request.expected_operation.encode()?;
+        let next_payload = next_operation.encode()?;
+        plan.replace(
+            MetadataFamily::Operation,
+            operation_key(
+                request.context.root_id,
+                OperationKind::Publish,
+                next_operation.operation_id,
+            ),
+            expected_payload,
+            next_payload.clone(),
+        )?;
+        let result = self.execute_reconcile_plan(request.context, plan, next_payload)?;
+        decode_operation_outcome(result, next_operation.operation_id)
+    }
+
+    /// Atomically resolve one fully-swept quarantined operation: CAS the
+    /// operator terminal error in, transition `Quarantined -> Cleaned`, and
+    /// release the revision claim when this operation owns it. The verdict's
+    /// revision predicate is pinned by the same command.
+    pub fn finish_reconcile_quarantined_publish(
+        &self,
+        request: FinishReconcileQuarantinedPublishRequest,
+    ) -> Result<PublishCommandOutcome, PublicationError> {
+        validate_operation_seals(&request.expected_operation)?;
+        require_operation_phase(&request.expected_operation, PublishPhase::Quarantined)?;
+
+        let mut plan = CommandPlan::default();
+        self.predicate_reconcile_revision_state(
+            request.context,
+            &request.expected_operation,
+            request.resolution,
+            &mut plan,
+        )?;
+        let original_evidence_digest = request
+            .expected_operation
+            .terminal_error
+            .as_ref()
+            .and_then(|error| error.evidence_digest);
+        let terminal_error = PublishTerminalError {
+            kind: PublishTerminalErrorKind::OperatorReconciled,
+            message: reconcile_terminal_message(request.resolution, &request.reason),
+            evidence_digest: Some(reconcile_evidence_digest(
+                request.resolution,
+                original_evidence_digest,
+                request.operator_evidence_digest,
+            )),
+        };
+        let mut next_operation = request.expected_operation.clone();
+        next_operation.reconcile_quarantine(terminal_error)?;
+
+        let expected_payload = request.expected_operation.encode()?;
+        let next_payload = next_operation.encode()?;
+        plan.replace(
+            MetadataFamily::Operation,
+            operation_key(
+                request.context.root_id,
+                OperationKind::Publish,
+                next_operation.operation_id,
+            ),
+            expected_payload,
+            next_payload.clone(),
+        )?;
+        // Reconciliation is the operator path the quarantine fail-closed
+        // default was waiting for: with the staged liability durably resolved,
+        // the revision identity becomes claimable again in the same command.
+        self.release_revision_claim(
+            request.context,
+            request.expected_operation.artifact_revision_id,
+            request.expected_operation.operation_id,
+            &mut plan,
+        )?;
+        let result = self.execute_reconcile_plan(request.context, plan, next_payload)?;
+        decode_operation_outcome(result, next_operation.operation_id)
+    }
+
+    /// Pin the authoritative revision row to the operator's verdict, refusing
+    /// loudly on contradiction. The predicate makes the verdict atomic with
+    /// every reconciliation mutation.
+    fn predicate_reconcile_revision_state(
+        &self,
+        context: PublicationContext,
+        operation: &PublishOperationRecord,
+        resolution: QuarantineReconcileResolution,
+        plan: &mut CommandPlan,
+    ) -> Result<(), PublicationError> {
+        let revision_key = artifact_revision_key(context.root_id, operation.artifact_revision_id);
+        let payload =
+            self.read_payload(context, MetadataFamily::ArtifactRevision, &revision_key)?;
+        match (resolution, payload) {
+            (QuarantineReconcileResolution::RevisionUnpublished, None) => {
+                plan.assert_value(MetadataFamily::ArtifactRevision, revision_key, None)?;
+            }
+            (QuarantineReconcileResolution::RevisionPublished, Some(payload)) => {
+                plan.assert_value(
+                    MetadataFamily::ArtifactRevision,
+                    revision_key,
+                    Some(payload),
+                )?;
+            }
+            (resolution, payload) => {
+                return Err(PublicationError::ReconcileResolutionMismatch {
+                    resolution,
+                    revision_published: payload.is_some(),
+                });
+            }
+        }
+        Ok(())
+    }
+
+    /// Execute a reconciliation plan without publication-authority predicates.
+    ///
+    /// A quarantined operation's workspace incarnation, commit build, or
+    /// restore may be long retired, so `predicate_publication_authority` would
+    /// wrongly make such operations unresolvable. Operator reconciliation is
+    /// fenced by the exact operation-row CAS, the verdict's revision-row
+    /// predicate, and the active root fence instead.
+    fn execute_reconcile_plan(
+        &self,
+        context: PublicationContext,
+        plan: CommandPlan,
+        deterministic_result: Vec<u8>,
+    ) -> Result<MetadataCommandResult, PublicationError> {
+        plan.validate_bounds()?;
+        let command = MetadataCommand {
+            schema_id: SCHEMA_ID.to_owned(),
+            root_id: context.root_id,
+            logical_shard_id: context.logical_shard_id,
+            placement_generation: context.placement_generation,
+            owner_epoch: context.owner_epoch,
+            request_id: context.request_id,
+            command_digest: CommandDigest::from_bytes([0; SHA256_BYTES]),
+            read_version: context.read_version,
+            root_fence_action: RootFenceAction::RequireActive,
+            predicates: plan.predicates,
+            mutations: plan.mutations,
+            history_projection: plan.history,
+            event_projection: plan.events,
+            deterministic_result,
+        }
+        .seal();
+        self.store.execute(&command).map_err(Into::into)
+    }
+
     fn predicate_publication_authority(
         &self,
         context: PublicationContext,
@@ -2413,7 +2802,8 @@ impl PublicationService<'_> {
     /// left untouched because it guards that operation's own lifecycle. A
     /// quarantined operation deliberately keeps its claim: its provider-side
     /// object state is unresolved, so the revision identity stays fail-closed
-    /// until operator reconciliation (which must release the claim) exists.
+    /// until `finish_reconcile_quarantined_publish` releases it under an
+    /// operator verdict.
     fn release_revision_claim(
         &self,
         context: PublicationContext,
@@ -5943,6 +6333,554 @@ mod tests {
             )
             .unwrap()
             .is_some());
+    }
+
+    fn quarantine_after_abort(
+        service: &PublicationService<'_>,
+        store: &AgentMetadataStore,
+        counter: &mut u128,
+        operation: PublishOperationRecord,
+        evidence: &[u8],
+    ) -> PublishOperationRecord {
+        let aborting = service
+            .transition_publish(TransitionPublishRequest {
+                context: publication_context(store, counter),
+                expected_operation: operation,
+                transition: PublishTransition::BeginAbort {
+                    terminal_error: PublishTerminalError {
+                        kind: PublishTerminalErrorKind::AbortedByCaller,
+                        message: "caller cancelled".to_owned(),
+                        evidence_digest: None,
+                    },
+                },
+            })
+            .unwrap()
+            .operation;
+        let cleaning = service
+            .transition_publish(TransitionPublishRequest {
+                context: publication_context(store, counter),
+                expected_operation: aborting,
+                transition: PublishTransition::BeginCleaning,
+            })
+            .unwrap()
+            .operation;
+        service
+            .transition_publish(TransitionPublishRequest {
+                context: publication_context(store, counter),
+                expected_operation: cleaning,
+                transition: PublishTransition::Quarantine {
+                    terminal_error: PublishTerminalError {
+                        kind: PublishTerminalErrorKind::CleanupFailed,
+                        message: "provider cleanup outcome is ambiguous".to_owned(),
+                        evidence_digest: Some(Sha256::digest(evidence).into()),
+                    },
+                },
+            })
+            .unwrap()
+            .operation
+    }
+
+    fn put_operation_row_raw(
+        store: &AgentMetadataStore,
+        counter: &mut u128,
+        operation: &PublishOperationRecord,
+    ) {
+        let key = operation_key(root(), OperationKind::Publish, operation.operation_id);
+        store
+            .execute(
+                &MetadataCommand {
+                    schema_id: SCHEMA_ID.to_owned(),
+                    root_id: root(),
+                    logical_shard_id: shard(),
+                    placement_generation: placement(),
+                    owner_epoch: owner(),
+                    request_id: request(*counter),
+                    command_digest: CommandDigest::from_bytes([0; SHA256_BYTES]),
+                    read_version: store.current_read_version().unwrap(),
+                    root_fence_action: RootFenceAction::RequireActive,
+                    predicates: vec![CommandPredicate::Value {
+                        family: MetadataFamily::Operation,
+                        key: key.clone(),
+                        expected: None,
+                    }],
+                    mutations: vec![CommandMutation::Put {
+                        family: MetadataFamily::Operation,
+                        key,
+                        value: operation.encode().unwrap(),
+                    }],
+                    history_projection: Vec::new(),
+                    event_projection: Vec::new(),
+                    deterministic_result: Vec::new(),
+                }
+                .seal(),
+            )
+            .expect("raw operation write for invariant-violation simulation");
+        *counter += 1;
+    }
+
+    #[test]
+    fn operator_reconcile_resolves_quarantined_publish_and_releases_claim() {
+        // A quarantined operation keeps its revision claim fail-closed. The
+        // operator reconciliation surface must sweep the durable staging rows,
+        // transition Quarantined -> Cleaned with a durable operator audit
+        // trail, and release the claim so the revision id is usable again.
+        let mut counter = 1;
+        let store = ready_store(&mut counter);
+        let service = PublicationService::new(&store);
+        let revision_id = revision(930);
+        let staged = staged_rows(revision_id, 3);
+        let uploaded = uploaded_rows(&staged);
+        let manifest = manifest_rows(&staged);
+        let operation = publish_operation(
+            operation_id(930),
+            revision_id,
+            path("outputs/reconcile.bin"),
+            PublishClaim::CreateOnly,
+            &staged,
+            &manifest,
+        );
+        let operation = begin_operation(&service, &store, &mut counter, operation);
+        let operation = stage_all(
+            &service,
+            &store,
+            &mut counter,
+            operation,
+            &staged,
+            &manifest,
+        );
+        let operation = quarantine_after_abort(
+            &service,
+            &store,
+            &mut counter,
+            operation,
+            b"ambiguous provider delete",
+        );
+        assert_eq!(operation.phase, PublishPhase::Quarantined);
+        let original_evidence_digest = operation
+            .terminal_error
+            .as_ref()
+            .and_then(|error| error.evidence_digest)
+            .expect("quarantine retains evidence");
+
+        let blocked = publish_operation(
+            operation_id(931),
+            revision_id,
+            path("outputs/reconcile.bin"),
+            PublishClaim::CreateOnly,
+            &staged,
+            &manifest,
+        );
+        assert_eq!(
+            service.begin_publish(BeginPublishRequest {
+                context: publication_context(&store, &mut counter),
+                operation: blocked.clone(),
+            }),
+            Err(PublicationError::RevisionClaimHeld {
+                revision: revision_id,
+                operation_id: operation_id(930),
+            })
+        );
+
+        // Staged rows sweep first; the phase and the claim stay fail-closed
+        // between batches so an abandoned reconciliation changes nothing.
+        let operation = service
+            .reconcile_quarantined_publish_batch(ReconcileQuarantinedPublishBatchRequest {
+                context: publication_context(&store, &mut counter),
+                expected_operation: operation,
+                resolution: QuarantineReconcileResolution::RevisionUnpublished,
+                staged_object_rows: uploaded.clone(),
+            })
+            .unwrap()
+            .operation;
+        assert_eq!(operation.phase, PublishPhase::Quarantined);
+        assert_eq!(operation.cleanup_staged_object_cursor, 3);
+        assert!(read_revision_claim(&store, revision_id).is_some());
+
+        let operation = service
+            .reconcile_quarantined_publish_batch(ReconcileQuarantinedPublishBatchRequest {
+                context: publication_context(&store, &mut counter),
+                expected_operation: operation,
+                resolution: QuarantineReconcileResolution::RevisionUnpublished,
+                staged_object_rows: Vec::new(),
+            })
+            .unwrap()
+            .operation;
+        assert_eq!(operation.phase, PublishPhase::Quarantined);
+        assert_eq!(operation.cleanup_manifest_cursor, 3);
+
+        let finish_context = publication_context(&store, &mut counter);
+        let finished = service
+            .finish_reconcile_quarantined_publish(FinishReconcileQuarantinedPublishRequest {
+                context: finish_context,
+                expected_operation: operation.clone(),
+                resolution: QuarantineReconcileResolution::RevisionUnpublished,
+                reason: "verified every staged key absent at the provider".to_owned(),
+                operator_evidence_digest: [7; SHA256_BYTES],
+            })
+            .unwrap();
+        assert!(!finished.replayed);
+        let resolved = finished.operation;
+        assert_eq!(resolved.phase, PublishPhase::Cleaned);
+        let terminal = resolved
+            .terminal_error
+            .as_ref()
+            .expect("reconciled operation retains its terminal error");
+        assert_eq!(terminal.kind, PublishTerminalErrorKind::OperatorReconciled);
+        assert!(terminal
+            .message
+            .contains("verified every staged key absent at the provider"));
+        assert_eq!(
+            terminal.evidence_digest,
+            Some(reconcile_evidence_digest(
+                QuarantineReconcileResolution::RevisionUnpublished,
+                Some(original_evidence_digest),
+                [7; SHA256_BYTES],
+            ))
+        );
+        assert_eq!(
+            count_prefix(
+                &store,
+                MetadataFamily::StagedObject,
+                &staged_object_prefix(root(), resolved.operation_id),
+            ),
+            0
+        );
+        assert_eq!(
+            count_prefix(
+                &store,
+                MetadataFamily::ArtifactManifest,
+                &artifact_manifest_prefix(root(), revision_id),
+            ),
+            0
+        );
+        assert_eq!(read_revision_claim(&store, revision_id), None);
+
+        // An exact response-loss replay of the finish returns the stored
+        // resolution without re-running it.
+        let replayed = service
+            .finish_reconcile_quarantined_publish(FinishReconcileQuarantinedPublishRequest {
+                context: finish_context,
+                expected_operation: operation,
+                resolution: QuarantineReconcileResolution::RevisionUnpublished,
+                reason: "verified every staged key absent at the provider".to_owned(),
+                operator_evidence_digest: [7; SHA256_BYTES],
+            })
+            .unwrap();
+        assert!(replayed.replayed);
+        assert_eq!(replayed.operation, resolved);
+
+        // The revision identity is claimable again.
+        let begun = service
+            .begin_publish(BeginPublishRequest {
+                context: publication_context(&store, &mut counter),
+                operation: blocked,
+            })
+            .expect("revision claimable after operator reconciliation");
+        assert!(!begun.replayed);
+    }
+
+    #[test]
+    fn operator_reconcile_republished_revision_removes_bookkeeping_only() {
+        // Rolling-upgrade shape: a claimless legacy loser shares its revision
+        // id with a claimed winner that published. The loser's staged keys are
+        // the winner's live provider objects, so the revision-published
+        // verdict must delete only the loser's private bookkeeping rows and
+        // must refuse the contradictory verdict loudly.
+        let mut counter = 1;
+        let store = ready_store(&mut counter);
+        let service = PublicationService::new(&store);
+        let revision_id = revision(940);
+
+        let staged = staged_rows(revision_id, 2);
+        let manifest = manifest_rows(&staged);
+        let loser = publish_operation(
+            operation_id(940),
+            revision_id,
+            path("outputs/reconcile-legacy.bin"),
+            PublishClaim::CreateOnly,
+            &staged,
+            &manifest,
+        );
+        let loser = begin_operation(&service, &store, &mut counter, loser);
+        overwrite_revision_claim(&store, &mut counter, revision_id, None);
+        let loser = service
+            .stage_objects_batch(StageObjectsBatchRequest {
+                context: publication_context(&store, &mut counter),
+                expected_operation: loser,
+                staged_objects: staged.clone(),
+            })
+            .unwrap()
+            .operation;
+        let loser = quarantine_after_abort(
+            &service,
+            &store,
+            &mut counter,
+            loser,
+            b"aborted publish cleanup found its artifact revision published",
+        );
+
+        let published = publish_full(
+            &service,
+            &store,
+            &mut counter,
+            operation_id(941),
+            revision_id,
+            path("outputs/reconcile-winner.bin"),
+            PublishClaim::CreateOnly,
+            1,
+        );
+        assert_eq!(published.operation.phase, PublishPhase::Published);
+
+        // The absent-objects verdict contradicts the published revision row.
+        assert_eq!(
+            service.reconcile_quarantined_publish_batch(ReconcileQuarantinedPublishBatchRequest {
+                context: publication_context(&store, &mut counter),
+                expected_operation: loser.clone(),
+                resolution: QuarantineReconcileResolution::RevisionUnpublished,
+                staged_object_rows: staged.clone(),
+            }),
+            Err(PublicationError::ReconcileResolutionMismatch {
+                resolution: QuarantineReconcileResolution::RevisionUnpublished,
+                revision_published: true,
+            })
+        );
+
+        let loser = service
+            .reconcile_quarantined_publish_batch(ReconcileQuarantinedPublishBatchRequest {
+                context: publication_context(&store, &mut counter),
+                expected_operation: loser,
+                resolution: QuarantineReconcileResolution::RevisionPublished,
+                staged_object_rows: staged.clone(),
+            })
+            .unwrap()
+            .operation;
+        assert_eq!(loser.cleanup_staged_object_cursor, 2);
+        let resolved = service
+            .finish_reconcile_quarantined_publish(FinishReconcileQuarantinedPublishRequest {
+                context: publication_context(&store, &mut counter),
+                expected_operation: loser,
+                resolution: QuarantineReconcileResolution::RevisionPublished,
+                reason: "revision was published by operation 941".to_owned(),
+                operator_evidence_digest: [9; SHA256_BYTES],
+            })
+            .unwrap()
+            .operation;
+        assert_eq!(resolved.phase, PublishPhase::Cleaned);
+
+        // The winner's published revision, manifest, and claim state stay
+        // exactly as publication left them; only loser bookkeeping is gone.
+        let version = store.current_read_version().unwrap();
+        assert!(payload_at(
+            &store,
+            MetadataFamily::ArtifactRevision,
+            &artifact_revision_key(root(), revision_id),
+            version,
+        )
+        .is_some());
+        assert_eq!(
+            count_prefix(
+                &store,
+                MetadataFamily::ArtifactManifest,
+                &artifact_manifest_prefix(root(), revision_id),
+            ),
+            1
+        );
+        assert_eq!(
+            count_prefix(
+                &store,
+                MetadataFamily::StagedObject,
+                &staged_object_prefix(root(), resolved.operation_id),
+            ),
+            0
+        );
+        assert_eq!(read_revision_claim(&store, revision_id), None);
+    }
+
+    #[test]
+    fn operator_reconcile_enforces_quarantined_phase_and_sealed_cursors() {
+        let mut counter = 1;
+        let store = ready_store(&mut counter);
+        let service = PublicationService::new(&store);
+        let revision_id = revision(950);
+        let staged = staged_rows(revision_id, 1);
+        let uploaded = uploaded_rows(&staged);
+        let manifest = manifest_rows(&staged);
+        let operation = publish_operation(
+            operation_id(950),
+            revision_id,
+            path("outputs/reconcile-guard.bin"),
+            PublishClaim::CreateOnly,
+            &staged,
+            &manifest,
+        );
+        let operation = begin_operation(&service, &store, &mut counter, operation);
+        let operation = stage_all(
+            &service,
+            &store,
+            &mut counter,
+            operation,
+            &staged,
+            &manifest,
+        );
+        let aborting = service
+            .transition_publish(TransitionPublishRequest {
+                context: publication_context(&store, &mut counter),
+                expected_operation: operation,
+                transition: PublishTransition::BeginAbort {
+                    terminal_error: PublishTerminalError {
+                        kind: PublishTerminalErrorKind::AbortedByCaller,
+                        message: "caller cancelled".to_owned(),
+                        evidence_digest: None,
+                    },
+                },
+            })
+            .unwrap()
+            .operation;
+        let cleaning = service
+            .transition_publish(TransitionPublishRequest {
+                context: publication_context(&store, &mut counter),
+                expected_operation: aborting,
+                transition: PublishTransition::BeginCleaning,
+            })
+            .unwrap()
+            .operation;
+
+        // Reconciliation is quarantine-only: normal cleanup owns Cleaning.
+        assert_eq!(
+            service.reconcile_quarantined_publish_batch(ReconcileQuarantinedPublishBatchRequest {
+                context: publication_context(&store, &mut counter),
+                expected_operation: cleaning.clone(),
+                resolution: QuarantineReconcileResolution::RevisionUnpublished,
+                staged_object_rows: uploaded.clone(),
+            }),
+            Err(PublicationError::InvalidOperationPhase {
+                expected: PublishPhase::Quarantined,
+                actual: PublishPhase::Cleaning,
+            })
+        );
+
+        let quarantined = service
+            .transition_publish(TransitionPublishRequest {
+                context: publication_context(&store, &mut counter),
+                expected_operation: cleaning,
+                transition: PublishTransition::Quarantine {
+                    terminal_error: PublishTerminalError {
+                        kind: PublishTerminalErrorKind::CleanupFailed,
+                        message: "provider cleanup outcome is ambiguous".to_owned(),
+                        evidence_digest: Some(Sha256::digest(b"ambiguous").into()),
+                    },
+                },
+            })
+            .unwrap()
+            .operation;
+
+        // The published-revision verdict contradicts the absent revision row.
+        assert_eq!(
+            service.reconcile_quarantined_publish_batch(ReconcileQuarantinedPublishBatchRequest {
+                context: publication_context(&store, &mut counter),
+                expected_operation: quarantined.clone(),
+                resolution: QuarantineReconcileResolution::RevisionPublished,
+                staged_object_rows: uploaded.clone(),
+            }),
+            Err(PublicationError::ReconcileResolutionMismatch {
+                resolution: QuarantineReconcileResolution::RevisionPublished,
+                revision_published: false,
+            })
+        );
+
+        // Finishing before every durable staging row is removed refuses.
+        assert!(matches!(
+            service.finish_reconcile_quarantined_publish(
+                FinishReconcileQuarantinedPublishRequest {
+                    context: publication_context(&store, &mut counter),
+                    expected_operation: quarantined,
+                    resolution: QuarantineReconcileResolution::RevisionUnpublished,
+                    reason: "premature".to_owned(),
+                    operator_evidence_digest: [1; SHA256_BYTES],
+                }
+            ),
+            Err(PublicationError::OperationCodec(
+                PublishRecordError::InvalidPhasePayload { .. }
+            ))
+        ));
+    }
+
+    #[test]
+    fn operator_reconcile_refuses_manifest_rows_under_published_revision() {
+        // Legal flows never leave a quarantined operation with un-swept
+        // manifest rows once its revision is published: those rows ARE the
+        // published manifest. If that derivation is ever wrong, reconciliation
+        // must stop loudly instead of deleting published data.
+        let mut counter = 1;
+        let store = ready_store(&mut counter);
+        let service = PublicationService::new(&store);
+        let revision_id = revision(960);
+        let published = publish_full(
+            &service,
+            &store,
+            &mut counter,
+            operation_id(960),
+            revision_id,
+            path("outputs/reconcile-live.bin"),
+            PublishClaim::CreateOnly,
+            1,
+        );
+        assert_eq!(published.operation.phase, PublishPhase::Published);
+
+        let staged = staged_rows(revision_id, 1);
+        let manifest = manifest_rows(&staged);
+        let mut planted = publish_operation(
+            operation_id(961),
+            revision_id,
+            path("outputs/reconcile-planted.bin"),
+            PublishClaim::CreateOnly,
+            &staged,
+            &manifest,
+        );
+        planted.phase = PublishPhase::Quarantined;
+        planted.manifest_cursor = 1;
+        planted.manifest_rolling_digest = planted.manifest_seal;
+        planted.manifest_last_position = Some(ManifestPosition { object_index: 0 });
+        planted.terminal_error = Some(PublishTerminalError {
+            kind: PublishTerminalErrorKind::CleanupFailed,
+            message: "provider cleanup outcome is ambiguous".to_owned(),
+            evidence_digest: Some(Sha256::digest(b"planted").into()),
+        });
+        put_operation_row_raw(&store, &mut counter, &planted);
+
+        assert_eq!(
+            service.reconcile_quarantined_publish_batch(ReconcileQuarantinedPublishBatchRequest {
+                context: publication_context(&store, &mut counter),
+                expected_operation: planted.clone(),
+                resolution: QuarantineReconcileResolution::RevisionPublished,
+                staged_object_rows: Vec::new(),
+            }),
+            Err(PublicationError::ReconcileManifestRowsRemain { remaining: 1 })
+        );
+        assert!(matches!(
+            service.finish_reconcile_quarantined_publish(
+                FinishReconcileQuarantinedPublishRequest {
+                    context: publication_context(&store, &mut counter),
+                    expected_operation: planted,
+                    resolution: QuarantineReconcileResolution::RevisionPublished,
+                    reason: "planted invariant violation".to_owned(),
+                    operator_evidence_digest: [2; SHA256_BYTES],
+                }
+            ),
+            Err(PublicationError::OperationCodec(
+                PublishRecordError::InvalidPhasePayload { .. }
+            ))
+        ));
+
+        // The published revision's manifest survives untouched.
+        assert_eq!(
+            count_prefix(
+                &store,
+                MetadataFamily::ArtifactManifest,
+                &artifact_manifest_prefix(root(), revision_id),
+            ),
+            1
+        );
     }
 
     #[test]

--- a/crates/nokv-meta/src/workspace/publish_operation_records.rs
+++ b/crates/nokv-meta/src/workspace/publish_operation_records.rs
@@ -92,6 +92,9 @@ pub enum PublishTerminalErrorKind {
     CleanupFailed = 7,
     OwnerEpochSuperseded = 8,
     ActivityLeaseExpired = 9,
+    /// An operator verified provider-side object state for a quarantined
+    /// operation and resolved it through the reconciliation command.
+    OperatorReconciled = 10,
 }
 
 impl TryFrom<u8> for PublishTerminalErrorKind {
@@ -108,6 +111,7 @@ impl TryFrom<u8> for PublishTerminalErrorKind {
             7 => Ok(Self::CleanupFailed),
             8 => Ok(Self::OwnerEpochSuperseded),
             9 => Ok(Self::ActivityLeaseExpired),
+            10 => Ok(Self::OperatorReconciled),
             value => Err(PublishRecordError::UnknownDiscriminant {
                 type_name: "PublishTerminalErrorKind",
                 value,
@@ -967,6 +971,44 @@ impl PublishOperationRecord {
         let mut next = self.clone();
         next.phase = PublishPhase::Aborting;
         next.publication_absence_proof = Some(publication_absence_proof);
+        next.terminal_error = Some(terminal_error);
+        next.validate()?;
+        *self = next;
+        Ok(())
+    }
+
+    /// Applies the operator-owned `Quarantined -> Cleaned` reconciliation
+    /// edge. Every durable staging row must already be removed, and the new
+    /// terminal error must retain reconciliation evidence so the operator
+    /// override stays durably distinguishable from a normal cleanup finish.
+    pub(super) fn reconcile_quarantine(
+        &mut self,
+        terminal_error: PublishTerminalError,
+    ) -> Result<(), PublishRecordError> {
+        self.validate()?;
+        if self.phase != PublishPhase::Quarantined {
+            return Err(PublishRecordError::PhaseMismatch {
+                expected: PublishPhase::Quarantined,
+                actual: self.phase,
+            });
+        }
+        validate_terminal_error(&terminal_error)?;
+        if terminal_error.evidence_digest.is_none() {
+            return Err(PublishRecordError::InvalidPhasePayload {
+                phase: PublishPhase::Quarantined,
+                reason: "reconciliation requires operator evidence",
+            });
+        }
+        if self.cleanup_staged_object_cursor != self.staged_object_cursor
+            || self.cleanup_manifest_cursor != self.manifest_cursor
+        {
+            return Err(PublishRecordError::InvalidPhasePayload {
+                phase: PublishPhase::Quarantined,
+                reason: "all durable staging rows must be removed before reconciliation completes",
+            });
+        }
+        let mut next = self.clone();
+        next.phase = PublishPhase::Cleaned;
         next.terminal_error = Some(terminal_error);
         next.validate()?;
         *self = next;

--- a/crates/nokv-protocol/src/lib.rs
+++ b/crates/nokv-protocol/src/lib.rs
@@ -38,9 +38,10 @@ pub use request::{
     FindWorkspacesRequest, GetOperationRequest, GetPathRequest, GetSnapshotRequest,
     GetWorkspaceRequest, ListPathsRequest, ListSnapshotsRequest,
     MarkArtifactObjectsUploadedRequest, MintSnapshotRequest, ObjectUploadProof,
-    PrepareRestoreRequest, QueryOperand, QueryOperator, QueryPredicate, QueryScope,
-    RemovePathRequest, RenewSnapshotRequest, RestoreManifestDescriptor, RestoreSource,
-    RetireSnapshotRequest, SearchRequest, SortDirection, SortField, StageArtifactManifestRequest,
+    PrepareRestoreRequest, QuarantineResolution, QueryOperand, QueryOperator, QueryPredicate,
+    QueryScope, ReconcileQuarantinedArtifactPublishRequest, RemovePathRequest,
+    RenewSnapshotRequest, RestoreManifestDescriptor, RestoreSource, RetireSnapshotRequest,
+    SearchRequest, SortDirection, SortField, StageArtifactManifestRequest,
     StageArtifactObjectsRequest, WorkspacePreflightRequest, WorkspaceRequest, WorkspaceRpcRequest,
 };
 pub use response::{

--- a/crates/nokv-protocol/src/request.rs
+++ b/crates/nokv-protocol/src/request.rs
@@ -58,6 +58,7 @@ pub enum WorkspaceRequest {
     StageArtifactManifest(StageArtifactManifestRequest),
     CompleteArtifactPublish(CompleteArtifactPublishRequest),
     AbortArtifactPublish(AbortArtifactPublishRequest),
+    ReconcileQuarantinedArtifactPublish(ReconcileQuarantinedArtifactPublishRequest),
     Commit(CommitRequest),
     GetSnapshot(GetSnapshotRequest),
     MintSnapshot(MintSnapshotRequest),
@@ -89,6 +90,7 @@ impl WorkspaceRequest {
             Self::StageArtifactManifest(request) => request.validate(),
             Self::CompleteArtifactPublish(request) => request.validate(),
             Self::AbortArtifactPublish(request) => request.validate(),
+            Self::ReconcileQuarantinedArtifactPublish(request) => request.validate(),
             Self::Commit(request) => request.validate(),
             Self::GetSnapshot(request) => request.validate(),
             Self::MintSnapshot(request) => request.validate(),
@@ -526,6 +528,49 @@ pub struct AbortArtifactPublishRequest {
 impl AbortArtifactPublishRequest {
     fn validate(&self) -> Result<(), ProtocolError> {
         validate_required_text("abort_artifact_publish.reason", &self.reason, 1_024)
+    }
+}
+
+/// Operator verdict about provider-side object state for one quarantined
+/// artifact publication. The operator must verify at the provider before
+/// calling; the server atomically enforces the machine-checkable half of the
+/// verdict and refuses on contradiction.
+#[derive(Clone, Copy, Debug, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum QuarantineResolution {
+    /// Every staged provider key was verified absent and the artifact
+    /// revision was never published; the revision identity is released for a
+    /// fresh publication.
+    ProviderObjectsAbsent,
+    /// The artifact revision is already published; staged provider keys are
+    /// the published revision's live objects and only this operation's
+    /// private bookkeeping rows are removed.
+    RevisionPublished,
+}
+
+/// Operator reconciliation of one quarantined artifact publication.
+///
+/// The token must digest the exact quarantined operation state the operator
+/// inspected, so a concurrent change invalidates the verdict.
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct ReconcileQuarantinedArtifactPublishRequest {
+    pub token: OperationToken,
+    pub resolution: QuarantineResolution,
+    /// Audit reason durably retained in the resolved operation.
+    pub reason: String,
+    /// Digest of the operator's provider verification transcript, durably
+    /// bound into the resolved operation's evidence chain.
+    pub evidence_digest: Digest,
+}
+
+impl ReconcileQuarantinedArtifactPublishRequest {
+    fn validate(&self) -> Result<(), ProtocolError> {
+        validate_required_text(
+            "reconcile_quarantined_artifact_publish.reason",
+            &self.reason,
+            1_024,
+        )
     }
 }
 

--- a/crates/nokv-server/src/executor.rs
+++ b/crates/nokv-server/src/executor.rs
@@ -88,6 +88,9 @@ impl MetadataWorkspaceRequestExecutor {
             protocol::WorkspaceRequest::AbortArtifactPublish(abort) => {
                 self.abort_artifact_publish(request, abort)
             }
+            protocol::WorkspaceRequest::ReconcileQuarantinedArtifactPublish(reconcile) => {
+                self.reconcile_quarantined_artifact_publish(request, reconcile)
+            }
             protocol::WorkspaceRequest::Commit(commit) => self.commit(request, commit),
             protocol::WorkspaceRequest::GetSnapshot(get) => self.get_snapshot(request, get),
             protocol::WorkspaceRequest::MintSnapshot(mint) => self.mint_snapshot(request, mint),
@@ -1414,6 +1417,136 @@ impl MetadataWorkspaceRequestExecutor {
             })
             .map_err(publication_failure)?;
         publish_operation_response(outcome)
+    }
+
+    /// Operator reconciliation of one quarantined publication. The operator
+    /// verifies provider-side object state out-of-band and presents a verdict
+    /// bound to the exact quarantined operation payload through the token;
+    /// this adapter only drives the durable metadata sweep and resolution.
+    fn reconcile_quarantined_artifact_publish(
+        &self,
+        rpc: &protocol::WorkspaceRpcRequest,
+        request: &protocol::ReconcileQuarantinedArtifactPublishRequest,
+    ) -> Result<ExecutedRequest, protocol::RpcFailure> {
+        self.claim_mutation(rpc)?;
+        let finish_id = derived_request_id(rpc.request_id, b"publish-reconcile-finish", 0);
+        if let Some(outcome) = self.replayed_publish(rpc.route, finish_id)? {
+            return publish_operation_response(outcome);
+        }
+        let resolution = match request.resolution {
+            protocol::QuarantineResolution::ProviderObjectsAbsent => {
+                meta::QuarantineReconcileResolution::RevisionUnpublished
+            }
+            protocol::QuarantineResolution::RevisionPublished => {
+                meta::QuarantineReconcileResolution::RevisionPublished
+            }
+        };
+        let service = meta::PublicationService::new(&self.store);
+        let read_version = self.store.current_read_version().map_err(engine_failure)?;
+        let mut operation =
+            self.load_publish_operation(rpc.route, read_version, request.token.operation_id)?;
+        require_publish_token(&operation, request.token)?;
+        if operation.phase != types::PublishPhase::Quarantined {
+            return Err(conflict(
+                protocol::ConflictKind::OperationState,
+                "operation is not quarantined",
+                None,
+            ));
+        }
+
+        let mut batch: u64 = 0;
+        while operation.cleanup_staged_object_cursor < operation.staged_object_cursor
+            || operation.cleanup_manifest_cursor < operation.manifest_cursor
+        {
+            let before = (
+                operation.cleanup_staged_object_cursor,
+                operation.cleanup_manifest_cursor,
+            );
+            let step_id = derived_request_id(rpc.request_id, b"publish-reconcile-batch", batch);
+            operation = if let Some(replayed) = self.replayed_publish(rpc.route, step_id)? {
+                replayed.operation
+            } else {
+                let staged_object_rows = self.reconcile_staged_batch_rows(rpc.route, &operation)?;
+                service
+                    .reconcile_quarantined_publish_batch(
+                        meta::ReconcileQuarantinedPublishBatchRequest {
+                            context: self.publication_context(rpc.route, step_id)?,
+                            expected_operation: operation,
+                            resolution,
+                            staged_object_rows,
+                        },
+                    )
+                    .map_err(publication_failure)?
+                    .operation
+            };
+            if (
+                operation.cleanup_staged_object_cursor,
+                operation.cleanup_manifest_cursor,
+            ) == before
+            {
+                return Err(internal(
+                    "quarantine reconciliation made no durable progress",
+                ));
+            }
+            batch = batch
+                .checked_add(1)
+                .ok_or_else(|| internal("quarantine reconciliation batch counter overflow"))?;
+        }
+
+        let outcome = service
+            .finish_reconcile_quarantined_publish(meta::FinishReconcileQuarantinedPublishRequest {
+                context: self.publication_context(rpc.route, finish_id)?,
+                expected_operation: operation,
+                resolution,
+                reason: request.reason.clone(),
+                operator_evidence_digest: request.evidence_digest.0,
+            })
+            .map_err(publication_failure)?;
+        publish_operation_response(outcome)
+    }
+
+    /// Read the exact durable staged rows for the next reconciliation batch.
+    /// Empty once the staged cursor is sealed and only manifest pages remain.
+    fn reconcile_staged_batch_rows(
+        &self,
+        route: protocol::RootRoute,
+        operation: &meta::PublishOperationRecord,
+    ) -> Result<Vec<meta::StagedObjectRecord>, protocol::RpcFailure> {
+        let remaining = operation
+            .staged_object_cursor
+            .saturating_sub(operation.cleanup_staged_object_cursor);
+        if remaining == 0 {
+            return Ok(Vec::new());
+        }
+        let route = route_parts(route)?;
+        let read_version = self.store.current_read_version().map_err(engine_failure)?;
+        let count = usize::try_from(remaining)
+            .unwrap_or(usize::MAX)
+            .min(meta::MAX_PUBLICATION_BATCH_ROWS);
+        let mut rows = Vec::with_capacity(count);
+        for offset in 0..count {
+            let sequence = operation.cleanup_staged_object_cursor
+                + u32::try_from(offset).expect("bounded batch offset fits u32");
+            let key =
+                meta::staged_object_key(route.root_id, operation.operation_id, u64::from(sequence));
+            let payload = self
+                .store
+                .read_at(
+                    route.root_id,
+                    route.placement_generation,
+                    route.owner_epoch,
+                    meta::MetadataFamily::StagedObject,
+                    &key,
+                    read_version,
+                )
+                .map_err(engine_failure)?
+                .ok_or_else(|| internal(format!("durable staged object {sequence} is missing")))?;
+            rows.push(
+                meta::StagedObjectRecord::decode(&payload)
+                    .map_err(|error| internal(format!("invalid durable staged object: {error}")))?,
+            );
+        }
+        Ok(rows)
     }
 
     fn commit(
@@ -3541,6 +3674,13 @@ fn publication_failure(error: meta::PublicationError) -> protocol::RpcFailure {
             error.to_string(),
             None,
         ),
+        meta::PublicationError::ReconcileResolutionMismatch { .. }
+        | meta::PublicationError::ReconcileManifestRowsRemain { .. } => failure(
+            protocol::ErrorCode::PreconditionFailed,
+            error.to_string(),
+            false,
+            Some(protocol::ConflictKind::OperationState),
+        ),
         meta::PublicationError::OperationInputMismatch => failure(
             protocol::ErrorCode::RequestReplayMismatch,
             error.to_string(),
@@ -5269,6 +5409,314 @@ mod tests {
         let failure = executor.execute(&stale_catalog).unwrap_err();
         assert_eq!(failure.code, protocol::ErrorCode::PreconditionFailed);
         assert_eq!(failure.conflict, Some(protocol::ConflictKind::ReadVersion));
+    }
+
+    #[test]
+    fn reconcile_quarantined_publish_rpc_resolves_operation_and_frees_revision() {
+        let (store, executor) = ready_executor();
+        executor
+            .execute(&create_request(0x70, "reconcile-test", 0x71, 1))
+            .unwrap();
+        let operation_identity = protocol::OperationIdentity([0x72; types::FIXED_ID_BYTES]);
+        let revision_identity = protocol::ArtifactRevisionIdentity([0x73; types::FIXED_ID_BYTES]);
+        let revision_id: types::ArtifactRevisionId = revision_identity.into();
+        let object_key = meta::object_block_key(shard(), root(), revision_id, 0);
+        let body_digest =
+            protocol::sha256_digest_uri(protocol::Digest(Sha256::digest([0x61]).into()));
+        let staged_objects = vec![protocol::StagedObject {
+            sequence: 0,
+            object_identity: protocol::ObjectIdentity::new(object_key.clone()).unwrap(),
+            expected_length: 1,
+            expected_digest: body_digest.clone(),
+            multipart_token: None,
+        }];
+        let manifest_rows = vec![protocol::ArtifactManifestRow {
+            object_index: 0,
+            physical_object_index: 0,
+            logical_offset: 0,
+            physical_owner_revision_id: revision_identity,
+            object_identity: protocol::ObjectIdentity::new(object_key).unwrap(),
+            object_offset: 0,
+            length: 1,
+            digest: body_digest.clone(),
+            append_segment: None,
+        }];
+        let seals = protocol::seal_artifact_publish_plan(
+            revision_identity,
+            &staged_objects,
+            &manifest_rows,
+        )
+        .unwrap();
+        let rpc = |fill: u8, operation: protocol::WorkspaceRequest| protocol::WorkspaceRpcRequest {
+            route: route(1),
+            request_id: protocol::RequestIdentity([fill; types::FIXED_ID_BYTES]),
+            operation,
+        };
+        let operation_status = |result: ExecutedRequest| {
+            let protocol::WorkspaceResult::Operation(status) = result.result else {
+                panic!("publish request returned the wrong result variant");
+            };
+            status
+        };
+        let status = operation_status(
+            executor
+                .execute(&rpc(
+                    0x74,
+                    protocol::WorkspaceRequest::BeginArtifactPublish(
+                        protocol::BeginArtifactPublishRequest {
+                            operation_id: operation_identity,
+                            artifact_revision_id: revision_identity,
+                            target: protocol::WorkspacePath {
+                                workbench: protocol::WorkbenchName::new("reconcile-test").unwrap(),
+                                path: protocol::RelativePath::new("outputs/quarantine.bin")
+                                    .unwrap(),
+                            },
+                            authority: protocol::PublicationAuthority::Visible,
+                            condition: protocol::PublishCondition::CreateOnly,
+                            staged_object_count: seals.staged_object_count,
+                            staged_object_seal: seals.staged_object_seal,
+                            manifest_row_count: seals.manifest_row_count,
+                            manifest_seal: seals.manifest_seal,
+                            dependency_owner_revision_ids: Vec::new(),
+                        },
+                    ),
+                ))
+                .unwrap(),
+        );
+        let status = operation_status(
+            executor
+                .execute(&rpc(
+                    0x75,
+                    protocol::WorkspaceRequest::StageArtifactObjects(
+                        protocol::StageArtifactObjectsRequest {
+                            token: status.token,
+                            objects: staged_objects,
+                        },
+                    ),
+                ))
+                .unwrap(),
+        );
+        let status = operation_status(
+            executor
+                .execute(&rpc(
+                    0x76,
+                    protocol::WorkspaceRequest::MarkArtifactObjectsUploaded(
+                        protocol::MarkArtifactObjectsUploadedRequest {
+                            token: status.token,
+                            objects: vec![protocol::ObjectUploadProof {
+                                sequence: 0,
+                                observed_length: 1,
+                                observed_digest: body_digest,
+                            }],
+                        },
+                    ),
+                ))
+                .unwrap(),
+        );
+        let status = operation_status(
+            executor
+                .execute(&rpc(
+                    0x77,
+                    protocol::WorkspaceRequest::StageArtifactManifest(
+                        protocol::StageArtifactManifestRequest {
+                            token: status.token,
+                            rows: manifest_rows,
+                            dependency_owner_revision_ids: Vec::new(),
+                        },
+                    ),
+                ))
+                .unwrap(),
+        );
+        let aborting_status = operation_status(
+            executor
+                .execute(&rpc(
+                    0x78,
+                    protocol::WorkspaceRequest::AbortArtifactPublish(
+                        protocol::AbortArtifactPublishRequest {
+                            token: status.token,
+                            reason: "orchestrator cancelled the publication".to_owned(),
+                        },
+                    ),
+                ))
+                .unwrap(),
+        );
+        assert_eq!(aborting_status.state, protocol::OperationState::Aborting);
+
+        // Drive the durable state machine into Quarantined the way lifecycle
+        // cleanup does when the provider deletion outcome is ambiguous.
+        let service = meta::PublicationService::new(&store);
+        let meta_context = |fill: u8| meta::PublicationContext {
+            root_id: root(),
+            logical_shard_id: shard(),
+            placement_generation: placement(),
+            owner_epoch: owner(1),
+            request_id: request_id(fill),
+            read_version: store.current_read_version().unwrap(),
+        };
+        let load_operation = || {
+            let key = meta::operation_key(
+                root(),
+                types::OperationKind::Publish,
+                operation_identity.into(),
+            );
+            let payload = store
+                .read_at(
+                    root(),
+                    placement(),
+                    owner(1),
+                    meta::MetadataFamily::Operation,
+                    &key,
+                    store.current_read_version().unwrap(),
+                )
+                .unwrap()
+                .expect("publish operation row exists");
+            meta::PublishOperationRecord::decode(&payload).unwrap()
+        };
+        let cleaning = service
+            .transition_publish(meta::TransitionPublishRequest {
+                context: meta_context(0xA0),
+                expected_operation: load_operation(),
+                transition: meta::PublishTransition::BeginCleaning,
+            })
+            .unwrap()
+            .operation;
+        service
+            .transition_publish(meta::TransitionPublishRequest {
+                context: meta_context(0xA1),
+                expected_operation: cleaning,
+                transition: meta::PublishTransition::Quarantine {
+                    terminal_error: meta::PublishTerminalError {
+                        kind: meta::PublishTerminalErrorKind::CleanupFailed,
+                        message: "provider cleanup outcome is ambiguous".to_owned(),
+                        evidence_digest: Some(Sha256::digest(b"ambiguous delete").into()),
+                    },
+                },
+            })
+            .unwrap();
+        let claim_key = meta::artifact_revision_claim_key(root(), revision_id);
+        assert!(store
+            .read_at(
+                root(),
+                placement(),
+                owner(1),
+                meta::MetadataFamily::ArtifactRevision,
+                &claim_key,
+                store.current_read_version().unwrap(),
+            )
+            .unwrap()
+            .is_some());
+
+        // The verdict binds to the exact quarantined payload: a token that
+        // digests any earlier operation state is refused.
+        let stale = executor
+            .execute(&rpc(
+                0x79,
+                protocol::WorkspaceRequest::ReconcileQuarantinedArtifactPublish(
+                    protocol::ReconcileQuarantinedArtifactPublishRequest {
+                        token: aborting_status.token,
+                        resolution: protocol::QuarantineResolution::ProviderObjectsAbsent,
+                        reason: "stale operator view".to_owned(),
+                        evidence_digest: protocol::Digest([3; types::SHA256_BYTES]),
+                    },
+                ),
+            ))
+            .unwrap_err();
+        assert_eq!(stale.code, protocol::ErrorCode::Conflict);
+
+        let quarantined_status = operation_status(
+            executor
+                .execute(&rpc(
+                    0x7A,
+                    protocol::WorkspaceRequest::GetOperation(protocol::GetOperationRequest {
+                        operation_id: operation_identity,
+                    }),
+                ))
+                .unwrap(),
+        );
+        assert_eq!(
+            quarantined_status.state,
+            protocol::OperationState::Quarantined
+        );
+
+        let reconcile = rpc(
+            0x7B,
+            protocol::WorkspaceRequest::ReconcileQuarantinedArtifactPublish(
+                protocol::ReconcileQuarantinedArtifactPublishRequest {
+                    token: quarantined_status.token,
+                    resolution: protocol::QuarantineResolution::ProviderObjectsAbsent,
+                    reason: "verified every staged key absent at the provider".to_owned(),
+                    evidence_digest: protocol::Digest([7; types::SHA256_BYTES]),
+                },
+            ),
+        );
+        let resolved = executor.execute(&reconcile).unwrap();
+        assert!(!resolved.replayed);
+        let resolved_status = operation_status(resolved);
+        assert_eq!(resolved_status.state, protocol::OperationState::Failed);
+        let failure_body = resolved_status
+            .failure
+            .as_ref()
+            .expect("reconciled operation reports its terminal failure");
+        assert!(failure_body.message.contains("operator reconciliation"));
+
+        // The same command released the revision claim; the staged ledger and
+        // invisible manifest are durably gone.
+        assert!(store
+            .read_at(
+                root(),
+                placement(),
+                owner(1),
+                meta::MetadataFamily::ArtifactRevision,
+                &claim_key,
+                store.current_read_version().unwrap(),
+            )
+            .unwrap()
+            .is_none());
+        let resolved_operation = load_operation();
+        assert_eq!(resolved_operation.phase, types::PublishPhase::Cleaned);
+        assert_eq!(
+            resolved_operation
+                .terminal_error
+                .as_ref()
+                .expect("terminal error retained")
+                .kind,
+            meta::PublishTerminalErrorKind::OperatorReconciled
+        );
+
+        // An exact response-loss retry replays the stored resolution.
+        let replayed = executor.execute(&reconcile).unwrap();
+        assert!(replayed.replayed);
+        assert_eq!(operation_status(replayed).token, resolved_status.token);
+
+        // The revision identity is claimable again through the normal path.
+        let retry_status = operation_status(
+            executor
+                .execute(&rpc(
+                    0x7C,
+                    protocol::WorkspaceRequest::BeginArtifactPublish(
+                        protocol::BeginArtifactPublishRequest {
+                            operation_id: protocol::OperationIdentity(
+                                [0x7D; types::FIXED_ID_BYTES],
+                            ),
+                            artifact_revision_id: revision_identity,
+                            target: protocol::WorkspacePath {
+                                workbench: protocol::WorkbenchName::new("reconcile-test").unwrap(),
+                                path: protocol::RelativePath::new("outputs/quarantine-retry.bin")
+                                    .unwrap(),
+                            },
+                            authority: protocol::PublicationAuthority::Visible,
+                            condition: protocol::PublishCondition::CreateOnly,
+                            staged_object_count: seals.staged_object_count,
+                            staged_object_seal: seals.staged_object_seal,
+                            manifest_row_count: seals.manifest_row_count,
+                            manifest_seal: seals.manifest_seal,
+                            dependency_owner_revision_ids: Vec::new(),
+                        },
+                    ),
+                ))
+                .unwrap(),
+        );
+        assert_eq!(retry_status.state, protocol::OperationState::Running);
     }
 
     #[test]

--- a/docs/metadata-schema.md
+++ b/docs/metadata-schema.md
@@ -301,7 +301,9 @@ ArtifactRevisionClaim (reserved key inside the artifact_revision tree)
   deleted in the same command that publishes the revision or finishes the
   owning operation's cleanup. A quarantined operation keeps its claim
   fail-closed: its provider-side object state is unresolved, so the revision
-  identity stays unclaimable until operator reconciliation releases it.
+  identity stays unclaimable until `ReconcileQuarantinedArtifactPublish`
+  resolves the operation under an operator verdict and releases the claim in
+  the same command that transitions it to `Cleaned`.
   Exact revision keys are 32 bytes, so the 33-byte discriminated key can
   never collide with one.
 
@@ -614,7 +616,7 @@ The mutually exclusive operation transitions are:
 ```text
 Uploading -> Finalizing -> Published
 Uploading -> Aborting -> Cleaning -> Cleaned
-                                  -> Quarantined
+                                  -> Quarantined -> Cleaned # operator reconcile
 Finalizing -> Aborting # fenced proof of no path/dedupe publication
 ```
 
@@ -631,6 +633,20 @@ A late upload completion must observe the operation state; after abort it joins
 cleanup instead of publishing. Ambiguous multipart completion, late PUT, or
 DELETE remains ledger-owned and `Quarantined` until reconciled. Object listing
 is never used to discover staged ownership.
+
+Reconciliation is operator-driven, never scanner-driven. The operator verifies
+provider-side object state for the operation's staged keys out-of-band and
+presents one of two verdicts through
+`ReconcileQuarantinedArtifactPublish`: every staged key verified absent with
+the revision unpublished, or the revision already published by another
+operation (staged keys are then that revision's live objects and only the
+quarantined operation's private bookkeeping rows are removed). Each durable
+command pins the verdict against the authoritative `ArtifactRevision` row and
+refuses loudly on contradiction; the final command rewrites the terminal error
+to `OperatorReconciled` with an evidence chain binding the original quarantine
+evidence and the operator's verification transcript, transitions
+`Quarantined -> Cleaned`, and releases the revision claim when this operation
+owns it.
 
 The final metadata command creates the `ArtifactRevision` as `Available`, its
 manifest, the first path reference, `PathCurrent`, workspace revision, indexes,


### PR DESCRIPTION
## Problem

`PublishPhase::Quarantined` is a terminal dead end: `apply_transition` has no outgoing edge from it, the lifecycle scanner skips it (`_ => {}`), and no executor RPC can resolve it. Since the begin-time ArtifactRevisionClaim (#432), a quarantined operation additionally retains its revision claim forever, permanently blocking `begin_publish` for that revision id with `RevisionClaimHeld`. That retention is deliberately fail-closed (the operation's provider-side object state is unresolved), but it was waiting on an operator reconciliation path that did not exist. #432's commit message states this explicitly: "A quarantined operation keeps its claim fail-closed until operator reconciliation exists."

## What this adds

The operator surface, keeping the fail-closed default:

- **protocol**: `ReconcileQuarantinedArtifactPublish` carries an operation token digesting the exact quarantined payload the operator inspected (any concurrent change invalidates the verdict), a `QuarantineResolution` verdict (`provider_objects_absent` | `revision_published`), a bounded audit reason, and the digest of the operator's provider verification transcript.
- **meta**: `reconcile_quarantined_publish_batch` removes staged-object and invisible-manifest rows in bounded batches while the phase stays `Quarantined`, so an abandoned reconciliation changes nothing and resumes. `finish_reconcile_quarantined_publish` seals the sweep, rewrites the terminal error to the new `OperatorReconciled` kind with an evidence chain binding the original quarantine evidence and the operator transcript, transitions `Quarantined -> Cleaned`, and releases the revision claim iff this operation owns it (absent tolerated, foreign untouched, matching existing claim semantics).
- **server**: the executor drives the batch loop and finish under derived step request ids, so an exact retry replays every completed step and the final resolution deterministically.

## Fail-closed decisions

- Every command pins the verdict against the authoritative `ArtifactRevision` row: asserted absent for `provider_objects_absent`, asserted present (exact payload) for `revision_published`. A verdict contradicting authoritative state fails with `ReconcileResolutionMismatch` without mutating anything.
- Under a published revision, any un-swept manifest rows under the revision prefix ARE the published revision's live manifest. Legal flows cannot leave a quarantined loser owning such rows (derivation in the review notes); if that derivation is ever wrong, `ReconcileManifestRowsRemain` stops the sweep loudly instead of deleting published data. Covered by a test that plants the illegal state via a raw command.
- Reconciliation plans intentionally skip `predicate_publication_authority`: a quarantined operation's workspace incarnation, commit build, or restore may be long retired, which would make such operations unresolvable. The operation-row CAS, the verdict's revision predicate, and the active root fence fence the command instead.
- The lifecycle scanner still skips `Quarantined`: reconciliation stays operator-driven by design.

## Tests

- meta: end-to-end resolve (claim released, `begin_publish` for the same revision id succeeds again, finish replay returns the stored result), rolling-upgrade claimless-loser/published-winner scenario (winner's revision, manifest, and path state untouched; only loser bookkeeping removed), contradicted-verdict refusal in both directions, phase and sealed-cursor guards, planted invariant-violation proving the manifest-remainder guard fires.
- server: full RPC e2e (begin -> stage -> mark uploaded -> stage manifest -> abort -> quarantine -> stale-token refusal -> reconcile -> claim released -> verbatim retry replays -> fresh begin for the same revision succeeds).
- `cargo test`: nokv-meta 197/197, nokv-server 52/52, nokv-protocol 27/27; clippy clean; `cargo fmt --check` clean; workspace compiles with zero errors on top of current main (#432 + #433).