### PR TITLE
fix(meta): avoid recovery outbox key fragmentation

### DIFF
--- a/crates/nokv-meta-holt/src/lib.rs
+++ b/crates/nokv-meta-holt/src/lib.rs
@@ -8,8 +8,8 @@
 //! The adapter maps each configured [`nokv_meta_store::Keyspace`] to the
 //! caller-configured physical Holt tree. It does not know the workspace schema
 //! or record codecs. One `HoltStore` instance owns one local physical authority.
-//! The `test-support` feature exposes an in-memory constructor to test and
-//! diagnostic packages.
+//! The `test-support` feature exposes an in-memory constructor plus explicit
+//! checkpoint and keyspace-stat probes to test and diagnostic packages.
 
 mod options;
 #[cfg(feature = "read-stats")]

--- a/crates/nokv-meta-holt/src/store.rs
+++ b/crates/nokv-meta-holt/src/store.rs
@@ -120,6 +120,32 @@ impl HoltStore {
         )
     }
 
+    /// Force one checkpoint round for adapter-backed storage tests.
+    #[cfg(feature = "test-support")]
+    pub fn checkpoint_for_test(&self) -> Result<(), StoreError> {
+        let state = self.read_state()?;
+        ensure_ready(&state)?;
+        state.db.checkpoint().map_err(map_holt_error)
+    }
+
+    /// Return physical Holt statistics for one configured keyspace in tests.
+    #[cfg(feature = "test-support")]
+    pub fn keyspace_stats_for_test(
+        &self,
+        keyspace: Keyspace,
+    ) -> Result<holt::TreeStats, StoreError> {
+        let state = self.read_state()?;
+        ensure_ready(&state)?;
+        let name = state.trees.get(&keyspace).ok_or_else(|| {
+            StoreError::InvalidRequest(format!(
+                "keyspace {:04x} is not configured for this HoltStore",
+                keyspace.get()
+            ))
+        })?;
+        let tree = state.db.open_tree(name).map_err(map_holt_error)?;
+        tree.stats().map_err(map_holt_error)
+    }
+
     fn read_state(&self) -> Result<RwLockReadGuard<'_, State>, StoreError> {
         self.state
             .read()

--- a/crates/nokv-meta/src/workspace/codec.rs
+++ b/crates/nokv-meta/src/workspace/codec.rs
@@ -20,7 +20,14 @@ const ARTIFACT_REVISION_CLAIM_DISCRIMINATOR: u8 = 0xff;
 
 const FIXED_ID_BYTES: usize = 16;
 pub(crate) const SYSTEM_SCHEMA_KEY: &[u8] = b"schema";
