### PR TITLE
refactor(workbench) standardize the Workbench module layout

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -13,20 +13,20 @@ permissions:
   contents: read
 
 jobs:
-  lingtai-first-client:
+  workbench-contract:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
 
-      - name: Check Workbench and LingTai first-client contracts
+      - name: Check Workbench contract and live workflow
         run: |
           set -euo pipefail
           python3 -m py_compile \
-            scripts/lingtai-workbench/workbench_contract.py \
-            scripts/lingtai-workbench/live_first_client.py
-          python3 scripts/lingtai-workbench/workbench_contract_test.py
-          python3 scripts/lingtai-workbench/live_first_client_test.py
-          bash -n scripts/lingtai-workbench/start_rustfs.sh
+            scripts/workbench/workbench_contract.py \
+            scripts/workbench/live_workbench.py
+          python3 scripts/workbench/workbench_contract_test.py
+          python3 scripts/workbench/live_workbench_test.py
+          bash -n scripts/workbench/start_rustfs.sh
 
   nokv-workspace:
     runs-on: ubuntu-latest

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -93,7 +93,7 @@ Run the repository contract gates before opening a PR:
 cargo fmt --all -- --check
 cargo clippy --workspace --all-targets -- -D warnings
 cargo test --workspace
-python3 scripts/lingtai-workbench/workbench_contract_test.py
+python3 scripts/workbench/workbench_contract_test.py
 git diff --check
 ```
 

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ help:
 	@echo "  make test        - Run the Rust workspace tests"
 	@echo "  make fmt         - Format the Rust workspace"
 	@echo "  make lint        - Run cargo clippy"
-	@echo "  make workbench-test - Run Workbench contract and LingTai first-client tests"
+	@echo "  make workbench-test - Run Workbench contract and live workflow tests"
 	@echo "  make verify      - Run Rust and Workbench validation"
 	@echo "  make clean       - Remove build artifacts"
 
@@ -32,8 +32,8 @@ lint:
 	cargo clippy --manifest-path $(NOKV_MANIFEST) -p nokv-meta -p nokv-bench --all-targets --features metadata-read-stats -- -D warnings
 
 workbench-test:
-	python3 scripts/lingtai-workbench/workbench_contract_test.py
-	python3 scripts/lingtai-workbench/live_first_client_test.py
+	python3 scripts/workbench/workbench_contract_test.py
+	python3 scripts/workbench/live_workbench_test.py
 
 verify:
 	cargo fmt --manifest-path $(NOKV_MANIFEST) --all -- --check
@@ -42,8 +42,8 @@ verify:
 	cargo test --manifest-path $(NOKV_MANIFEST) --workspace
 	cargo test --manifest-path $(NOKV_MANIFEST) -p nokv-meta --features metadata-read-stats
 	cargo test --manifest-path $(NOKV_MANIFEST) -p nokv-bench --features metadata-read-stats
-	python3 scripts/lingtai-workbench/workbench_contract_test.py
-	python3 scripts/lingtai-workbench/live_first_client_test.py
+	python3 scripts/workbench/workbench_contract_test.py
+	python3 scripts/workbench/live_workbench_test.py
 	git diff --check
 
 clean:

--- a/README.md
+++ b/README.md
@@ -215,10 +215,11 @@ adapter concern and does not dictate durable metadata families.
 
 See the [Workbench Contract](docs/workbench-contract.md).
 
-## First Client
+## Integration Model
 
-LingTai is the active design partner and first Workbench client. Its scientific
-reconstruction workflow exercises the product boundary end to end:
+The Workbench contract is runtime-neutral. Any MCP-compatible Agent runtime can
+exercise the product boundary end to end through the same scientific
+reconstruction workflow:
 
 ```text
 upload dataset
@@ -233,21 +234,24 @@ upload dataset
 Materialization creates a disposable local sandbox. It is not a NoKV namespace
 or a transparent host-filesystem access path.
 
+LingTai is the active design partner and first integrated client, but it uses
+this same public boundary rather than a partner-specific NoKV route.
+
 ## Use Case: A Research Workbench for Agents
 
-LingTai mounts NoKV as the durable artifact store behind its research agents.
-The runtime keeps agent state — locks, heartbeats, mailboxes, event logs — in
-a disposable local workdir; what a task produces and needs to prove crosses
+An Agent runtime uses NoKV as the durable artifact store behind its research
+agents. Runtime state — locks, heartbeats, mailboxes, and event logs — can stay
+in a disposable local workdir; what a task produces and needs to prove crosses
 into a Workbench.
 
 One MCP registry entry is the whole integration. Each agent spawns the `nokv`
 binary as a stdio MCP server:
 
 ```text
-nokv ... mcp --profile workbench --workbench-root /agents/{agent_id}/wb
+nokv ... --workbench-root /agents/{agent_id}/wb mcp
 ```
 
-LingTai expands `{agent_id}` per agent, so a single registry template gives
+The runtime expands `{agent_id}` per agent, so a single registry template gives
 every agent its own path-scoped Workbench root, and the 18 `workbench_*`
 tools land next to the agent's local file tools instead of replacing them.
 There is no client library and no NoKV-specific client code beyond that
@@ -295,12 +299,12 @@ cargo build --release -p nokv --bin nokv
 Run the offline Workbench contract gate:
 
 ```bash
-python3 scripts/lingtai-workbench/workbench_contract_test.py
+python3 scripts/workbench/workbench_contract_test.py
 ```
 
 A live deployment additionally needs a root id, persisted logical-shard
 placement, one admitted shard owner, and S3-compatible object coordinates. The
