### PR TITLE
fix(client): converge a retried publication that already succeeded

### DIFF
--- a/crates/nokv-client/src/artifact.rs
+++ b/crates/nokv-client/src/artifact.rs
@@ -278,15 +278,10 @@ where
             },
         );
         let (mut token, resume, begin_replayed) = match begin {
-            Ok(status) => {
-                let replayed = status.replayed;
-                match running_publish_resume(
-                    status.value,
-                    operation_id,
-                    staged_objects.len(),
-                    manifest_rows.len(),
-                ) {
-                    Ok(resume) => (resume.token, resume, replayed),
+            Ok(call) => {
+                let (replayed, commit_version) = (call.replayed, call.commit_version);
+                let status = match validated_publish_status(call.value, operation_id) {
+                    Ok(status) => status,
                     Err(source) => {
                         return Err(self.failed_publication(
                             logical_shard,
@@ -296,6 +291,71 @@ where
                             source,
                         ));
                     }
+                };
+                // Begin observes whichever durable state the operation row is
+                // already in, so every state the engine can declare is handled
+                // here rather than collapsed into one running-state assertion.
+                match status.state {
+                    OperationState::Succeeded => {
+                        // The engine compares the operation identity and
+                        // initialization digests before it replays a terminal
+                        // row, so this record describes exactly this
+                        // publication: same target, same revision, same bytes.
+                        // Nothing was staged or uploaded on this attempt.
+                        let value = match published_result_from_status(&status) {
+                            Ok(value) => value,
+                            Err(source) => {
+                                return Err(self.failed_publication(
+                                    logical_shard,
+                                    operation_id,
+                                    None,
+                                    ArtifactPublishStage::Begin,
+                                    source,
+                                ));
+                            }
+                        };
+                        return Ok(ArtifactPublishOutcome {
+                            publication: ClientCall {
+                                value,
+                                commit_version,
+                                replayed: true,
+                            },
+                            upload_stats: ArtifactUploadStats::default(),
+                        });
+                    }
+                    OperationState::Aborting
+                    | OperationState::Failed
+                    | OperationState::Quarantined => {
+                        // The operation identity is durably spent. Aborting it
+                        // again is meaningless, so report the terminal state
+                        // instead of attempting one.
+                        return Err(ClientError::ArtifactPublishFailed {
+                            stage: ArtifactPublishStage::Begin,
+                            source: Box::new(ClientError::ResponseMismatch(format!(
+                                "artifact publication operation is durably {:?} and cannot be \
+                                 resumed; retry with a new operation identity",
+                                status.state
+                            ))),
+                            abort_failure: None,
+                        });
+                    }
+                    OperationState::Running => match running_publish_resume(
+                        status,
+                        operation_id,
+                        staged_objects.len(),
+                        manifest_rows.len(),
+                    ) {
+                        Ok(resume) => (resume.token, resume, replayed),
+                        Err(source) => {
+                            return Err(self.failed_publication(
+                                logical_shard,
+                                operation_id,
+                                None,
+                                ArtifactPublishStage::Begin,
+                                source,
+                            ));
+                        }
+                    },
                 }
             }
             Err(source) if is_definitive_append_race(&source) => return Err(source),
@@ -936,14 +996,7 @@ where
         if status.state != OperationState::Succeeded {
             return Ok(None);
         }
-        let result = match status.result {
-            Some(OperationResult::ArtifactPublish(result)) => result,
-            _ => {
-                return Err(ClientError::ResponseMismatch(
-                    "succeeded artifact operation did not contain a publish result".to_owned(),
-                ));
-            }
-        };
+        let result = published_result_from_status(&status)?;
         Ok(Some(ClientCall {
             value: result,
             commit_version: operation.commit_version,
@@ -1736,6 +1789,20 @@ fn running_publish_resume(
     })
 }
 
+/// The publication a terminal, successful operation record carries.
+///
+/// One definition shared by every path that observes a succeeded publication,
+/// whether it is discovered at `Begin` or recovered after a lost `Complete`
+/// response.
+fn published_result_from_status(status: &OperationStatus) -> Result<PublishResult, ClientError> {
+    match &status.result {
+        Some(OperationResult::ArtifactPublish(result)) => Ok(result.clone()),
+        _ => Err(ClientError::ResponseMismatch(
+            "succeeded artifact operation did not contain a publish result".to_owned(),
+        )),
+    }
+}
+
 fn running_publish_token(
     status: OperationStatus,
     operation_id: OperationIdentity,
@@ -1893,6 +1960,20 @@ mod tests {
             }
         }
 
+        /// The durable operation row the engine would replay for `operation_id`
+        /// when it has already reached a terminal state.
+        fn replayable_terminal_status(
+            &self,
+            operation_id: OperationIdentity,
+        ) -> Option<OperationStatus> {
+            let status = self.operation.as_ref()?;
+            if status.token.operation_id != operation_id || status.state == OperationState::Running
+            {
+                return None;
+            }
+            Some(status.clone())
+        }
+
         fn running_status(&mut self, operation_id: OperationIdentity) -> OperationStatus {
             OperationStatus {
                 token: self.next_token(operation_id),
@@ -2021,6 +2102,14 @@ mod tests {
     ) -> Result<WorkspaceResult, TransportError> {
         match &request.operation {
             WorkspaceRequest::BeginArtifactPublish(begin) => {
+                // The engine replays a durable operation row whose identity and
+                // initialization digests match, including one that already
+                // reached a terminal state. Model that here: an exact retry of a
+                // publication that already succeeded observes the stored
+                // terminal record rather than a fresh running one.
+                if let Some(status) = state.replayable_terminal_status(begin.operation_id) {
+                    return Ok(WorkspaceResult::Operation(status));
+                }
                 state.begin = Some(begin.clone());
                 state.staged_objects.clear();
                 state.manifest_rows.clear();
@@ -2920,6 +3009,48 @@ mod tests {
         assert_eq!(
             state.operation.as_ref().unwrap().state,
             OperationState::Succeeded
+        );
+    }
+
+    #[test]
+    fn retrying_a_succeeded_publication_converges_without_reuploading() {
+        let events = Arc::new(Mutex::new(Vec::new()));
+        let transport = ScriptedArtifactTransport::new(Arc::clone(&events), false);
+        let inspector = transport.clone();
+        let client = client(transport);
+        let store = RecordingStore::new(events, None);
+
+        let first = client
+            .publish_artifact(&store, publish_options(4), b"abcdefgh")
+            .unwrap();
+        assert!(!first.publication.replayed);
+        let uploads_after_first = inspector.state().stage_applies;
+
+        // A scheduler resubmits the job. A fresh process republishes the same
+        // bytes to the same path under the same durable identities.
+        let retry = client
+            .publish_artifact(&store, publish_options(4), b"abcdefgh")
+            .unwrap();
+
+        assert!(
+            retry.publication.replayed,
+            "an exact retry must report replay"
+        );
+        assert_eq!(retry.publication.value, first.publication.value);
+        assert_eq!(
+            inspector.state().stage_applies,
+            uploads_after_first,
+            "a replayed publication must not stage objects again"
+        );
+        assert_eq!(
+            inspector.state().abort_applies,
+            0,
+            "a replayed publication must not attempt an abort"
+        );
+        assert_eq!(
+            (retry.upload_stats.blocks, retry.upload_stats.bytes),
+            (0, 0),
+            "a replayed publication uploads nothing"
         );
     }
 


### PR DESCRIPTION
## What changed

`begin_publish` replays a durable operation row whose identity and initialization digests match, including one that already reached a terminal state. The client discarded that answer: it asserted the row was `Running` and otherwise failed, then tried to abort an operation the engine had already completed.

```
ArtifactPublishFailed { stage: Begin,
  source: ResponseMismatch("artifact publication stage did not remain in running state"),
  abort_failure: Some(ResponseMismatch("cannot abort an artifact publication that already succeeded")) }
```

The `Begin` case analysis is now total over `OperationState`:

- **`Succeeded`** returns the stored publication from the status already in hand, marked replayed, with empty upload stats. No extra round trip: the engine compares both digests before replaying, so the record describes exactly this publication, and nothing was staged on this attempt.
- **`Aborting` / `Failed` / `Quarantined`** report the durable state and no longer attempt an abort. Aborting a terminal operation is meaningless and was the source of the second error. The message tells the caller to retry under a new operation identity, which is the only way forward once the id is spent.
- **`Running`** keeps resuming from the durable cursor, unchanged.

`published_result_from_status` now holds the single definition of the publication a succeeded record carries, shared with the existing post-`Complete` recovery path.

## Why

An exact retry from a fresh process is what a scheduler resubmitting a job produces. A completed ingest failed loudly instead of converging, so a caller with stable operation identities could not distinguish "already done" from a real failure.

This is not a new capability. `commit` and `restore` in `workbench_workflow.rs` already match every `OperationState` and lift the stored result out of a terminal record (`(Succeeded, Some(OperationResult::Commit(result)), None) => result.clone()` and its restore twin). Publish was the only durable workflow whose case analysis stopped at `Running`; this brings it onto the same shape.

`running_publish_token` is untouched at the `StageObjects` / `MarkUploaded` / `StageManifest` call sites, where a non-running state really is an error.

## Test change

The scripted transport modelled `Begin` as always returning a fresh running status, so it could not express the engine contract the client was violating. It now replays a stored terminal row for a matching operation id. That harness gap is why the defect survived: `retrying_a_succeeded_publication_converges_without_reuploading` fails with the exact production error without the client change.

## Validation

```
cargo test --workspace
cargo fmt --all -- --check
cargo clippy --workspace --all-targets -- -D warnings
```

All green; `nokv-client` 49/49.

Live stack (etcd + rustfs + `nokv serve`, Python SDK driving the publish path), five resubmissions of one publication under stable identities:

| attempt | replayed | generation | revision | body digest |
|---|---|---|---|---|
| 0 | false | 1 | 746fbb3eb0c9 | sha256:480cb27ce1d7 |
| 1-4 | true | 1 | 746fbb3eb0c9 | sha256:480cb27ce1d7 |

Concurrent same-operation A/B, 20 trials each side: 6/20 trials had a winner before the change, 5/20 after. That race is decided in `stage_objects` / `mark_uploaded`, which this PR does not touch, and the difference is noise.

## Scope

Out of scope, unchanged, and separately tracked:

- the `invalid publish transition Finalizing -> Aborting` trailer on a `Complete`-stage `PathAlreadyExists` conflict, which has a different root cause (the engine refusing that transition);
- `initiating_owner_epoch` being sealed into both digests, so replay holds only within one owner epoch. That is engine-side and deliberate;
- two clients driving the same operation id concurrently mostly failing closed. Pre-existing, measured above, unchanged.