-const SYSTEM_FORMAT_VERSION: u32 = 8;
+const SYSTEM_FORMAT_VERSION: u32 = 9;
+const PREVIOUS_SYSTEM_FORMAT_VERSION: u32 = 8;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum SchemaMarkerVersion {
+    Current,
+    Format8,
+}
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub(crate) struct SchemaMarkerError;
@@ -589,16 +596,32 @@ pub fn object_block_key(
 }
 
 pub(crate) fn encode_schema_marker() -> Vec<u8> {
+    encode_schema_marker_version(SYSTEM_FORMAT_VERSION)
+}
+
+fn encode_schema_marker_version(format_version: u32) -> Vec<u8> {
     let mut value = Vec::with_capacity(1 + 4 + SCHEMA_ID.len() + 4);
     value.push(VALUE_FORMAT_VERSION);
     push_len_prefixed(&mut value, SCHEMA_ID.as_bytes());
-    value.extend_from_slice(&SYSTEM_FORMAT_VERSION.to_be_bytes());
+    value.extend_from_slice(&format_version.to_be_bytes());
     value
 }
 
 pub(crate) fn validate_schema_marker(value: &[u8]) -> Result<(), SchemaMarkerError> {
     if value == encode_schema_marker() {
         Ok(())
+    } else {
+        Err(SchemaMarkerError)
+    }
+}
+
+pub(crate) fn classify_schema_marker_for_open(
+    value: &[u8],
+) -> Result<SchemaMarkerVersion, SchemaMarkerError> {
+    if value == encode_schema_marker() {
+        Ok(SchemaMarkerVersion::Current)
+    } else if value == encode_schema_marker_version(PREVIOUS_SYSTEM_FORMAT_VERSION) {
+        Ok(SchemaMarkerVersion::Format8)
     } else {
         Err(SchemaMarkerError)
     }
@@ -951,6 +974,7 @@ mod tests {
 
     #[test]
     fn schema_marker_is_exact_and_versioned() {
+        assert_eq!(SYSTEM_FORMAT_VERSION, 9);
         let marker = encode_schema_marker();
         assert_eq!(marker[0], VALUE_FORMAT_VERSION);
         assert_eq!(
@@ -958,17 +982,27 @@ mod tests {
             &SYSTEM_FORMAT_VERSION.to_be_bytes()
         );
         validate_schema_marker(&marker).unwrap();
+        assert_eq!(
+            classify_schema_marker_for_open(&marker).unwrap(),
+            SchemaMarkerVersion::Current
+        );
 
-        let mut previous_layout = marker.clone();
-        let version_start = previous_layout.len() - std::mem::size_of::<u32>();
-        previous_layout[version_start..].copy_from_slice(&7_u32.to_be_bytes());
+        let previous_layout = encode_schema_marker_version(PREVIOUS_SYSTEM_FORMAT_VERSION);
         assert_eq!(
             validate_schema_marker(&previous_layout),
             Err(SchemaMarkerError)
+        );
+        assert_eq!(
+            classify_schema_marker_for_open(&previous_layout).unwrap(),
+            SchemaMarkerVersion::Format8
         );
 
         let mut unknown = marker;
         unknown[0] = VALUE_FORMAT_VERSION + 1;
         assert_eq!(validate_schema_marker(&unknown), Err(SchemaMarkerError));
+        assert_eq!(
+            classify_schema_marker_for_open(&unknown),
+            Err(SchemaMarkerError)
+        );
     }
 }

--- a/crates/nokv-meta/src/workspace/engine.rs
+++ b/crates/nokv-meta/src/workspace/engine.rs
@@ -20,7 +20,8 @@ use nokv_types::{
 use sha2::{Digest, Sha256};
 
 use super::codec::{
-    change_event_key, encode_schema_marker, validate_schema_marker, SCHEMA_ID, SYSTEM_SCHEMA_KEY,
+    change_event_key, classify_schema_marker_for_open, encode_schema_marker,
+    validate_schema_marker, SchemaMarkerVersion, SCHEMA_ID, SYSTEM_SCHEMA_KEY,
 };
 use super::keyspace::{
     keyspaces, MetadataFamily, CHANGE_EVENT, COMMAND_DEDUPE, HISTORY, RECOVERY_OUTBOX, ROOT_FENCE,
@@ -31,8 +32,9 @@ use super::read_stats::{self, MetadataReadStats, MetadataReadStatsSessionError};
 use super::records::{CommandDedupeRecord, CurrentValue, HistoryValue, RootFence};
 use super::recovery::{
     assemble_recovery_storage, decode_recovery_outbox_key, recovery_chunk_key,
-    recovery_genesis_digest, recovery_outbox_key, recovery_storage_chunk_count,
-    recovery_storage_logical_length, split_recovery_storage, RecoveryMutationV1,
+    recovery_chunk_key_for_layout, recovery_genesis_digest, recovery_outbox_key,
+    recovery_outbox_scan_start, recovery_storage_chunk_count, recovery_storage_logical_length,
+    split_recovery_storage, DecodedRecoveryOutboxKey, RecoveryKeyLayout, RecoveryMutationV1,
     RecoveryOutboxRecord, RecoveryResultV1, RecoveryState, MAX_RECOVERY_BYTES,
     RECOVERY_CHAIN_DIGEST_BYTES,
 };
@@ -582,9 +584,10 @@ impl MetaShard {
 
     fn open_domain(self) -> Result<Self, MetaError> {
         let schema = self.required_value(SYSTEM.id, SYSTEM_SCHEMA_KEY, "System(schema)")?;
-        validate_schema_marker(&schema).map_err(|error| MetaError::SchemaGate {
-            reason: error.to_string(),
-        })?;
+        let schema_version =
+            classify_schema_marker_for_open(&schema).map_err(|error| MetaError::SchemaGate {
+                reason: error.to_string(),
+            })?;
         let shard = self.required_value(
             SYSTEM.id,
             SYSTEM_SHARD_IDENTITY_KEY,
@@ -629,7 +632,34 @@ impl MetaShard {
             "System(lease_clock_high_water)",
         )?;
         self.verify_recovery_chain_unlocked()?;
+        if schema_version == SchemaMarkerVersion::Format8 {
+            self.upgrade_format8_schema_marker(&schema)?;
+        }
         Ok(self)
+    }
+
+    fn upgrade_format8_schema_marker(&self, previous: &[u8]) -> Result<(), MetaError> {
+        let current = encode_schema_marker();
+        let txn = WriteTxn {
+            checks: vec![value_check(SYSTEM.id, SYSTEM_SCHEMA_KEY, previous)],
+            mutations: vec![Mutation::Put {
+                key: Key::new(SYSTEM.id, SYSTEM_SCHEMA_KEY),
+                value: current,
+            }],
+        };
+        match self.commit("upgrade format-8 schema marker", txn)? {
+            Commit::Applied => Ok(()),
+            Commit::Conflict => {
+                let observed =
+                    self.required_value(SYSTEM.id, SYSTEM_SCHEMA_KEY, "System(schema)")?;
+                match validate_schema_marker(&observed) {
+                    Ok(()) => Ok(()),
+                    Err(_) => Err(MetaError::SchemaGate {
+                        reason: "format-8 schema upgrade lost its compare-and-swap".to_owned(),
+                    }),
+                }
+            }
+        }
     }
 
     pub fn current_read_version(&self) -> Result<ReadVersion, MetaError> {
@@ -753,55 +783,63 @@ impl MetaShard {
             .command_gate
             .read()
             .map_err(|error| internal("lock read gate", error))?;
-        let start = recovery_outbox_key(start_after_lsn).to_vec();
         let mut rows = Vec::with_capacity(limit);
         let mut encoded_bytes = 0_usize;
-        let mut after = Some(start);
-        loop {
-            let page = self.scan_page(
-                RECOVERY_OUTBOX.id,
-                &[0],
-                after.as_deref(),
-                (limit - rows.len()).min(MAX_HISTORICAL_SCAN_PAGE_ROWS),
-                None,
-                0,
-                "scan RecoveryOutbox",
-            )?;
-            let more = page.more;
-            for item in page.items {
-                let ScanItem::Row { key, value } = item else {
-                    return Err(corrupt(
-                        "RecoveryOutbox",
-                        "non-delimited scan returned a common prefix",
-                    ));
-                };
-                after = Some(key.clone());
-                let key_lsn = decode_recovery_outbox_key(&key)
-                    .map_err(|error| corrupt("RecoveryOutbox key", error))?;
-                let row_encoded_bytes = recovery_storage_logical_length(&value)
-                    .map_err(|error| corrupt("RecoveryOutbox storage header", error))?;
-                if !rows.is_empty()
-                    && encoded_bytes.saturating_add(row_encoded_bytes) > max_encoded_bytes
-                {
-                    return Ok(rows);
+        for layout in RecoveryKeyLayout::ORDERED {
+            let mut after = Some(recovery_outbox_scan_start(layout, start_after_lsn));
+            loop {
+                let page = self.scan_page(
+                    RECOVERY_OUTBOX.id,
+                    &[layout.header_tag()],
+                    after.as_deref(),
+                    (limit - rows.len()).min(MAX_HISTORICAL_SCAN_PAGE_ROWS),
+                    None,
+                    0,
+                    "scan RecoveryOutbox",
+                )?;
+                let more = page.more;
+                for item in page.items {
+                    let ScanItem::Row { key, value } = item else {
+                        return Err(corrupt(
+                            "RecoveryOutbox",
+                            "non-delimited scan returned a common prefix",
+                        ));
+                    };
+                    after = Some(key.clone());
+                    let decoded = decode_recovery_outbox_key(&key)
+                        .map_err(|error| corrupt("RecoveryOutbox key", error))?;
+                    if decoded.layout != layout {
+                        return Err(corrupt(
+                            "RecoveryOutbox key",
+                            "header tag and decoded layout disagree",
+                        ));
+                    }
+                    let row_encoded_bytes = recovery_storage_logical_length(&value)
+                        .map_err(|error| corrupt("RecoveryOutbox storage header", error))?;
+                    if !rows.is_empty()
+                        && encoded_bytes.saturating_add(row_encoded_bytes) > max_encoded_bytes
+                    {
+                        return Ok(rows);
+                    }
+                    let row = self.read_recovery_record(decoded, &value)?;
+                    if row.recovery_lsn != decoded.recovery_lsn {
+                        return Err(MetaError::CorruptRecord {
+                            record: "RecoveryOutbox",
+                            reason: "row LSN does not match ordered key".to_owned(),
+                        });
+                    }
+                    encoded_bytes = encoded_bytes.saturating_add(row_encoded_bytes);
+                    rows.push(row);
+                    if rows.len() == limit {
+                        return Ok(rows);
+                    }
                 }
-                let row = self.read_recovery_record(key_lsn, &value)?;
-                if row.recovery_lsn != key_lsn {
-                    return Err(MetaError::CorruptRecord {
-                        record: "RecoveryOutbox",
-                        reason: "row LSN does not match ordered key".to_owned(),
-                    });
+                if !more {
+                    break;
                 }
-                encoded_bytes = encoded_bytes.saturating_add(row_encoded_bytes);
-                rows.push(row);
-                if rows.len() == limit {
-                    return Ok(rows);
-                }
-            }
-            if !more {
-                return Ok(rows);
             }
         }
+        Ok(rows)
     }
 
     /// Verify every durable recovery row and the `System` tail.
@@ -2289,21 +2327,26 @@ impl MetaShard {
                 };
                 after = Some(key.clone());
                 match key.first().copied() {
-                    Some(0) => {
-                        let key_lsn = decode_recovery_outbox_key(&key)
+                    Some(tag) if RecoveryKeyLayout::from_header_tag(tag).is_some() => {
+                        let decoded = decode_recovery_outbox_key(&key)
                             .map_err(|error| corrupt("RecoveryOutbox key", error))?;
                         let chunk_count = recovery_storage_chunk_count(&value)
                             .map_err(|error| corrupt("RecoveryOutbox storage header", error))?;
                         for index in 0..chunk_count {
-                            expected_chunk_keys.insert(recovery_chunk_key(key_lsn, index).to_vec());
+                            expected_chunk_keys.insert(recovery_chunk_key_for_layout(
+                                decoded.layout,
+                                decoded.recovery_lsn,
+                                index,
+                            ));
                         }
-                        let row = self.read_recovery_record(key_lsn, &value)?;
-                        if key_lsn != expected_lsn || row.recovery_lsn != expected_lsn {
+                        let row = self.read_recovery_record(decoded, &value)?;
+                        if decoded.recovery_lsn != expected_lsn || row.recovery_lsn != expected_lsn
+                        {
                             return Err(MetaError::CorruptRecord {
                                 record: "RecoveryOutbox",
                                 reason: format!(
-                                    "expected contiguous LSN {expected_lsn}, found key {key_lsn} row {}",
-                                    row.recovery_lsn
+                                    "expected contiguous LSN {expected_lsn}, found key {} row {}",
+                                    decoded.recovery_lsn, row.recovery_lsn
                                 ),
                             });
                         }
@@ -2320,7 +2363,7 @@ impl MetaShard {
                             .checked_add(1)
                             .ok_or(MetaError::VersionOverflow)?;
                     }
-                    Some(1) => {
+                    Some(tag) if RecoveryKeyLayout::from_chunk_tag(tag).is_some() => {
                         if !expected_chunk_keys.remove(&key) {
                             return Err(MetaError::CorruptRecord {
                                 record: "RecoveryOutbox chunk",
@@ -2362,7 +2405,7 @@ impl MetaShard {
 
     fn read_recovery_record(
         &self,
-        recovery_lsn: u64,
+        decoded: DecodedRecoveryOutboxKey,
         header: &[u8],
     ) -> Result<RecoveryOutboxRecord, MetaError> {
         let chunk_count = recovery_storage_chunk_count(header)
@@ -2372,13 +2415,13 @@ impl MetaShard {
             let value = self
                 .read_value(
                     RECOVERY_OUTBOX.id,
-                    &recovery_chunk_key(recovery_lsn, index),
+                    &recovery_chunk_key_for_layout(decoded.layout, decoded.recovery_lsn, index),
                     MetadataPointReadSource::Other,
                     "read RecoveryOutbox chunk",
                 )?
                 .ok_or_else(|| MetaError::CorruptRecord {
                     record: "RecoveryOutbox chunk",
-                    reason: format!("missing LSN {recovery_lsn} chunk {index}"),
+                    reason: format!("missing LSN {} chunk {index}", decoded.recovery_lsn),
                 })?;
             chunks.push(value);
         }
@@ -5329,6 +5372,46 @@ mod tests {
     }
 
     #[test]
+    fn sequential_recovery_outbox_writes_avoid_pathological_holt_fragmentation() {
+        const COMMANDS: u8 = 160;
+        const VALUE_BYTES: usize = 3 * 1024;
+
+        let temporary = tempdir().unwrap();
+        let (store, physical) = crate::workspace::test_support::initialize_file_with_holt_store(
+            &temporary.path().join("metadata"),
+            shard(1),
+        )
+        .unwrap();
+        let store = make_store_ready(store);
+        let value = vec![0x5a; VALUE_BYTES];
+        for index in 0..COMMANDS {
+            let command = create_command(
+                &store,
+                request(index + 10),
+                scoped_key(root(2), &[b'w', index]),
+                &value,
+            );
+            store.execute(&command).unwrap();
+        }
+
+        physical.checkpoint_for_test().unwrap();
+        let stats = physical
+            .keyspace_stats_for_test(RECOVERY_OUTBOX.id)
+            .unwrap();
+        // The fixed-width decimal layout uses two blobs. Keep 4x headroom for
+        // Holt shape changes while rejecting the binary-LSN layout's cliff.
+        assert!(
+            stats.blob_count <= 8,
+            "{} sequential outbox records fragmented across {} Holt blobs (space={}, max_fill={}, underfilled={})",
+            COMMANDS + 3,
+            stats.blob_count,
+            stats.total_space_used,
+            stats.max_blob_fill_per_mille,
+            stats.underfilled_child_blobs
+        );
+    }
+
+    #[test]
     fn recovery_outbox_survives_file_reopen_with_exact_tail() {
         let temporary = tempdir().unwrap();
         let database = temporary.path().join("metadata");
@@ -5364,6 +5447,129 @@ mod tests {
         assert_eq!(reopened.verify_recovery_chain().unwrap(), expected);
         assert_eq!(reopened.recovery_outbox_after(0, 10).unwrap().len(), 4);
         assert_eq!(reopened.lease_clock_high_water().unwrap(), 55);
+    }
+
+    #[test]
+    fn format8_store_upgrades_without_rewriting_legacy_recovery_rows() {
+        let temporary = tempdir().unwrap();
+        let database = temporary.path().join("metadata");
+        let expected;
+        {
+            let store = ready_file_store(&database);
+            expected = store.verify_recovery_chain().unwrap();
+            assert_eq!(expected.applied_recovery_lsn, 3);
+
+            for recovery_lsn in 1..=expected.applied_recovery_lsn {
+                let current_header_key = recovery_outbox_key(recovery_lsn);
+                let header = store
+                    .required_value(
+                        RECOVERY_OUTBOX.id,
+                        &current_header_key,
+                        "RecoveryOutbox header",
+                    )
+                    .unwrap();
+                let chunk_count = recovery_storage_chunk_count(&header).unwrap();
+                raw_put(
+                    &store,
+                    RECOVERY_OUTBOX.id,
+                    &recovery_outbox_scan_start(RecoveryKeyLayout::Format8, recovery_lsn),
+                    &header,
+                );
+                raw_delete(&store, RECOVERY_OUTBOX.id, &current_header_key);
+
+                for index in 0..chunk_count {
+                    let current_chunk_key = recovery_chunk_key(recovery_lsn, index);
+                    let chunk = store
+                        .required_value(
+                            RECOVERY_OUTBOX.id,
+                            &current_chunk_key,
+                            "RecoveryOutbox chunk",
+                        )
+                        .unwrap();
+                    raw_put(
+                        &store,
+                        RECOVERY_OUTBOX.id,
+                        &recovery_chunk_key_for_layout(
+                            RecoveryKeyLayout::Format8,
+                            recovery_lsn,
+                            index,
+                        ),
+                        &chunk,
+                    );
+                    raw_delete(&store, RECOVERY_OUTBOX.id, &current_chunk_key);
+                }
+            }
+
+            let mut format8_marker = encode_schema_marker();
+            let version_start = format8_marker.len() - std::mem::size_of::<u32>();
+            format8_marker[version_start..].copy_from_slice(&8_u32.to_be_bytes());
+            raw_put(&store, SYSTEM.id, SYSTEM_SCHEMA_KEY, &format8_marker);
+        }
+
+        let reopened = crate::workspace::test_support::open_file(&database, shard(1)).unwrap();
+        assert_eq!(reopened.verify_recovery_chain().unwrap(), expected);
+        assert_eq!(
+            reopened
+                .required_value(SYSTEM.id, SYSTEM_SCHEMA_KEY, "System(schema)")
+                .unwrap(),
+            encode_schema_marker()
+        );
+        for recovery_lsn in 1..=expected.applied_recovery_lsn {
+            reopened
+                .required_value(
+                    RECOVERY_OUTBOX.id,
+                    &recovery_outbox_scan_start(RecoveryKeyLayout::Format8, recovery_lsn),
+                    "legacy RecoveryOutbox header",
+                )
+                .unwrap();
+        }
+
+        let command = create_command(
+            &reopened,
+            request(9),
+            scoped_key(root(2), b"after-format8-upgrade"),
+            b"value",
+        );
+        reopened.execute(&command).unwrap();
+        let rows = reopened.recovery_outbox_after(0, 10).unwrap();
+        assert_eq!(
+            rows.iter().map(|row| row.recovery_lsn).collect::<Vec<_>>(),
+            vec![1, 2, 3, 4]
+        );
+        assert_eq!(
+            reopened
+                .recovery_outbox_after(2, 10)
+                .unwrap()
+                .iter()
+                .map(|row| row.recovery_lsn)
+                .collect::<Vec<_>>(),
+            vec![3, 4]
+        );
+        assert_eq!(
+            reopened
+                .verify_recovery_chain()
+                .unwrap()
+                .applied_recovery_lsn,
+            4
+        );
+        reopened
+            .required_value(
+                RECOVERY_OUTBOX.id,
+                &recovery_outbox_key(4),
+                "format-9 RecoveryOutbox header",
+            )
+            .unwrap();
+        drop(reopened);
+
+        let mixed = crate::workspace::test_support::open_file(&database, shard(1)).unwrap();
+        assert_eq!(
+            mixed.recovery_outbox_after(3, 10).unwrap()[0].recovery_lsn,
+            4
+        );
+        assert_eq!(
+            mixed.verify_recovery_chain().unwrap().applied_recovery_lsn,
+            4
+        );
     }
 
     #[test]

--- a/crates/nokv-meta/src/workspace/publication.rs
+++ b/crates/nokv-meta/src/workspace/publication.rs
@@ -5611,7 +5611,7 @@ mod tests {
         assert_eq!(replaced.result.path_generation, Generation::new(2).unwrap());
         let replace_bytes =
             capture.with_last_commit(crate::workspace::test_support::transaction_bytes);
-        assert_eq!(replace_bytes, 11_797_794);
+        assert_eq!(replace_bytes, 11_799_402);
 
         let removed = remove_path(
             &store,
@@ -5634,7 +5634,7 @@ mod tests {
         assert_eq!(removed.removed_artifact_revision_id, revision(216));
         let remove_bytes =
             capture.with_last_commit(crate::workspace::test_support::transaction_bytes);
-        assert_eq!(remove_bytes, 11_791_459);
+        assert_eq!(remove_bytes, 11_793_043);
     }
 
     #[test]
@@ -5788,7 +5788,7 @@ mod tests {
 
         assert_eq!(
             capture.with_last_commit(crate::workspace::test_support::transaction_bytes),
-            9_859_091
+            9_860_675
         );
     }
 

--- a/crates/nokv-meta/src/workspace/recovery.rs
+++ b/crates/nokv-meta/src/workspace/recovery.rs
@@ -27,9 +27,53 @@ const GENESIS_DOMAIN: &[u8] = b"nokv.metadata.recovery.genesis.v1\0";
 const CHAIN_DOMAIN: &[u8] = b"nokv.metadata.recovery.chain.v1\0";
 const STORAGE_HEADER_VERSION: u8 = 1;
 const STORAGE_CHUNK_VERSION: u8 = 1;
-const STORAGE_HEADER_KEY_TAG: u8 = 0;
-const STORAGE_CHUNK_KEY_TAG: u8 = 1;
+const LEGACY_STORAGE_HEADER_KEY_TAG: u8 = 0;
+const LEGACY_STORAGE_CHUNK_KEY_TAG: u8 = 1;
+const STORAGE_HEADER_KEY_TAG: u8 = 2;
+const STORAGE_CHUNK_KEY_TAG: u8 = 3;
+const RECOVERY_LSN_DECIMAL_BYTES: usize = 20;
+const RECOVERY_OUTBOX_KEY_BYTES: usize = 1 + RECOVERY_LSN_DECIMAL_BYTES;
+const RECOVERY_CHUNK_KEY_BYTES: usize = RECOVERY_OUTBOX_KEY_BYTES + 4;
 const MAX_STORAGE_CHUNK_DATA_BYTES: usize = 60 * 1024;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum RecoveryKeyLayout {
+    Format8,
+    Format9,
+}
+
+impl RecoveryKeyLayout {
+    pub(crate) const ORDERED: [Self; 2] = [Self::Format8, Self::Format9];
+
+    pub(crate) const fn header_tag(self) -> u8 {
+        match self {
+            Self::Format8 => LEGACY_STORAGE_HEADER_KEY_TAG,
+            Self::Format9 => STORAGE_HEADER_KEY_TAG,
+        }
+    }
+
+    pub(crate) const fn from_header_tag(tag: u8) -> Option<Self> {
+        match tag {
+            LEGACY_STORAGE_HEADER_KEY_TAG => Some(Self::Format8),
+            STORAGE_HEADER_KEY_TAG => Some(Self::Format9),
+            _ => None,
+        }
+    }
+
+    pub(crate) const fn from_chunk_tag(tag: u8) -> Option<Self> {
+        match tag {
+            LEGACY_STORAGE_CHUNK_KEY_TAG => Some(Self::Format8),
+            STORAGE_CHUNK_KEY_TAG => Some(Self::Format9),
+            _ => None,
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) struct DecodedRecoveryOutboxKey {
+    pub(crate) recovery_lsn: u64,
+    pub(crate) layout: RecoveryKeyLayout,
+}
 
 /// One canonical input to a real metadata write entrypoint.
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -555,26 +599,83 @@ pub(crate) fn recovery_genesis_digest(
     hasher.finalize().into()
 }
 
-pub(crate) fn recovery_outbox_key(recovery_lsn: u64) -> [u8; 9] {
-    let mut key = [0; 9];
+/// Format-v9 header key. Fixed-width decimal preserves numeric order while
+/// keeping sequential LSNs in Holt's well-filled key shape.
+pub(crate) fn recovery_outbox_key(recovery_lsn: u64) -> [u8; RECOVERY_OUTBOX_KEY_BYTES] {
+    let mut key = [0; RECOVERY_OUTBOX_KEY_BYTES];
     key[0] = STORAGE_HEADER_KEY_TAG;
-    key[1..].copy_from_slice(&recovery_lsn.to_be_bytes());
+    key[1..].copy_from_slice(&encode_recovery_lsn(recovery_lsn));
     key
 }
 
-pub(crate) fn decode_recovery_outbox_key(key: &[u8]) -> Result<u64, RecoveryCodecError> {
-    if key.len() != 9 || key.first() != Some(&STORAGE_HEADER_KEY_TAG) {
-        return Err(RecoveryCodecError::InvalidValue {
-            field: "recovery_outbox_key",
-        });
+pub(crate) fn recovery_outbox_scan_start(layout: RecoveryKeyLayout, recovery_lsn: u64) -> Vec<u8> {
+    match layout {
+        RecoveryKeyLayout::Format8 => legacy_recovery_outbox_key(recovery_lsn).to_vec(),
+        RecoveryKeyLayout::Format9 => recovery_outbox_key(recovery_lsn).to_vec(),
     }
-    let lsn = u64::from_be_bytes(key[1..].try_into().expect("width checked"));
+}
+
+pub(crate) fn decode_recovery_outbox_key(
+    key: &[u8],
+) -> Result<DecodedRecoveryOutboxKey, RecoveryCodecError> {
+    let (layout, lsn) = match key.first().copied() {
+        Some(LEGACY_STORAGE_HEADER_KEY_TAG) if key.len() == 9 => (
+            RecoveryKeyLayout::Format8,
+            u64::from_be_bytes(key[1..].try_into().expect("width checked")),
+        ),
+        Some(STORAGE_HEADER_KEY_TAG) if key.len() == RECOVERY_OUTBOX_KEY_BYTES => {
+            (RecoveryKeyLayout::Format9, decode_recovery_lsn(&key[1..])?)
+        }
+        _ => {
+            return Err(RecoveryCodecError::InvalidValue {
+                field: "recovery_outbox_key",
+            });
+        }
+    };
     if lsn == 0 {
         return Err(RecoveryCodecError::ZeroScalar {
             field: "recovery_lsn",
         });
     }
-    Ok(lsn)
+    Ok(DecodedRecoveryOutboxKey {
+        recovery_lsn: lsn,
+        layout,
+    })
+}
+
+fn legacy_recovery_outbox_key(recovery_lsn: u64) -> [u8; 9] {
+    let mut key = [0; 9];
+    key[0] = LEGACY_STORAGE_HEADER_KEY_TAG;
+    key[1..].copy_from_slice(&recovery_lsn.to_be_bytes());
+    key
+}
+
+fn encode_recovery_lsn(mut recovery_lsn: u64) -> [u8; RECOVERY_LSN_DECIMAL_BYTES] {
+    let mut encoded = [b'0'; RECOVERY_LSN_DECIMAL_BYTES];
+    for digit in encoded.iter_mut().rev() {
+        *digit = b'0' + (recovery_lsn % 10) as u8;
+        recovery_lsn /= 10;
+    }
+    debug_assert_eq!(recovery_lsn, 0);
+    encoded
+}
+
+fn decode_recovery_lsn(encoded: &[u8]) -> Result<u64, RecoveryCodecError> {
+    let mut recovery_lsn = 0_u64;
+    for digit in encoded {
+        if !digit.is_ascii_digit() {
+            return Err(RecoveryCodecError::InvalidValue {
+                field: "recovery_outbox_key",
+            });
+        }
+        recovery_lsn = recovery_lsn
+            .checked_mul(10)
+            .and_then(|value| value.checked_add(u64::from(digit - b'0')))
+            .ok_or(RecoveryCodecError::InvalidValue {
+                field: "recovery_outbox_key",
+            })?;
+    }
+    Ok(recovery_lsn)
 }
 
 pub(crate) fn split_recovery_storage(
@@ -596,12 +697,29 @@ pub(crate) fn split_recovery_storage(
     Ok((header, chunks))
 }
 
-pub(crate) fn recovery_chunk_key(recovery_lsn: u64, index: u32) -> [u8; 13] {
-    let mut key = [0; 13];
+pub(crate) fn recovery_chunk_key(recovery_lsn: u64, index: u32) -> [u8; RECOVERY_CHUNK_KEY_BYTES] {
+    let mut key = [0; RECOVERY_CHUNK_KEY_BYTES];
     key[0] = STORAGE_CHUNK_KEY_TAG;
-    key[1..9].copy_from_slice(&recovery_lsn.to_be_bytes());
-    key[9..].copy_from_slice(&index.to_be_bytes());
+    key[1..RECOVERY_OUTBOX_KEY_BYTES].copy_from_slice(&encode_recovery_lsn(recovery_lsn));
+    key[RECOVERY_OUTBOX_KEY_BYTES..].copy_from_slice(&index.to_be_bytes());
     key
+}
+
+pub(crate) fn recovery_chunk_key_for_layout(
+    layout: RecoveryKeyLayout,
+    recovery_lsn: u64,
+    index: u32,
+) -> Vec<u8> {
+    match layout {
+        RecoveryKeyLayout::Format8 => {
+            let mut key = [0; 13];
+            key[0] = LEGACY_STORAGE_CHUNK_KEY_TAG;
+            key[1..9].copy_from_slice(&recovery_lsn.to_be_bytes());
+            key[9..].copy_from_slice(&index.to_be_bytes());
+            key.to_vec()
+        }
+        RecoveryKeyLayout::Format9 => recovery_chunk_key(recovery_lsn, index).to_vec(),
+    }
 }
 
 pub(crate) fn assemble_recovery_storage(
@@ -1237,6 +1355,59 @@ mod tests {
                 field: "owner_epoch_transition"
             })
         ));
+    }
+
+    #[test]
+    fn recovery_storage_keys_use_fixed_width_decimal_lsns() {
+        assert_eq!(
+            recovery_outbox_key(42).as_slice(),
+            b"\x0200000000000000000042"
+        );
+        assert_eq!(
+            recovery_chunk_key(42, 7).as_slice(),
+            b"\x0300000000000000000042\x00\x00\x00\x07"
+        );
+        assert_eq!(
+            decode_recovery_outbox_key(b"\x0218446744073709551615").unwrap(),
+            DecodedRecoveryOutboxKey {
+                recovery_lsn: u64::MAX,
+                layout: RecoveryKeyLayout::Format9,
+            }
+        );
+
+        let ordered = [0, 1, 9, 10, 99, 100, u64::MAX - 1, u64::MAX];
+        for pair in ordered.windows(2) {
+            assert!(recovery_outbox_key(pair[0]) < recovery_outbox_key(pair[1]));
+        }
+    }
+
+    #[test]
+    fn recovery_outbox_key_decoder_accepts_format8_binary_lsns() {
+        assert_eq!(
+            decode_recovery_outbox_key(&legacy_recovery_outbox_key(42)).unwrap(),
+            DecodedRecoveryOutboxKey {
+                recovery_lsn: 42,
+                layout: RecoveryKeyLayout::Format8,
+            }
+        );
+    }
+
+    #[test]
+    fn recovery_outbox_key_decoder_rejects_malformed_decimal_lsns() {
+        assert!(decode_recovery_outbox_key(b"\x0200000000000000000000").is_err());
+        assert!(decode_recovery_outbox_key(b"\x020000000000000000001").is_err());
+
+        let mut non_digit = recovery_outbox_key(1);
+        non_digit[10] = b'x';
+        assert!(decode_recovery_outbox_key(&non_digit).is_err());
+
+        let mut overflow = [b'9'; RECOVERY_OUTBOX_KEY_BYTES];
+        overflow[0] = STORAGE_HEADER_KEY_TAG;
+        assert!(decode_recovery_outbox_key(&overflow).is_err());
+
+        let mut wrong_tag = recovery_outbox_key(1);
+        wrong_tag[0] = 0xff;
+        assert!(decode_recovery_outbox_key(&wrong_tag).is_err());
     }
 
     #[test]

--- a/crates/nokv-meta/src/workspace/test_support.rs
+++ b/crates/nokv-meta/src/workspace/test_support.rs
@@ -97,6 +97,19 @@ pub(crate) fn initialize_file(
     MetaShard::initialize(initialize_file_txn_store(path)?, logical_shard_id)
 }
 
+pub(crate) fn initialize_file_with_holt_store(
+    path: &Path,
+    logical_shard_id: LogicalShardId,
+) -> Result<(MetaShard, Arc<HoltStore>), MetaError> {
+    let physical = Arc::new(
+        HoltStore::initialize(HoltOptions::file(path, catalog(), store_limits()))
+            .map_err(|source| store_error("initialize test metadata store", source))?,
+    );
+    let store: Arc<dyn TxnStore> = physical.clone();
+    let shard = MetaShard::initialize(store, logical_shard_id)?;
+    Ok((shard, physical))
+}
+
 pub(crate) fn open_file(
     path: &Path,
     logical_shard_id: LogicalShardId,

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -103,7 +103,7 @@ This reserves both markers, places a child's delimiter rollup before its exact
 artifact and both before longer siblings, and prevents an exact key from being
 a strict prefix of another valid path key. The same normalizer/codec owns
 storage keys, request identities, index identities, and restore member ids.
-System format version 8 gates this layout.
+System format version 9 retains and gates this layout.
 
 Directories are implicit. The Workbench root and five standard sections are
 virtual. A file stat is a point read; an implicit-directory stat is a prefix

--- a/docs/development/path-native-metadata-comparison.md
+++ b/docs/development/path-native-metadata-comparison.md
@@ -111,11 +111,12 @@ The adapter folds each deeper subtree into a `CommonPrefix`. NoKV retains that
 as one storage-neutral implicit `Prefix` item. An exact artifact at the same
 child wins during logical coalescing. Prefixes and artifacts both count toward the
 page limit and can become cursor anchors. Recursive pages retain the ordinary
-ordered prefix iterator and emit artifacts only. System format version 8 uses
-NUL between components and `0x01` at exact keys so a rollup, exact child, and
-longer sibling have one pagination-safe order. Each UTF-8 component byte is
-shifted by one so the delimiter and exact marker cannot occur inside an encoded
-component, while byte order and key length stay unchanged.
+ordered prefix iterator and emit artifacts only. System format version 9
+retains the version-8 path layout: NUL between components and `0x01` at exact
+keys give a rollup, exact child, and longer sibling one pagination-safe order.
+Each UTF-8 component byte is shifted by one so the delimiter and exact marker
+cannot occur inside an encoded component, while byte order and key length stay
+unchanged.
 
 Historical MVCC is a distinct path. A key that is absent or newer in current
 state may still be visible at the requested version, so historical listing

--- a/docs/metadata-schema.md
+++ b/docs/metadata-schema.md
@@ -19,15 +19,18 @@ Every logical-shard store has one authoritative marker:
 System("schema")
   -> value_format_version = 1
      schema_id = "nokv_workspace"
-     format_version = 8
+     format_version = 9
 ```
 
 Startup is fail-closed:
 
 - an empty store is initialized with the exact supported marker and logical
   keyspace catalog;
-- a nonempty store opens only when its marker, value format, and configured
-  adapter catalog match this contract;
+- a format-8 store first passes the complete shard, system-record, and recovery
+  chain validation, then atomically advances only its schema marker to version
+  9; existing recovery rows are not rewritten;
+- a nonempty current store opens only when its marker, value format, and
+  configured adapter catalog match this contract;
 - a missing, malformed, unknown-version, or inconsistent store is rejected.
 
 ## Ids, Names, And Keys
@@ -51,8 +54,9 @@ OperationId             16 bytes, unique within one RootId
 CommitId                32 bytes, root-global SHA-256 identity
 ```
 
-All integers are unsigned big-endian. General variable byte strings use a
-four-byte big-endian length followed by exact bytes.
+Integers are unsigned big-endian unless a family defines an order-preserving
+key codec. General variable byte strings use a four-byte big-endian length
+followed by exact bytes.
 
 An external `workbench_id`:
 
@@ -78,9 +82,9 @@ delimiter; `0x01` terminates an exact row. The resulting order is `a/NUL
 subtree`, exact `a`, then longer siblings such as `a\u{1}` and `ab`, and no
 exact key is a strict prefix of another valid path key. A child/subtree prefix
 appends NUL, so `a` cannot match `ab`. The empty path has no `PathCurrent`
-record; the workspace root is synthesized from `WorkspaceCurrent`. This
-key-layout cutover is gated by system format version 8; older stores are
-rejected rather than dual-read.
+record; the workspace root is synthesized from `WorkspaceCurrent`. This path
+key layout was introduced by system format version 8 and is retained by
+version 9.
 
 The one shared normalizer enforces:
 
@@ -101,7 +105,20 @@ float, timestamp, bytes, and string values.
 
 ## Durable Format Registry
 
-`System.format_version` is `8`. Durable codecs are independently versioned:
+`System.format_version` is `9`. Version 9 writes RecoveryOutbox LSNs as
+canonical fixed-width decimal keys. Numeric ordering is unchanged, while the
+sequential key shape avoids pathological underfilled Holt frames. Logical
+recovery records, deterministic results, and hash-chain bytes are unchanged.
+
+Opening a format-8 store validates its complete recovery chain before an
+atomic, one-way marker upgrade. Its `0x00`/`0x01` binary-LSN rows remain in
+place and readable; later writes use the disjoint version-9 `0x02`/`0x03`
+tags, so old and new rows retain one unambiguous chronological order. A binary
+that understands only format 8 rejects the upgraded marker rather than
+misreading the mixed physical layout. Other older or unknown markers remain
+fail-closed.
+
+Durable codecs are independently versioned:
 publication-owned workspace/path/revision records and immutable commit records
 use value version `2`; `ChangeEvent` and the logical recovery-outbox record use
 value version `2`; other ordinary workspace records and the recovery storage
@@ -258,8 +275,10 @@ System
        recovery chain digest
 
 RecoveryOutbox
-  header key: 0x00 | recovery_lsn
-  chunk key:  0x01 | recovery_lsn | chunk_index
+  format-9 header key: 0x02 | decimal20(recovery_lsn)
+  format-9 chunk key:  0x03 | decimal20(recovery_lsn) | chunk_index_u32_be
+  retained format-8 header key: 0x00 | recovery_lsn_u64_be
+  retained format-8 chunk key:  0x01 | recovery_lsn_u64_be | chunk_index_u32_be
   val: canonical mutation plus typed deterministic result evidence,
        previous/current chain digest, and strict storage framing
 


### PR DESCRIPTION
## Related Issue

Relates to #177

## Summary

- Replace new RecoveryOutbox physical keys with fixed-width decimal LSN keys while leaving canonical commands, deterministic results, and recovery-chain digests unchanged.
- Open format-8 stores by validating the full shard and recovery chain first, then atomically upgrading only the schema marker. Existing binary-LSN rows remain readable and are not rewritten.
- Add a file-backed Holt 0.8.5 regression test and migration/reopen coverage. The dependency remains exactly Holt 0.8.5; this PR does not adopt the new Holt WAL.
- Preserve the existing NoKV dataflow topology, placement/fencing rules, object boundary, and public interfaces.

## Scope

- [x] This PR changes one logical boundary only.
- [x] No unrelated refactor, benchmark, metadata model, Holt layout,
      object-store, agent interface, or docs change is mixed in.
- [x] The linked issue describes the user-visible problem, design decision, or
      maintenance task this PR resolves.
- [x] Any breaking change is intentional and documented.
- [x] No compatibility shim, deprecated alias, or forwarding wrapper was added without a removal condition.

The durable format marker advances from 8 to 9. Old binaries reject the new marker instead of misreading mixed physical keys. The format-8 reader is a durable migration boundary for persisted stores, not a forwarding shim.

## Code Contract (Code Changes Only)

- [ ] Not applicable; this is a docs/config-only change.
- [x] Package boundaries follow `docs/development/code_contract.md`.
- [x] Shared helpers reuse the standard library or existing repository helpers.
      New generic helper modules are domain-neutral and tested.
- [x] File names and file placement follow the code contract.
- [x] New types, interfaces, structs, fields, and functions use domain-specific names.
- [x] New errors are in the owning package's `errors.rs` and carry stable error kinds when crossing package boundaries.
- [x] New metrics/stats are owned by the package that reports or serves them.
- [x] Metadata changes document durability, atomicity, revision-reference
      lifetime, snapshot/commit/event retention, GC epochs, and fail-closed
      recovery boundaries.
- [x] Placement or routing changes preserve persisted `RootId -> LogicalShardId`
      affinity, one active writer per shard, owner-epoch fencing, and explicit
      shard-local atomicity; no split root or cross-shard transaction is implied.
- [x] Agent-interface changes keep the transport-free facade and schemas in
      `nokv-agent`, routing and workflows in `nokv-client`, and the concrete
      backend plus MCP wiring in the `nokv` CLI.

No production error, metric, placement, routing, object-store, or agent-interface behavior changes.

## Claims and Evidence

- [x] User-facing documentation distinguishes current, experimental, and
      planned capabilities.
- [x] Security claims do not treat a Workbench root or Agent scope as tenant
      authentication or authorization.
- [x] Performance claims state the topology, comparison boundary, cache state,
      run count, and raw-evidence location.
- [x] Benchmark-only behavior does not alter product semantics.

Regression boundary: one fresh file-backed Holt 0.8.5 database on macOS arm64, 160 sequential 3 KiB create-only commands plus three bootstrap recovery rows, and one checkpoint. The format-8 binary-key control produced 26 RecoveryOutbox blobs; the fixed layout produced 2, with a committed guard of at most 8. The executable evidence is `workspace::engine::tests::sequential_recovery_outbox_writes_avoid_pathological_holt_fragmentation`.

## Validation

- `cargo fmt --all -- --check` — PASS.
- `git diff --check` — PASS.
- `cargo clippy --workspace --all-targets -- -D warnings` — PASS.
- `cargo clippy -p nokv-meta -p nokv-bench --all-targets --features metadata-read-stats -- -D warnings` — PASS.
- `cargo clippy -p nokv-meta-holt --all-targets --features read-stats -- -D warnings` — PASS.
- `cargo test --workspace` — PASS across all crates, integration tests, and doc tests.
- `cargo test --locked -p nokv-meta --features metadata-read-stats` — PASS (234 tests).
- `cargo test --locked -p nokv-meta-holt --features read-stats` — PASS (21 tests).
- `cargo test --locked -p nokv-bench --features metadata-read-stats` — PASS.
- `python3 scripts/workbench/workbench_contract_test.py` — PASS (8 tests).
- `python3 scripts/workbench/live_workbench_test.py` — PASS (7 tests).
- Live `scripts/workbench/live_workbench.py` against isolated etcd and checksum-verified RustFS 1.0.0-rc.1 — all 18 Workbench tools PASS; transcript SHA-256 `68dd6a25b7d502e402aceb02193038918839fbeae1732b592177448855150c18`. Overall Gate 0 remains intentionally NOT QUALIFIED because this bounded run does not wait one day for the snapshot lease to reach reaped state.
- `cargo package --locked --workspace --allow-dirty` — PASS.
- `cargo tree --locked -p nokv-meta-holt` — confirms `holt v0.8.5`.

## Contributor Sign-off

- [x] Every commit in this PR includes a DCO `Signed-off-by` trailer.
