### PR TITLE
fix(client): re-check live state before returning a replayed publication

### DIFF
--- a/crates/nokv-client/src/artifact.rs
+++ b/crates/nokv-client/src/artifact.rs
@@ -314,6 +314,25 @@ where
                                 ));
                             }
                         };
+                        // The replay branch is the one path the engine takes
+                        // without re-checking the live path claim, so a
+                        // visible publication whose path was later removed and
+                        // reclaimed by another writer would otherwise be
+                        // reported as current. Commit and restore both re-read
+                        // live state before returning a replayed terminal
+                        // result; publish does the same rather than handing
+                        // back a generation the caller could CAS against.
+                        if matches!(authority, PublicationAuthority::Visible) {
+                            if let Err(source) =
+                                self.confirm_replayed_publication_is_live(logical_shard, &value)
+                            {
+                                return Err(ClientError::ArtifactPublishFailed {
+                                    stage: ArtifactPublishStage::Begin,
+                                    source: Box::new(source),
+                                    abort_failure: None,
+                                });
+                            }
+                        }
                         return Ok(ArtifactPublishOutcome {
                             publication: ClientCall {
                                 value,
@@ -981,6 +1000,41 @@ where
                 ))
             }
         }
+    }
+
+    /// Confirm a replayed publication still describes the live path.
+    ///
+    /// `begin_publish` returns a terminal operation row after comparing its
+    /// digests, without re-evaluating the path claim, so a create-only
+    /// publication whose path was later removed and reclaimed replays as
+    /// succeeded while the path holds a different revision. Returning that
+    /// record unchecked would hand the caller a generation to compare-and-swap
+    /// against a revision that is not theirs.
+    fn confirm_replayed_publication_is_live(
+        &self,
+        logical_shard: LogicalShardIdentity,
+        published: &PublishResult,
+    ) -> Result<(), ClientError> {
+        let metadata = self
+            .load_artifact_metadata(logical_shard, &published.target, WorkspaceReadView::Live)
+            .map_err(|source| match source {
+                ClientError::Rpc(failure) if failure.code == ErrorCode::NotFound => {
+                    ClientError::ResponseMismatch(
+                        "this publication succeeded earlier but its path no longer exists; the \
+                         replayed result cannot describe live state"
+                            .to_owned(),
+                    )
+                }
+                other => other,
+            })?;
+        if metadata.artifact_revision_id != published.artifact_revision_id {
+            return Err(ClientError::ResponseMismatch(
+                "this publication succeeded earlier but its path now holds a different revision; \
+                 the replayed result cannot describe live state"
+                    .to_owned(),
+            ));
+        }
+        Ok(())
     }
 
     fn recover_completed_publish(
@@ -3052,6 +3106,51 @@ mod tests {
             (0, 0),
             "a replayed publication uploads nothing"
         );
+    }
+
+    #[test]
+    fn a_replayed_publication_whose_path_moved_is_not_reported_as_current() {
+        let events = Arc::new(Mutex::new(Vec::new()));
+        let transport = ScriptedArtifactTransport::new(Arc::clone(&events), false);
+        let inspector = transport.clone();
+        let client = client(transport);
+        let store = RecordingStore::new(events, None);
+
+        client
+            .publish_artifact(&store, publish_options(4), b"abcdefgh")
+            .unwrap();
+
+        // The path is removed and reclaimed by another writer, so the durable
+        // operation row still says succeeded while the path holds a revision
+        // that is not this caller's.
+        {
+            let mut state = inspector.state();
+            let metadata = state.path.as_mut().unwrap().metadata.as_mut().unwrap();
+            metadata.artifact_revision_id = ArtifactRevisionIdentity([0x5c; 16]);
+        }
+
+        let error = client
+            .publish_artifact(&store, publish_options(4), b"abcdefgh")
+            .unwrap_err();
+        let ClientError::ArtifactPublishFailed {
+            stage,
+            source,
+            abort_failure,
+        } = error
+        else {
+            panic!("expected a publish failure, got {error:?}");
+        };
+        assert_eq!(stage, ArtifactPublishStage::Begin);
+        assert!(
+            abort_failure.is_none(),
+            "a terminal row must not be aborted"
+        );
+        assert!(
+            matches!(*source, ClientError::ResponseMismatch(ref reason)
+                if reason.contains("holds a different revision")),
+            "unexpected source: {source:?}"
+        );
+        assert_eq!(inspector.state().abort_applies, 0);
     }
 
     #[test]


