### PR TITLE
Bump holt to 0.8.3 for crash-safe checkpoint frame rewrites

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -474,7 +474,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -750,9 +750,9 @@ dependencies = [
 
 [[package]]
 name = "holt"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6b5cba76b2e775dd8022fde20007387cba13a1526744424db01a460ee43241f"
+checksum = "a77f93b53614145e41674fd56c1ae83a71253d65f09039a3b5b201f89f54b688"
 dependencies = [
  "crc32fast",
  "crossbeam-channel",
@@ -2191,7 +2191,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2248,7 +2248,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2506,7 +2506,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2595,7 +2595,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3118,7 +3118,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ nokv-server = { path = "crates/nokv-server", version = "0.1.0" }
 nokv = { path = "crates/nokv", version = "0.1.0" }
 nokv-python = { path = "crates/nokv-python", version = "0.1.0" }
 nokv-bench = { path = "bench", version = "0.1.0" }
-holt = { version = "=0.8.2", default-features = false }
+holt = { version = "=0.8.3", default-features = false }
 etcd-client = { version = "0.19.0", default-features = false }
 opendal = { version = "0.57.0", default-features = false, features = ["blocking", "executors-tokio", "reqwest-rustls-tls", "services-s3"] }
 rmp-serde = "1.3"

--- a/crates/nokv-meta/src/workspace/commit.rs
+++ b/crates/nokv-meta/src/workspace/commit.rs
@@ -3425,6 +3425,337 @@ mod tests {
         assert_eq!(complete.operation.phase, BuildCommitPhase::Complete);
     }
 
+    /// Power-loss torn-write probe for the file-backed metadata store.
+    ///
+    /// Crash model: the process dies while holt's checkpoint round is
+    /// `pwrite`ing 512 KiB blob frames into `blobs.dat`. A frame write is
+    /// not power-loss atomic — any subset of the in-flight bytes may
+    /// persist — so a slot the durable manifest still references must
+    /// never be modified before a manifest flush stops referencing it.
+    /// An in-place same-GUID rewrite (holt <= 0.8.2) violates this and
+    /// tears the only complete copy of the frame the sync-WAL redo needs
+    /// as its base image.
+    ///
+    /// The probe drives the real store through public commands, brackets
+    /// one checkpoint round with directory snapshots (`journal.wal`
+    /// truncating back to its header marks a completed, quiescent round),
+    /// and asserts the round never rewrote a slot whose GUID -> slot
+    /// mapping was durable both before and after it. If violated, it
+    /// reconstructs the torn crash image and reports what reopening it
+    /// does to acked metadata. It then verifies recovery tolerates torn
+    /// bytes in slots the crash-time manifest does not reference.
+    #[test]
+    fn file_store_checkpoint_never_rewrites_durable_slots_in_place() {
+        use std::path::Path;
+        use std::time::{Duration, Instant};
+
+        const SLOT_BYTES: usize = 0x80000;
+
+        fn snapshot_store_dir(src: &Path, dst: &Path) {
+            std::fs::create_dir_all(dst).unwrap();
+            for entry in std::fs::read_dir(src).unwrap() {
+                let entry = entry.unwrap();
+                if entry.file_name().to_string_lossy() == "store.lock" {
+                    continue;
+                }
+                let target = dst.join(entry.file_name());
+                if entry.path().is_dir() {
+                    snapshot_store_dir(&entry.path(), &target);
+                } else {
+                    std::fs::copy(entry.path(), &target).unwrap();
+                }
+            }
+        }
+
+        /// A checkpoint round ends by truncating `journal.wal` back to
+        /// its file header; once that happens nothing is dirty and the
+        /// store files are stable until the next command.
+        fn wait_for_wal_truncation(dir: &Path, header_len: u64) {
+            let wal = dir.join("journal.wal");
+            let deadline = Instant::now() + Duration::from_secs(30);
+            loop {
+                let len = std::fs::metadata(&wal).map(|m| m.len()).unwrap_or(u64::MAX);
+                if len <= header_len {
+                    return;
+                }
+                assert!(
+                    Instant::now() < deadline,
+                    "checkpoint round did not complete within 30s (wal at {len} bytes)",
+                );
+                std::thread::sleep(Duration::from_millis(20));
+            }
+        }
+
+        /// GUID -> slot map of a snapshot's durable manifest, decoded
+        /// from holt's `manifest.bin` (ARTSNMNF header + fixed records)
+        /// and `manifest.log` (MLG1 length-framed set/delete deltas).
+        /// Byte-level parsing keeps the probe independent of the store
+        /// implementation under test.
+        fn durable_manifest(dir: &Path) -> BTreeMap<[u8; 16], u64> {
+            let mut entries = BTreeMap::new();
+            if let Ok(buf) = std::fs::read(dir.join("manifest.bin")) {
+                assert!(buf.len() >= 24, "manifest.bin header");
+                assert_eq!(&buf[..8], b"ARTSNMNF", "manifest.bin magic");
+                let count = u32::from_le_bytes(buf[10..14].try_into().unwrap()) as usize;
+                let mut off = 24;
+                for _ in 0..count {
+                    let mut guid = [0u8; 16];
+                    guid.copy_from_slice(&buf[off..off + 16]);
+                    let slot = u64::from_le_bytes(buf[off + 16..off + 24].try_into().unwrap());
+                    entries.insert(guid, slot);
+                    off += 24;
+                }
+            }
+            if let Ok(buf) = std::fs::read(dir.join("manifest.log")) {
+                let mut off = 0usize;
+                while off + 9 <= buf.len() {
+                    let start = off;
+                    assert_eq!(&buf[start..start + 4], b"MLG1", "manifest.log magic");
+                    let body_len =
+                        u32::from_le_bytes(buf[start + 4..start + 8].try_into().unwrap()) as usize;
+                    let record_len = 9 + body_len + 4;
+                    if buf.len() - start < record_len {
+                        break; // torn tail is legal; replay stops here
+                    }
+                    let body = &buf[start + 9..start + 9 + body_len];
+                    match buf[start + 8] {
+                        1 => {
+                            let mut guid = [0u8; 16];
+                            guid.copy_from_slice(&body[..16]);
+                            let slot = u64::from_le_bytes(body[16..24].try_into().unwrap());
+                            entries.insert(guid, slot);
+                        }
+                        2 => {
+                            let mut guid = [0u8; 16];
+                            guid.copy_from_slice(body);
+                            entries.remove(&guid);
+                        }
+                        other => panic!("manifest.log unknown op {other}"),
+                    }
+                    off = start + record_len;
+                }
+            }
+            entries
+        }
+
+        fn changed_slots(a: &[u8], b: &[u8]) -> Vec<u64> {
+            let overlap = a.len().min(b.len()) / SLOT_BYTES;
+            (0..overlap)
+                .filter(|s| {
+                    a[s * SLOT_BYTES..(s + 1) * SLOT_BYTES]
+                        != b[s * SLOT_BYTES..(s + 1) * SLOT_BYTES]
+                })
+                .map(|s| s as u64)
+                .collect()
+        }
+
+        let directory = tempdir().unwrap();
+        let database = directory.path().join("torn-frame.holt");
+        let mut counter = 7_000_u128;
+
+        let store = AgentMetadataStore::create_file(&database, shard()).unwrap();
+        let wal_header_len = std::fs::metadata(database.join("journal.wal"))
+            .unwrap()
+            .len();
+        initialize(&store, &mut counter);
+        seed_paths(&store, &mut counter, 128);
+        wait_for_wal_truncation(&database, wal_header_len);
+        let pre = directory.path().join("pre");
+        snapshot_store_dir(&database, &pre);
+
+        // One acked command: fresh revisions and paths that insert into
+        // the already-checkpointed ART frames, forcing same-GUID frame
+        // rewrites in the next round. The sync-WAL ack makes every
+        // record recovery-mandatory before that round starts.
+        let mut phase2 = Vec::new();
+        for index in 500..536usize {
+            let revision_id = revision(20_000 + index as u128);
+            let path = NormalizedRelativePath::new(format!("data/{index:04}.bin")).unwrap();
+            phase2.push((
+                MetadataFamily::ArtifactRevision,
+                artifact_revision_key(root(), revision_id),
+                artifact(index).encode().unwrap(),
+            ));
+            phase2.push((
+                MetadataFamily::PathCurrent,
+                path_current_key(root(), incarnation(), &path),
+                path_entry(index, revision_id).encode().unwrap(),
+            ));
+        }
+        let phase2_paths: Vec<(Vec<u8>, Vec<u8>)> = phase2
+            .iter()
+            .filter(|(family, ..)| *family == MetadataFamily::PathCurrent)
+            .map(|(_, key, value)| (key.clone(), value.clone()))
+            .collect();
+        raw_put(&store, &mut counter, phase2);
+
+        // Crash-time image: acked WAL plus store files the interrupted
+        // round has not touched yet. The copy must win the race against
+        // the background planner's idle interval; the equality asserts
+        // verify it did, so a lost race fails loudly instead of lying.
+        let mid = directory.path().join("mid");
+        snapshot_store_dir(&database, &mid);
+        assert_eq!(
+            std::fs::read(pre.join("blobs.dat")).unwrap(),
+            std::fs::read(mid.join("blobs.dat")).unwrap(),
+            "mid snapshot raced the checkpoint round (blobs.dat moved)",
+        );
+        assert_eq!(
+            std::fs::read(pre.join("manifest.bin")).ok(),
+            std::fs::read(mid.join("manifest.bin")).ok(),
+            "mid snapshot raced the checkpoint round (manifest.bin moved)",
+        );
+        assert_eq!(
+            std::fs::read(pre.join("manifest.log")).ok(),
+            std::fs::read(mid.join("manifest.log")).ok(),
+            "mid snapshot raced the checkpoint round (manifest.log moved)",
+        );
+        assert!(
+            std::fs::metadata(mid.join("journal.wal")).unwrap().len() > wal_header_len,
+            "acked command must be in the crash-time WAL",
+        );
+
+        // Let the interrupted round complete so its writes are the
+        // donor bytes for the torn overlay.
+        wait_for_wal_truncation(&database, wal_header_len);
+        let post = directory.path().join("post");
+        snapshot_store_dir(&database, &post);
+        drop(store);
+
+        let mid_blobs = std::fs::read(mid.join("blobs.dat")).unwrap();
+        let post_blobs = std::fs::read(post.join("blobs.dat")).unwrap();
+        let changed = changed_slots(&mid_blobs, &post_blobs);
+        assert!(
+            !changed.is_empty(),
+            "the round must rewrite at least one pre-existing frame slot",
+        );
+        let mid_manifest = durable_manifest(&mid);
+        let post_manifest = durable_manifest(&post);
+
+        // A slot whose GUID -> slot mapping is durable on both sides of
+        // the round was referenced by the durable manifest at every
+        // moment of it (the workload dirties each frame once, so no
+        // free/reuse cycle can produce the same pair). Modifying its
+        // bytes is the torn-base-frame crash window.
+        let in_place: Vec<u64> = changed
+            .iter()
+            .copied()
+            .filter(|slot| {
+                mid_manifest
+                    .iter()
+                    .any(|(guid, s)| s == slot && post_manifest.get(guid) == Some(slot))
+            })
+            .collect();
+
+        if !in_place.is_empty() {
+            // Demonstrate the consequence before failing: reconstruct
+            // the crash image — acked WAL, pre-round manifest, and the
+            // in-flight frame pwrites persisted in alternating 4 KiB
+            // blocks (device-level reordering inside one frame) — and
+            // reopen. The interleave lands inside the frames' used
+            // bytes even when the payload is far smaller than a slot.
+            let torn = directory.path().join("torn-demo");
+            snapshot_store_dir(&mid, &torn);
+            let mut blobs = mid_blobs.clone();
+            for &slot in &in_place {
+                const BLOCK: usize = 4096;
+                let start = slot as usize * SLOT_BYTES;
+                for (i, off) in (start..start + SLOT_BYTES).step_by(BLOCK).enumerate() {
+                    if i % 2 == 0 {
+                        blobs[off..off + BLOCK].copy_from_slice(&post_blobs[off..off + BLOCK]);
+                    }
+                }
+            }
+            std::fs::write(torn.join("blobs.dat"), &blobs).unwrap();
+            let outcome = match AgentMetadataStore::reopen_file(&torn, shard()) {
+                Err(error) => format!("reopen failed: {error}"),
+                Ok(reopened) => {
+                    let version = reopened.current_read_version().unwrap();
+                    let mut lost = 0;
+                    for (key, value) in &phase2_paths {
+                        match reopened.read_at(
+                            root(),
+                            placement(),
+                            owner(),
+                            MetadataFamily::PathCurrent,
+                            key,
+                            version,
+                        ) {
+                            Ok(Some(got)) if &got == value => {}
+                            other => {
+                                lost += 1;
+                                let _ = other;
+                            }
+                        }
+                    }
+                    format!(
+                        "reopen succeeded but {lost}/{} acked records lost",
+                        phase2_paths.len()
+                    )
+                }
+            };
+            panic!(
+                "checkpoint rewrote durable manifest slots {in_place:?} in place; \
+                 a power cut during those pwrites tears the WAL's only base image. \
+                 Torn-crash reopen outcome: {outcome}",
+            );
+        }
+
+        // Recovery leg: the round confined its writes to slots the
+        // crash-time manifest does not reference, so tearing all of
+        // them — half-frame prefix and 4 KiB interleave — must leave
+        // every acked record readable after reopen.
+        let torn_slots: Vec<u64> = changed
+            .iter()
+            .copied()
+            .filter(|slot| !mid_manifest.values().any(|s| s == slot))
+            .collect();
+        assert!(
+            !torn_slots.is_empty(),
+            "shadow rewrites must land in slots the crash-time manifest does not reference",
+        );
+        for (label, half) in [("new-prefix", true), ("interleave-4k", false)] {
+            let torn = directory.path().join(format!("torn-{label}"));
+            snapshot_store_dir(&mid, &torn);
+            let mut blobs = mid_blobs.clone();
+            for &slot in &torn_slots {
+                let start = slot as usize * SLOT_BYTES;
+                if half {
+                    let split = start + SLOT_BYTES / 2;
+                    blobs[start..split].copy_from_slice(&post_blobs[start..split]);
+                } else {
+                    const BLOCK: usize = 4096;
+                    for (i, off) in (start..start + SLOT_BYTES).step_by(BLOCK).enumerate() {
+                        if i % 2 == 0 {
+                            blobs[off..off + BLOCK].copy_from_slice(&post_blobs[off..off + BLOCK]);
+                        }
+                    }
+                }
+            }
+            std::fs::write(torn.join("blobs.dat"), &blobs).unwrap();
+
+            let reopened = AgentMetadataStore::reopen_file(&torn, shard())
+                .unwrap_or_else(|error| {
+                    panic!("reopen with torn unreferenced slots {torn_slots:?} ({label}) failed: {error}")
+                });
+            let version = reopened.current_read_version().unwrap();
+            for (key, value) in &phase2_paths {
+                let got = reopened
+                    .read_at(
+                        root(),
+                        placement(),
+                        owner(),
+                        MetadataFamily::PathCurrent,
+                        key,
+                        version,
+                    )
+                    .unwrap_or_else(|error| panic!("acked record unreadable ({label}): {error}"))
+                    .unwrap_or_else(|| panic!("acked record lost ({label})"));
+                assert_eq!(&got, value, "acked record corrupted ({label})");
+            }
+        }
+    }
+
     #[test]
     fn prepare_only_reopen_reuses_first_commit_time_after_later_proposal() {
         let directory = tempdir().unwrap();


### PR DESCRIPTION
## Summary

holt 0.8.2 rewrites a same-GUID blob **in place** over the slot its durable manifest still references. A 512 KiB frame `pwrite` is not power-loss atomic, so a crash during a checkpoint round can tear the only complete copy of the frame the sync WAL needs as its redo base. Reconstructing that crash image against our pinned 0.8.2 makes `AgentMetadataStore::reopen_file` fail with `node corrupt at walker: body resolution failed` — every acked metadata record behind it becomes unreachable. Any file-mode deployment was exposed to this on power loss.

- **`test(meta)`: torn-checkpoint-frame probe** — drives the real file store through public commands, brackets one background checkpoint round with directory snapshots (`journal.wal` truncation marks a quiescent round), asserts no slot with a stable durable GUID→slot mapping is rewritten in place, and verifies recovery tolerates torn bytes in unreferenced slots. Red on 0.8.2 (in-place slots `[1, 5, 6, 22, 26]`, torn reopen fails); green on 0.8.3.
- **`fix(deps)`: pin `=0.8.2` → `=0.8.3`** — [holt 0.8.3](https://github.com/NoKV-Lab/holt/pull/41) shadow-writes every rewrite to a fresh slot and recycles the old one only after the manifest delta is durable and in-flight readers have drained.

## Test plan

- [x] probe red on holt 0.8.2, green on 0.8.3
- [x] `cargo test -p nokv-meta` — 194 passed
- [x] `cargo check --workspace` clean on 0.8.3

🤖 Generated with [Claude Code](https://claude.com/claude-code)