### PR TITLE
release: add source-only Homebrew formula pipeline

### DIFF
--- a/.github/workflows/release-homebrew.yml
+++ b/.github/workflows/release-homebrew.yml
@@ -1,0 +1,354 @@
+# Copyright 2024-2026 The NoKV Authors.
+# SPDX-License-Identifier: Apache-2.0
+
+name: Release Homebrew Source Formula
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Canonical stable tag, for example v1.0.0"
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    name: Validate immutable release identity
+    runs-on: ubuntu-latest
+    outputs:
+      commit: ${{ steps.resolve.outputs.commit }}
+      tag: ${{ steps.resolve.outputs.tag }}
+      version: ${{ steps.resolve.outputs.version }}
+    env:
+      RELEASE_TAG: ${{ inputs.tag }}
+    steps:
+      - name: Checkout trusted release tooling
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+        with:
+          fetch-depth: 1
+          persist-credentials: false
+          sparse-checkout: scripts/release
+
+      - name: Validate tag before resolving a ref
+        id: resolve
+        shell: bash
+        run: |
+          set -euo pipefail
+          version="$(python3 scripts/release/homebrew_source_release.py validate-tag "$RELEASE_TAG")"
+          git fetch --no-tags https://github.com/NoKV-Lab/NoKV.git \
+            "refs/tags/$RELEASE_TAG:refs/tags/$RELEASE_TAG"
+          commit="$(git rev-parse "refs/tags/$RELEASE_TAG^{commit}")"
+          if [[ ! "$commit" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "::error title=Invalid release commit::Resolved commit is not canonical."
+            exit 1
+          fi
+          {
+            echo "tag=$RELEASE_TAG"
+            echo "version=$version"
+            echo "commit=$commit"
+          } >>"$GITHUB_OUTPUT"
+
+  source:
+    name: Build deterministic source release
+    needs: validate
+    runs-on: ubuntu-latest
+    env:
+      EXPECTED_COMMIT: ${{ needs.validate.outputs.commit }}
+      RELEASE_TAG: ${{ needs.validate.outputs.tag }}
+      RELEASE_VERSION: ${{ needs.validate.outputs.version }}
+    steps:
+      - name: Checkout validated commit
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+          ref: ${{ needs.validate.outputs.commit }}
+
+      - name: Test release safety boundary
+        shell: bash
+        run: |
+          set -euo pipefail
+          python3 scripts/release/test_homebrew_source_release.py
+          python3 scripts/workbench/workbench_contract_test.py
+
+      - name: Build archive, manifest, and published Formula
+        shell: bash
+        env:
+          RELEASE_DIR: ${{ runner.temp }}/nokv-homebrew-release
+        run: |
+          set -euo pipefail
+          python3 scripts/release/homebrew_source_release.py prepare \
+            --repository . \
+            --tag "$RELEASE_TAG" \
+            --expected-commit "$EXPECTED_COMMIT" \
+            --no-local-tag \
+            --output "$RELEASE_DIR"
+          source_url="https://github.com/NoKV-Lab/NoKV/releases/download/$RELEASE_TAG/nokv-$RELEASE_VERSION-source.tar.gz"
+          python3 scripts/release/homebrew_source_release.py render-formula \
+            --manifest "$RELEASE_DIR/nokv-$RELEASE_VERSION-homebrew.json" \
+            --source-url "$source_url" \
+            --output "$RELEASE_DIR/Formula/nokv.rb"
+          cp scripts/release/private_tap_marker.json "$RELEASE_DIR/.nokv-tap.json"
+          python3 scripts/release/homebrew_source_release.py verify-tap \
+            --marker "$RELEASE_DIR/.nokv-tap.json"
+
+      - name: Upload exact release candidate
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+        with:
+          name: nokv-homebrew-${{ needs.validate.outputs.commit }}
+          path: ${{ runner.temp }}/nokv-homebrew-release
+          if-no-files-found: error
+          include-hidden-files: true
+          retention-days: 7
+
+  formula-smoke:
+    name: Source Formula smoke (${{ matrix.runner }})
+    needs:
+      - validate
+      - source
+    strategy:
+      fail-fast: false
+      matrix:
+        runner:
+          - macos-15
+          - macos-15-intel
+    runs-on: ${{ matrix.runner }}
+    env:
+      RELEASE_VERSION: ${{ needs.validate.outputs.version }}
+    steps:
+      - name: Checkout validated release tooling
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+        with:
+          fetch-depth: 1
+          persist-credentials: false
+          ref: ${{ needs.validate.outputs.commit }}
+
+      - name: Download exact release candidate
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
+        with:
+          name: nokv-homebrew-${{ needs.validate.outputs.commit }}
+          path: ${{ runner.temp }}/nokv-homebrew-release
+
+      - name: Render an equivalent local-source Formula
+        shell: bash
+        env:
+          RELEASE_DIR: ${{ runner.temp }}/nokv-homebrew-release
+          TAP_DIR: ${{ runner.temp }}/homebrew-tap
+        run: |
+          set -euo pipefail
+          archive="$RELEASE_DIR/nokv-$RELEASE_VERSION-source.tar.gz"
+          manifest="$RELEASE_DIR/nokv-$RELEASE_VERSION-homebrew.json"
+          python3 scripts/release/homebrew_source_release.py verify-archive \
+            --manifest "$manifest" \
+            --archive "$archive"
+          source_url="$(python3 -c 'import pathlib, sys; print(pathlib.Path(sys.argv[1]).resolve().as_uri())' "$archive")"
+          mkdir -p "$TAP_DIR/Formula"
+          python3 scripts/release/homebrew_source_release.py render-formula \
+            --manifest "$manifest" \
+            --source-url "$source_url" \
+            --output "$TAP_DIR/Formula/nokv.rb"
+          cp "$RELEASE_DIR/.nokv-tap.json" "$TAP_DIR/.nokv-tap.json"
+          python3 scripts/release/homebrew_source_release.py verify-tap \
+            --marker "$TAP_DIR/.nokv-tap.json"
+          git -C "$TAP_DIR" init --initial-branch=main
+          git -C "$TAP_DIR" config user.name "NoKV Release Test"
+          git -C "$TAP_DIR" config user.email "nokv-release-test@example.invalid"
+          git -C "$TAP_DIR" add .
+          git -C "$TAP_DIR" commit -m "Test NoKV source Formula"
+
+      - name: Install and verify the source-built Formula
+        shell: bash
+        env:
+          HOMEBREW_NO_AUTO_UPDATE: "1"
+          RELEASE_DIR: ${{ runner.temp }}/nokv-homebrew-release
+          TAP_DIR: ${{ runner.temp }}/homebrew-tap
+        run: |
+          set -euo pipefail
+          brew tap NoKV-Lab/tap "file://$TAP_DIR"
+          brew style NoKV-Lab/tap/nokv
+          brew install --formula --build-from-source NoKV-Lab/tap/nokv
+          brew test NoKV-Lab/tap/nokv
+          python3 scripts/release/homebrew_source_release.py verify-install \
+            --manifest "$RELEASE_DIR/nokv-$RELEASE_VERSION-homebrew.json" \
+            --binary "$(brew --prefix)/bin/nokv"
+
+      - name: Remove smoke installation
+        if: always()
+        shell: bash
+        env:
+          HOMEBREW_NO_AUTO_UPDATE: "1"
+        run: |
+          brew uninstall --force nokv >/dev/null 2>&1 || true
+          brew untap NoKV-Lab/tap >/dev/null 2>&1 || true
+
+  publish:
+    name: Publish source assets after both macOS gates
+    needs:
+      - validate
+      - source
+      - formula-smoke
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    env:
+      EXPECTED_COMMIT: ${{ needs.validate.outputs.commit }}
+      GH_TOKEN: ${{ github.token }}
+      RELEASE_TAG: ${{ needs.validate.outputs.tag }}
+      RELEASE_VERSION: ${{ needs.validate.outputs.version }}
+    steps:
+      - name: Checkout validated commit
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+        with:
+          fetch-depth: 1
+          persist-credentials: false
+          ref: ${{ needs.validate.outputs.commit }}
+
+      - name: Download tested release candidate
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
+        with:
+          name: nokv-homebrew-${{ needs.validate.outputs.commit }}
+          path: ${{ runner.temp }}/nokv-homebrew-release
+
+      - name: Revalidate tag binding before publication
+        shell: bash
+        run: |
+          set -euo pipefail
+          git fetch --no-tags --force https://github.com/NoKV-Lab/NoKV.git \
+            "refs/tags/$RELEASE_TAG:refs/nokv-release/$RELEASE_TAG"
+          actual="$(git rev-parse "refs/nokv-release/$RELEASE_TAG^{commit}")"
+          if [[ "$actual" != "$EXPECTED_COMMIT" ]]; then
+            echo "::error title=Release tag moved::Expected $EXPECTED_COMMIT, found $actual."
+            exit 1
+          fi
+
+      - name: Publish immutable source assets
+        shell: bash
+        env:
+          RELEASE_DIR: ${{ runner.temp }}/nokv-homebrew-release
+        run: |
+          set -euo pipefail
+          archive="nokv-$RELEASE_VERSION-source.tar.gz"
+          manifest="nokv-$RELEASE_VERSION-homebrew.json"
+          if gh release view "$RELEASE_TAG" >/dev/null 2>&1; then
+            existing="$RUNNER_TEMP/existing-homebrew-release"
+            mkdir -p "$existing"
+            gh release download "$RELEASE_TAG" \
+              --dir "$existing" \
+              --pattern "$archive" \
+              --pattern "$manifest" \
+              --pattern SHA256SUMS
+            cmp "$RELEASE_DIR/$archive" "$existing/$archive"
+            cmp "$RELEASE_DIR/$manifest" "$existing/$manifest"
+            cmp "$RELEASE_DIR/SHA256SUMS" "$existing/SHA256SUMS"
+          else
+            gh release create "$RELEASE_TAG" \
+              "$RELEASE_DIR/$archive" \
+              "$RELEASE_DIR/$manifest" \
+              "$RELEASE_DIR/SHA256SUMS" \
+              --verify-tag \
+              --title "NoKV $RELEASE_VERSION" \
+              --notes "Source-only Homebrew release for commit $EXPECTED_COMMIT."
+          fi
+
+  update-private-tap:
+    name: Open private tap update PR
+    needs:
+      - validate
+      - source
+      - publish
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    env:
+      RELEASE_VERSION: ${{ needs.validate.outputs.version }}
+      TAP_REPOSITORY: NoKV-Lab/homebrew-tap
+    steps:
+      - name: Checkout validated release tooling
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+        with:
+          fetch-depth: 1
+          path: nokv-source
+          persist-credentials: false
+          ref: ${{ needs.validate.outputs.commit }}
+
+      - name: Create repository-scoped GitHub App token
+        id: tap-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1
+        with:
+          client-id: ${{ vars.HOMEBREW_TAP_APP_CLIENT_ID }}
+          private-key: ${{ secrets.HOMEBREW_TAP_APP_PRIVATE_KEY }}
+          owner: NoKV-Lab
+          repositories: homebrew-tap
+          permission-contents: write
+          permission-pull-requests: write
+
+      - name: Fail closed unless the tap is private
+        shell: bash
+        env:
+          GH_TOKEN: ${{ steps.tap-token.outputs.token }}
+        run: |
+          set -euo pipefail
+          private="$(gh api "repos/$TAP_REPOSITORY" --jq '.private')"
+          visibility="$(gh api "repos/$TAP_REPOSITORY" --jq '.visibility')"
+          if [[ "$private" != "true" || "$visibility" != "private" ]]; then
+            echo "::error title=Unsafe tap visibility::$TAP_REPOSITORY must remain private."
+            exit 1
+          fi
+
+      - name: Checkout private tap
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+        with:
+          repository: NoKV-Lab/homebrew-tap
+          path: homebrew-tap
+          token: ${{ steps.tap-token.outputs.token }}
+          persist-credentials: false
+
+      - name: Download tested release candidate
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
+        with:
+          name: nokv-homebrew-${{ needs.validate.outputs.commit }}
+          path: ${{ runner.temp }}/nokv-homebrew-release
+
+      - name: Commit and open tap update PR
+        shell: bash
+        working-directory: homebrew-tap
+        env:
+          GH_TOKEN: ${{ steps.tap-token.outputs.token }}
+          RELEASE_DIR: ${{ runner.temp }}/nokv-homebrew-release
+        run: |
+          set -euo pipefail
+          python3 "$GITHUB_WORKSPACE/nokv-source/scripts/release/homebrew_source_release.py" verify-tap \
+            --marker "$GITHUB_WORKSPACE/homebrew-tap/.nokv-tap.json"
+          branch="release/nokv-$RELEASE_VERSION"
+          if git ls-remote --exit-code --heads origin "$branch" >/dev/null 2>&1; then
+            git fetch origin "$branch"
+            git switch --create "$branch" FETCH_HEAD
+          else
+            git switch --create "$branch"
+          fi
+          mkdir -p Formula
+          cp "$RELEASE_DIR/Formula/nokv.rb" Formula/nokv.rb
+          git add Formula/nokv.rb
+          if git diff --cached --quiet; then
+            echo "The private tap already contains this exact Formula."
+            exit 0
+          fi
+          git config user.name "wchwawa"
+          git config user.email "wch19961116@gmail.com"
+          git commit --signoff --message "release: update nokv to $RELEASE_VERSION"
+          gh auth setup-git
+          git push origin "HEAD:refs/heads/$branch"
+          existing="$(gh pr list --repo "$TAP_REPOSITORY" --head "$branch" --state open --json url --jq '.[0].url // empty')"
+          if [[ -z "$existing" ]]; then
+            gh pr create \
+              --repo "$TAP_REPOSITORY" \
+              --base main \
+              --head "$branch" \
+              --title "release: update nokv to $RELEASE_VERSION" \
+              --body "Updates the private tap to the source-only NoKV $RELEASE_VERSION Formula after Intel and Apple Silicon installation gates passed."
+          else
+            echo "Tap update PR already exists: $existing"
+          fi

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -28,6 +28,9 @@ jobs:
           python3 scripts/workbench/live_workbench_test.py
           bash -n scripts/workbench/start_rustfs.sh
 
+      - name: Check Homebrew release safety
+        run: python3 scripts/release/test_homebrew_source_release.py
+
   nokv-workspace:
     runs-on: ubuntu-latest
     steps:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1270,7 +1270,7 @@ checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
 
 [[package]]
 name = "nokv"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
  "base64 0.23.0",
  "nokv-agent",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ nokv-object = { path = "crates/nokv-object", version = "0.1.0" }
 nokv-client = { path = "crates/nokv-client", version = "0.1.0" }
 nokv-agent = { path = "crates/nokv-agent", version = "0.1.0" }
 nokv-server = { path = "crates/nokv-server", version = "0.1.0" }
-nokv = { path = "crates/nokv", version = "0.1.0" }
+nokv = { path = "crates/nokv", version = "1.0.0" }
 nokv-python = { path = "crates/nokv-python", version = "0.1.0" }
 nokv-bench = { path = "bench", version = "0.1.0" }
 holt = { version = "=0.8.4", default-features = false }

--- a/README.md
+++ b/README.md
@@ -296,6 +296,16 @@ cargo build --release -p nokv --bin nokv
 ./target/release/nokv schema
 ```
 
+Maintainers and integration partners with access to the private tap can instead
+build the same locked source release through Homebrew:
+
+```bash
+brew tap NoKV-Lab/tap
+brew install nokv
+nokv version --json
+nokv schema
+```
+
 Run the offline Workbench contract gate:
 
 ```bash
@@ -323,6 +333,7 @@ without hiding the current recovery limitations.
 - [Code Contract](docs/development/code_contract.md)
 - [PR Review Checklist](docs/development/pr_review_checklist.md)
 - [Workbench Deployment Preflight](docs/workbench-preflight.md)
+- [Source-only Homebrew Release](scripts/release/README.md)
 
 ## Contributing
 

--- a/crates/nokv/Cargo.toml
+++ b/crates/nokv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nokv"
-version = "0.1.0"
+version = "1.0.0"
 description = "Custom CLI and MCP wiring for NoKV Agent workspaces."
 edition.workspace = true
 rust-version.workspace = true
@@ -25,6 +25,9 @@ nokv-types.workspace = true
 sha2.workspace = true
 serde.workspace = true
 serde_json.workspace = true
+
+[build-dependencies]
+sha2.workspace = true
 
 [[bin]]
 name = "nokv"

--- a/crates/nokv/build.rs
+++ b/crates/nokv/build.rs
@@ -1,0 +1,218 @@
+/*
+ * Copyright 2024-2026 The NoKV Authors.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+use std::env;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use sha2::{Digest, Sha256};
+
+const CRATES_IO_SOURCE: &str = "registry+https://github.com/rust-lang/crates.io-index";
+
+#[derive(Debug, PartialEq, Eq)]
+struct LockedPackage {
+    version: String,
+    source: String,
+    checksum: String,
+}
+
+fn main() {
+    println!("cargo:rerun-if-env-changed=NOKV_BUILD_GIT_COMMIT");
+    println!("cargo:rerun-if-env-changed=NOKV_BUILD_CARGO_LOCK_SHA256");
+    println!("cargo:rerun-if-env-changed=NOKV_BUILD_HOLT_VERSION");
+    println!("cargo:rerun-if-env-changed=NOKV_BUILD_HOLT_SOURCE");
+    println!("cargo:rerun-if-env-changed=NOKV_BUILD_HOLT_CHECKSUM");
+
+    let manifest_directory = env::var("CARGO_MANIFEST_DIR").expect("Cargo sets manifest dir");
+    let repository = Path::new(&manifest_directory).join("../..");
+    let lock_path = repository.join("Cargo.lock");
+    println!("cargo:rerun-if-changed={}", lock_path.display());
+
+    let lock = fs::read(&lock_path).expect("NoKV builds require the workspace Cargo.lock");
+    let lock_sha256 = encode_hex(&Sha256::digest(&lock));
+    require_matching_override("NOKV_BUILD_CARGO_LOCK_SHA256", &lock_sha256);
+
+    let lock_text = std::str::from_utf8(&lock).expect("Cargo.lock must be UTF-8");
+    let holt = locked_package(lock_text, "holt");
+    assert_eq!(
+        holt.source, CRATES_IO_SOURCE,
+        "Holt must resolve from canonical crates.io"
+    );
+    assert!(
+        is_lower_hex(&holt.checksum, 64),
+        "Holt checksum must be 64 lowercase hexadecimal characters"
+    );
+    require_matching_override("NOKV_BUILD_HOLT_VERSION", &holt.version);
+    require_matching_override("NOKV_BUILD_HOLT_SOURCE", &holt.source);
+    require_matching_override("NOKV_BUILD_HOLT_CHECKSUM", &holt.checksum);
+
+    let repository_commit = git_commit(&repository);
+    let release_commit = env::var("NOKV_BUILD_GIT_COMMIT").ok();
+    if let (Some(expected), Some(actual)) = (&release_commit, &repository_commit) {
+        assert_eq!(
+            expected, actual,
+            "NOKV_BUILD_GIT_COMMIT does not match the checked-out commit"
+        );
+    }
+    let commit = release_commit
+        .or(repository_commit)
+        .unwrap_or_else(|| "unknown".to_owned());
+    assert!(
+        commit == "unknown" || is_lower_hex(&commit, 40),
+        "NoKV git commit must be 40 lowercase hexadecimal characters"
+    );
+
+    emit("NOKV_GIT_COMMIT", &commit);
+    emit("NOKV_CARGO_LOCK_SHA256", &lock_sha256);
+    emit("NOKV_HOLT_VERSION", &holt.version);
+    emit("NOKV_HOLT_SOURCE", &holt.source);
+    emit("NOKV_HOLT_CHECKSUM", &holt.checksum);
+}
+
+fn locked_package(lock: &str, package_name: &str) -> LockedPackage {
+    let matches = lock
+        .split("[[package]]")
+        .skip(1)
+        .filter_map(|section| {
+            let name = toml_string(section, "name")?;
+            (name == package_name).then(|| LockedPackage {
+                version: toml_string(section, "version")
+                    .expect("locked package must have a version"),
+                source: toml_string(section, "source")
+                    .expect("locked registry package must have a source"),
+                checksum: toml_string(section, "checksum")
+                    .expect("locked registry package must have a checksum"),
+            })
+        })
+        .collect::<Vec<_>>();
+    assert_eq!(
+        matches.len(),
+        1,
+        "Cargo.lock must contain exactly one {package_name} package"
+    );
+    matches.into_iter().next().expect("one package exists")
+}
+
+fn toml_string(section: &str, key: &str) -> Option<String> {
+    section.lines().find_map(|line| {
+        let (candidate, value) = line.split_once('=')?;
+        if candidate.trim() != key {
+            return None;
+        }
+        let value = value.trim();
+        value
+            .strip_prefix('"')
+            .and_then(|value| value.strip_suffix('"'))
+            .map(ToOwned::to_owned)
+    })
+}
+
+fn require_matching_override(name: &str, actual: &str) {
+    if let Ok(expected) = env::var(name) {
+        assert_eq!(expected, actual, "{name} does not match Cargo.lock");
+    }
+}
+
+fn git_commit(repository: &Path) -> Option<String> {
+    for identity_path in git_identity_paths(repository) {
+        println!("cargo:rerun-if-changed={}", identity_path.display());
+    }
+    let output = Command::new("git")
+        .args(["rev-parse", "HEAD"])
+        .current_dir(repository)
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let commit = String::from_utf8(output.stdout).ok()?;
+    let commit = commit.trim().to_owned();
+    is_lower_hex(&commit, 40).then_some(commit)
+}
+
+fn git_identity_paths(repository: &Path) -> Vec<PathBuf> {
+    let mut names = vec!["HEAD".to_owned(), "packed-refs".to_owned()];
+    if let Ok(output) = Command::new("git")
+        .args(["symbolic-ref", "--quiet", "HEAD"])
+        .current_dir(repository)
+        .output()
+    {
+        if output.status.success() {
+            if let Ok(reference) = String::from_utf8(output.stdout) {
+                names.push(reference.trim().to_owned());
+            }
+        }
+    }
+    names
+        .into_iter()
+        .filter_map(|name| {
+            let output = Command::new("git")
+                .args(["rev-parse", "--git-path", &name])
+                .current_dir(repository)
+                .output()
+                .ok()?;
+            if !output.status.success() {
+                return None;
+            }
+            let value = String::from_utf8(output.stdout).ok()?;
+            let path = PathBuf::from(value.trim());
+            Some(if path.is_absolute() {
+                path
+            } else {
+                repository.join(path)
+            })
+        })
+        .collect()
+}
+
+fn emit(name: &str, value: &str) {
+    assert!(
+        !value.contains(['\n', '\r', '\0']),
+        "build identity cannot contain control characters"
+    );
+    println!("cargo:rustc-env={name}={value}");
+}
+
+fn is_lower_hex(value: &str, length: usize) -> bool {
+    value.len() == length
+        && value
+            .bytes()
+            .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte))
+}
+
+fn encode_hex(bytes: &[u8]) -> String {
+    const HEX: &[u8; 16] = b"0123456789abcdef";
+    let mut encoded = String::with_capacity(bytes.len() * 2);
+    for byte in bytes {
+        encoded.push(char::from(HEX[usize::from(byte >> 4)]));
+        encoded.push(char::from(HEX[usize::from(byte & 0x0f)]));
+    }
+    encoded
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn extracts_exact_locked_package() {
+        let lock = r#"
+[[package]]
+name = "holt"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+"#;
+        assert_eq!(
+            locked_package(lock, "holt"),
+            LockedPackage {
+                version: "0.8.4".to_owned(),
+                source: CRATES_IO_SOURCE.to_owned(),
+                checksum: "a".repeat(64),
+            }
+        );
+    }
+}

--- a/crates/nokv/src/build_info.rs
+++ b/crates/nokv/src/build_info.rs
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2024-2026 The NoKV Authors.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+//! Build and dependency identity reported by the installed CLI.
+
+use serde_json::{json, Value};
+
+pub const VERSION: &str = env!("CARGO_PKG_VERSION");
+pub const GIT_COMMIT: &str = env!("NOKV_GIT_COMMIT");
+pub const CARGO_LOCK_SHA256: &str = env!("NOKV_CARGO_LOCK_SHA256");
+pub const HOLT_VERSION: &str = env!("NOKV_HOLT_VERSION");
+pub const HOLT_SOURCE: &str = env!("NOKV_HOLT_SOURCE");
+pub const HOLT_CHECKSUM: &str = env!("NOKV_HOLT_CHECKSUM");
+
+pub fn identity(workbench_contract_schema: &str, workbench_tool_count: usize) -> Value {
+    json!({
+        "version": VERSION,
+        "git_commit": GIT_COMMIT,
+        "cargo_lock_sha256": CARGO_LOCK_SHA256,
+        "holt": {
+            "version": HOLT_VERSION,
+            "source": HOLT_SOURCE,
+            "checksum": HOLT_CHECKSUM,
+        },
+        "workbench_contract_schema": workbench_contract_schema,
+        "workbench_tool_count": workbench_tool_count,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn compiled_identity_is_complete() {
+        assert_eq!(VERSION, "1.0.0");
+        assert!(GIT_COMMIT == "unknown" || GIT_COMMIT.len() == 40);
+        assert_eq!(CARGO_LOCK_SHA256.len(), 64);
+        assert_eq!(HOLT_VERSION, "0.8.4");
+        assert_eq!(
+            HOLT_SOURCE,
+            "registry+https://github.com/rust-lang/crates.io-index"
+        );
+        assert_eq!(HOLT_CHECKSUM.len(), 64);
+    }
+}

--- a/crates/nokv/src/cli.rs
+++ b/crates/nokv/src/cli.rs
@@ -111,6 +111,9 @@ pub enum Command {
     },
     Serve,
     Schema,
+    Version {
+        json: bool,
+    },
     Help,
 }
 
@@ -350,6 +353,7 @@ pub fn parse(arguments: impl IntoIterator<Item = String>) -> Result<Invocation, 
                 )?;
             }
             "--help" => break Command::Help,
+            "--version" => break Command::Version { json: false },
             _ => return Err(CliError::UnknownOption(argument)),
         }
     };
@@ -442,8 +446,18 @@ fn parse_command(
         }),
         "serve" => Ok(Command::Serve),
         "schema" => Ok(Command::Schema),
+        "version" => parse_version(arguments),
         "help" => Ok(Command::Help),
         _ => Err(CliError::UnknownCommand(command)),
+    }
+}
+
+fn parse_version(arguments: &mut impl Iterator<Item = String>) -> Result<Command, CliError> {
+    match arguments.next() {
+        None => Ok(Command::Version { json: false }),
+        Some(argument) if argument == "--json" => Ok(Command::Version { json: true }),
+        Some(argument) if argument.starts_with("--") => Err(CliError::UnknownOption(argument)),
+        Some(argument) => Err(CliError::UnexpectedArgument(argument)),
     }
 }
 
@@ -584,6 +598,22 @@ mod tests {
     #[test]
     fn absent_command_is_help() {
         assert_eq!(parse(Vec::new()).unwrap().command, Command::Help);
+    }
+
+    #[test]
+    fn parses_human_and_machine_readable_version_commands() {
+        assert_eq!(
+            parse(args(&["--version"])).unwrap().command,
+            Command::Version { json: false }
+        );
+        assert_eq!(
+            parse(args(&["version"])).unwrap().command,
+            Command::Version { json: false }
+        );
+        assert_eq!(
+            parse(args(&["version", "--json"])).unwrap().command,
+            Command::Version { json: true }
+        );
     }
 
     #[test]

--- a/crates/nokv/src/main.rs
+++ b/crates/nokv/src/main.rs
@@ -6,6 +6,7 @@
 //! Custom CLI, MCP adapter, and shard-owner process for NoKV Agent workspaces.
 
 mod backend;
+mod build_info;
 mod cli;
 mod connection;
 mod object_store;
@@ -62,6 +63,7 @@ fn run() -> Result<(), String> {
             Ok(())
         }
         Command::Schema => print_schema(),
+        Command::Version { json } => print_version(*json),
         Command::Provision { logical_shard_id } => run_provision(&invocation, logical_shard_id),
         Command::Serve => run_server(&invocation),
         Command::Workbench { tool, arguments } => {
@@ -230,6 +232,18 @@ fn print_schema() -> Result<(), String> {
     }))
 }
 
+fn print_version(json: bool) -> Result<(), String> {
+    if json {
+        print_json(&build_info::identity(
+            WORKBENCH_CONTRACT_SCHEMA,
+            tool_definitions().len(),
+        ))
+    } else {
+        println!("nokv {}", build_info::VERSION);
+        Ok(())
+    }
+}
+
 fn print_json(value: &Value) -> Result<(), String> {
     println!(
         "{}",
@@ -262,6 +276,8 @@ USAGE:
   nokv --root-id HEX32 --etcd-endpoint URL provision <logical-shard-id-hex32>
   nokv [owner options] serve
   nokv schema
+  nokv version [--json]
+  nokv --version
 
 CLIENT ROUTING:
   --root-id HEX32

--- a/scripts/release/README.md
+++ b/scripts/release/README.md
@@ -1,0 +1,94 @@
+# NoKV source-only Homebrew release
+
+NoKV is distributed through the private `NoKV-Lab/homebrew-tap` as a Homebrew
+Formula. The Formula downloads one release-owned source archive and compiles the
+`nokv` CLI locally with Homebrew's locked standard Cargo install arguments. It
+is deliberately not a Cask, does not install a precompiled executable, and does
+not require Apple signing or notarization.
+
+## Consumer flow
+
+Developers with read access to the private tap authenticate GitHub for Git and
+then run:
+
+```shell
+brew tap NoKV-Lab/tap
+brew install nokv
+nokv version --json
+nokv schema
+```
+
+After a tap update is merged, the same installation is updated with:
+
+```shell
+brew update
+brew upgrade nokv
+```
+
+The Formula declares Homebrew `rust` and `protobuf` as build-only dependencies.
+The Rust dependency graph is resolved exclusively from the release
+`Cargo.lock`; the installed binary reports its NoKV version, exact source
+commit, `Cargo.lock` SHA-256, and exact Holt version/source/checksum.
+
+Installing the executable does not create a NoKV deployment. A LingTai MCP
+configuration must still supply the selected NoKV control-plane endpoint,
+object-store configuration, root identity, and stable Agent presentation root.
+Its command is the Homebrew-installed `nokv` executable and its final argument
+is `mcp`.
+
+## Release invariants
+
+`.github/workflows/release-homebrew.yml` accepts only a canonical stable tag of
+the form `vMAJOR.MINOR.PATCH`. Before any user-selected ref is checked out, the
+workflow validates that syntax and resolves the tag to one commit. A release is
+rejected unless all of these identities agree:
+
+- the tag and `crates/nokv` package version;
+- the workspace `nokv` dependency and `Cargo.lock` package version;
+- the tag commit and the commit embedded in the installed CLI;
+- the archive checksum and Formula checksum;
+- the workspace Holt exact pin and the unique checksummed Holt lock entry;
+- the frozen 18-tool Workbench schema and the installed CLI schema.
+
+The generated archive comes from `git archive` at the validated commit and is
+gzip-compressed with a fixed timestamp. GitHub-generated tag archives and
+`latest` URLs are rejected.
+
+## Operator flow
+
+1. Merge the release PR, including the `crates/nokv` version update.
+2. Create the matching stable tag on that exact commit.
+3. Dispatch `Release Homebrew Source Formula` with that tag.
+4. The workflow builds one deterministic source release candidate.
+5. Apple Silicon and Intel macOS runners each install, test, and inspect the
+   same candidate through Homebrew.
+6. Only after both gates pass does the workflow publish the source archive,
+   manifest, and checksums to the GitHub release.
+7. A repository-scoped GitHub App opens a PR against the private tap. A human
+   merges that PR to make the version available to consumers.
+
+The tap repository must already exist with private visibility and contain
+`.nokv-tap.json` equal to `scripts/release/private_tap_marker.json`. Configure
+the GitHub App client ID as `HOMEBREW_TAP_APP_CLIENT_ID` and its private key as
+`HOMEBREW_TAP_APP_PRIVATE_KEY`. The App must be installed only where needed and
+grant `contents: write` plus `pull requests: write` on `homebrew-tap`.
+
+The workflow fails closed if the repository API does not report the tap as
+private. It never accepts a broad personal access token and never pushes
+directly to the tap's default branch.
+
+## Local release checks
+
+```shell
+python3 scripts/release/test_homebrew_source_release.py
+python3 scripts/workbench/workbench_contract_test.py
+actionlint .github/workflows/release-homebrew.yml
+cargo fmt --all -- --check
+cargo clippy --locked --workspace --all-targets -- -D warnings
+cargo test --locked --workspace
+```
+
+For a local Homebrew installation test, commit the candidate in an isolated
+worktree, create the matching local tag in a disposable clone, run `prepare`,
+render a Formula with the archive's absolute `file://` URL, and tap that local
+Git repository. Do not create or move a release tag in the primary checkout.

--- a/scripts/release/homebrew_source_release.py
+++ b/scripts/release/homebrew_source_release.py
@@ -1,0 +1,698 @@
+#!/usr/bin/env python3
+# Copyright 2024-2026 The NoKV Authors.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Build and verify a source-only NoKV Homebrew release."""
+
+from __future__ import annotations
+
+import argparse
+import dataclasses
+import gzip
+import hashlib
+import json
+import re
+import subprocess
+import sys
+import tarfile
+import tomllib
+import urllib.parse
+from pathlib import Path, PurePosixPath
+from typing import Any, NoReturn
+
+
+MANIFEST_SCHEMA = "nokv.homebrew.source_release.v1"
+TAP_MARKER_SCHEMA = "nokv.homebrew.private_tap.v1"
+SOURCE_REPOSITORY = "NoKV-Lab/NoKV"
+TAP_REPOSITORY = "NoKV-Lab/homebrew-tap"
+WORKBENCH_TOOL_COUNT = 18
+STABLE_TAG = re.compile(
+    r"v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)",
+    re.ASCII,
+)
+HEX_40 = re.compile(r"[0-9a-f]{40}", re.ASCII)
+HEX_64 = re.compile(r"[0-9a-f]{64}", re.ASCII)
+CRATES_IO_SOURCE = "registry+https://github.com/rust-lang/crates.io-index"
+
+
+class ReleaseError(ValueError):
+    """The requested release is not safe or internally consistent."""
+
+
+@dataclasses.dataclass(frozen=True)
+class HoltLock:
+    version: str
+    source: str
+    checksum: str
+
+
+@dataclasses.dataclass(frozen=True)
+class WorkbenchContract:
+    schema: str
+    tool_count: int
+    schemas_sha256: str
+
+
+@dataclasses.dataclass(frozen=True)
+class ReleaseMetadata:
+    version: str
+    tag: str
+    commit: str
+    tree: str
+    cargo_lock_sha256: str
+    holt: HoltLock
+    workbench: WorkbenchContract
+
+
+def validate_stable_tag(tag: str) -> str:
+    """Return the plain version for one canonical vMAJOR.MINOR.PATCH tag."""
+    if not isinstance(tag, str) or STABLE_TAG.fullmatch(tag) is None:
+        raise ReleaseError(
+            f"invalid release tag {tag!r}; expected canonical vMAJOR.MINOR.PATCH"
+        )
+    return tag[1:]
+
+
+def _run(
+    arguments: list[str],
+    *,
+    cwd: Path,
+    capture_bytes: bool = False,
+) -> str | bytes:
+    try:
+        completed = subprocess.run(
+            arguments,
+            cwd=cwd,
+            check=True,
+            capture_output=True,
+            text=not capture_bytes,
+        )
+    except (OSError, subprocess.CalledProcessError) as error:
+        detail = ""
+        if isinstance(error, subprocess.CalledProcessError):
+            stderr = error.stderr
+            if isinstance(stderr, bytes):
+                stderr = stderr.decode("utf-8", errors="replace")
+            detail = f": {stderr.strip()}" if stderr else ""
+        raise ReleaseError(f"command failed: {arguments!r}{detail}") from error
+    if capture_bytes:
+        return completed.stdout
+    return completed.stdout.strip()
+
+
+def _git(repository: Path, *arguments: str) -> str:
+    output = _run(["git", *arguments], cwd=repository)
+    if not isinstance(output, str):
+        raise AssertionError("text git command returned bytes")
+    return output
+
+
+def _load_toml(path: Path) -> dict[str, Any]:
+    try:
+        with path.open("rb") as source:
+            value = tomllib.load(source)
+    except (OSError, tomllib.TOMLDecodeError) as error:
+        raise ReleaseError(f"cannot read TOML file {path}: {error}") from error
+    if not isinstance(value, dict):
+        raise ReleaseError(f"TOML root must be a table: {path}")
+    return value
+
+
+def _load_json(path: Path) -> dict[str, Any]:
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as error:
+        raise ReleaseError(f"cannot read JSON file {path}: {error}") from error
+    if not isinstance(value, dict):
+        raise ReleaseError(f"JSON root must be an object: {path}")
+    return value
+
+
+def _sha256_bytes(value: bytes) -> str:
+    return hashlib.sha256(value).hexdigest()
+
+
+def _sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    try:
+        with path.open("rb") as source:
+            for chunk in iter(lambda: source.read(1024 * 1024), b""):
+                digest.update(chunk)
+    except OSError as error:
+        raise ReleaseError(f"cannot hash {path}: {error}") from error
+    return digest.hexdigest()
+
+
+def _package_entries(lock: dict[str, Any], name: str) -> list[dict[str, Any]]:
+    packages = lock.get("package")
+    if not isinstance(packages, list):
+        raise ReleaseError("Cargo.lock lacks a package array")
+    return [
+        package
+        for package in packages
+        if isinstance(package, dict) and package.get("name") == name
+    ]
+
+
+def read_holt_lock(lock_path: Path) -> HoltLock:
+    entries = _package_entries(_load_toml(lock_path), "holt")
+    if len(entries) != 1:
+        raise ReleaseError(
+            f"Cargo.lock must contain exactly one Holt package; found {len(entries)}"
+        )
+    entry = entries[0]
+    version = entry.get("version")
+    source = entry.get("source")
+    checksum = entry.get("checksum")
+    if not isinstance(version, str) or not version:
+        raise ReleaseError("Holt lock entry lacks a version")
+    if source != CRATES_IO_SOURCE:
+        raise ReleaseError(f"Holt lock source is not canonical crates.io: {source!r}")
+    if not isinstance(checksum, str) or HEX_64.fullmatch(checksum) is None:
+        raise ReleaseError("Holt lock entry lacks a canonical SHA-256 checksum")
+    return HoltLock(version=version, source=source, checksum=checksum)
+
+
+def read_workbench_contract(repository: Path) -> WorkbenchContract:
+    path = repository / "crates/nokv-agent/workbench_contract_schema.json"
+    snapshot = _load_json(path)
+    schema = snapshot.get("schema")
+    schemas = snapshot.get("inputSchemas")
+    if not isinstance(schema, str) or not schema:
+        raise ReleaseError("Workbench contract snapshot lacks its schema marker")
+    if not isinstance(schemas, dict):
+        raise ReleaseError("Workbench contract snapshot lacks inputSchemas")
+    if len(schemas) != WORKBENCH_TOOL_COUNT:
+        raise ReleaseError(
+            "Workbench contract must contain exactly "
+            f"{WORKBENCH_TOOL_COUNT} tools; found {len(schemas)}"
+        )
+    encoded = json.dumps(
+        schemas,
+        ensure_ascii=False,
+        separators=(",", ":"),
+        sort_keys=True,
+    ).encode("utf-8")
+    return WorkbenchContract(
+        schema=schema,
+        tool_count=len(schemas),
+        schemas_sha256=_sha256_bytes(encoded),
+    )
+
+
+def _dependency_version(value: Any, name: str) -> str:
+    if isinstance(value, str):
+        return value
+    if isinstance(value, dict) and isinstance(value.get("version"), str):
+        return value["version"]
+    raise ReleaseError(f"workspace dependency {name} lacks an explicit version")
+
+
+def collect_release(
+    repository: Path,
+    tag: str,
+    *,
+    expected_commit: str | None = None,
+    require_tag: bool = True,
+    require_clean: bool = True,
+) -> ReleaseMetadata:
+    """Validate and collect all identities that define a NoKV source release."""
+    version = validate_stable_tag(tag)
+    repository = repository.resolve()
+    if require_clean:
+        dirty = _git(repository, "status", "--porcelain", "--untracked-files=all")
+        if dirty:
+            raise ReleaseError("release worktree is not clean")
+
+    commit = _git(repository, "rev-parse", "HEAD")
+    if HEX_40.fullmatch(commit) is None:
+        raise ReleaseError(f"HEAD is not a canonical SHA-1 commit: {commit!r}")
+    if expected_commit is not None:
+        if HEX_40.fullmatch(expected_commit) is None:
+            raise ReleaseError("expected commit is not a canonical SHA-1")
+        if commit != expected_commit:
+            raise ReleaseError(
+                f"HEAD {commit} does not match validated commit {expected_commit}"
+            )
+    if require_tag:
+        tag_commit = _git(repository, "rev-parse", f"refs/tags/{tag}^{{commit}}")
+        if tag_commit != commit:
+            raise ReleaseError(
+                f"release tag {tag} does not point to HEAD; tag={tag_commit}, HEAD={commit}"
+            )
+
+    tree = _git(repository, "rev-parse", "HEAD^{tree}")
+    if HEX_40.fullmatch(tree) is None:
+        raise ReleaseError(f"HEAD tree is not a canonical SHA-1: {tree!r}")
+
+    package = _load_toml(repository / "crates/nokv/Cargo.toml")
+    package_version = package.get("package", {}).get("version")
+    if package_version != version:
+        raise ReleaseError(
+            f"nokv package version {package_version!r} does not match tag {tag}"
+        )
+
+    workspace = _load_toml(repository / "Cargo.toml")
+    dependencies = workspace.get("workspace", {}).get("dependencies")
+    if not isinstance(dependencies, dict):
+        raise ReleaseError("workspace.dependencies is missing")
+    nokv_dependency_version = _dependency_version(dependencies.get("nokv"), "nokv")
+    if nokv_dependency_version != version:
+        raise ReleaseError(
+            "workspace nokv dependency version "
+            f"{nokv_dependency_version!r} does not match tag {tag}"
+        )
+
+    lock_path = repository / "Cargo.lock"
+    lock = _load_toml(lock_path)
+    nokv_entries = _package_entries(lock, "nokv")
+    if len(nokv_entries) != 1 or nokv_entries[0].get("version") != version:
+        versions = [entry.get("version") for entry in nokv_entries]
+        raise ReleaseError(
+            f"Cargo.lock nokv package versions {versions!r} do not match tag {tag}"
+        )
+
+    holt = read_holt_lock(lock_path)
+    holt_pin = _dependency_version(dependencies.get("holt"), "holt")
+    if holt_pin != f"={holt.version}":
+        raise ReleaseError(
+            f"Holt manifest pin {holt_pin!r} does not match locked ={holt.version}"
+        )
+
+    return ReleaseMetadata(
+        version=version,
+        tag=tag,
+        commit=commit,
+        tree=tree,
+        cargo_lock_sha256=_sha256_file(lock_path),
+        holt=holt,
+        workbench=read_workbench_contract(repository),
+    )
+
+
+def _validate_archive(path: Path, metadata: ReleaseMetadata) -> None:
+    expected_prefix = f"nokv-{metadata.version}"
+    required = {
+        f"{expected_prefix}/Cargo.lock",
+        f"{expected_prefix}/Cargo.toml",
+        f"{expected_prefix}/crates/nokv/Cargo.toml",
+        f"{expected_prefix}/crates/nokv/src/main.rs",
+        f"{expected_prefix}/crates/nokv-agent/workbench_contract_schema.json",
+    }
+    names: set[str] = set()
+    try:
+        with tarfile.open(path, "r:gz") as archive:
+            for member in archive.getmembers():
+                candidate = PurePosixPath(member.name)
+                if candidate.is_absolute() or ".." in candidate.parts:
+                    raise ReleaseError(f"source archive contains unsafe path {member.name!r}")
+                if not candidate.parts or candidate.parts[0] != expected_prefix:
+                    raise ReleaseError(
+                        f"source archive path escapes {expected_prefix!r}: {member.name!r}"
+                    )
+                if ".git" in candidate.parts:
+                    raise ReleaseError(f"source archive contains Git metadata: {member.name!r}")
+                if member.issym() or member.islnk():
+                    link = PurePosixPath(member.linkname)
+                    if link.is_absolute() or ".." in link.parts:
+                        raise ReleaseError(
+                            f"source archive contains unsafe link {member.name!r}"
+                        )
+                names.add(member.name.rstrip("/"))
+    except (OSError, tarfile.TarError) as error:
+        raise ReleaseError(f"cannot validate source archive {path}: {error}") from error
+    missing = required - names
+    if missing:
+        raise ReleaseError(f"source archive lacks required files: {sorted(missing)}")
+
+
+def create_source_archive(
+    repository: Path,
+    metadata: ReleaseMetadata,
+    output_directory: Path,
+) -> Path:
+    """Create a deterministic gzip-compressed archive from the validated commit."""
+    repository = repository.resolve()
+    output_directory.mkdir(parents=True, exist_ok=True)
+    output = output_directory / f"nokv-{metadata.version}-source.tar.gz"
+    tar_bytes = _run(
+        [
+            "git",
+            "archive",
+            "--format=tar",
+            f"--prefix=nokv-{metadata.version}/",
+            metadata.commit,
+        ],
+        cwd=repository,
+        capture_bytes=True,
+    )
+    if not isinstance(tar_bytes, bytes):
+        raise AssertionError("binary git archive command returned text")
+    try:
+        with output.open("wb") as raw:
+            with gzip.GzipFile(
+                filename="",
+                mode="wb",
+                fileobj=raw,
+                compresslevel=9,
+                mtime=0,
+            ) as compressed:
+                compressed.write(tar_bytes)
+    except OSError as error:
+        raise ReleaseError(f"cannot write source archive {output}: {error}") from error
+    _validate_archive(output, metadata)
+    return output
+
+
+def build_manifest(metadata: ReleaseMetadata, archive: Path) -> dict[str, Any]:
+    expected_name = f"nokv-{metadata.version}-source.tar.gz"
+    if archive.name != expected_name:
+        raise ReleaseError(
+            f"source archive must be named {expected_name!r}, got {archive.name!r}"
+        )
+    _validate_archive(archive, metadata)
+    return {
+        "schema": MANIFEST_SCHEMA,
+        "version": metadata.version,
+        "tag": metadata.tag,
+        "commit": metadata.commit,
+        "tree": metadata.tree,
+        "cargo_lock_sha256": metadata.cargo_lock_sha256,
+        "holt": dataclasses.asdict(metadata.holt),
+        "source": {
+            "name": archive.name,
+            "prefix": f"nokv-{metadata.version}",
+            "sha256": _sha256_file(archive),
+        },
+        "workbench": dataclasses.asdict(metadata.workbench),
+    }
+
+
+def write_manifest(manifest: dict[str, Any], path: Path) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(manifest, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+
+
+def load_manifest(path: Path) -> dict[str, Any]:
+    manifest = _load_json(path)
+    if manifest.get("schema") != MANIFEST_SCHEMA:
+        raise ReleaseError(f"manifest {path} has the wrong schema")
+    version = manifest.get("version")
+    tag = manifest.get("tag")
+    if not isinstance(tag, str) or validate_stable_tag(tag) != version:
+        raise ReleaseError("manifest tag and version do not match")
+    if HEX_40.fullmatch(str(manifest.get("commit", ""))) is None:
+        raise ReleaseError("manifest commit is not canonical")
+    if HEX_64.fullmatch(str(manifest.get("cargo_lock_sha256", ""))) is None:
+        raise ReleaseError("manifest Cargo.lock checksum is not canonical")
+    source = manifest.get("source")
+    if not isinstance(source, dict):
+        raise ReleaseError("manifest lacks source identity")
+    if source.get("name") != f"nokv-{version}-source.tar.gz":
+        raise ReleaseError("manifest source name does not match version")
+    if HEX_64.fullmatch(str(source.get("sha256", ""))) is None:
+        raise ReleaseError("manifest source checksum is not canonical")
+    return manifest
+
+
+def verify_manifest_archive(manifest: dict[str, Any], archive: Path) -> None:
+    source = manifest["source"]
+    if archive.name != source["name"]:
+        raise ReleaseError(
+            f"archive name {archive.name!r} does not match manifest {source['name']!r}"
+        )
+    actual = _sha256_file(archive)
+    if actual != source["sha256"]:
+        raise ReleaseError(
+            f"archive checksum {actual} does not match manifest {source['sha256']}"
+        )
+
+
+def _validate_source_url(manifest: dict[str, Any], source_url: str) -> None:
+    parsed = urllib.parse.urlparse(source_url)
+    if parsed.query or parsed.fragment or parsed.params:
+        raise ReleaseError("source URL cannot contain query, fragment, or parameters")
+    expected_name = manifest["source"]["name"]
+    if parsed.scheme == "file":
+        if not parsed.path.startswith("/") or PurePosixPath(parsed.path).name != expected_name:
+            raise ReleaseError("local source URL must be absolute and use the exact archive name")
+        return
+    expected_path = (
+        f"/{SOURCE_REPOSITORY}/releases/download/"
+        f"{manifest['tag']}/{expected_name}"
+    )
+    if (
+        parsed.scheme != "https"
+        or parsed.netloc != "github.com"
+        or parsed.path != expected_path
+    ):
+        raise ReleaseError(
+            "release Formula must use the exact versioned GitHub release asset URL"
+        )
+
+
+def _ruby_string(value: str) -> str:
+    if "\n" in value or "\r" in value or "\x00" in value:
+        raise ReleaseError("Formula string contains a forbidden control character")
+    return json.dumps(value, ensure_ascii=True)
+
+
+def render_formula(manifest: dict[str, Any], source_url: str) -> str:
+    if manifest.get("schema") != MANIFEST_SCHEMA:
+        raise ReleaseError("cannot render Formula from an unknown manifest schema")
+    _validate_source_url(manifest, source_url)
+    holt = manifest.get("holt")
+    workbench = manifest.get("workbench")
+    source = manifest.get("source")
+    if not all(isinstance(value, dict) for value in (holt, workbench, source)):
+        raise ReleaseError("release manifest is incomplete")
+
+    values = {
+        "version": str(manifest["version"]),
+        "url": source_url,
+        "source_sha": str(source["sha256"]),
+        "commit": str(manifest["commit"]),
+        "lock_sha": str(manifest["cargo_lock_sha256"]),
+        "holt_version": str(holt["version"]),
+        "holt_source": str(holt["source"]),
+        "holt_checksum": str(holt["checksum"]),
+        "workbench_schema": str(workbench["schema"]),
+    }
+    return f'''# Copyright 2024-2026 The NoKV Authors.
+# SPDX-License-Identifier: Apache-2.0
+
+class Nokv < Formula
+  desc "Metadata control plane and Workbench MCP server for agent workspaces"
+  homepage "https://nokv.io/"
+  url {_ruby_string(values["url"])}
+  sha256 {_ruby_string(values["source_sha"])}
+  license "Apache-2.0"
+
+  depends_on "protobuf" => :build
+  depends_on "rust" => :build
+
+  def install
+    ENV["NOKV_BUILD_GIT_COMMIT"] = {_ruby_string(values["commit"])}
+    ENV["NOKV_BUILD_CARGO_LOCK_SHA256"] = {_ruby_string(values["lock_sha"])}
+    ENV["NOKV_BUILD_HOLT_VERSION"] = {_ruby_string(values["holt_version"])}
+    ENV["NOKV_BUILD_HOLT_SOURCE"] = {_ruby_string(values["holt_source"])}
+    ENV["NOKV_BUILD_HOLT_CHECKSUM"] = {_ruby_string(values["holt_checksum"])}
+
+    system "cargo", "install", *std_cargo_args(path: "crates/nokv")
+  end
+
+  test do
+    assert_equal "nokv {values['version']}", shell_output("#{{bin}}/nokv --version").strip
+
+    identity = JSON.parse(shell_output("#{{bin}}/nokv version --json"))
+    assert_equal {_ruby_string(values["version"])}, identity.fetch("version")
+    assert_equal {_ruby_string(values["commit"])}, identity.fetch("git_commit")
+    assert_equal {_ruby_string(values["lock_sha"])},
+                 identity.fetch("cargo_lock_sha256")
+    assert_equal {_ruby_string(values["holt_version"])}, identity.dig("holt", "version")
+    assert_equal {_ruby_string(values["holt_source"])}, identity.dig("holt", "source")
+    assert_equal {_ruby_string(values["holt_checksum"])}, identity.dig("holt", "checksum")
+    assert_equal {_ruby_string(values["workbench_schema"])}, identity.fetch("workbench_contract_schema")
+    assert_equal {WORKBENCH_TOOL_COUNT}, identity.fetch("workbench_tool_count")
+
+    schema = JSON.parse(shell_output("#{{bin}}/nokv schema"))
+    assert_equal {_ruby_string(values["workbench_schema"])}, schema.fetch("schema")
+    assert_equal {WORKBENCH_TOOL_COUNT}, schema.fetch("tools").length
+  end
+end
+'''
+
+
+def _same(actual: Any, expected: Any, field: str) -> None:
+    if actual != expected:
+        raise ReleaseError(
+            f"installed {field} {actual!r} does not match release {expected!r}"
+        )
+
+
+def verify_installed_identity(
+    manifest: dict[str, Any],
+    version_payload: dict[str, Any],
+    schema_payload: dict[str, Any],
+) -> None:
+    if manifest.get("schema") != MANIFEST_SCHEMA:
+        raise ReleaseError("release manifest has the wrong schema")
+    holt = manifest["holt"]
+    workbench = manifest["workbench"]
+    _same(version_payload.get("version"), manifest["version"], "version")
+    _same(version_payload.get("git_commit"), manifest["commit"], "commit")
+    _same(
+        version_payload.get("cargo_lock_sha256"),
+        manifest["cargo_lock_sha256"],
+        "Cargo.lock checksum",
+    )
+    _same(version_payload.get("holt"), holt, "Holt identity")
+    _same(
+        version_payload.get("workbench_contract_schema"),
+        workbench["schema"],
+        "Workbench contract schema",
+    )
+    _same(
+        version_payload.get("workbench_tool_count"),
+        workbench["tool_count"],
+        "Workbench tool count",
+    )
+    _same(schema_payload.get("schema"), workbench["schema"], "live schema")
+    tools = schema_payload.get("tools")
+    if not isinstance(tools, list):
+        raise ReleaseError("installed schema does not contain a tools array")
+    _same(len(tools), workbench["tool_count"], "live Workbench tool count")
+
+
+def verify_tap_marker(marker_path: Path) -> None:
+    marker = _load_json(marker_path)
+    expected = {
+        "schema": TAP_MARKER_SCHEMA,
+        "repository": TAP_REPOSITORY,
+        "visibility": "private",
+        "source_repository": SOURCE_REPOSITORY,
+    }
+    if marker != expected:
+        raise ReleaseError(
+            f"tap marker does not identify the exact private repository: {marker!r}"
+        )
+
+
+def _read_command_json(arguments: list[str]) -> dict[str, Any]:
+    try:
+        completed = subprocess.run(
+            arguments,
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+    except (OSError, subprocess.CalledProcessError) as error:
+        stderr = getattr(error, "stderr", "") or ""
+        raise ReleaseError(f"installed command failed: {arguments!r}: {stderr.strip()}") from error
+    try:
+        value = json.loads(completed.stdout)
+    except json.JSONDecodeError as error:
+        raise ReleaseError(f"installed command returned invalid JSON: {error}") from error
+    if not isinstance(value, dict):
+        raise ReleaseError("installed command JSON must be an object")
+    return value
+
+
+def _command_prepare(arguments: argparse.Namespace) -> None:
+    metadata = collect_release(
+        arguments.repository,
+        arguments.tag,
+        expected_commit=arguments.expected_commit,
+        require_tag=not arguments.no_local_tag,
+    )
+    archive = create_source_archive(arguments.repository, metadata, arguments.output)
+    manifest = build_manifest(metadata, archive)
+    manifest_path = arguments.output / f"nokv-{metadata.version}-homebrew.json"
+    write_manifest(manifest, manifest_path)
+    checksums = arguments.output / "SHA256SUMS"
+    checksums.write_text(
+        f"{_sha256_file(archive)}  {archive.name}\n"
+        f"{_sha256_file(manifest_path)}  {manifest_path.name}\n",
+        encoding="utf-8",
+    )
+    print(manifest_path)
+
+
+def _command_render(arguments: argparse.Namespace) -> None:
+    manifest = load_manifest(arguments.manifest)
+    formula = render_formula(manifest, arguments.source_url)
+    arguments.output.parent.mkdir(parents=True, exist_ok=True)
+    arguments.output.write_text(formula, encoding="utf-8")
+
+
+def _command_verify_archive(arguments: argparse.Namespace) -> None:
+    manifest = load_manifest(arguments.manifest)
+    verify_manifest_archive(manifest, arguments.archive)
+
+
+def _command_verify_install(arguments: argparse.Namespace) -> None:
+    manifest = load_manifest(arguments.manifest)
+    version = _read_command_json([str(arguments.binary), "version", "--json"])
+    schema = _read_command_json([str(arguments.binary), "schema"])
+    verify_installed_identity(manifest, version, schema)
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    subcommands = parser.add_subparsers(dest="command", required=True)
+
+    validate = subcommands.add_parser("validate-tag")
+    validate.add_argument("tag")
+
+    prepare = subcommands.add_parser("prepare")
+    prepare.add_argument("--repository", type=Path, default=Path.cwd())
+    prepare.add_argument("--tag", required=True)
+    prepare.add_argument("--expected-commit")
+    prepare.add_argument("--output", type=Path, required=True)
+    prepare.add_argument("--no-local-tag", action="store_true")
+    prepare.set_defaults(handler=_command_prepare)
+
+    render = subcommands.add_parser("render-formula")
+    render.add_argument("--manifest", type=Path, required=True)
+    render.add_argument("--source-url", required=True)
+    render.add_argument("--output", type=Path, required=True)
+    render.set_defaults(handler=_command_render)
+
+    archive = subcommands.add_parser("verify-archive")
+    archive.add_argument("--manifest", type=Path, required=True)
+    archive.add_argument("--archive", type=Path, required=True)
+    archive.set_defaults(handler=_command_verify_archive)
+
+    install = subcommands.add_parser("verify-install")
+    install.add_argument("--manifest", type=Path, required=True)
+    install.add_argument("--binary", type=Path, required=True)
+    install.set_defaults(handler=_command_verify_install)
+
+    tap = subcommands.add_parser("verify-tap")
+    tap.add_argument("--marker", type=Path, required=True)
+    tap.set_defaults(handler=lambda args: verify_tap_marker(args.marker))
+    return parser
+
+
+def _die(message: str) -> NoReturn:
+    print(f"homebrew-source-release: {message}", file=sys.stderr)
+    raise SystemExit(2)
+
+
+def main() -> None:
+    parser = _parser()
+    arguments = parser.parse_args()
+    try:
+        if arguments.command == "validate-tag":
+            print(validate_stable_tag(arguments.tag))
+            return
+        arguments.handler(arguments)
+    except ReleaseError as error:
+        _die(str(error))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/release/private_tap_marker.json
+++ b/scripts/release/private_tap_marker.json
@@ -1,0 +1,6 @@
+{
+  "repository": "NoKV-Lab/homebrew-tap",
+  "schema": "nokv.homebrew.private_tap.v1",
+  "source_repository": "NoKV-Lab/NoKV",
+  "visibility": "private"
+}

--- a/scripts/release/test_homebrew_source_release.py
+++ b/scripts/release/test_homebrew_source_release.py
@@ -1,0 +1,414 @@
+#!/usr/bin/env python3
+# Copyright 2024-2026 The NoKV Authors.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for the source-built Homebrew release boundary."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import subprocess
+import sys
+import tarfile
+import tempfile
+import unittest
+from pathlib import Path
+
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+REPOSITORY_ROOT = SCRIPT_DIR.parents[1]
+sys.path.insert(0, str(SCRIPT_DIR))
+
+import homebrew_source_release as release  # noqa: E402
+
+
+HOLT_CHECKSUM = "c0e62dad7ce341d1e1995cc0034cb347d0e562e444b2354f8418410e2ba770e4"
+REGISTRY = "registry+https://github.com/rust-lang/crates.io-index"
+
+
+def run(*arguments: str, cwd: Path) -> str:
+    completed = subprocess.run(
+        arguments,
+        cwd=cwd,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return completed.stdout.strip()
+
+
+def write(path: Path, contents: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(contents, encoding="utf-8")
+
+
+def repository_fixture(root: Path) -> Path:
+    write(
+        root / "Cargo.toml",
+        """\
+[workspace]
+members = ["crates/nokv"]
+resolver = "2"
+
+[workspace.dependencies]
+nokv = { path = "crates/nokv", version = "1.0.0" }
+holt = { version = "=0.8.4", default-features = false }
+""",
+    )
+    write(
+        root / "crates/nokv/Cargo.toml",
+        """\
+[package]
+name = "nokv"
+version = "1.0.0"
+edition = "2021"
+""",
+    )
+    write(root / "crates/nokv/src/main.rs", "fn main() {}\n")
+    write(
+        root / "Cargo.lock",
+        f"""\
+version = 4
+
+[[package]]
+name = "holt"
+version = "0.8.4"
+source = "{REGISTRY}"
+checksum = "{HOLT_CHECKSUM}"
+
+[[package]]
+name = "nokv"
+version = "1.0.0"
+dependencies = [
+ "holt",
+]
+""",
+    )
+    write(
+        root / "crates/nokv-agent/workbench_contract_schema.json",
+        json.dumps(
+            {
+                "schema": "nokv.workbench.mcp_input_schemas.v1",
+                "inputSchemas": {
+                    f"workbench_tool_{index:02d}": {"type": "object"}
+                    for index in range(18)
+                },
+            }
+        ),
+    )
+    write(root / "README.md", "fixture\n")
+    run("git", "init", "-q", cwd=root)
+    run("git", "config", "user.name", "NoKV Test", cwd=root)
+    run("git", "config", "user.email", "nokv-test@example.invalid", cwd=root)
+    run("git", "add", ".", cwd=root)
+    run("git", "commit", "-q", "-m", "fixture", cwd=root)
+    run("git", "tag", "v1.0.0", cwd=root)
+    return root
+
+
+class StableTagTest(unittest.TestCase):
+    def test_accepts_only_canonical_stable_tags(self) -> None:
+        for tag, version in {
+            "v0.1.0": "0.1.0",
+            "v1.0.0": "1.0.0",
+            "v12.345.6789": "12.345.6789",
+        }.items():
+            with self.subTest(tag=tag):
+                self.assertEqual(release.validate_stable_tag(tag), version)
+
+    def test_rejects_ambiguous_or_executable_refs(self) -> None:
+        invalid = [
+            "1.0.0",
+            "v1.0",
+            "v1.0.0-alpha.1",
+            "v1.0.0+build",
+            "v01.0.0",
+            "v1.00.0",
+            "v1.0.00",
+            "v1.0.0^{}",
+            "refs/tags/v1.0.0",
+            "v1.0.0/../main",
+            "v1.0.0;echo owned",
+            "v1.0.0$(id)",
+            "v1.0.0`id`",
+            "v1.0.0\nmain",
+            "ｖ1.0.0",
+            "v١.٠.٠",
+            "",
+        ]
+        for tag in invalid:
+            with self.subTest(tag=tag):
+                with self.assertRaises(release.ReleaseError):
+                    release.validate_stable_tag(tag)
+
+
+class RepositoryValidationTest(unittest.TestCase):
+    def test_tag_head_package_lock_and_holt_are_one_release(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = repository_fixture(Path(directory))
+            metadata = release.collect_release(root, "v1.0.0")
+
+        self.assertEqual(metadata.version, "1.0.0")
+        self.assertEqual(metadata.tag, "v1.0.0")
+        self.assertRegex(metadata.commit, r"^[0-9a-f]{40}$")
+        self.assertRegex(metadata.tree, r"^[0-9a-f]{40}$")
+        self.assertRegex(metadata.cargo_lock_sha256, r"^[0-9a-f]{64}$")
+        self.assertEqual(metadata.holt.version, "0.8.4")
+        self.assertEqual(metadata.holt.source, REGISTRY)
+        self.assertEqual(metadata.holt.checksum, HOLT_CHECKSUM)
+        self.assertEqual(metadata.workbench.tool_count, 18)
+
+    def test_tag_must_resolve_to_head(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = repository_fixture(Path(directory))
+            write(root / "after-tag", "drift\n")
+            run("git", "add", "after-tag", cwd=root)
+            run("git", "commit", "-q", "-m", "drift", cwd=root)
+            with self.assertRaisesRegex(release.ReleaseError, "does not point to HEAD"):
+                release.collect_release(root, "v1.0.0")
+
+    def test_worktree_must_be_clean(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = repository_fixture(Path(directory))
+            write(root / "untracked", "not released\n")
+            with self.assertRaisesRegex(release.ReleaseError, "worktree is not clean"):
+                release.collect_release(root, "v1.0.0")
+
+    def test_package_and_lock_versions_must_match_tag(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = repository_fixture(Path(directory))
+            package = root / "crates/nokv/Cargo.toml"
+            package.write_text(
+                package.read_text(encoding="utf-8").replace("1.0.0", "1.0.1"),
+                encoding="utf-8",
+            )
+            run("git", "add", ".", cwd=root)
+            run("git", "commit", "-q", "-m", "package drift", cwd=root)
+            run("git", "tag", "v1.0.1", cwd=root)
+            with self.assertRaisesRegex(release.ReleaseError, "workspace nokv dependency"):
+                release.collect_release(root, "v1.0.1")
+
+    def test_holt_manifest_pin_must_match_exact_lock_entry(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = repository_fixture(Path(directory))
+            manifest = root / "Cargo.toml"
+            manifest.write_text(
+                manifest.read_text(encoding="utf-8").replace("=0.8.4", "=0.8.3"),
+                encoding="utf-8",
+            )
+            run("git", "add", ".", cwd=root)
+            run("git", "commit", "-q", "-m", "holt drift", cwd=root)
+            run("git", "tag", "-f", "v1.0.0", cwd=root)
+            with self.assertRaisesRegex(release.ReleaseError, "Holt manifest pin"):
+                release.collect_release(root, "v1.0.0")
+
+    def test_holt_lock_entry_must_be_unique_and_checksummed(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = repository_fixture(Path(directory))
+            lock = root / "Cargo.lock"
+            lock.write_text(
+                lock.read_text(encoding="utf-8")
+                + "\n[[package]]\nname = \"holt\"\nversion = \"9.9.9\"\n",
+                encoding="utf-8",
+            )
+            run("git", "add", ".", cwd=root)
+            run("git", "commit", "-q", "-m", "duplicate holt", cwd=root)
+            run("git", "tag", "-f", "v1.0.0", cwd=root)
+            with self.assertRaisesRegex(release.ReleaseError, "exactly one Holt"):
+                release.collect_release(root, "v1.0.0")
+
+
+class SourceArchiveTest(unittest.TestCase):
+    def test_archive_is_deterministic_complete_and_path_safe(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = repository_fixture(Path(directory) / "repo")
+            output = Path(directory) / "dist"
+            metadata = release.collect_release(root, "v1.0.0")
+            first = release.create_source_archive(root, metadata, output / "first")
+            second = release.create_source_archive(root, metadata, output / "second")
+
+            first_bytes = first.read_bytes()
+            second_bytes = second.read_bytes()
+            self.assertEqual(first_bytes, second_bytes)
+            self.assertEqual(
+                hashlib.sha256(first_bytes).hexdigest(),
+                hashlib.sha256(second_bytes).hexdigest(),
+            )
+            with tarfile.open(first, "r:gz") as archive:
+                names = [member.name for member in archive.getmembers()]
+
+        self.assertIn("nokv-1.0.0/Cargo.lock", names)
+        self.assertIn("nokv-1.0.0/crates/nokv/Cargo.toml", names)
+        self.assertTrue(
+            all(name == "nokv-1.0.0" or name.startswith("nokv-1.0.0/") for name in names)
+        )
+        self.assertFalse(any(".git" in Path(name).parts for name in names))
+
+    def test_manifest_and_formula_bind_exact_source_and_runtime_identity(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = repository_fixture(Path(directory) / "repo")
+            output = Path(directory) / "dist"
+            metadata = release.collect_release(root, "v1.0.0")
+            archive = release.create_source_archive(root, metadata, output)
+            manifest = release.build_manifest(metadata, archive)
+            formula = release.render_formula(
+                manifest,
+                "https://github.com/NoKV-Lab/NoKV/releases/download/"
+                "v1.0.0/nokv-1.0.0-source.tar.gz",
+            )
+            archive_sha256 = hashlib.sha256(archive.read_bytes()).hexdigest()
+
+        self.assertEqual(manifest["source"]["sha256"], archive_sha256)
+        self.assertIn('class Nokv < Formula', formula)
+        self.assertNotIn("Cask", formula)
+        self.assertNotIn("on_arm", formula)
+        self.assertNotIn("on_intel", formula)
+        self.assertNotIn('  version "1.0.0"', formula)
+        self.assertIn('depends_on "rust" => :build', formula)
+        self.assertIn('depends_on "protobuf" => :build', formula)
+        self.assertIn('"cargo", "install", *std_cargo_args(path: "crates/nokv")', formula)
+        self.assertIn(metadata.commit, formula)
+        self.assertIn(metadata.cargo_lock_sha256, formula)
+        self.assertIn(HOLT_CHECKSUM, formula)
+        self.assertIn('assert_equal 18, schema.fetch("tools").length', formula)
+
+    def test_formula_rejects_github_generated_or_mismatched_sources(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = repository_fixture(Path(directory) / "repo")
+            output = Path(directory) / "dist"
+            metadata = release.collect_release(root, "v1.0.0")
+            archive = release.create_source_archive(root, metadata, output)
+            manifest = release.build_manifest(metadata, archive)
+
+            invalid_urls = [
+                "https://github.com/NoKV-Lab/NoKV/archive/refs/tags/v1.0.0.tar.gz",
+                "https://github.com/NoKV-Lab/NoKV/releases/latest/download/"
+                "nokv-1.0.0-source.tar.gz",
+                "https://github.com/NoKV-Lab/NoKV/releases/download/v1.0.1/"
+                "nokv-1.0.0-source.tar.gz",
+            ]
+            for url in invalid_urls:
+                with self.subTest(url=url):
+                    with self.assertRaises(release.ReleaseError):
+                        release.render_formula(manifest, url)
+
+
+class InstalledIdentityTest(unittest.TestCase):
+    def test_installed_binary_must_match_every_release_identity(self) -> None:
+        manifest = {
+            "schema": release.MANIFEST_SCHEMA,
+            "version": "1.0.0",
+            "tag": "v1.0.0",
+            "commit": "a" * 40,
+            "cargo_lock_sha256": "b" * 64,
+            "holt": {
+                "version": "0.8.4",
+                "source": REGISTRY,
+                "checksum": HOLT_CHECKSUM,
+            },
+            "workbench": {
+                "schema": "nokv.workbench.mcp_input_schemas.v1",
+                "tool_count": 18,
+            },
+        }
+        version = {
+            "version": "1.0.0",
+            "git_commit": "a" * 40,
+            "cargo_lock_sha256": "b" * 64,
+            "holt": manifest["holt"],
+            "workbench_contract_schema": "nokv.workbench.mcp_input_schemas.v1",
+            "workbench_tool_count": 18,
+        }
+        schema = {
+            "schema": "nokv.workbench.mcp_input_schemas.v1",
+            "tools": [{} for _ in range(18)],
+        }
+
+        release.verify_installed_identity(manifest, version, schema)
+        for path, replacement in [
+            (("version",), "1.0.1"),
+            (("git_commit",), "c" * 40),
+            (("cargo_lock_sha256",), "d" * 64),
+            (("holt", "checksum"), "e" * 64),
+            (("workbench_tool_count",), 17),
+        ]:
+            drifted = json.loads(json.dumps(version))
+            target = drifted
+            for key in path[:-1]:
+                target = target[key]
+            target[path[-1]] = replacement
+            with self.subTest(path=path):
+                with self.assertRaises(release.ReleaseError):
+                    release.verify_installed_identity(manifest, drifted, schema)
+
+
+class PrivateTapAndWorkflowTest(unittest.TestCase):
+    def test_private_tap_marker_is_exact(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            marker = Path(directory) / ".nokv-tap.json"
+            marker.write_text(
+                json.dumps(
+                    {
+                        "schema": release.TAP_MARKER_SCHEMA,
+                        "repository": "NoKV-Lab/homebrew-tap",
+                        "visibility": "private",
+                        "source_repository": "NoKV-Lab/NoKV",
+                    }
+                ),
+                encoding="utf-8",
+            )
+            release.verify_tap_marker(marker)
+            marker.write_text(
+                marker.read_text(encoding="utf-8").replace("private", "public"),
+                encoding="utf-8",
+            )
+            with self.assertRaises(release.ReleaseError):
+                release.verify_tap_marker(marker)
+
+    def test_workflow_keeps_untrusted_tag_away_from_shell_and_tokens(self) -> None:
+        workflow = (
+            REPOSITORY_ROOT / ".github/workflows/release-homebrew.yml"
+        ).read_text(encoding="utf-8")
+        lines = workflow.splitlines()
+        run_blocks: list[str] = []
+        index = 0
+        while index < len(lines):
+            line = lines[index]
+            if line.lstrip().startswith("run: |"):
+                indent = len(line) - len(line.lstrip())
+                block: list[str] = []
+                index += 1
+                while index < len(lines):
+                    candidate = lines[index]
+                    if candidate.strip() and len(candidate) - len(candidate.lstrip()) <= indent:
+                        break
+                    block.append(candidate)
+                    index += 1
+                run_blocks.append("\n".join(block))
+                continue
+            index += 1
+
+        self.assertNotIn("${{ inputs.tag }}", "\n".join(run_blocks))
+        self.assertIn("persist-credentials: false", workflow)
+        self.assertIn("macos-15-intel", workflow)
+        self.assertIn("macos-15", workflow)
+        self.assertIn("NoKV-Lab/homebrew-tap", workflow)
+        self.assertIn("create-github-app-token", workflow)
+        self.assertIn("gh pr create", workflow)
+        self.assertNotIn("HOMEBREW_TAP_PAT", workflow)
+        self.assertNotIn("archive/refs/tags", workflow)
+
+        action_refs = [
+            line.split("@", 1)[1].strip()
+            for line in lines
+            if line.strip().startswith("uses:")
+        ]
+        self.assertTrue(action_refs)
+        for action_ref in action_refs:
+            with self.subTest(action_ref=action_ref):
+                self.assertRegex(action_ref, r"^[0-9a-f]{40}$")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Related Issue

Release-chore exception: this PR has no issue. It is the reviewed delivery work for the private Homebrew tap and depends on #444 so the published Workbench path includes the cross-layer page-limit fix.

## Summary

- Publish NoKV 1.0.0 as a source-only Homebrew Formula: no Cask and no precompiled NoKV binary.
- Add fail-closed `nokv version --json` identity covering the exact NoKV commit, Cargo.lock digest, Holt version/source/checksum, and Workbench contract.
- Accept only canonical stable `vMAJOR.MINOR.PATCH` tags bound to a clean exact commit.
- Build deterministic release-owned source archives and checksums from the same immutable tag.
- Run Intel and Apple Silicon source-install smoke gates before creating a GitHub Release.
- Use a repository-scoped GitHub App to open a PR against the private `NoKV-Lab/homebrew-tap`; never push directly to its default branch.
- Document `brew tap NoKV-Lab/tap`, install, upgrade, and maintainer release steps.

## Scope

- [x] This PR changes one logical boundary only: source release identity and Homebrew distribution.
- [x] No metadata model, Holt layout, object-store behavior, or Agent tool schema is changed.
- [x] This release-chore exception is explained above.
- [x] The 1.0.0 package version is intentional and release identity is fail closed.
- [x] No compatibility shim, deprecated alias, forwarding wrapper, Cask, or binary-package path is added.

## Code Contract (Code Changes Only)

- [ ] Not applicable; this is a docs/config-only change.
- [x] Package boundaries follow `docs/development/code_contract.md`.
- [x] Release helpers are isolated under `scripts/release` and covered by adversarial tests.
- [x] File names and placement are responsibility-based.
- [x] New identity fields and CLI commands use release-domain names.
- [x] No new domain error type, metric, metadata layout, durability rule, or routing behavior is introduced.
- [x] The `nokv` crate remains thin: it reports build identity and wires the existing MCP/CLI implementation.

## Claims and Evidence

- [x] Documentation states that this is a private source Formula and names the required build dependencies.
- [x] The workflow verifies private tap visibility before checkout or mutation.
- [x] No performance claim is introduced.
- [x] Workbench semantics and the frozen 18-tool schema are unchanged.

## Validation

- `python3 -m unittest scripts.release.test_homebrew_source_release` — PASS (14/14 tag, archive, manifest, Formula, tap, and workflow safety tests)
- `actionlint` 1.7.12 — PASS
- `cargo fmt --all -- --check` — PASS
- `cargo clippy --locked --workspace --all-targets -- -D warnings` — PASS
- `cargo test --locked --workspace` — PASS
- `python3 scripts/workbench/workbench_contract_test.py` — PASS (8/8)
- Deterministic source archive generated twice with identical SHA-256 — PASS
- `brew style` and strict Formula audit — PASS
- Local `brew install --build-from-source`, `brew test`, version/identity verification, and source-built upgrade — PASS; bottle and Cask paths remained false
- Installed identity matched repo-locked Holt 0.8.4, its registry source/checksum, Cargo.lock checksum, and the exact source commit
- LingTai production `Agent.connect_mcp -> ToolExecutor -> nokv` process registered all 18 tools and passed create/put/read/list/catalog before and after upgrade
- Live RustFS 18-tool Workbench workflow — PASS; overall one-day lease-expiry acceptance remains NOT QUALIFIED and is not claimed here
- `git diff --check` — PASS

## Contributor Sign-off

- [x] Every commit in this PR includes a DCO `Signed-off-by` trailer.