-[LingTai setup and preflight guide](docs/lingtai-workbench-preflight.md) gives
+[Workbench deployment preflight](docs/workbench-preflight.md) gives
 the complete provision, serve, MCP, materialize, collect, and acceptance flow
 without hiding the current recovery limitations.
 
@@ -318,7 +322,7 @@ without hiding the current recovery limitations.
 - [Agent Contributor Handbook](docs/development/nokv-agent.md)
 - [Code Contract](docs/development/code_contract.md)
 - [PR Review Checklist](docs/development/pr_review_checklist.md)
-- [LingTai Workbench Setup](docs/lingtai-workbench-preflight.md)
+- [Workbench Deployment Preflight](docs/workbench-preflight.md)
 
 ## Contributing
 
@@ -336,7 +340,7 @@ Before pushing a substantial change, run:
 cargo fmt --all -- --check
 cargo clippy --workspace --all-targets -- -D warnings
 cargo test --workspace
-python3 scripts/lingtai-workbench/workbench_contract_test.py
+python3 scripts/workbench/workbench_contract_test.py
 git diff --check
 ```
 

--- a/bench/workbench-live/README.md
+++ b/bench/workbench-live/README.md
@@ -3,13 +3,13 @@ Copyright 2024-2026 The NoKV Authors.
 SPDX-License-Identifier: Apache-2.0
 -->
 
-# LingTai first-client evidence
+# Live Workbench evidence
 
 The executable product-boundary workload lives at
-`scripts/lingtai-workbench/live_first_client.py`. It exercises the flat `nokv`
+`scripts/workbench/live_workbench.py`. It exercises the flat `nokv`
 CLI and MCP adapter against real root routing, Holt metadata ownership, and an
 S3-compatible object provider. Its deterministic runtime evidence directory is
-under `target/lingtai-workbench/evidence/` by default; evidence is not checked
+under `target/workbench-live/evidence/` by default; evidence is not checked
 into this source directory.
 
 This is a correctness and interoperability workload, not a performance result.
@@ -17,5 +17,5 @@ It records all 18 tool inputs and exact responses, one deliberate create-only
 error, commit replay, frozen reads, restore projections, and the explicit
 materialize/collect boundary. Missing external services are `NOT QUALIFIED`.
 
-See `scripts/lingtai-workbench/README.md` for commands and
+See `scripts/workbench/README.md` for commands and
 `docs/development/workspace-acceptance.md` for the qualification boundary.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -11,7 +11,7 @@ Status: normative workspace architecture.
 
 ```mermaid
 flowchart LR
-    Workbench["LingTai Workbench adapter"] --> SDK["Agent SDK"]
+    Workbench["Workbench adapter"] --> SDK["Agent SDK"]
     CLI["Custom CLI / MCP"] --> SDK
     Python["Python SDK"] --> SDK
     Local["Materialize / collect"] --> Python
@@ -326,6 +326,6 @@ experiments. The required evidence covers:
 3. protocol, server, SDK, CLI, MCP, control routing, and lifecycle workers on
    the same schema and identity model;
 4. owner failover, checkpoint/log recovery, ambiguous provider outcomes, and
-   first-client workflows;
+   live Workbench workflows;
 5. the complete [acceptance plan](./development/workspace-acceptance.md),
    with each applicable gate reported as `PASS`, `FAIL`, or `NOT QUALIFIED`.

--- a/docs/development/code_contract.md
+++ b/docs/development/code_contract.md
@@ -143,7 +143,7 @@ git diff --check
 For Workbench-facing changes also run:
 
 ```bash
-python3 scripts/lingtai-workbench/workbench_contract_test.py
+python3 scripts/workbench/workbench_contract_test.py
 ```
 
 When a checked-in documentation build exists, run it for documentation or

--- a/docs/development/nokv-agent.md
+++ b/docs/development/nokv-agent.md
@@ -129,7 +129,7 @@ Run:
 
 ```bash
 cargo test -p nokv-agent
-python3 scripts/lingtai-workbench/workbench_contract_test.py
+python3 scripts/workbench/workbench_contract_test.py
 ```
 
 Schema-only success is not complete conformance. Product qualification follows

--- a/docs/development/path-native-metadata-comparison.md
+++ b/docs/development/path-native-metadata-comparison.md
@@ -170,5 +170,5 @@ runner and its implementation-invariant tests remain byte-identical; both
 patches are bound by the harness digest. Published comparisons must retain raw
 old/new reports from matched release builds and profiles. Even then, this
 metadata-domain diagnostic does not qualify Workspace Acceptance Gate 8.
-`bench/lingtai-first-client` remains correctness and interoperability evidence
+`bench/workbench-live` remains correctness and interoperability evidence
 rather than a performance result.

--- a/docs/development/pr_review_checklist.md
+++ b/docs/development/pr_review_checklist.md
@@ -159,6 +159,6 @@ boundaries, or Workbench behavior.
 cargo fmt --all -- --check
 cargo clippy --workspace --all-targets -- -D warnings
 cargo test --workspace