### PR DESCRIPTION
`begin_publish` returns a terminal operation row after comparing its identity and initialization digests, without re-evaluating the path claim. The create-only condition contributes only a tag byte to those digests, so a publication whose path was later removed and reclaimed by another writer replays as succeeded while the path holds a different revision. Returning that record unchecked hands the caller a generation to compare-and-swap against a revision that is not theirs.

Commit and restore never do this: their `Succeeded` arms re-read live state before returning a replayed terminal result, commit through `validate_commit_manifest` and restore through a live manifest read plus a full byte comparison. The publish replay added in the previous commit returned with no cross-validation at all, which made it the only such path in the client.

A visible publication now confirms the live path still carries the replayed revision before converging. Staging authorities are exempt: a `CommitStaging` or `RestoreStaging` revision is deliberately not visible at its canonical path yet, so a live path read there would assert something the authority does not promise.

Validation:
- cargo test --workspace
- cargo fmt --all -- --check; cargo clippy --workspace --all-targets -- -D warnings
- the new test fails when the check is bypassed and passes with it

<!--
Copyright 2024-2026 The NoKV Authors.
SPDX-License-Identifier: Apache-2.0
-->

## Related Issue

<!--
Every non-trivial PR should be tied to an existing issue so maintainers can
review the agreed problem, scope, and design history before reading the diff.

Use one of:
- Closes #issue_number
- Fixes #issue_number
- Relates to #issue_number

Small exceptions are allowed for typo-only docs edits, CI/dependency chores,
release chores, and maintainer-approved emergency fixes. If this PR has no
issue, explain the exception here.
-->

Closes | Fixes | Relates to #

## Summary

-

## Scope

- [ ] This PR changes one logical boundary only.
- [ ] No unrelated refactor, benchmark, metadata model, Holt layout,
      object-store, agent interface, or docs change is mixed in.
- [ ] The linked issue describes the user-visible problem, design decision, or
      maintenance task this PR resolves.
- [ ] Any breaking change is intentional and documented.
- [ ] No compatibility shim, deprecated alias, or forwarding wrapper was added without a removal condition.

## Code Contract (Code Changes Only)

- [ ] Not applicable; this is a docs/config-only change.
- [ ] Package boundaries follow `docs/development/code_contract.md`.
- [ ] Shared helpers reuse the standard library or existing repository helpers.
      New generic helper modules are domain-neutral and tested.
- [ ] File names and file placement follow the code contract.
- [ ] New types, interfaces, structs, fields, and functions use domain-specific names.
- [ ] New errors are in the owning package's `errors.rs` and carry stable error kinds when crossing package boundaries.
- [ ] New metrics/stats are owned by the package that reports or serves them.
- [ ] Metadata changes document durability, atomicity, revision-reference
      lifetime, snapshot/commit/event retention, GC epochs, and fail-closed
      recovery boundaries.
- [ ] Placement or routing changes preserve persisted `RootId -> LogicalShardId`
      affinity, one active writer per shard, owner-epoch fencing, and explicit
      shard-local atomicity; no split root or cross-shard transaction is implied.
- [ ] Agent-interface changes keep the transport-free facade and schemas in
      `nokv-agent`, routing and workflows in `nokv-client`, and the concrete
      backend plus MCP wiring in the `nokv` CLI.

## Claims and Evidence

- [ ] User-facing documentation distinguishes current, experimental, and
      planned capabilities.
- [ ] Security claims do not treat a Workbench root or Agent scope as tenant
      authentication or authorization.
- [ ] Performance claims state the topology, comparison boundary, cache state,
      run count, and raw-evidence location.
- [ ] Benchmark-only behavior does not alter product semantics.

## Validation

<!-- List exact commands and key results. For each relevant check not run,
explain why. Docs-only changes may mark Rust checks not applicable. -->

- Command and result:
- Not run (with reason):

## Contributor Sign-off

- [ ] Every commit in this PR includes a DCO `Signed-off-by` trailer.
