### PR TITLE
fix: align query page limits across layers

### DIFF
--- a/crates/nokv-protocol/src/lib.rs
+++ b/crates/nokv-protocol/src/lib.rs
@@ -43,6 +43,7 @@ pub use request::{
     RenewSnapshotRequest, RestoreManifestDescriptor, RestoreSource, RetireSnapshotRequest,
     SearchRequest, SortDirection, SortField, StageArtifactManifestRequest,
     StageArtifactObjectsRequest, WorkspacePreflightRequest, WorkspaceRequest, WorkspaceRpcRequest,
+    MAX_QUERY_PAGE_LIMIT,
 };
 pub use response::{
     AggregateGroup, AggregateResult, CatalogField, CatalogResult, ChangeEvent, ChangeKind,

--- a/crates/nokv-protocol/src/request.rs
+++ b/crates/nokv-protocol/src/request.rs
@@ -23,8 +23,11 @@ const MAX_QUERY_IN_VALUES: usize = 64;
 const MAX_QUERY_FIELDS: usize = 64;
 const MAX_SORT_FIELDS: usize = 8;
 const MAX_FACET_FIELDS: usize = 16;
+/// Maximum page size accepted by metadata query, catalog, discovery, and event RPCs.
+pub const MAX_QUERY_PAGE_LIMIT: u32 = 256;
 pub(crate) const MAX_PARENT_COMMITS: usize = 32;
 const MAX_RESTORE_MANIFEST_BYTES: u64 = 1024 * 1024;
+const _: () = assert!(MAX_QUERY_PAGE_LIMIT <= PageRequest::MAX_LIMIT);
 
 /// One root-routed metadata or lifecycle request.
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
@@ -990,7 +993,7 @@ impl SearchRequest {
             sort.validate()?;
         }
         validate_field_ids("search.facets", &self.facets, MAX_FACET_FIELDS)?;
-        self.page.validate("search.page")
+        validate_query_page(&self.page, "search.page")
     }
 }
 
@@ -1071,7 +1074,7 @@ impl AggregateRequest {
         for sort in &self.sort {
             sort.validate()?;
         }
-        self.page.validate("aggregate.page")
+        validate_query_page(&self.page, "aggregate.page")
     }
 }
 
@@ -1089,7 +1092,7 @@ impl CatalogRequest {
         if let Some(prefix) = self.field_prefix.as_deref() {
             validate_field_id("catalog.field_prefix", prefix)?;
         }
-        self.page.validate("catalog.page")
+        validate_query_page(&self.page, "catalog.page")
     }
 }
 
@@ -1102,7 +1105,7 @@ pub struct FindWorkspacesRequest {
 
 impl FindWorkspacesRequest {
     fn validate(&self) -> Result<(), ProtocolError> {
-        self.page.validate("find_workspaces.page")
+        validate_query_page(&self.page, "find_workspaces.page")
     }
 }
 
@@ -1122,8 +1125,18 @@ impl ChangePageRequest {
                 "must be greater than zero",
             ));
         }
-        self.page.validate("read_changes.page")
+        validate_query_page(&self.page, "read_changes.page")
     }