-python3 scripts/lingtai-workbench/workbench_contract_test.py
+python3 scripts/workbench/workbench_contract_test.py
 git diff --check
 ```

--- a/docs/development/workspace-acceptance.md
+++ b/docs/development/workspace-acceptance.md
@@ -39,12 +39,12 @@ Performance records additionally retain warm/cold state, object and metadata
 payload distributions, concurrency, duration, retries, error counts,
 throughput, and p50/p95/p99/maximum latency.
 
-## Gate 0: First Client And Workbench Contract
+## Gate 0: Workbench Contract And Live Workflow
 
-The LingTai integration and scientific reconstruction workflow must exercise
-the complete 18-tool Workbench surface through the real adapter boundary.
+The scientific reconstruction workflow must exercise the complete 18-tool
+Workbench surface through the real adapter boundary.
 The black-box runner is
-[`scripts/lingtai-workbench/live_first_client.py`](../../scripts/lingtai-workbench/live_first_client.py).
+[`scripts/workbench/live_workbench.py`](../../scripts/workbench/live_workbench.py).
 Its dry-run proves only command construction and tool coverage. A live run
 retains exact MCP and process evidence; absent etcd, S3-compatible storage, or
 the requested binary is `NOT QUALIFIED`, never `PASS`.
@@ -63,7 +63,7 @@ Required evidence:
 - stable `metadata/run_manifest.json` and
   `metadata/restore_manifest.json` projections.
 
-The bounded first-client runner uses a minimum one-day snapshot lease. Even
+The bounded live Workbench runner uses a minimum one-day snapshot lease. Even
 when its 18-tool workflow passes, Gate 0 remains `NOT QUALIFIED` until separate
 retained evidence observes expiry and the terminal `reaped` state.
 
@@ -235,7 +235,7 @@ A release is qualified only when:
 3. the package and dependency graph contains one authoritative implementation;
 4. operator documentation names the exact schema, placement, object backend,
    backup, restore, fsck, and evidence-retention procedures;
-5. the first-client golden workflow passes against the release artifacts.
+5. the live Workbench golden workflow passes against the release artifacts.
 
 The decision record links raw evidence. Design documents, source presence, and
 unit-test counts are context, not substitutes for boundary-level results.
@@ -246,6 +246,6 @@ unit-test counts are context, not substitutes for boundary-level results.
 cargo fmt --all -- --check
 cargo clippy --workspace --all-targets -- -D warnings
 cargo test --workspace
-python3 scripts/lingtai-workbench/workbench_contract_test.py
+python3 scripts/workbench/workbench_contract_test.py
 git diff --check
 ```

--- a/docs/index.md
+++ b/docs/index.md
@@ -23,7 +23,7 @@ hero:
       link: /development/workspace-acceptance
 features:
   - title: Stable Agent surface
-    details: Preserve the complete 18-tool LingTai Workbench contract and expose the same semantics through SDK, custom CLI, and MCP adapters.
+    details: Preserve the complete 18-tool NoKV Workbench contract and expose the same semantics through SDK, custom CLI, and MCP adapters.
   - title: Path-primary Holt metadata
     details: One normalized full path is namespace truth. Exact artifacts use point reads; child listing uses component-safe delimiter scans.
   - title: Immutable revisions
@@ -94,7 +94,7 @@ SPDX-License-Identifier: Apache-2.0
   [RustFS Provider Profile](./rustfs.md).
 - Workloads and evidence: [AI Training Workload](./ai-training.md),
   [Benchmarks](./benchmarks.md),
-  [LingTai Workbench Preflight](./lingtai-workbench-preflight.md), and
+  [Workbench Deployment Preflight](./workbench-preflight.md), and
   [Workspace Acceptance](./development/workspace-acceptance.md).
 - Development: [Code Contract](./development/code_contract.md),
   [`nokv-agent` Handbook](./development/nokv-agent.md),
@@ -105,7 +105,7 @@ SPDX-License-Identifier: Apache-2.0
 
 <div class="nokv-section nokv-section--tight">
   <div class="nokv-section-head nokv-section-head--center">
-    <p class="nokv-eyebrow">First client</p>
+    <p class="nokv-eyebrow">Research workflow</p>
     <h2 class="nokv-h2">Reproducible reconstruction runs</h2>
     <p class="nokv-lead">Seal one immutable input dataset, materialize verified
     files for the local scientific executable, collect declared outputs, and

--- a/docs/product-design.md
+++ b/docs/product-design.md
@@ -219,10 +219,10 @@ Splitting one root and cross-shard transactions are deferred. They require
 version vectors, k-way query/list merge, distributed restore, and explicit
 cross-shard reference ownership.
 
-## First Client Flow
+## Reference Research Workflow
 
-The first client validates the product through a scientific reconstruction
-workflow:
+The runtime-neutral reference validates the product through a scientific
+reconstruction workflow:
 
 ```text
 upload input dataset

--- a/docs/workbench-contract.md
+++ b/docs/workbench-contract.md
@@ -18,7 +18,7 @@ The contract sources are:
 - the Rust tool definitions and result shaping owned by `crates/nokv-agent/`;
 - the frozen normalized input-schema snapshot in
   `crates/nokv-agent/workbench_contract_schema.json`;
-- `scripts/lingtai-workbench/workbench_contract.py` for checking tool names and
+- `scripts/workbench/workbench_contract.py` for checking tool names and
   normalized input schemas.
 
 CLI and MCP wiring are consumers of this contract, not schema authorities.

--- a/docs/workbench-preflight.md
+++ b/docs/workbench-preflight.md
@@ -3,11 +3,11 @@ Copyright 2024-2026 The NoKV Authors.
 SPDX-License-Identifier: Apache-2.0
 -->
 
-# LingTai Workbench Preflight
+# Workbench Deployment Preflight
 
-LingTai is the active NoKV design partner and first Workbench client. It uses
-the normal `nokv mcp` stdio endpoint; there is no partner-specific metadata
-format or compatibility route.
+This guide prepares any MCP-compatible Agent runtime to use the normal
+`nokv mcp` stdio endpoint. There is no runtime-specific metadata format or
+compatibility route.
 
 ## Required Inputs
 
@@ -33,7 +33,7 @@ Run:
 cargo fmt --all -- --check
 cargo clippy --workspace --all-targets -- -D warnings
 cargo test --workspace
-python3 scripts/lingtai-workbench/workbench_contract_test.py
+python3 scripts/workbench/workbench_contract_test.py
 git diff --check
 ```
 
