### PR TITLE
fix: align Homebrew release with public tap

### DIFF
--- a/.github/workflows/release-homebrew.yml
+++ b/.github/workflows/release-homebrew.yml
@@ -91,7 +91,7 @@ jobs:
             --manifest "$RELEASE_DIR/nokv-$RELEASE_VERSION-homebrew.json" \
             --source-url "$source_url" \
             --output "$RELEASE_DIR/Formula/nokv.rb"
-          cp scripts/release/private_tap_marker.json "$RELEASE_DIR/.nokv-tap.json"
+          cp scripts/release/public_tap_marker.json "$RELEASE_DIR/.nokv-tap.json"
           python3 scripts/release/homebrew_source_release.py verify-tap \
             --marker "$RELEASE_DIR/.nokv-tap.json"
 
@@ -253,8 +253,8 @@ jobs:
               --notes "Source-only Homebrew release for commit $EXPECTED_COMMIT."
           fi
 
-  update-private-tap:
-    name: Open private tap update PR
+  update-public-tap:
+    name: Open public tap update PR
     needs:
       - validate
       - source
@@ -285,7 +285,7 @@ jobs:
           permission-contents: write
           permission-pull-requests: write
 
-      - name: Fail closed unless the tap is private
+      - name: Fail closed unless the tap is public
         shell: bash
         env:
           GH_TOKEN: ${{ steps.tap-token.outputs.token }}
@@ -293,12 +293,12 @@ jobs:
           set -euo pipefail
           private="$(gh api "repos/$TAP_REPOSITORY" --jq '.private')"
           visibility="$(gh api "repos/$TAP_REPOSITORY" --jq '.visibility')"
-          if [[ "$private" != "true" || "$visibility" != "private" ]]; then
-            echo "::error title=Unsafe tap visibility::$TAP_REPOSITORY must remain private."
+          if [[ "$private" != "false" || "$visibility" != "public" ]]; then
+            echo "::error title=Unavailable public tap::$TAP_REPOSITORY must remain public."
             exit 1
           fi
 
-      - name: Checkout private tap
+      - name: Checkout public tap
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         with:
           repository: NoKV-Lab/homebrew-tap
@@ -333,7 +333,7 @@ jobs:
           cp "$RELEASE_DIR/Formula/nokv.rb" Formula/nokv.rb
           git add Formula/nokv.rb
           if git diff --cached --quiet; then
-            echo "The private tap already contains this exact Formula."
+            echo "The public tap already contains this exact Formula."
             exit 0
           fi
           git config user.name "wchwawa"
@@ -348,7 +348,7 @@ jobs:
               --base main \
               --head "$branch" \
               --title "release: update nokv to $RELEASE_VERSION" \
-              --body "Updates the private tap to the source-only NoKV $RELEASE_VERSION Formula after Intel and Apple Silicon installation gates passed."
+              --body "Updates the public tap to the source-only NoKV $RELEASE_VERSION Formula after Intel and Apple Silicon installation gates passed."
           else
             echo "Tap update PR already exists: $existing"
           fi

--- a/README.md
+++ b/README.md
@@ -296,15 +296,41 @@ cargo build --release -p nokv --bin nokv
 ./target/release/nokv schema
 ```
 
-Maintainers and integration partners with access to the private tap can instead
-build the same locked source release through Homebrew:
+Anyone can instead install the current stable source release from NoKV's public
+Homebrew tap. The fully qualified command adds the tap and trusts only the
+`nokv` Formula:
 
 ```bash