+}
+
+fn validate_query_page(page: &PageRequest, field: &'static str) -> Result<(), ProtocolError> {
+    if !(1..=MAX_QUERY_PAGE_LIMIT).contains(&page.limit) {
+        return Err(ProtocolError::invalid(
+            field,
+            format!("limit must be between 1 and {MAX_QUERY_PAGE_LIMIT}"),
+        ));
+    }
+    page.validate(field)
 }
 
 fn validate_artifact_batch<T>(field: &'static str, rows: &[T]) -> Result<(), ProtocolError> {
@@ -1187,6 +1200,82 @@ fn validate_field_ids(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    const EXPECTED_QUERY_PAGE_LIMIT: u32 = 256;
+
+    fn query_requests(limit: u32) -> Vec<(WorkspaceRequest, &'static str)> {
+        let page = || PageRequest {
+            cursor: None,
+            limit,
+        };
+        let scope = || QueryScope::Root { path_prefix: None };
+        vec![
+            (
+                WorkspaceRequest::Search(SearchRequest {
+                    scope: scope(),
+                    predicates: Vec::new(),
+                    projection: Vec::new(),
+                    sort: Vec::new(),
+                    facets: Vec::new(),
+                    page: page(),
+                }),
+                "search.page",
+            ),
+            (
+                WorkspaceRequest::Aggregate(AggregateRequest {
+                    scope: scope(),
+                    predicates: Vec::new(),
+                    group_by: Vec::new(),
+                    aggregates: vec![AggregateSpec {
+                        function: AggregateFunction::Count,
+                        field_id: None,
+                        result_id: "count".to_owned(),
+                    }],
+                    sort: Vec::new(),
+                    page: page(),
+                }),
+                "aggregate.page",
+            ),
+            (
+                WorkspaceRequest::Catalog(CatalogRequest {
+                    scope: scope(),
+                    field_prefix: None,
+                    page: page(),
+                }),
+                "catalog.page",
+            ),
+            (
+                WorkspaceRequest::FindWorkspaces(FindWorkspacesRequest {
+                    committed_only: false,
+                    page: page(),
+                }),
+                "find_workspaces.page",
+            ),
+            (
+                WorkspaceRequest::ReadChanges(ChangePageRequest {
+                    after_commit_version: None,
+                    workbench: None,
+                    page: page(),
+                }),
+                "read_changes.page",
+            ),
+        ]
+    }
+
+    #[test]
+    fn query_requests_reject_pages_above_the_execution_limit() {
+        assert_eq!(MAX_QUERY_PAGE_LIMIT, EXPECTED_QUERY_PAGE_LIMIT);
+        for (request, _) in query_requests(EXPECTED_QUERY_PAGE_LIMIT) {
+            request.validate().unwrap();
+        }
+
+        for (request, expected_field) in query_requests(EXPECTED_QUERY_PAGE_LIMIT + 1) {
+            let ProtocolError::InvalidField { field, .. } = request.validate().unwrap_err() else {
+                panic!("query page limit must fail as invalid input");
+            };
+            assert_eq!(field, expected_field);
+        }
+    }
 
     fn get_path(range: Option<ByteRange>, plan_page: Option<PageRequest>) -> GetPathRequest {
         GetPathRequest {

--- a/crates/nokv-server/src/executor.rs
+++ b/crates/nokv-server/src/executor.rs
@@ -24,6 +24,7 @@ const _: () =
     assert!(protocol::MAX_ARTIFACT_DEPENDENCY_DEPTH == meta::MAX_REVISION_DEPENDENCY_DEPTH);
 const _: () =
     assert!(protocol::PageRequest::MAX_LIMIT as usize == meta::MAX_VISIBLE_PATH_LIST_PAGE_SIZE);
+const _: () = assert!(protocol::MAX_QUERY_PAGE_LIMIT as usize == meta::MAX_QUERY_PAGE_SIZE);
 const SUPPORTED_WORKSPACE_CAPABILITIES: [protocol::WorkspaceCapability; 9] = [
     protocol::WorkspaceCapability::ArtifactPublishV1,
     protocol::WorkspaceCapability::ArtifactRangeReadV1,

--- a/crates/nokv/src/backend.rs
+++ b/crates/nokv/src/backend.rs
@@ -34,7 +34,7 @@ const RESTORE_MANIFEST_PATH: &str = "metadata/restore_manifest.json";
 const JSON_CONTENT_TYPE: &str = "application/json";
 const CURSOR_VERSION: &[u8] = b"nokv.workspace.cursor\0";
 const LIST_CURSOR_VERSION: &[u8] = b"nokv.workspace.list-cursor.v3\0";
-const SERVER_PAGE_LIMIT: u32 = wire::PageRequest::MAX_LIMIT;
+const QUERY_SERVER_PAGE_LIMIT: u32 = wire::MAX_QUERY_PAGE_LIMIT;
 const CONSISTENT_READ_MAX_ATTEMPTS: u32 = 3;
 
 static ID_SEQUENCE: AtomicU64 = AtomicU64::new(1);
@@ -698,7 +698,7 @@ impl agent::WorkbenchBackend for CliWorkbenchBackend {
                         .as_deref()
                         .map(|cursor| decode_cursor("search", cursor))
                         .transpose()?,
-                    limit: page_limit(request.limit)?,
+                    limit: query_page_limit(request.limit)?,
                 },
             })
             .map_err(map_client_error)?;
@@ -756,7 +756,7 @@ impl agent::WorkbenchBackend for CliWorkbenchBackend {
                 sort: query_sort(&request.sort),
                 page: wire::PageRequest {
                     cursor: None,
-                    limit: page_limit(request.limit)?,
+                    limit: query_page_limit(request.limit)?,
                 },
             })
             .map_err(map_client_error)?;
@@ -791,7 +791,7 @@ impl agent::WorkbenchBackend for CliWorkbenchBackend {
                     field_prefix: request.field_prefix.clone(),
                     page: wire::PageRequest {
                         cursor,
-                        limit: SERVER_PAGE_LIMIT,
+                        limit: QUERY_SERVER_PAGE_LIMIT,
                     },
                 }) {
                     Ok(call) => call,
@@ -851,7 +851,7 @@ impl agent::WorkbenchBackend for CliWorkbenchBackend {
                         .as_deref()
                         .map(|cursor| decode_cursor("find", cursor))
                         .transpose()?,
-                    limit: page_limit(request.limit)?,
+                    limit: query_page_limit(request.limit)?,
                 },
             })
             .map_err(map_client_error)?;