@@ -43,13 +43,13 @@ It does not qualify persistence, object I/O, failover, restore, or latency.
 ## Live Contract Check
 
 Start `nokv mcp` with the same root, route, owner, and object configuration that
-LingTai will use. Send `initialize`, then `tools/list`, and validate the response
-with `workbench_contract.validate_tool_contract`.
+the Agent runtime will use. Send `initialize`, then `tools/list`, and validate
+the response with `workbench_contract.validate_tool_contract`.
 
-For the complete first-client path, run
-`scripts/lingtai-workbench/live_first_client.py`. It calls `nokv provision`,
+For the complete live Workbench path, run
+`scripts/workbench/live_workbench.py`. It calls `nokv provision`,
 starts `nokv serve` with explicit metadata create/reopen intent, starts
-`nokv mcp --workbench-root /agents/{agent}/wb`, exercises all 18 tools, and
+`nokv ... --workbench-root /agents/{agent}/wb mcp`, exercises all 18 tools, and
 retains exact requests/responses plus materialize/collect evidence. Run
 `--dry-run` first to inspect the redacted command and normalized-input plan.
 In the current local-WAL profile, `reopen` is a negative qualification run:

--- a/scripts/workbench/README.md
+++ b/scripts/workbench/README.md
@@ -3,11 +3,12 @@ Copyright 2024-2026 The NoKV Authors.
 SPDX-License-Identifier: Apache-2.0
 -->
 
-# LingTai Workbench Integration
+# Workbench Validation
 
-LingTai consumes the same 18-tool Workbench surface exported by
-`crates/nokv-agent` and served by `nokv mcp`. There is no alternate LingTai
-metadata layout, capability alias, migration helper, or filesystem frontend.
+These assets validate the same 18-tool Workbench surface exported by
+`crates/nokv-agent` and served by `nokv mcp`. They do not define a
+runtime-specific metadata layout, capability alias, migration helper, or
+filesystem frontend.
 
 The checked-in integration assets are deliberately small:
 
@@ -15,10 +16,10 @@ The checked-in integration assets are deliberately small:
   exact Rust-owned schema at
   `crates/nokv-agent/workbench_contract_schema.json`.
 - `workbench_contract_test.py` tests normalization and exact surface matching.
-- `live_first_client.py` provisions one root, starts one explicit metadata
+- `live_workbench.py` provisions one root, starts one explicit metadata
   owner and the flat `nokv mcp` command, then records a real
-  LingTai/Viking/Ptycho workflow through all 18 tools.
-- `live_first_client_test.py` checks exact coverage/order, flat commands,
+  scientific reconstruction workflow through all 18 tools.
+- `live_workbench_test.py` checks exact coverage/order, flat commands,
   secret redaction, dry-run evidence, and fail-closed qualification.
 - `start_rustfs.sh` starts the optional local S3-compatible artifact backend.
 
@@ -27,14 +28,15 @@ Build and validate the product directly:
 ```bash
 cargo build -p nokv --bin nokv
 cargo test --workspace
-python3 scripts/lingtai-workbench/workbench_contract_test.py
-python3 scripts/lingtai-workbench/live_first_client_test.py
+python3 scripts/workbench/workbench_contract_test.py
+python3 scripts/workbench/live_workbench_test.py
 ```
 
-Register the built binary in LingTai as a stdio MCP command:
+Register the built binary in any MCP-compatible Agent runtime as a stdio MCP
+command:
 
 ```text
-/absolute/path/to/nokv mcp <root and route options>
+/absolute/path/to/nokv <root, route, object, and workbench options> mcp
 ```
 
 The deployment must provide one persisted `RootId` placement, its
@@ -42,15 +44,15 @@ The deployment must provide one persisted `RootId` placement, its
 metadata owner, and S3-compatible artifact credentials. Unknown or mixed
 metadata schemas are rejected; the sole marker is `nokv_workspace`.
 
-## First-client live evidence
+## Live Workbench evidence
 
 Dry-run validates the redacted command graph and exact 18-tool coverage without
 claiming that any dependency ran:
 
 ```bash
-python3 scripts/lingtai-workbench/live_first_client.py \
+python3 scripts/workbench/live_workbench.py \
   --dry-run \
-  --evidence-dir target/lingtai-workbench/evidence/dry-run
+  --evidence-dir target/workbench-live/evidence/dry-run
 ```
 
 A live run consumes already-running etcd and S3-compatible services.