-brew tap NoKV-Lab/tap
-brew install nokv
+brew install NoKV-Lab/tap/nokv
 nokv version --json
 nokv schema
 ```
+
+The current source Formula release gate covers Apple Silicon and Intel macOS.
+Linuxbrew is not yet a qualified release target.
+
+To add the tap separately before installing by short name, grant the same
+Formula-scoped trust explicitly:
+
+```bash
+brew tap NoKV-Lab/tap
+brew trust --formula NoKV-Lab/tap/nokv
+brew install nokv
+```
+
+Pull a merged tap update and install a newer NoKV release with:
+
+```bash
+brew update
+brew upgrade nokv
+nokv version --json
+```
+
+The Formula version follows the stable NoKV release tag and the `crates/nokv`
+package version, not Holt, Rust, or protobuf. Every NoKV release carries its
+own `Cargo.lock` and embeds the exact Holt version, source, and checksum in the
+installed identity. A Holt update reaches the tap only as part of a new NoKV
+release whose generated Formula has been merged into the tap.
 
 Run the offline Workbench contract gate:
 

--- a/scripts/release/README.md
+++ b/scripts/release/README.md
@@ -1,6 +1,6 @@
 # NoKV source-only Homebrew release
 
-NoKV is distributed through the private `NoKV-Lab/homebrew-tap` as a Homebrew
+NoKV is distributed through the public `NoKV-Lab/homebrew-tap` as a Homebrew
 Formula. The Formula downloads one release-owned source archive and compiles the
 `nokv` CLI locally with Homebrew's locked standard Cargo install arguments. It
 is deliberately not a Cask, does not install a precompiled executable, and does
@@ -8,14 +8,24 @@ not require Apple signing or notarization.
 
 ## Consumer flow
 
-Developers with read access to the private tap authenticate GitHub for Git and
-then run:
+Anyone can install the fully qualified Formula without GitHub repository
+credentials. Homebrew adds the public tap and trusts only that Formula:
+
+```shell
+brew install NoKV-Lab/tap/nokv
+nokv version --json
+nokv schema
+```
+
+The current release gate covers Apple Silicon and Intel macOS. Linuxbrew is not
+yet a qualified release target.
+
+The equivalent explicit tap flow is:
 
 ```shell
 brew tap NoKV-Lab/tap
+brew trust --formula NoKV-Lab/tap/nokv
 brew install nokv