@@ -1962,6 +1962,17 @@ fn page_limit(limit: usize) -> Result<u32, agent::BackendError> {
     Ok(limit)
 }
 
+fn query_page_limit(limit: usize) -> Result<u32, agent::BackendError> {
+    let limit = page_limit(limit)?;
+    if limit > wire::MAX_QUERY_PAGE_LIMIT {
+        return Err(invalid_backend_input(format!(
+            "query page limit must be between 1 and {}",
+            wire::MAX_QUERY_PAGE_LIMIT
+        )));
+    }
+    Ok(limit)
+}
+
 fn list_server_page_limit(limit: usize, candidate_count: usize, first_page: bool) -> u32 {
     let union_target = limit.saturating_add(1);
     let requested = if first_page {
@@ -2584,6 +2595,14 @@ mod tests {
     }
 
     #[test]
+    fn query_page_limits_match_the_execution_bound() {
+        assert_eq!(query_page_limit(256).unwrap(), 256);
+        assert!(query_page_limit(257).is_err());
+        assert_eq!(page_limit(1_000).unwrap(), 1_000);
+        assert_eq!(list_server_page_limit(1_000, 0, true), 1_000);
+    }
+
+    #[test]
     fn virtual_only_list_still_performs_one_authoritative_path_read() {
         let (backend, requests, server) = scripted_backend(vec![success(
             wire::WorkspaceResult::Paths(wire::PathPage {
@@ -2847,6 +2866,12 @@ mod tests {
         assert!(requests
             .iter()
             .all(|request| matches!(request.operation, wire::WorkspaceRequest::Catalog(_))));
+        assert!(requests.iter().all(|request| {
+            let wire::WorkspaceRequest::Catalog(catalog) = &request.operation else {
+                return false;
+            };
+            catalog.page.limit == 256
+        }));
     }
 
     #[test]


### PR DESCRIPTION
## Related Issue

Relates to #428 and #433. This is a follow-up contract hardening change: the visible catalog failure was fixed, but the 256-row query execution bound was still not owned consistently across protocol validation, server execution, and CLI request construction.

## Summary

- Define one protocol-owned 256-row maximum for search, aggregate, catalog, workspace discovery, and change-event pages.
- Validate every query-shaped RPC against that maximum.
- Compile-time assert that the server metadata execution bound matches the wire contract.
- Make the CLI use the same bound while preserving the existing 1,000-row ordinary path-list limit.
- Add 256/257 boundary coverage and cross-layer regression tests.

## Scope

- [x] This PR changes one logical boundary only.
- [x] No unrelated refactor, benchmark, metadata model, Holt layout, object-store, agent interface, or docs change is mixed in.
- [x] The linked issue describes the user-visible problem, design decision, or maintenance task this PR resolves.
- [x] Any breaking change is intentional and documented.
- [x] No compatibility shim, deprecated alias, or forwarding wrapper was added without a removal condition.

## Code Contract (Code Changes Only)

- [ ] Not applicable; this is a docs/config-only change.
- [x] Package boundaries follow `docs/development/code_contract.md`.
- [x] Shared helpers reuse the standard library or existing repository helpers.
- [x] File names and file placement follow the code contract.
- [x] New types, interfaces, structs, fields, and functions use domain-specific names.
- [x] New errors remain owned by the protocol validation boundary and retain stable invalid-request behavior.
- [x] New metrics/stats are not introduced.
- [x] Metadata durability, layout, retention, and recovery semantics are unchanged.
- [x] Placement, routing, and fencing are unchanged.
- [x] The Agent facade remains unchanged; only the concrete CLI backend uses the protocol-owned bound.

## Claims and Evidence

- [x] User-facing documentation claims are unchanged.
- [x] No authentication or authorization claim is introduced.
- [x] No performance claim is introduced.
- [x] Benchmark-only behavior does not alter product semantics.

## Validation

- `cargo fmt --all -- --check` — PASS
- `cargo clippy --locked --workspace --all-targets -- -D warnings` — PASS
- `cargo test --locked --workspace` — PASS
- `python3 scripts/workbench/workbench_contract_test.py` — PASS (8/8)
- Live 18-tool Workbench workflow through the production MCP process and RustFS — PASS; overall one-day lease-expiry acceptance remains NOT QUALIFIED and is not claimed by this PR.
- `git diff --check` — PASS

## Contributor Sign-off

- [x] Every commit in this PR includes a DCO `Signed-off-by` trailer.