@@ -58,16 +60,16 @@ Credentials may be supplied with `NOKV_LIVE_S3_ACCESS_KEY_ID` and
 `NOKV_LIVE_S3_SECRET_ACCESS_KEY`; evidence hashes and redacts secrets.
 
 ```bash
-python3 scripts/lingtai-workbench/live_first_client.py \
+python3 scripts/workbench/live_workbench.py \
   --build \
   --root-id 11111111111111111111111111111111 \
   --logical-shard-id 22222222222222222222222222222222 \
   --etcd-endpoint http://127.0.0.1:2379 \
   --object-endpoint http://127.0.0.1:9000 \
-  --object-bucket nokv-lingtai-workbench \
+  --object-bucket nokv-workbench-live \
   --metadata-mode create \
-  --metadata-dir target/lingtai-workbench/metadata/live-01 \
-  --evidence-dir target/lingtai-workbench/evidence/live-01
+  --metadata-dir target/workbench-live/metadata/live-01 \
+  --evidence-dir target/workbench-live/evidence/live-01
 ```
 
 `--metadata-mode reopen` is currently a negative qualification path, not a
@@ -75,7 +77,7 @@ supported standalone restart: local-WAL bootstrap refuses successor ownership
 until checkpoint/log recovery and fsck are verified. The harness always calls
 `nokv provision`, starts `nokv serve` with exactly one of `--metadata-create`
 or `--metadata-reopen`, and starts
-`nokv mcp --workbench-root /agents/{agent}/wb`. The scientific step uses the
+`nokv ... --workbench-root /agents/{agent}/wb mcp`. The scientific step uses the
 explicit `materialize` and `collect` commands; its local sandbox is not a NoKV
 namespace. Keep the configured Workbench root stable across restarts because
 canonical v1 manifest presentation paths are replay-bound; `RootId`, not this