-nokv version --json
-nokv schema
 ```
 
 After a tap update is merged, the same installation is updated with:
@@ -29,6 +39,11 @@ The Formula declares Homebrew `rust` and `protobuf` as build-only dependencies.
 The Rust dependency graph is resolved exclusively from the release
 `Cargo.lock`; the installed binary reports its NoKV version, exact source
 commit, `Cargo.lock` SHA-256, and exact Holt version/source/checksum.
+
+The Formula version follows the stable NoKV tag and the `crates/nokv` package
+version. It does not follow Holt or either Homebrew build dependency. A Holt
+change is published only inside a new NoKV release after its exact pin and lock
+entry pass the release gates and the generated Formula is merged into the tap.
 
 Installing the executable does not create a NoKV deployment. A LingTai MCP
 configuration must still supply the selected NoKV control-plane endpoint,
@@ -64,17 +79,17 @@ gzip-compressed with a fixed timestamp. GitHub-generated tag archives and
    same candidate through Homebrew.
 6. Only after both gates pass does the workflow publish the source archive,
    manifest, and checksums to the GitHub release.
-7. A repository-scoped GitHub App opens a PR against the private tap. A human
+7. A repository-scoped GitHub App opens a PR against the public tap. A human
    merges that PR to make the version available to consumers.
 
-The tap repository must already exist with private visibility and contain
-`.nokv-tap.json` equal to `scripts/release/private_tap_marker.json`. Configure
+The tap repository must have public visibility and contain `.nokv-tap.json`
+equal to `scripts/release/public_tap_marker.json`. Configure
 the GitHub App client ID as `HOMEBREW_TAP_APP_CLIENT_ID` and its private key as
 `HOMEBREW_TAP_APP_PRIVATE_KEY`. The App must be installed only where needed and
 grant `contents: write` plus `pull requests: write` on `homebrew-tap`.
 
 The workflow fails closed if the repository API does not report the tap as
-private. It never accepts a broad personal access token and never pushes
+public. It never accepts a broad personal access token and never pushes
 directly to the tap's default branch.
 
 ## Local release checks

--- a/scripts/release/homebrew_source_release.py
+++ b/scripts/release/homebrew_source_release.py
@@ -22,7 +22,7 @@ from typing import Any, NoReturn
 
 
 MANIFEST_SCHEMA = "nokv.homebrew.source_release.v1"
-TAP_MARKER_SCHEMA = "nokv.homebrew.private_tap.v1"
+TAP_MARKER_SCHEMA = "nokv.homebrew.public_tap.v1"
 SOURCE_REPOSITORY = "NoKV-Lab/NoKV"
 TAP_REPOSITORY = "NoKV-Lab/homebrew-tap"
 WORKBENCH_TOOL_COUNT = 18
@@ -572,12 +572,12 @@ def verify_tap_marker(marker_path: Path) -> None:
     expected = {
         "schema": TAP_MARKER_SCHEMA,
         "repository": TAP_REPOSITORY,
-        "visibility": "private",
+        "visibility": "public",
         "source_repository": SOURCE_REPOSITORY,
     }
     if marker != expected:
         raise ReleaseError(
-            f"tap marker does not identify the exact private repository: {marker!r}"
+            f"tap marker does not identify the exact public repository: {marker!r}"
         )
 
 

--- a/scripts/release/public_tap_marker.json
+++ b/scripts/release/public_tap_marker.json
@@ -1,6 +1,6 @@
 {
   "repository": "NoKV-Lab/homebrew-tap",
-  "schema": "nokv.homebrew.private_tap.v1",
+  "schema": "nokv.homebrew.public_tap.v1",
   "source_repository": "NoKV-Lab/NoKV",
-  "visibility": "private"
+  "visibility": "public"
 }

--- a/scripts/release/test_homebrew_source_release.py
+++ b/scripts/release/test_homebrew_source_release.py
@@ -343,8 +343,8 @@ class InstalledIdentityTest(unittest.TestCase):
                     release.verify_installed_identity(manifest, drifted, schema)
 
 
-class PrivateTapAndWorkflowTest(unittest.TestCase):
-    def test_private_tap_marker_is_exact(self) -> None:
+class PublicTapAndWorkflowTest(unittest.TestCase):
+    def test_public_tap_marker_is_exact(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
             marker = Path(directory) / ".nokv-tap.json"
             marker.write_text(
@@ -352,7 +352,7 @@ class PrivateTapAndWorkflowTest(unittest.TestCase):
                     {
                         "schema": release.TAP_MARKER_SCHEMA,
                         "repository": "NoKV-Lab/homebrew-tap",
-                        "visibility": "private",
+                        "visibility": "public",
                         "source_repository": "NoKV-Lab/NoKV",
                     }
                 ),
@@ -360,11 +360,18 @@ class PrivateTapAndWorkflowTest(unittest.TestCase):
             )
             release.verify_tap_marker(marker)
             marker.write_text(
-                marker.read_text(encoding="utf-8").replace("private", "public"),
+                marker.read_text(encoding="utf-8").replace("public", "private"),
                 encoding="utf-8",
             )
             with self.assertRaises(release.ReleaseError):
                 release.verify_tap_marker(marker)
+
+    def test_checked_in_marker_declares_the_public_tap(self) -> None:
+        marker = REPOSITORY_ROOT / "scripts/release/public_tap_marker.json"
+        release.verify_tap_marker(marker)
+        self.assertFalse(
+            (REPOSITORY_ROOT / "scripts/release/private_tap_marker.json").exists()
+        )
 
     def test_workflow_keeps_untrusted_tag_away_from_shell_and_tokens(self) -> None:
         workflow = (
@@ -396,6 +403,12 @@ class PrivateTapAndWorkflowTest(unittest.TestCase):
         self.assertIn("NoKV-Lab/homebrew-tap", workflow)
         self.assertIn("create-github-app-token", workflow)
         self.assertIn("gh pr create", workflow)
+        self.assertIn("Fail closed unless the tap is public", workflow)
+        self.assertIn('"$private" != "false"', workflow)
+        self.assertIn('"$visibility" != "public"', workflow)
+        self.assertIn("public_tap_marker.json", workflow)
+        self.assertNotIn("must remain private", workflow)
+        self.assertNotIn("Updates the private tap", workflow)
         self.assertNotIn("HOMEBREW_TAP_PAT", workflow)
         self.assertNotIn("archive/refs/tags", workflow)
 


### PR DESCRIPTION
## Related Issue

Relates to NoKV-Lab/homebrew-tap#1

## Summary

- Makes public tap visibility a fail-closed release invariant.
- Renames and validates the public tap marker.
- Documents public one-command install, update, release identity, and the current macOS-only qualification boundary.

## Scope

- [x] This PR changes one logical boundary only.
- [x] No unrelated storage, Holt, object-store, Agent interface, or benchmark change is mixed in.
- [x] The public visibility change is intentional and documented.
- [x] No compatibility shim or fallback path was added.

## Code Contract

- [x] Not applicable; this is a release configuration, test, and documentation change.

## Claims and Evidence

- [x] Public access is distinguished from platform qualification.
- [x] Linuxbrew remains explicitly not qualified.
- [x] Installed NoKV/Holt identity remains bound to the immutable source release.

## Validation

- `python3 scripts/release/test_homebrew_source_release.py` — 15 passed.
- `python3 scripts/workbench/workbench_contract_test.py` — 8 passed.
- `actionlint v1.7.12 .github/workflows/release-homebrew.yml` — passed.
- `brew style NoKV-Lab/tap/nokv` — passed.
- `brew audit --strict --online NoKV-Lab/tap/nokv` — passed.
- `brew test NoKV-Lab/tap/nokv` — passed.
- Rust checks were not run because no Rust source or package boundary changed.

## Contributor Sign-off

- [x] Every commit includes a DCO `Signed-off-by` trailer.
