### PR TITLE
chore(deps): bump holt to 0.8.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -750,9 +750,9 @@ dependencies = [
 
 [[package]]
 name = "holt"
-version = "0.8.3"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a77f93b53614145e41674fd56c1ae83a71253d65f09039a3b5b201f89f54b688"
+checksum = "c0e62dad7ce341d1e1995cc0034cb347d0e562e444b2354f8418410e2ba770e4"
 dependencies = [
  "crc32fast",
  "crossbeam-channel",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ nokv-server = { path = "crates/nokv-server", version = "0.1.0" }
 nokv = { path = "crates/nokv", version = "0.1.0" }
 nokv-python = { path = "crates/nokv-python", version = "0.1.0" }
 nokv-bench = { path = "bench", version = "0.1.0" }
-holt = { version = "=0.8.3", default-features = false }
+holt = { version = "=0.8.4", default-features = false }
 etcd-client = { version = "0.19.0", default-features = false }
 opendal = { version = "0.57.0", default-features = false, features = ["blocking", "executors-tokio", "reqwest-rustls-tls", "services-s3"] }
 rmp-serde = "1.3"


### PR DESCRIPTION
## Summary

Routine upgrade `=0.8.3` → `=0.8.4`. Picks up two additions from [holt 0.8.4](https://github.com/NoKV-Lab/holt/blob/main/CHANGELOG.md):

- read-only `assert_absent` batch guard (no marker, no WAL op, no record version)
- `Tree::atomic` / `DB::atomic` reject oversized WAL records before reserving record versions or applying walker mutations

## Test plan

- [x] torn-checkpoint-frame guard probe green on 0.8.4
- [x] `cargo test -p nokv-meta` — 198 passed
- [x] `cargo check --workspace` clean
- [x] commit carries DCO sign-off
- [ ] full CI green before merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)