--- a/scripts/workbench/live_workbench.py
+++ b/scripts/workbench/live_workbench.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Black-box LingTai/Viking/Ptycho evidence over the flat ``nokv`` binary."""
+"""Black-box scientific Workbench evidence over the flat ``nokv`` binary."""
 
 from __future__ import annotations
 
@@ -25,7 +25,7 @@ from typing import Any, Iterable, TextIO
 from workbench_contract import WORKBENCH_TOOLS, contract_evidence, validate_tool_contract
 
 
-SCHEMA = "nokv.lingtai.first_client_evidence.v1"
+SCHEMA = "nokv.workbench.live_evidence.v1"
 PROTOCOL_VERSION = "2025-11-25"
 HEX_ID = re.compile(r"^[0-9a-f]{32}$")
 WORKBENCH_ID = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_-]{0,127}$")
@@ -120,9 +120,8 @@ def now() -> str:
 
 def scan_bytes(state: str, revision: int) -> bytes:
     value = {
-        "experiment": "ptycho",
+        "experiment": "ptychography",
         "frames": 2,
-        "partner": "viking",
         "revision": revision,
         "state": state,
     }
@@ -131,7 +130,7 @@ def scan_bytes(state: str, revision: int) -> bytes:
 
 def reconstruction_bytes() -> bytes:
     value = {
-        "algorithm": "viking-ptycho",
+        "algorithm": "phase-retrieval",
         "frames": 2,
         "source_state": "calibrated",
         "status": "converged",
@@ -169,7 +168,7 @@ def tool_plan(config: Config) -> list[ToolStep]:
             "append-log",
             "workbench_append",
             {"id": wb, "section": "logs", "path": "reconstruction.log",
-             "text": "ptycho reconstruction started\n", "content_type": "text/plain"},
+             "text": "ptychography reconstruction started\n", "content_type": "text/plain"},
         ),
         ToolStep(
             "read-input",
@@ -190,7 +189,7 @@ def tool_plan(config: Config) -> list[ToolStep]:
         ToolStep(
             "grep-input",
             "workbench_grep",
-            {"id": wb, "section": "input", "pattern": "PTYCHO", "glob": "*.json",
+            {"id": wb, "section": "input", "pattern": "PTYCHOGRAPHY", "glob": "*.json",
              "recursive": True, "limit": 10},
         ),
         ToolStep(
@@ -216,16 +215,16 @@ def tool_plan(config: Config) -> list[ToolStep]:
             "commit",
             "workbench_commit",
             {"id": wb,
-             "manifest": {"dataset": "viking-first-client",
-                          "model": "scientific-reconstruction", "task": "ptycho"},
+             "manifest": {"dataset": "ptychography-scan",
+                          "model": "scientific-reconstruction", "task": "ptychography"},
              "content_digest_uri": commit_digest, "replace": False},
         ),
         ToolStep(
             "commit-replay",
             "workbench_commit",
             {"id": wb,
-             "manifest": {"dataset": "viking-first-client",
-                          "model": "scientific-reconstruction", "task": "ptycho"},
+             "manifest": {"dataset": "ptychography-scan",
+                          "model": "scientific-reconstruction", "task": "ptychography"},
              "content_digest_uri": commit_digest, "replace": False},
         ),
         ToolStep(
@@ -238,8 +237,8 @@ def tool_plan(config: Config) -> list[ToolStep]:
             "snapshot",
             "workbench_snapshot",
             {"id": wb, "name": snapshot, "ttl_days": 1,
-             "reason": "first-client frozen reconstruction",
-             "metadata": {"partner": "viking", "workflow": "ptycho"}},
+             "reason": "research workbench frozen reconstruction",
+             "metadata": {"domain": "imaging", "workflow": "ptychography"}},
         ),
         ToolStep(
             "post-snapshot-edit",
@@ -288,13 +287,13 @@ def tool_plan(config: Config) -> list[ToolStep]:
         ToolStep(
             "find",
             "workbench_find",
-            {"committed": True, "manifest_pattern": "ptycho",
+            {"committed": True, "manifest_pattern": "ptychography",
              "include_manifest": True, "limit": 100},
         ),
         ToolStep(
             "snapshot-retire",
             "workbench_snapshot_retire",
-            {"id": wb, "name": snapshot, "reason": "first-client workflow complete"},
+            {"id": wb, "name": snapshot, "reason": "workbench workflow complete"},
         ),
         ToolStep(
             "snapshot-retire-replay",
@@ -533,7 +532,7 @@ def assert_results(results: dict[str, dict[str, Any]], config: Config) -> None:
     if read_generation != replacement.get("generation") \
             or results["stat-input"].get("card", {}).get("generation") != read_generation:
         raise WorkflowFailure("put/read/stat generations differ")
-    delta = b"ptycho reconstruction started\n"
+    delta = b"ptychography reconstruction started\n"
     append = results["append-log"]
     if append.get("digest") != "sha256:" + digest(delta) \
             or append.get("appended_bytes") != len(delta):
@@ -583,7 +582,7 @@ def assert_results(results: dict[str, dict[str, Any]], config: Config) -> None:
     replayed_retire = results["snapshot-retire-replay"]
     expected_retire_annotation = {
         "metadata": None,
-        "reason": "first-client workflow complete",
+        "reason": "workbench workflow complete",
     }
     if retired.get("retired") is not True or retired.get("state") != "retired" \
             or retired.get("retire_annotation") != expected_retire_annotation:
@@ -671,7 +670,7 @@ def start_mcp(config: Config, evidence: Evidence, server: subprocess.Popen[str])
             initialized = session.request("initialize", {
                 "protocolVersion": PROTOCOL_VERSION,
                 "capabilities": {},
-                "clientInfo": {"name": "nokv-first-client-harness", "version": "1"},
+                "clientInfo": {"name": "nokv-workbench-harness", "version": "1"},
             })
             result = initialized.get("result", {})
             if result.get("serverInfo", {}).get("name") != "nokv-mcp" \
@@ -815,12 +814,12 @@ def qualification(state: str, reason: str, workflow: str,
                        "did not expire and reach reaped state; Gate 0 is partial evidence.")
     return {
         "schema": SCHEMA, "recorded_at": now(), "overall_status": state, "reason": reason,
-        "first_client_workflow": {"status": workflow, "transcript_sha256": transcript},
+        "workbench_workflow": {"status": workflow, "transcript_sha256": transcript},
         "acceptance_gates": {
             str(index): {
                 "status": gate_zero if index == 0 else "NOT QUALIFIED",
                 "reason": gate_reason if index == 0
-                else "This first-client harness does not qualify this gate.",
+                else "This Workbench harness does not qualify this gate.",
             }
             for index in range(9)
         },
@@ -840,10 +839,10 @@ def parse_args(argv: list[str] | None = None) -> Config:
     parser.add_argument("--root-id", default=os.getenv("NOKV_LIVE_ROOT_ID", "11" * 16))
     parser.add_argument("--logical-shard-id",
                         default=os.getenv("NOKV_LIVE_LOGICAL_SHARD_ID", "22" * 16))
-    parser.add_argument("--agent-id", default="lingtai")
-    parser.add_argument("--workbench-id", default="ptycho-first-client")
-    parser.add_argument("--restored-workbench-id", default="ptycho-first-client-restored")
-    parser.add_argument("--snapshot-name", default="ptycho-frozen")
+    parser.add_argument("--agent-id", default="research-agent")
+    parser.add_argument("--workbench-id", default="ptychography-run")
+    parser.add_argument("--restored-workbench-id", default="ptychography-run-restored")
+    parser.add_argument("--snapshot-name", default="ptychography-frozen")
     parser.add_argument("--etcd-endpoint", action="append")
     parser.add_argument("--etcd-key-prefix", default="/nokv/control")
     parser.add_argument("--server-bind", default="127.0.0.1:7750")
@@ -851,7 +850,7 @@ def parse_args(argv: list[str] | None = None) -> Config:
     parser.add_argument("--node-id")
     parser.add_argument("--object-bucket", default=os.getenv("NOKV_LIVE_S3_BUCKET", ""))
     parser.add_argument("--object-endpoint", default=os.getenv("NOKV_LIVE_S3_ENDPOINT", ""))
-    parser.add_argument("--object-root", default="lingtai-first-client")
+    parser.add_argument("--object-root", default="workbench-live")
     parser.add_argument("--object-region", default="us-east-1")
     parser.add_argument("--object-access-key-id",
                         default=os.getenv("NOKV_LIVE_S3_ACCESS_KEY_ID"))
@@ -866,11 +865,11 @@ def parse_args(argv: list[str] | None = None) -> Config:
         args.object_bucket = args.object_bucket or "nokv-live-dry-run"
         args.object_endpoint = args.object_endpoint or "http://127.0.0.1:9000"
     evidence = args.evidence_dir or (
-        repo / "target/lingtai-workbench/evidence" /
+        repo / "target/workbench-live/evidence" /
         f"gate0-{args.agent_id}-{args.workbench_id}-{args.root_id[:8]}"
     )
     metadata = args.metadata_dir or (
-        repo / "target/lingtai-workbench/metadata" /
+        repo / "target/workbench-live/metadata" /
         f"{args.root_id}-{args.metadata_mode}"
     )
     return Config(
@@ -878,7 +877,7 @@ def parse_args(argv: list[str] | None = None) -> Config:
         args.metadata_mode, args.root_id, args.logical_shard_id, args.agent_id,
         args.workbench_id, args.restored_workbench_id, args.snapshot_name, tuple(etcd),
         args.etcd_key_prefix, args.server_bind, args.advertise_endpoint,
-        args.node_id or f"lingtai-{args.root_id[:8]}", args.object_bucket,
+        args.node_id or f"workbench-{args.root_id[:8]}", args.object_bucket,
         args.object_endpoint, args.object_root, args.object_region,
         args.object_access_key_id, args.object_secret_access_key, args.build,
         args.dry_run, args.command_timeout_seconds,
@@ -916,7 +915,7 @@ def main(argv: list[str] | None = None) -> int:
         run_live(config, evidence, steps)
         transcript = digest_file(evidence.root / "mcp-transcript.jsonl")
         record = qualification(
-            "NOT QUALIFIED", "Live first-client workflow passed; full system acceptance "
+            "NOT QUALIFIED", "Live Workbench workflow passed; full system acceptance "
             "requires the remaining gates.", "PASS", transcript
         )
         evidence.json("qualification.json", record)

--- a/scripts/workbench/live_workbench_test.py
+++ b/scripts/workbench/live_workbench_test.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Unit tests for the first-client live evidence harness."""
+"""Unit tests for the generic live Workbench evidence harness."""
 
 from __future__ import annotations
 
@@ -10,7 +10,7 @@ import tempfile
 import unittest
 from pathlib import Path
 
-import live_first_client as harness
+import live_workbench as harness
 
 
 REQUIRED_FIRST_OCCURRENCE_ORDER = [
@@ -45,7 +45,24 @@ def config(evidence_dir: Path) -> harness.Config:
     )
 
 
-class LiveFirstClientTest(unittest.TestCase):
+class LiveWorkbenchTest(unittest.TestCase):
+    def test_default_workflow_evidence_is_runtime_neutral(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            current = config(Path(directory) / "evidence")
+            encoded = harness.canonical_json(
+                {
+                    "agent": current.agent,
+                    "node": current.node,
+                    "object_root": current.object_root,
+                    "plan": harness.plan(current, harness.tool_plan(current)),
+                    "qualification": harness.qualification(
+                        "NOT QUALIFIED", "test", "NOT QUALIFIED"
+                    ),
+                }
+            ).lower()
+
+        self.assertNotIn("lingtai", encoded)
+
     def test_plan_covers_exact_eighteen_tools_in_dependency_order(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
             steps = harness.tool_plan(config(Path(directory) / "evidence"))
@@ -91,7 +108,7 @@ class LiveFirstClientTest(unittest.TestCase):
             )
 
     def test_dry_run_writes_not_qualified_evidence_and_complete_coverage(self) -> None:
-        script = Path(__file__).with_name("live_first_client.py")
+        script = Path(__file__).with_name("live_workbench.py")
         with tempfile.TemporaryDirectory() as directory:
             evidence = Path(directory) / "evidence"
             completed = subprocess.run(
@@ -115,11 +132,11 @@ class LiveFirstClientTest(unittest.TestCase):
         self.assertTrue(plan["tool_coverage"]["complete"])
         self.assertEqual(qualification["overall_status"], "NOT QUALIFIED")
         self.assertEqual(
-            qualification["first_client_workflow"]["status"], "NOT QUALIFIED"
+            qualification["workbench_workflow"]["status"], "NOT QUALIFIED"
         )
 
     def test_missing_live_binary_is_not_qualified_not_pass(self) -> None:
-        script = Path(__file__).with_name("live_first_client.py")
+        script = Path(__file__).with_name("live_workbench.py")
         with tempfile.TemporaryDirectory() as directory:
             root = Path(directory)
             evidence = root / "evidence"
@@ -149,7 +166,7 @@ class LiveFirstClientTest(unittest.TestCase):
                 (evidence / "qualification.json").read_text(encoding="utf-8")
             )
         self.assertEqual(qualification["overall_status"], "NOT QUALIFIED")
-        self.assertNotEqual(qualification["first_client_workflow"]["status"], "PASS")
+        self.assertNotEqual(qualification["workbench_workflow"]["status"], "PASS")
 
 
 if __name__ == "__main__":

--- a/scripts/workbench/start_rustfs.sh
+++ b/scripts/workbench/start_rustfs.sh
@@ -2,22 +2,22 @@
 set -euo pipefail
 
 if [ "$#" -ne 0 ]; then
-  echo "start_rustfs.sh accepts no arguments; use LINGTAI_WORKBENCH_* environment variables" >&2
+  echo "start_rustfs.sh accepts no arguments; use NOKV_WORKBENCH_* environment variables" >&2
   exit 1
 fi
 
 repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
-data_root="${LINGTAI_WORKBENCH_DATA_ROOT:-${repo_root}/target/lingtai-workbench}"
-container="${LINGTAI_WORKBENCH_RUSTFS_CONTAINER:-lingtai-workbench-rustfs}"
-image="${LINGTAI_WORKBENCH_RUSTFS_IMAGE:-rustfs/rustfs:latest}"
-host="${LINGTAI_WORKBENCH_RUSTFS_HOST:-127.0.0.1}"
-port="${LINGTAI_WORKBENCH_RUSTFS_PORT:-9000}"
-console_port="${LINGTAI_WORKBENCH_RUSTFS_CONSOLE_PORT:-9001}"
-access_key="${LINGTAI_WORKBENCH_S3_ACCESS_KEY_ID:-rustfsadmin}"
-secret_key="${LINGTAI_WORKBENCH_S3_SECRET_ACCESS_KEY:-rustfsadmin}"
-bucket="${LINGTAI_WORKBENCH_S3_BUCKET:-nokv-lingtai-workbench}"
-endpoint="${LINGTAI_WORKBENCH_S3_ENDPOINT:-http://${host}:${port}}"
-rustfs_data="${LINGTAI_WORKBENCH_RUSTFS_DATA_DIR:-${data_root}/rustfs}"
+data_root="${NOKV_WORKBENCH_DATA_ROOT:-${repo_root}/target/workbench-live}"
+container="${NOKV_WORKBENCH_RUSTFS_CONTAINER:-nokv-workbench-rustfs}"
+image="${NOKV_WORKBENCH_RUSTFS_IMAGE:-rustfs/rustfs:latest}"
+host="${NOKV_WORKBENCH_RUSTFS_HOST:-127.0.0.1}"
+port="${NOKV_WORKBENCH_RUSTFS_PORT:-9000}"
+console_port="${NOKV_WORKBENCH_RUSTFS_CONSOLE_PORT:-9001}"
+access_key="${NOKV_WORKBENCH_S3_ACCESS_KEY_ID:-rustfsadmin}"
+secret_key="${NOKV_WORKBENCH_S3_SECRET_ACCESS_KEY:-rustfsadmin}"
+bucket="${NOKV_WORKBENCH_S3_BUCKET:-nokv-workbench-live}"
+endpoint="${NOKV_WORKBENCH_S3_ENDPOINT:-http://${host}:${port}}"
+rustfs_data="${NOKV_WORKBENCH_RUSTFS_DATA_DIR:-${data_root}/rustfs}"
 
 if ! command -v aws >/dev/null 2>&1; then
   echo "aws CLI is required to create and verify the RustFS bucket" >&2
@@ -84,7 +84,7 @@ if ! aws --endpoint-url "${endpoint}" s3api head-bucket --bucket "${bucket}" >/d
 fi
 
 cat <<EOF
-LingTai workbench RustFS ready
+NoKV Workbench RustFS ready
   container: ${container}
   endpoint:  ${endpoint}
   bucket:    ${bucket}

--- a/scripts/workbench/workbench_contract.py
+++ b/scripts/workbench/workbench_contract.py
@@ -2,7 +2,7 @@
 # Copyright 2024-2026 The NoKV Authors.
 # SPDX-License-Identifier: Apache-2.0
 
-"""Frozen semantic contract for LingTai's NoKV workbench MCP surface."""
+"""Frozen semantic contract for NoKV's Workbench MCP surface."""
 
 from __future__ import annotations
 
@@ -81,7 +81,7 @@ SCHEMA_VALUE_KEYWORDS = frozenset(
 
 
 class WorkbenchContractError(ValueError):
-    """A live MCP surface cannot satisfy the LingTai workbench contract."""
+    """A live MCP surface cannot satisfy the NoKV Workbench contract."""
 
 
 def canonical_json(value: Any) -> str:

--- a/scripts/workbench/workbench_contract_test.py
+++ b/scripts/workbench/workbench_contract_test.py
@@ -2,6 +2,8 @@
 # Copyright 2024-2026 The NoKV Authors.
 # SPDX-License-Identifier: Apache-2.0
 
+"""Tests for the NoKV Workbench contract gate."""
+
 from __future__ import annotations
 
 import copy


### PR DESCRIPTION
## Related Issue

No linked issue. This is a self-contained Workbench module-layout cleanup and validation-asset update with no product-contract change.

## Summary

- Standardize Workbench validation assets under one product-owned module layout.
- Align the live workflow, evidence naming, CI gate, and deployment documentation with that layout.
- Preserve the exact 18-tool contract, storage semantics, and runtime behavior.

## Scope

- [x] This PR changes one logical boundary only.
- [x] No metadata model, Holt layout, object-store behavior, or Agent interface change is mixed in.
- [x] The helper path, evidence marker, environment prefix, and CI check rename is intentional.
- [x] No compatibility shim, deprecated alias, or forwarding wrapper is added.

## Code Contract

- [x] Package boundaries remain unchanged.
- [x] Workbench validation remains outside the metadata, protocol, object, and SDK state machines.
- [x] File placement and names are product-owned and domain-specific.
- [x] The transport-free facade and frozen schemas remain unchanged.

## Claims and Evidence

- [x] Documentation keeps current capabilities separate from unqualified recovery and failover claims.
- [x] This PR makes no performance or security claim.
- [x] The live harness remains a bounded Workbench gate, not full system qualification.

## Validation

- `python3 scripts/workbench/workbench_contract_test.py` — 8 passed
- `python3 scripts/workbench/live_workbench_test.py` — 7 passed
- `cargo fmt --all -- --check` — passed
- `cargo clippy --workspace --all-targets -- -D warnings` — passed
- `cargo test --workspace` — passed
- `git diff --check` — passed

## Contributor Sign-off

- [x] Every commit in this PR includes a DCO `Signed-off-by` trailer.
