### PR TITLE
fix(server): recover local metadata successors

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -23,9 +23,11 @@ jobs:
           set -euo pipefail
           python3 -m py_compile \
             scripts/workbench/workbench_contract.py \
-            scripts/workbench/live_workbench.py
+            scripts/workbench/live_workbench.py \
+            scripts/workbench/local_wal_recovery_gate.py
           python3 scripts/workbench/workbench_contract_test.py
           python3 scripts/workbench/live_workbench_test.py
+          python3 scripts/workbench/local_wal_recovery_gate_test.py
           bash -n scripts/workbench/start_rustfs.sh
 
       - name: Check Homebrew release safety
@@ -33,6 +35,10 @@ jobs:
 
   nokv-workspace:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
+    env:
+      ETCD_VERSION: v3.7.1
+      ETCD_LINUX_AMD64_SHA256: e8cd3fa8064c98137c5dbd78b76f969417ace84efb83c481041d7a52ffdd8fb9
     steps:
       - uses: actions/checkout@v7
 
@@ -66,3 +72,41 @@ jobs:
           cargo test -p nokv-meta --features metadata-read-stats
           cargo test -p nokv-meta-holt --features read-stats
           cargo test -p nokv-bench --features metadata-read-stats
+
+      - name: Install pinned etcd
+        shell: bash
+        run: |
+          set -euo pipefail
+          archive="$RUNNER_TEMP/etcd-$ETCD_VERSION-linux-amd64.tar.gz"
+          install_dir="$RUNNER_TEMP/etcd-$ETCD_VERSION"
+          curl --fail --location --retry 3 \
+            --output "$archive" \
+            "https://github.com/etcd-io/etcd/releases/download/$ETCD_VERSION/etcd-$ETCD_VERSION-linux-amd64.tar.gz"
+          echo "$ETCD_LINUX_AMD64_SHA256  $archive" | sha256sum --check
+          mkdir -p "$install_dir"
+          tar -xzf "$archive" -C "$install_dir" --strip-components=1
+          echo "$install_dir" >>"$GITHUB_PATH"
+          "$install_dir/etcd" --version
+          "$install_dir/etcdctl" version
+
+      - name: Qualify interrupted local-WAL successor recovery
+        id: local_wal_recovery
+        shell: bash
+        env:
+          RECOVERY_EVIDENCE_DIR: ${{ runner.temp }}/local-wal-recovery-evidence
+        run: |
+          set -euo pipefail
+          python3 scripts/workbench/local_wal_recovery_gate.py \
+            --build \
+            --target-dir target \
+            --evidence-dir "$RECOVERY_EVIDENCE_DIR" \
+            --timeout 45
+
+      - name: Upload local-WAL recovery evidence
+        if: ${{ always() && steps.local_wal_recovery.outcome != 'skipped' }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+        with:
+          name: local-wal-recovery-${{ github.sha }}
+          path: ${{ runner.temp }}/local-wal-recovery-evidence
+          if-no-files-found: error
+          retention-days: 7

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1302,6 +1302,7 @@ dependencies = [
 name = "nokv-bench"
 version = "0.1.0"
 dependencies = [
+ "nokv-control",
  "nokv-meta",
  "nokv-meta-holt",
  "nokv-meta-store",

--- a/bench/Cargo.toml
+++ b/bench/Cargo.toml
@@ -14,6 +14,7 @@ homepage.workspace = true
 metadata-read-stats = ["nokv-meta/metadata-read-stats", "nokv-meta-holt/read-stats"]
 
 [dependencies]
+nokv-control = { workspace = true, features = ["etcd"] }
 nokv-meta.workspace = true
 nokv-meta-holt = { workspace = true, features = ["test-support"] }
 nokv-meta-store.workspace = true
@@ -26,6 +27,10 @@ serde_json.workspace = true
 [[bin]]
 name = "nokv-workspace-bench"
 path = "src/bin/nokv-workspace-bench.rs"
+
+[[bin]]
+name = "nokv-local-wal-recovery-fault"
+path = "src/bin/nokv-local-wal-recovery-fault.rs"
 
 [[bin]]
 name = "nokv-bench"

--- a/bench/src/bin/nokv-local-wal-recovery-fault.rs
+++ b/bench/src/bin/nokv-local-wal-recovery-fault.rs
@@ -1,0 +1,212 @@
+/*
+ * Copyright 2024-2026 The NoKV Authors.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+//! Real-etcd fault driver for the local-WAL recovery qualification workload.
+
+use std::fs::OpenOptions;
+use std::io::Write;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+use std::thread;
+use std::time::Duration;
+
+use nokv_control::{
+    ControlStore, EtcdControlStore, EtcdControlStoreOptions, LogicalShardId, NodeId, OwnerEpoch,
+};
+use nokv_meta::workspace as meta;
+use nokv_meta_holt::{HoltOptions, HoltStore, TreeBinding};
+use nokv_meta_store::TxnStore;
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Copy, Debug, Deserialize, Serialize)]
+#[serde(rename_all = "kebab-case")]
+enum CrashStage {
+    BeforeLocalFence,
+    AfterLocalFence,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct Config {
+    etcd_endpoints: Vec<String>,
+    etcd_key_prefix: String,
+    lease_ttl_seconds: i64,
+    logical_shard_id: String,
+    metadata_path: PathBuf,
+    previous_owner_epoch: u64,
+    node_id: String,
+    endpoint: String,
+    stage: CrashStage,
+    ready_path: PathBuf,
+}
+
+#[derive(Debug, Serialize)]
+struct ReadyRecord {
+    stage: CrashStage,
+    previous_owner_epoch: u64,
+    recovery_owner_epoch: u64,
+    local_epoch_at_crash: u64,
+    lease_id: u64,
+}
+
+fn main() {
+    if let Err(error) = run() {
+        eprintln!("nokv-local-wal-recovery-fault: {error}");
+        std::process::exit(2);
+    }
+}
+
+fn run() -> Result<(), String> {
+    let config_path = std::env::args_os()
+        .nth(1)
+        .ok_or_else(|| "usage: nokv-local-wal-recovery-fault CONFIG.json".to_owned())?;
+    if std::env::args_os().nth(2).is_some() {
+        return Err("usage: nokv-local-wal-recovery-fault CONFIG.json".to_owned());
+    }
+    let config_bytes = std::fs::read(&config_path).map_err(|error| {
+        format!(
+            "read config {}: {error}",
+            PathBuf::from(config_path).display()
+        )
+    })?;
+    let config: Config = serde_json::from_slice(&config_bytes)
+        .map_err(|error| format!("decode fault-driver config: {error}"))?;
+    validate_config(&config)?;
+
+    let logical_shard_id = parse_logical_shard_id(&config.logical_shard_id)?;
+    let previous_owner_epoch = OwnerEpoch::new(config.previous_owner_epoch)
+        .map_err(|error| format!("invalid previous owner epoch: {error}"))?;
+
+    // The production bootstrap opens and validates the exclusive local
+    // authority before changing the control epoch. Keep that authority open
+    // until the parent kills this process so the crash boundary is faithful.
+    let catalog = meta::keyspaces()
+        .iter()
+        .map(|definition| TreeBinding::new(definition.id, definition.name));
+    let holt = HoltStore::open(HoltOptions::file(
+        &config.metadata_path,
+        catalog,
+        meta::store_limits(),
+    ))
+    .map_err(|error| format!("open local Holt authority: {error}"))?;
+    let store: Arc<dyn TxnStore> = Arc::new(holt);
+    let meta = meta::MetaShard::open(store, logical_shard_id)
+        .map_err(|error| format!("open metadata shard: {error}"))?;
+    let local_before = meta
+        .current_owner_epoch()
+        .map_err(|error| format!("read local owner epoch: {error}"))?;
+    if local_before != Some(previous_owner_epoch) {
+        return Err(format!(
+            "local authority is fenced at {}, expected previous epoch {}",
+            display_epoch(local_before),
+            previous_owner_epoch
+        ));
+    }
+
+    let control = EtcdControlStore::connect(
+        EtcdControlStoreOptions::new(config.etcd_endpoints.clone())
+            .with_key_prefix(config.etcd_key_prefix.clone())
+            .with_lease_ttl_seconds(config.lease_ttl_seconds),
+    )
+    .map_err(|error| format!("connect etcd control store: {error}"))?;
+    let lease = control
+        .acquire_successor(
+            &logical_shard_id,
+            previous_owner_epoch,
+            NodeId::new(config.node_id.clone())
+                .map_err(|error| format!("invalid node id: {error}"))?,
+            config.endpoint.clone(),
+        )
+        .map_err(|error| format!("acquire successor: {error}"))?;
+
+    if matches!(config.stage, CrashStage::AfterLocalFence) {
+        meta.advance_owner_epoch(Some(previous_owner_epoch), lease.owner_epoch)
+            .map_err(|error| format!("advance local owner epoch: {error}"))?;
+    }
+    let local_epoch_at_crash = meta
+        .current_owner_epoch()
+        .map_err(|error| format!("read crash-boundary owner epoch: {error}"))?
+        .ok_or_else(|| "crash-boundary local owner epoch is absent".to_owned())?;
+
+    write_ready(
+        &config.ready_path,
+        &ReadyRecord {
+            stage: config.stage,
+            previous_owner_epoch: previous_owner_epoch.get(),
+            recovery_owner_epoch: lease.owner_epoch.get(),
+            local_epoch_at_crash: local_epoch_at_crash.get(),
+            lease_id: lease.lease_id,
+        },
+    )?;
+
+    // Stay live until the qualification parent sends SIGKILL. Renewing avoids
+    // accidentally testing natural expiry before the requested crash boundary.
+    let renew_interval_ms = u64::try_from(config.lease_ttl_seconds)
+        .map_err(|_| "lease TTL must be positive".to_owned())?
+        .saturating_mul(1_000)
+        .saturating_div(3)
+        .max(100);
+    loop {
+        thread::sleep(Duration::from_millis(renew_interval_ms));
+        control
+            .renew_owner(&lease)
+            .map_err(|error| format!("renew crash-boundary owner: {error}"))?;
+    }
+}
+
+fn validate_config(config: &Config) -> Result<(), String> {
+    if config.etcd_endpoints.is_empty() || config.etcd_endpoints.iter().any(String::is_empty) {
+        return Err("etcd_endpoints must contain at least one non-empty endpoint".to_owned());
+    }
+    if config.etcd_key_prefix.is_empty() || !config.etcd_key_prefix.starts_with('/') {
+        return Err("etcd_key_prefix must be an absolute non-empty key prefix".to_owned());
+    }
+    if config.lease_ttl_seconds <= 0 {
+        return Err("lease_ttl_seconds must be positive".to_owned());
+    }
+    if config.endpoint.is_empty() {
+        return Err("endpoint must be non-empty".to_owned());
+    }
+    if config.ready_path.exists() {
+        return Err(format!(
+            "ready path already exists: {}",
+            config.ready_path.display()
+        ));
+    }
+    Ok(())
+}
+
+fn parse_logical_shard_id(raw: &str) -> Result<LogicalShardId, String> {
+    if raw.len() != LogicalShardId::BYTE_WIDTH * 2
+        || !raw.bytes().all(|byte| byte.is_ascii_hexdigit())
+    {
+        return Err("logical_shard_id must be exactly 32 hexadecimal characters".to_owned());
+    }
+    let mut bytes = [0_u8; LogicalShardId::BYTE_WIDTH];
+    for (index, slot) in bytes.iter_mut().enumerate() {
+        let offset = index * 2;
+        *slot = u8::from_str_radix(&raw[offset..offset + 2], 16)
+            .map_err(|error| format!("decode logical_shard_id: {error}"))?;
+    }
+    Ok(LogicalShardId::from_bytes(bytes))
+}
+
+fn write_ready(path: &Path, record: &ReadyRecord) -> Result<(), String> {
+    let mut file = OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .open(path)
+        .map_err(|error| format!("create ready record {}: {error}", path.display()))?;
+    serde_json::to_writer_pretty(&mut file, record)
+        .map_err(|error| format!("encode ready record: {error}"))?;
+    file.write_all(b"\n")
+        .map_err(|error| format!("finish ready record: {error}"))?;
+    file.sync_all()
+        .map_err(|error| format!("sync ready record: {error}"))
+}
+
+fn display_epoch(epoch: Option<OwnerEpoch>) -> String {
+    epoch.map_or_else(|| "epoch-zero".to_owned(), |epoch| epoch.get().to_string())
+}

--- a/crates/nokv-control/src/errors.rs
+++ b/crates/nokv-control/src/errors.rs
@@ -1,6 +1,8 @@
 use std::fmt;
 
-use crate::{LogicalShardId, LogicalShardLease, NodeId, OwnerEpoch, RootId, RootPlacement};
+use crate::{
+    LogicalShardId, LogicalShardLease, LogicalShardState, NodeId, OwnerEpoch, RootId, RootPlacement,
+};
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum ControlError {
@@ -31,6 +33,14 @@ pub enum ControlError {
     PreviousOwnerSessionLive {
         logical_shard_id: LogicalShardId,
         owner_epoch: OwnerEpoch,
+    },
+    RecoveryAttemptPending {
+        logical_shard_id: LogicalShardId,
+        owner_epoch: OwnerEpoch,
+    },
+    RecoveryStateConflict {
+        logical_shard_id: LogicalShardId,
+        actual: LogicalShardState,
     },
     StaleOwnerEpoch {
         logical_shard_id: LogicalShardId,
@@ -104,6 +114,20 @@ impl fmt::Display for ControlError {
             } => write!(
                 formatter,
                 "logical shard {logical_shard_id:?} still has a live owner session at epoch {owner_epoch}"
+            ),
+            Self::RecoveryAttemptPending {
+                logical_shard_id,
+                owner_epoch,
+            } => write!(
+                formatter,
+                "logical shard {logical_shard_id:?} has an unfinished recovery attempt at epoch {owner_epoch}; reacquire that recovery epoch instead of advancing it"
+            ),
+            Self::RecoveryStateConflict {
+                logical_shard_id,
+                actual,
+            } => write!(
+                formatter,
+                "logical shard {logical_shard_id:?} is {actual:?}, not Recovering"
             ),
             Self::StaleOwnerEpoch {
                 logical_shard_id,

--- a/crates/nokv-control/src/etcd.rs
+++ b/crates/nokv-control/src/etcd.rs
@@ -9,8 +9,8 @@ use crate::codec::{
 };
 use crate::store::{
     prepare_mark_serving, prepare_owner_acquisition, prepare_owner_release,
-    validate_new_root_placement, validate_record_lease, validate_root_placement_update,
-    ControlStore,
+    prepare_recovery_reacquisition, prepare_recovery_suspension, validate_new_root_placement,
+    validate_record_lease, validate_root_placement_update, ControlStore,
 };
 use crate::{
     ControlError, EtcdControlStoreOptions, LogicalShardId, LogicalShardLease, LogicalShardRecord,
@@ -333,6 +333,55 @@ impl ControlStore for EtcdControlStore {
         })
     }
 
+    fn reacquire_recovery(
+        &self,
+        logical_shard_id: &LogicalShardId,
+        recovery_epoch: OwnerEpoch,
+        owner: NodeId,
+        endpoint: String,
+    ) -> Result<LogicalShardLease, ControlError> {
+        let mut client = self.client.clone();
+        let options = self.options.clone();
+        let logical_shard_id = *logical_shard_id;
+        self.block_on(async move {
+            let placement = find_write_placement(&mut client, &options, &logical_shard_id).await?;
+            let current = fetch_logical_shard(&mut client, &options, &logical_shard_id)
+                .await?
+                .ok_or(ControlError::LogicalShardNotFound(logical_shard_id))?;
+            if current.record.owner_epoch != Some(recovery_epoch) {
+                return Err(ControlError::StaleOwnerEpoch {
+                    logical_shard_id,
+                    expected: Some(recovery_epoch),
+                    actual: current.record.owner_epoch,
+                });
+            }
+            let lease_id = grant_lease(&mut client, options.lease_ttl_seconds()).await?;
+            let (next, lease) = match prepare_recovery_reacquisition(
+                &current.record,
+                recovery_epoch,
+                owner,
+                endpoint,
+                lease_id,
+            ) {
+                Ok(prepared) => prepared,
+                Err(error) => {
+                    revoke_lease_best_effort(&mut client, lease_id).await;
+                    return Err(error);
+                }
+            };
+            install_owner(
+                &mut client,
+                &options,
+                &current,
+                &placement,
+                &next,
+                &lease,
+                Some(recovery_epoch),
+            )
+            .await
+        })
+    }
+
     fn renew_owner(&self, lease: &LogicalShardLease) -> Result<LogicalShardRecord, ControlError> {
         let mut client = self.client.clone();
         let options = self.options.clone();
@@ -399,6 +448,46 @@ impl ControlStore for EtcdControlStore {
                     classify_mark_serving_failure(&mut client, &options, &lease, &next).await
                 }
             }
+        })
+    }
+
+    fn suspend_recovery(
+        &self,
+        lease: &LogicalShardLease,
+    ) -> Result<LogicalShardRecord, ControlError> {
+        let mut client = self.client.clone();
+        let options = self.options.clone();
+        let lease = lease.clone();
+        self.block_on(async move {
+            let current = fetch_logical_shard(&mut client, &options, &lease.logical_shard_id)
+                .await?
+                .ok_or(ControlError::LogicalShardNotFound(lease.logical_shard_id))?;
+            let session = validate_owner_session(&mut client, &options, &lease).await?;
+            let retained = prepare_recovery_suspension(&current.record, &lease)?;
+            let record_key = options.logical_shard_record_key(&lease.logical_shard_id);
+            let session_key = options.logical_shard_session_key(&lease.logical_shard_id);
+            let txn = Txn::new()
+                .when(vec![
+                    Compare::value(record_key, CompareOp::Equal, current.encoded),
+                    Compare::value(session_key.clone(), CompareOp::Equal, session.encoded),
+                    Compare::lease(
+                        session_key.clone(),
+                        CompareOp::Equal,
+                        lease_id_i64(lease.lease_id)?,
+                    ),
+                ])
+                .and_then(vec![TxnOp::delete(session_key, None)]);
+            let result = match client.txn(txn).await {
+                Ok(response) if response.succeeded() => Ok(retained),
+                Ok(_) | Err(_) => {
+                    classify_suspend_recovery_failure(&mut client, &options, &lease, &retained)
+                        .await
+                }
+            };
+            if result.is_ok() {
+                revoke_lease_best_effort(&mut client, lease.lease_id).await;
+            }
+            result
         })
     }
 
@@ -800,6 +889,29 @@ async fn classify_mark_serving_failure(
     validate_owner_session(client, options, lease).await?;
     Err(ControlError::Backend(
         "owner mutation CAS failed while the exact owner session remained current".to_owned(),
+    ))
+}
+
+async fn classify_suspend_recovery_failure(
+    client: &mut Client,
+    options: &EtcdControlStoreOptions,
+    lease: &LogicalShardLease,
+    retained: &LogicalShardRecord,
+) -> Result<LogicalShardRecord, ControlError> {
+    let latest = fetch_logical_shard(client, options, &lease.logical_shard_id)
+        .await?
+        .ok_or(ControlError::LogicalShardNotFound(lease.logical_shard_id))?;
+    if latest.record == *retained
+        && fetch_owner_session(client, options, &lease.logical_shard_id)
+            .await?
+            .is_none()
+    {
+        return Ok(retained.clone());
+    }
+    validate_record_lease(&latest.record, lease)?;
+    validate_owner_session(client, options, lease).await?;
+    Err(ControlError::Backend(
+        "recovery suspension CAS failed while the exact owner session remained current".to_owned(),
     ))
 }
 

--- a/crates/nokv-control/src/store.rs
+++ b/crates/nokv-control/src/store.rs
@@ -52,6 +52,16 @@ pub trait ControlStore: Send + Sync {
         endpoint: String,
     ) -> Result<LogicalShardLease, ControlError>;
 
+    /// Rebind the lease/session of an unfinished recovery attempt without
+    /// consuming another owner epoch. The previous session must be gone.
+    fn reacquire_recovery(
+        &self,
+        logical_shard_id: &LogicalShardId,
+        recovery_epoch: OwnerEpoch,
+        owner: NodeId,
+        endpoint: String,
+    ) -> Result<LogicalShardLease, ControlError>;
+
     fn renew_owner(&self, lease: &LogicalShardLease) -> Result<LogicalShardRecord, ControlError>;
 
     /// Publish a caller-serialized recovery frontier and make the exact owner
@@ -62,6 +72,13 @@ pub trait ControlStore: Send + Sync {
         publication: RecoveryPublication,
     ) -> Result<LogicalShardRecord, ControlError>;
 
+    /// End the live session for a boot that has not reached `Serving`, while
+    /// retaining its durable recovery epoch for an exact retry.
+    fn suspend_recovery(
+        &self,
+        lease: &LogicalShardLease,
+    ) -> Result<LogicalShardRecord, ControlError>;
+
     fn release_owner(&self, lease: &LogicalShardLease) -> Result<LogicalShardRecord, ControlError>;
 }
 
@@ -69,6 +86,7 @@ pub trait ControlStore: Send + Sync {
 struct InMemoryState {
     root_placements: BTreeMap<RootId, RootPlacement>,
     logical_shards: BTreeMap<LogicalShardId, LogicalShardRecord>,
+    owner_sessions: BTreeMap<LogicalShardId, LogicalShardLease>,
     next_lease_id: u64,
 }
 
@@ -205,6 +223,9 @@ impl ControlStore for InMemoryControlStore {
         let lease_id = allocate_lease_id(&mut state, *logical_shard_id)?;
         let (next, lease) = prepare_owner_acquisition(&current, None, owner, endpoint, lease_id)?;
         state.logical_shards.insert(*logical_shard_id, next);
+        state
+            .owner_sessions
+            .insert(*logical_shard_id, lease.clone());
         Ok(lease)
     }
 
@@ -230,7 +251,13 @@ impl ControlStore for InMemoryControlStore {
                 actual: current.owner_epoch,
             });
         }
-        if current.owner.is_some() {
+        if current.state == LogicalShardState::Recovering {
+            return Err(ControlError::RecoveryAttemptPending {
+                logical_shard_id: *logical_shard_id,
+                owner_epoch: expected_owner_epoch,
+            });
+        }
+        if state.owner_sessions.contains_key(logical_shard_id) {
             return Err(ControlError::PreviousOwnerSessionLive {
                 logical_shard_id: *logical_shard_id,
                 owner_epoch: expected_owner_epoch,
@@ -245,6 +272,47 @@ impl ControlStore for InMemoryControlStore {
             lease_id,
         )?;
         state.logical_shards.insert(*logical_shard_id, next);
+        state
+            .owner_sessions
+            .insert(*logical_shard_id, lease.clone());
+        Ok(lease)
+    }
+
+    fn reacquire_recovery(
+        &self,
+        logical_shard_id: &LogicalShardId,
+        recovery_epoch: OwnerEpoch,
+        owner: NodeId,
+        endpoint: String,
+    ) -> Result<LogicalShardLease, ControlError> {
+        validate_endpoint(&endpoint)?;
+        let mut state = self.state.lock().expect("control store mutex poisoned");
+        ensure_root_placement(&state, logical_shard_id)?;
+        let current = state
+            .logical_shards
+            .get(logical_shard_id)
+            .cloned()
+            .ok_or(ControlError::LogicalShardNotFound(*logical_shard_id))?;
+        if current.owner_epoch != Some(recovery_epoch) {
+            return Err(ControlError::StaleOwnerEpoch {
+                logical_shard_id: *logical_shard_id,
+                expected: Some(recovery_epoch),
+                actual: current.owner_epoch,
+            });
+        }
+        if state.owner_sessions.contains_key(logical_shard_id) {
+            return Err(ControlError::PreviousOwnerSessionLive {
+                logical_shard_id: *logical_shard_id,
+                owner_epoch: recovery_epoch,
+            });
+        }
+        let lease_id = allocate_lease_id(&mut state, *logical_shard_id)?;
+        let (next, lease) =
+            prepare_recovery_reacquisition(&current, recovery_epoch, owner, endpoint, lease_id)?;
+        state.logical_shards.insert(*logical_shard_id, next);
+        state
+            .owner_sessions
+            .insert(*logical_shard_id, lease.clone());
         Ok(lease)
     }
 
@@ -255,6 +323,7 @@ impl ControlStore for InMemoryControlStore {
             .get(&lease.logical_shard_id)
             .ok_or(ControlError::LogicalShardNotFound(lease.logical_shard_id))?;
         validate_record_lease(record, lease)?;
+        validate_in_memory_session(&state, lease)?;
         Ok(record.clone())
     }
 
@@ -269,11 +338,30 @@ impl ControlStore for InMemoryControlStore {
             .get(&lease.logical_shard_id)
             .cloned()
             .ok_or(ControlError::LogicalShardNotFound(lease.logical_shard_id))?;
+        validate_record_lease(&current, lease)?;
+        validate_in_memory_session(&state, lease)?;
         let next = prepare_mark_serving(&current, lease, publication)?;
         state
             .logical_shards
             .insert(lease.logical_shard_id, next.clone());
         Ok(next)
+    }
+
+    fn suspend_recovery(
+        &self,
+        lease: &LogicalShardLease,
+    ) -> Result<LogicalShardRecord, ControlError> {
+        let mut state = self.state.lock().expect("control store mutex poisoned");
+        let current = state
+            .logical_shards
+            .get(&lease.logical_shard_id)
+            .cloned()
+            .ok_or(ControlError::LogicalShardNotFound(lease.logical_shard_id))?;
+        validate_record_lease(&current, lease)?;
+        validate_in_memory_session(&state, lease)?;
+        let retained = prepare_recovery_suspension(&current, lease)?;
+        state.owner_sessions.remove(&lease.logical_shard_id);
+        Ok(retained)
     }
 
     fn release_owner(&self, lease: &LogicalShardLease) -> Result<LogicalShardRecord, ControlError> {
@@ -283,11 +371,25 @@ impl ControlStore for InMemoryControlStore {
             .get(&lease.logical_shard_id)
             .cloned()
             .ok_or(ControlError::LogicalShardNotFound(lease.logical_shard_id))?;
+        validate_record_lease(&current, lease)?;
+        validate_in_memory_session(&state, lease)?;
         let next = prepare_owner_release(&current, lease)?;
         state
             .logical_shards
             .insert(lease.logical_shard_id, next.clone());
+        state.owner_sessions.remove(&lease.logical_shard_id);
         Ok(next)
+    }
+}
+
+fn validate_in_memory_session(
+    state: &InMemoryState,
+    lease: &LogicalShardLease,
+) -> Result<(), ControlError> {
+    if state.owner_sessions.get(&lease.logical_shard_id) == Some(lease) {
+        Ok(())
+    } else {
+        Err(ControlError::StaleLease(lease.clone()))
     }
 }
 
@@ -424,6 +526,14 @@ pub(crate) fn prepare_owner_acquisition(
             actual: current.owner_epoch,
         });
     }
+    if let Some(owner_epoch) = expected_owner_epoch {
+        if current.state == LogicalShardState::Recovering {
+            return Err(ControlError::RecoveryAttemptPending {
+                logical_shard_id: current.logical_shard_id,
+                owner_epoch,
+            });
+        }
+    }
     if expected_owner_epoch.is_none() {
         if let (Some(current_owner), Some(owner_epoch)) =
             (current.owner.clone(), current.owner_epoch)
@@ -467,6 +577,47 @@ pub(crate) fn prepare_owner_acquisition(
     Ok((next, lease))
 }
 
+pub(crate) fn prepare_recovery_reacquisition(
+    current: &LogicalShardRecord,
+    recovery_epoch: OwnerEpoch,
+    owner: NodeId,
+    endpoint: String,
+    lease_id: u64,
+) -> Result<(LogicalShardRecord, LogicalShardLease), ControlError> {
+    validate_logical_shard_record(current)?;
+    validate_endpoint(&endpoint)?;
+    if current.state != LogicalShardState::Recovering {
+        return Err(ControlError::RecoveryStateConflict {
+            logical_shard_id: current.logical_shard_id,
+            actual: current.state,
+        });
+    }
+    if current.owner_epoch != Some(recovery_epoch) {
+        return Err(ControlError::StaleOwnerEpoch {
+            logical_shard_id: current.logical_shard_id,
+            expected: Some(recovery_epoch),
+            actual: current.owner_epoch,
+        });
+    }
+    if lease_id == 0 {
+        return Err(ControlError::InvalidRecord(
+            "active owner lease id must be non-zero".to_owned(),
+        ));
+    }
+    let lease = LogicalShardLease {
+        logical_shard_id: current.logical_shard_id,
+        owner: owner.clone(),
+        owner_epoch: recovery_epoch,
+        lease_id,
+    };
+    let mut next = current.clone();
+    next.owner = Some(owner);
+    next.lease_id = lease_id;
+    next.endpoint = Some(endpoint);
+    validate_logical_shard_record(&next)?;
+    Ok((next, lease))
+}
+
 pub(crate) fn prepare_mark_serving(
     current: &LogicalShardRecord,
     lease: &LogicalShardLease,
@@ -485,6 +636,12 @@ pub(crate) fn prepare_owner_release(
     lease: &LogicalShardLease,
 ) -> Result<LogicalShardRecord, ControlError> {
     validate_record_lease(current, lease)?;
+    if current.state == LogicalShardState::Recovering {
+        return Err(ControlError::RecoveryAttemptPending {
+            logical_shard_id: current.logical_shard_id,
+            owner_epoch: lease.owner_epoch,
+        });
+    }
     let mut next = current.clone();
     next.owner = None;
     next.lease_id = 0;
@@ -492,6 +649,20 @@ pub(crate) fn prepare_owner_release(
     next.endpoint = None;
     validate_logical_shard_record(&next)?;
     Ok(next)
+}
+
+pub(crate) fn prepare_recovery_suspension(
+    current: &LogicalShardRecord,
+    lease: &LogicalShardLease,
+) -> Result<LogicalShardRecord, ControlError> {
+    validate_record_lease(current, lease)?;
+    if current.state != LogicalShardState::Recovering {
+        return Err(ControlError::RecoveryStateConflict {
+            logical_shard_id: current.logical_shard_id,
+            actual: current.state,
+        });
+    }
+    Ok(current.clone())
 }
 
 pub(crate) fn validate_record_lease(
@@ -1004,6 +1175,16 @@ mod tests {
         let store = InMemoryControlStore::new();
         let first = acquire_placed_shard(&store, 1, 1);
         assert_eq!(first.owner_epoch.get(), 1);
+        store
+            .mark_serving(
+                &first,
+                RecoveryPublication {
+                    checkpoint: None,
+                    log: None,
+                    durable_lsn: 0,
+                },
+            )
+            .unwrap();
         let released = store.release_owner(&first).unwrap();
         assert_eq!(released.owner_epoch, Some(first.owner_epoch));
         assert!(released.owner.is_none());
@@ -1034,6 +1215,89 @@ mod tests {
             store.renew_owner(&first),
             Err(ControlError::NotOwner { .. }) | Err(ControlError::StaleLease(_))
         ));
+    }
+
+    #[test]
+    fn unfinished_recovery_rebinds_the_same_epoch_after_session_loss() {
+        let store = InMemoryControlStore::new();
+        let first = acquire_placed_shard(&store, 1, 1);
+        assert_eq!(first.owner_epoch.get(), 1);
+
+        let retained = store.suspend_recovery(&first).unwrap();
+        assert_eq!(retained.state, LogicalShardState::Recovering);
+        assert_eq!(retained.owner_epoch, Some(first.owner_epoch));
+        assert_eq!(retained.owner.as_ref(), Some(&first.owner));
+        assert_eq!(retained.lease_id, first.lease_id);
+        assert!(matches!(
+            store.renew_owner(&first),
+            Err(ControlError::StaleLease(_))
+        ));
+        assert!(matches!(
+            store.acquire_successor(
+                &shard_id(1),
+                first.owner_epoch,
+                node("node-b"),
+                "node-b:7000".to_owned()
+            ),
+            Err(ControlError::RecoveryAttemptPending { .. })
+        ));
+
+        let rebound = store
+            .reacquire_recovery(
+                &shard_id(1),
+                first.owner_epoch,
+                node("node-b"),
+                "node-b:7000".to_owned(),
+            )
+            .unwrap();
+        assert_eq!(rebound.owner_epoch, first.owner_epoch);
+        assert_ne!(rebound.lease_id, first.lease_id);
+        assert!(matches!(
+            store.reacquire_recovery(
+                &shard_id(1),
+                first.owner_epoch,
+                node("node-c"),
+                "node-c:7000".to_owned()
+            ),
+            Err(ControlError::PreviousOwnerSessionLive { .. })
+        ));
+
+        store
+            .mark_serving(
+                &rebound,
+                RecoveryPublication {
+                    checkpoint: None,
+                    log: None,
+                    durable_lsn: 0,
+                },
+            )
+            .unwrap();
+        store.release_owner(&rebound).unwrap();
+    }
+
+    #[test]
+    fn serving_owner_cannot_be_suspended_as_recovery() {
+        let store = InMemoryControlStore::new();
+        let lease = acquire_placed_shard(&store, 1, 1);
+        store
+            .mark_serving(
+                &lease,
+                RecoveryPublication {
+                    checkpoint: None,
+                    log: None,
+                    durable_lsn: 0,
+                },
+            )
+            .unwrap();
+
+        assert!(matches!(
+            store.suspend_recovery(&lease),
+            Err(ControlError::RecoveryStateConflict {
+                actual: LogicalShardState::Serving,
+                ..
+            })
+        ));
+        store.release_owner(&lease).unwrap();
     }
 
     #[test]

--- a/crates/nokv-control/src/types.rs
+++ b/crates/nokv-control/src/types.rs
@@ -79,14 +79,19 @@ pub struct RootPlacement {
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct LogicalShardRecord {
     pub logical_shard_id: LogicalShardId,
+    /// Last owner admitted into this durable generation. Session liveness is
+    /// proved separately by the backend's lease-attached session key.
     pub owner: Option<NodeId>,
     /// `None` means the shard has never had an owner. Once assigned, the last
     /// epoch remains present after release and every successor must increment it.
     pub owner_epoch: Option<OwnerEpoch>,
-    /// Backend lease identity. Zero means there is no current owner session.
+    /// Backend lease identity installed with this record. A non-zero value may
+    /// remain after lease expiry; only the separate session key proves that it
+    /// is still live. A clean `Serving` release resets it to zero.
     pub lease_id: u64,
     pub state: LogicalShardState,
-    /// Reachable endpoint of the current owner. `None` while unowned.
+    /// Endpoint admitted with `owner`. It may describe an expired session
+    /// retained for recovery reconciliation. `None` only when unassigned.
     pub endpoint: Option<String>,
     pub checkpoint: Option<CheckpointRef>,
     pub log: Option<LogRef>,

--- a/crates/nokv-meta-store/src/types.rs
+++ b/crates/nokv-meta-store/src/types.rs
@@ -54,7 +54,9 @@ pub enum AckBoundary {
 /// that reached [`Commit::Applied`] under the same authority.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum Authority {
-    /// One process-local durable namespace. A successor must not attach.
+    /// One exclusive, persistent local namespace. A restarted owner may
+    /// reattach only by reopening that same namespace and completing its
+    /// WAL/schema/recovery-chain and owner-epoch admission checks.
     Local,
     /// One shared transactional namespace available to a successor.
     Shared,

--- a/crates/nokv-server/src/bootstrap.rs
+++ b/crates/nokv-server/src/bootstrap.rs
@@ -8,8 +8,8 @@ use std::path::PathBuf;
 use std::sync::Arc;
 
 use nokv_control::{
-    ControlStore, LogicalShardLease, LogicalShardRecord, NodeId, OwnerEpoch, RecoveryPublication,
-    RootId, RootPlacement, RootPlacementLifecycle,
+    ControlStore, LogicalShardLease, LogicalShardRecord, LogicalShardState, NodeId, OwnerEpoch,
+    RecoveryPublication, RootId, RootPlacement, RootPlacementLifecycle,
 };
 use nokv_meta::workspace as meta;
 use nokv_meta_holt::{HoltOptions, HoltStore, TreeBinding};
@@ -156,19 +156,32 @@ pub fn bootstrap_shard(
 ) -> Result<ShardOwner, ServerError> {
     validate_boot(&boot)?;
     let placements = load_placements(control.as_ref(), boot.shard_id, &boot.roots)?;
-    reject_unrecovered_shared_frontier(control.as_ref(), boot.shard_id, &boot.recovery)?;
+    let control_record = load_control_record(control.as_ref(), boot.shard_id, &boot.recovery)?;
     validate_open_lease(&boot.open, &boot.lease)?;
 
-    // Initialize a new first-owner store, or reopen the same prepared
-    // epoch-zero store, before the control plane consumes the first epoch.
-    // Exact resumes keep the existing admission-before-open order.
-    let prepared_meta = prepare_first_owner_meta(&boot.open, &boot.lease, boot.shard_id)?;
-    let prepared_path = prepared_meta.as_ref().map(|_| match &boot.open {
-        OpenMode::New(path) | OpenMode::Existing(path) => path.clone(),
-    });
+    // Every new acquisition opens and validates the exclusive local authority
+    // before it mutates the control epoch. This prevents a bad/missing/stale
+    // local store from consuming an epoch that the store cannot install.
+    // Exact live-session resumes retain their admission-before-open order.
+    let prepared_meta =
+        prepare_acquiring_meta(&boot.open, &boot.lease, boot.shard_id, &control_record)?;
+    let prepared_first_owner_path = match &boot.lease {
+        LeaseMode::Acquire {
+            previous_epoch: None,
+            ..
+        } if prepared_meta.is_some() => Some(match &boot.open {
+            OpenMode::New(path) | OpenMode::Existing(path) => path.clone(),
+        }),
+        _ => None,
+    };
 
-    let admission = admit_owner(control.as_ref(), boot.shard_id, &boot.lease);
-    let (lease, acquired) = match (admission, prepared_path) {
+    let admission = admit_owner(
+        control.as_ref(),
+        boot.shard_id,
+        &boot.lease,
+        &control_record,
+    );
+    let (lease, acquired) = match (admission, prepared_first_owner_path) {
         (Ok(admission), _) => admission,
         (Err(ServerError::Control(source)), Some(path)) => {
             return Err(ServerError::PreparedOwnerAdmission { path, source });
@@ -325,15 +338,22 @@ fn validate_open_lease(open: &OpenMode, lease: &LeaseMode) -> Result<(), ServerE
                 ..
             },
         )
+        | (
+            OpenMode::Existing(_),
+            LeaseMode::Acquire {
+                previous_epoch: Some(_),
+                ..
+            },
+        )
         | (OpenMode::Existing(_), LeaseMode::Resume { .. }) => Ok(()),
         (
-            _,
+            OpenMode::New(_),
             LeaseMode::Acquire {
                 previous_epoch: Some(previous),
                 ..
             },
         ) => Err(ServerError::InvalidBootstrap(format!(
-            "successor acquisition after owner epoch {previous} is unavailable in the local-WAL profile; verified checkpoint/log recovery must complete before a new owner may serve"
+            "successor acquisition after owner epoch {previous} must reopen the existing local metadata authority"
         ))),
         (OpenMode::New(_), LeaseMode::Resume { .. }) => {
             Err(ServerError::InvalidBootstrap(
@@ -343,36 +363,64 @@ fn validate_open_lease(open: &OpenMode, lease: &LeaseMode) -> Result<(), ServerE
     }
 }
 
-fn prepare_first_owner_meta(
+fn prepare_acquiring_meta(
     open: &OpenMode,
     lease: &LeaseMode,
     logical_shard_id: nokv_types::LogicalShardId,
+    control_record: &LogicalShardRecord,
 ) -> Result<Option<Arc<meta::MetaShard>>, ServerError> {
-    if !matches!(
-        lease,
-        LeaseMode::Acquire {
-            previous_epoch: None,
-            ..
-        }
-    ) {
+    let LeaseMode::Acquire { previous_epoch, .. } = lease else {
         return Ok(None);
-    }
+    };
 
     let meta = open_meta(open.clone(), logical_shard_id)?;
     validate_meta_shard(&meta, logical_shard_id)?;
-    if let Some(owner_epoch) = meta.current_owner_epoch()? {
-        return Err(ServerError::InvalidBootstrap(format!(
-            "metadata shard is already fenced at owner epoch {owner_epoch}; reopen it only with Resume and the exact lease"
-        )));
+    let local_epoch = meta.current_owner_epoch()?;
+    match previous_epoch {
+        None => {
+            if let Some(owner_epoch) = local_epoch {
+                return Err(ServerError::InvalidBootstrap(format!(
+                    "metadata shard is already fenced at owner epoch {owner_epoch}; reopen it only with Resume and the exact lease or acquire from that durable epoch"
+                )));
+            }
+        }
+        Some(expected) => {
+            if control_record.owner_epoch != Some(*expected) {
+                return Err(ServerError::InvalidBootstrap(format!(
+                    "control record changed while preparing local recovery: requested epoch {expected}, actual {}",
+                    display_epoch(control_record.owner_epoch)
+                )));
+            }
+            let valid_local_epoch = if control_record.state == LogicalShardState::Recovering {
+                local_epoch == Some(*expected) || local_epoch == predecessor(*expected)
+            } else {
+                local_epoch == Some(*expected)
+            };
+            if !valid_local_epoch {
+                let requirement = if control_record.state == LogicalShardState::Recovering {
+                    format!(
+                        "predecessor {} or exact recovery epoch {expected}",
+                        display_epoch(predecessor(*expected))
+                    )
+                } else {
+                    format!("exact durable epoch {expected}")
+                };
+                return Err(ServerError::InvalidBootstrap(format!(
+                    "local metadata authority is fenced at {}, but control state {:?} requires {requirement}",
+                    display_epoch(local_epoch),
+                    control_record.state
+                )));
+            }
+        }
     }
     Ok(Some(meta))
 }
 
-fn reject_unrecovered_shared_frontier(
+fn load_control_record(
     control: &dyn ControlStore,
     shard_id: nokv_types::LogicalShardId,
     requested: &RecoveryPublication,
-) -> Result<(), ServerError> {
+) -> Result<LogicalShardRecord, ServerError> {
     let shard = control
         .get_logical_shard(&shard_id)?
         .ok_or_else(|| ServerError::InvalidBootstrap("logical shard does not exist".to_owned()))?;
@@ -386,7 +434,7 @@ fn reject_unrecovered_shared_frontier(
             shard_id, shard.durable_lsn, requested.durable_lsn
         )));
     }
-    Ok(())
+    Ok(shard)
 }
 
 fn validate_serving_placement(placement: &RootPlacement) -> Result<(), ServerError> {
@@ -406,6 +454,7 @@ fn admit_owner(
     control: &dyn ControlStore,
     shard_id: nokv_types::LogicalShardId,
     mode: &LeaseMode,
+    control_record: &LogicalShardRecord,
 ) -> Result<(LogicalShardLease, bool), ServerError> {
     match mode {
         LeaseMode::Acquire {
@@ -415,6 +464,8 @@ fn admit_owner(
         } => {
             let lease = match previous_epoch {
                 None => control.acquire_owner(&shard_id, owner.clone(), endpoint.clone())?,
+                Some(expected) if control_record.state == LogicalShardState::Recovering => control
+                    .reacquire_recovery(&shard_id, *expected, owner.clone(), endpoint.clone())?,
                 Some(expected) => control.acquire_successor(
                     &shard_id,
                     *expected,
@@ -629,8 +680,8 @@ fn rollback_bootstrap(
 ) -> ServerError {
     let mut rollback = uninstall_routes(registry, routes, "bootstrap rollback");
     if release_acquired_lease {
-        if let Err(error) = control.release_owner(lease) {
-            rollback.push(format!("release logical-shard lease: {error}"));
+        if let Err(error) = control.suspend_recovery(lease) {
+            rollback.push(format!("suspend logical-shard recovery: {error}"));
         }
     }
     if rollback.is_empty() {
@@ -1064,9 +1115,9 @@ mod tests {
         .to_string();
         assert!(error.contains("outcome is unknown"));
         assert!(error.contains("preserve the store"));
-        assert!(error.contains("automatic owner reconciliation is not implemented"));
         assert!(error.contains("--metadata-reopen prepared-meta"));
-        assert!(error.contains("do not delete"));
+        assert!(error.contains("rebind the durable Recovering epoch one"));
+        assert!(error.contains("do not delete the prepared store"));
     }
 
     #[test]
@@ -1173,7 +1224,7 @@ mod tests {
     }
 
     #[test]
-    fn empty_frontier_successor_is_rejected_before_opening_any_store() {
+    fn released_local_authority_restarts_as_the_next_owner() {
         let temporary = TempDir::new().unwrap();
         let database = temporary.path().join("metadata");
         let root_id = root(1);
@@ -1186,7 +1237,10 @@ mod tests {
         )
         .unwrap();
         let first_epoch = first.lease().owner_epoch;
+        let durable_fence = first.meta().root_fence(root_id).unwrap().unwrap();
+        let durable_version = first.meta().current_read_version().unwrap();
         first.release().unwrap();
+        let registry = Arc::new(RootOwnerRegistry::new());
 
         let boot = ShardBoot {
             shard_id: shard(),
@@ -1199,16 +1253,402 @@ mod tests {
             recovery: empty_recovery(),
             roots: vec![root_attach(root_id, 33)],
         };
-        let error = bootstrap_shard(as_control(&control), Arc::clone(&registry), boot)
-            .err()
+        let successor = bootstrap_shard(as_control(&control), Arc::clone(&registry), boot).unwrap();
+
+        assert_eq!(successor.lease().owner_epoch.get(), first_epoch.get() + 1);
+        assert_eq!(
+            successor.meta().current_owner_epoch().unwrap(),
+            Some(successor.lease().owner_epoch)
+        );
+        assert_eq!(
+            successor.meta().root_fence(root_id).unwrap(),
+            Some(durable_fence)
+        );
+        assert!(successor.meta().current_read_version().unwrap() >= durable_version);
+        let record = control.get_logical_shard(&shard()).unwrap().unwrap();
+        assert_eq!(record.state, LogicalShardState::Serving);
+        assert_eq!(record.owner_epoch, Some(successor.lease().owner_epoch));
+        assert_eq!(record.durable_lsn, 0);
+        assert_eq!(registry.installed_root_count().unwrap(), 1);
+        successor.release().unwrap();
+    }
+
+    #[test]
+    fn live_local_authority_lock_blocks_takeover_before_control_mutation() {
+        let temporary = TempDir::new().unwrap();
+        let database = temporary.path().join("metadata");
+        let root_id = root(1);
+        let control = active_control(&[root_id]);
+        let first = bootstrap_shard(
+            as_control(&control),
+            Arc::new(RootOwnerRegistry::new()),
+            acquire_boot(database.clone(), &[root_id]),
+        )
+        .unwrap();
+        let before = control.get_logical_shard(&shard()).unwrap().unwrap();
+
+        let error = bootstrap_shard(
+            as_control(&control),
+            Arc::new(RootOwnerRegistry::new()),
+            ShardBoot {
+                shard_id: shard(),
+                open: OpenMode::Existing(database),
+                lease: LeaseMode::Acquire {
+                    owner: NodeId::new("competing-node").unwrap(),
+                    endpoint: "127.0.0.1:9020".to_owned(),
+                    previous_epoch: Some(first.lease().owner_epoch),
+                },
+                recovery: empty_recovery(),
+                roots: vec![root_attach(root_id, 35)],
+            },
+        )
+        .err()
+        .unwrap();
+
+        assert!(error.to_string().contains("incompatible live access mode"));
+        assert_eq!(control.get_logical_shard(&shard()).unwrap(), Some(before));
+        first.release().unwrap();
+    }
+
+    #[test]
+    fn bootstrap_rollback_rebinds_the_same_recovery_epoch() {
+        let temporary = TempDir::new().unwrap();
+        let database = temporary.path().join("metadata");
+        let roots = [root(1), root(2)];
+        let control = active_control(&roots);
+        let first = bootstrap_shard(
+            as_control(&control),
+            Arc::new(RootOwnerRegistry::new()),
+            acquire_boot(database.clone(), &roots[..1]),
+        )
+        .unwrap();
+        let first_epoch = first.lease().owner_epoch;
+        let future_root_two = RootPlacement {
+            root_id: roots[1],
+            logical_shard_id: shard(),
+            placement_generation: PlacementGeneration::new(4).unwrap(),
+            lifecycle: RootPlacementLifecycle::Active,
+        };
+        execute_fence_command(
+            first.meta(),
+            &future_root_two,
+            first.lease(),
+            request_id(61),
+            meta::RootFenceAction::Install,
+            b"future root-two fence".to_vec(),
+        )
+        .unwrap();
+        first.release().unwrap();
+
+        let registry = Arc::new(RootOwnerRegistry::new());
+        let error = bootstrap_shard(
+            as_control(&control),
+            Arc::clone(&registry),
+            ShardBoot {
+                shard_id: shard(),
+                open: OpenMode::Existing(database.clone()),
+                lease: LeaseMode::Acquire {
+                    owner: NodeId::new("interrupted-node").unwrap(),
+                    endpoint: "127.0.0.1:9015".to_owned(),
+                    previous_epoch: Some(first_epoch),
+                },
+                recovery: empty_recovery(),
+                roots: vec![root_attach(roots[0], 47), root_attach(roots[1], 49)],
+            },
+        )
+        .err()
+        .unwrap();
+
+        assert!(error
+            .to_string()
+            .contains("root fence placement does not match the control-plane placement"));
+        assert_eq!(registry.installed_root_count().unwrap(), 0);
+        let interrupted = control.get_logical_shard(&shard()).unwrap().unwrap();
+        let recovery_epoch = interrupted.owner_epoch.unwrap();
+        assert_eq!(recovery_epoch.get(), first_epoch.get() + 1);
+        assert_eq!(interrupted.state, LogicalShardState::Recovering);
+        assert_eq!(
+            open_meta(OpenMode::Existing(database.clone()), shard())
+                .unwrap()
+                .current_owner_epoch()
+                .unwrap(),
+            Some(recovery_epoch),
+            "the failed boot had already installed its local fence"
+        );
+
+        let active = control.get_root_placement(&roots[1]).unwrap().unwrap();
+        let draining = control
+            .compare_and_set_root_placement(
+                &active,
+                RootPlacement {
+                    placement_generation: PlacementGeneration::new(3).unwrap(),
+                    lifecycle: RootPlacementLifecycle::Draining,
+                    ..active
+                },
+            )
+            .unwrap();
+        control
+            .compare_and_set_root_placement(
+                &draining,
+                RootPlacement {
+                    placement_generation: PlacementGeneration::new(4).unwrap(),
+                    lifecycle: RootPlacementLifecycle::Active,
+                    ..draining
+                },
+            )
             .unwrap();
 
-        assert!(error.to_string().contains("local-WAL profile"));
+        let recovered = bootstrap_shard(
+            as_control(&control),
+            Arc::clone(&registry),
+            ShardBoot {
+                shard_id: shard(),
+                open: OpenMode::Existing(database),
+                lease: LeaseMode::Acquire {
+                    owner: NodeId::new("recovery-node").unwrap(),
+                    endpoint: "127.0.0.1:9020".to_owned(),
+                    previous_epoch: Some(recovery_epoch),
+                },
+                recovery: empty_recovery(),
+                roots: vec![root_attach(roots[0], 51), root_attach(roots[1], 53)],
+            },
+        )
+        .unwrap();
+
+        assert_eq!(recovered.lease().owner_epoch, recovery_epoch);
+        assert_eq!(registry.installed_root_count().unwrap(), 2);
+        recovered.release().unwrap();
+    }
+
+    #[test]
+    fn interrupted_successor_reuses_its_recovery_epoch_before_local_fence() {
+        let temporary = TempDir::new().unwrap();
+        let database = temporary.path().join("metadata");
+        let root_id = root(1);
+        let control = active_control(&[root_id]);
+        let first = bootstrap_shard(
+            as_control(&control),
+            Arc::new(RootOwnerRegistry::new()),
+            acquire_boot(database.clone(), &[root_id]),
+        )
+        .unwrap();
+        let first_epoch = first.lease().owner_epoch;
+        first.release().unwrap();
+
+        let interrupted = control
+            .acquire_successor(
+                &shard(),
+                first_epoch,
+                NodeId::new("interrupted-node").unwrap(),
+                "127.0.0.1:9015".to_owned(),
+            )
+            .unwrap();
+        control.suspend_recovery(&interrupted).unwrap();
+        assert_eq!(
+            open_meta(OpenMode::Existing(database.clone()), shard())
+                .unwrap()
+                .current_owner_epoch()
+                .unwrap(),
+            Some(first_epoch),
+            "the crash happened before the local fence advanced"
+        );
+
+        let recovered = bootstrap_shard(
+            as_control(&control),
+            Arc::new(RootOwnerRegistry::new()),
+            ShardBoot {
+                shard_id: shard(),
+                open: OpenMode::Existing(database),
+                lease: LeaseMode::Acquire {
+                    owner: NodeId::new("recovery-node").unwrap(),
+                    endpoint: "127.0.0.1:9020".to_owned(),
+                    previous_epoch: Some(interrupted.owner_epoch),
+                },
+                recovery: empty_recovery(),
+                roots: vec![root_attach(root_id, 37)],
+            },
+        )
+        .unwrap();
+
+        assert_eq!(recovered.lease().owner_epoch, interrupted.owner_epoch);
+        assert_eq!(
+            recovered.meta().current_owner_epoch().unwrap(),
+            Some(interrupted.owner_epoch)
+        );
+        recovered.release().unwrap();
+    }
+
+    #[test]
+    fn interrupted_successor_reuses_its_recovery_epoch_after_local_fence() {
+        let temporary = TempDir::new().unwrap();
+        let database = temporary.path().join("metadata");
+        let root_id = root(1);
+        let control = active_control(&[root_id]);
+        let first = bootstrap_shard(
+            as_control(&control),
+            Arc::new(RootOwnerRegistry::new()),
+            acquire_boot(database.clone(), &[root_id]),
+        )
+        .unwrap();
+        let first_epoch = first.lease().owner_epoch;
+        first.release().unwrap();
+
+        let interrupted = control
+            .acquire_successor(
+                &shard(),
+                first_epoch,
+                NodeId::new("interrupted-node").unwrap(),
+                "127.0.0.1:9015".to_owned(),
+            )
+            .unwrap();
+        let meta = open_meta(OpenMode::Existing(database.clone()), shard()).unwrap();
+        meta.advance_owner_epoch(Some(first_epoch), interrupted.owner_epoch)
+            .unwrap();
+        drop(meta);
+        control.suspend_recovery(&interrupted).unwrap();
+
+        let recovered = bootstrap_shard(
+            as_control(&control),
+            Arc::new(RootOwnerRegistry::new()),
+            ShardBoot {
+                shard_id: shard(),
+                open: OpenMode::Existing(database),
+                lease: LeaseMode::Acquire {
+                    owner: NodeId::new("recovery-node").unwrap(),
+                    endpoint: "127.0.0.1:9020".to_owned(),
+                    previous_epoch: Some(interrupted.owner_epoch),
+                },
+                recovery: empty_recovery(),
+                roots: vec![root_attach(root_id, 39)],
+            },
+        )
+        .unwrap();
+
+        assert_eq!(recovered.lease().owner_epoch, interrupted.owner_epoch);
+        assert_eq!(
+            recovered.meta().current_owner_epoch().unwrap(),
+            Some(interrupted.owner_epoch)
+        );
+        recovered.release().unwrap();
+    }
+
+    #[test]
+    fn stale_local_epoch_is_rejected_before_consuming_another_control_epoch() {
+        let temporary = TempDir::new().unwrap();
+        let database = temporary.path().join("metadata");
+        let root_id = root(1);
+        let control = active_control(&[root_id]);
+        let first = bootstrap_shard(
+            as_control(&control),
+            Arc::new(RootOwnerRegistry::new()),
+            acquire_boot(database.clone(), &[root_id]),
+        )
+        .unwrap();
+        let first_epoch = first.lease().owner_epoch;
+        first.release().unwrap();
+
+        // Advance only the control plane. The local authority remains at the
+        // first epoch and therefore cannot prove it contains the second
+        // owner's applied history.
+        let control_only = control
+            .acquire_successor(
+                &shard(),
+                first_epoch,
+                NodeId::new("control-only-node").unwrap(),
+                "127.0.0.1:9015".to_owned(),
+            )
+            .unwrap();
+        control
+            .mark_serving(&control_only, empty_recovery())
+            .unwrap();
+        control.release_owner(&control_only).unwrap();
+
+        let error = bootstrap_shard(
+            as_control(&control),
+            Arc::new(RootOwnerRegistry::new()),
+            ShardBoot {
+                shard_id: shard(),
+                open: OpenMode::Existing(database),
+                lease: LeaseMode::Acquire {
+                    owner: NodeId::new("stale-store-node").unwrap(),
+                    endpoint: "127.0.0.1:9020".to_owned(),
+                    previous_epoch: Some(control_only.owner_epoch),
+                },
+                recovery: empty_recovery(),
+                roots: vec![root_attach(root_id, 43)],
+            },
+        )
+        .err()
+        .unwrap();
+
+        assert!(error.to_string().contains("exact durable epoch 2"));
         let record = control.get_logical_shard(&shard()).unwrap().unwrap();
+        assert_eq!(record.owner_epoch, Some(control_only.owner_epoch));
         assert_eq!(record.state, LogicalShardState::Unassigned);
+    }
+
+    #[test]
+    fn corrupt_recovery_outbox_is_rejected_before_successor_acquisition() {
+        use nokv_meta_store::{Commit, Key, Mutation, WriteTxn};
+
+        let temporary = TempDir::new().unwrap();
+        let database = temporary.path().join("metadata");
+        let root_id = root(1);
+        let control = active_control(&[root_id]);
+        let first = bootstrap_shard(
+            as_control(&control),
+            Arc::new(RootOwnerRegistry::new()),
+            acquire_boot(database.clone(), &[root_id]),
+        )
+        .unwrap();
+        let first_epoch = first.lease().owner_epoch;
+        first.release().unwrap();
+
+        let catalog = meta::keyspaces()
+            .iter()
+            .map(|definition| TreeBinding::new(definition.id, definition.name));
+        let holt =
+            HoltStore::open(HoltOptions::file(&database, catalog, meta::store_limits())).unwrap();
+        let recovery_keyspace = meta::keyspaces()
+            .iter()
+            .find(|definition| definition.name == "recovery_outbox")
+            .unwrap()
+            .id;
+        assert_eq!(
+            holt.commit(WriteTxn {
+                checks: Vec::new(),
+                mutations: vec![Mutation::Put {
+                    key: Key::new(recovery_keyspace, b"malformed-key".to_vec()),
+                    value: b"malformed-value".to_vec(),
+                }],
+            })
+            .unwrap(),
+            Commit::Applied
+        );
+        drop(holt);
+
+        let error = bootstrap_shard(
+            as_control(&control),
+            Arc::new(RootOwnerRegistry::new()),
+            ShardBoot {
+                shard_id: shard(),
+                open: OpenMode::Existing(database),
+                lease: LeaseMode::Acquire {
+                    owner: NodeId::new("recovery-node").unwrap(),
+                    endpoint: "127.0.0.1:9020".to_owned(),
+                    previous_epoch: Some(first_epoch),
+                },
+                recovery: empty_recovery(),
+                roots: vec![root_attach(root_id, 45)],
+            },
+        )
+        .err()
+        .unwrap();
+
+        assert!(error.to_string().contains("RecoveryOutbox key"));
+        let record = control.get_logical_shard(&shard()).unwrap().unwrap();
         assert_eq!(record.owner_epoch, Some(first_epoch));
-        assert_eq!(record.durable_lsn, 0);
-        assert_eq!(registry.installed_root_count().unwrap(), 0);
+        assert_eq!(record.state, LogicalShardState::Unassigned);
     }
 
     #[test]

--- a/crates/nokv-server/src/error.rs
+++ b/crates/nokv-server/src/error.rs
@@ -55,12 +55,10 @@ impl fmt::Display for ServerError {
                         formatter,
                         "control-plane owner acquisition outcome is unknown after preparing the \
                          epoch-zero metadata store at {}: {source}; preserve the store and \
-                         inspect the configured control backend because automatic owner \
-                         reconciliation is not implemented; only after proving acquisition did \
-                         not apply, retry the corrected first-owner command with \
-                         --metadata-reopen {}; otherwise retain the store and owner record for \
-                         operator recovery; do not delete either while acquisition may have \
-                         succeeded",
+                         retry with --metadata-reopen {} after the prior owner session settles; \
+                         startup will acquire epoch one if the transaction did not apply, or \
+                         rebind the durable Recovering epoch one if it did; do not delete the \
+                         prepared store while acquisition may have succeeded",
                         path.display(),
                         path.display()
                     )

--- a/crates/nokv/src/main.rs
+++ b/crates/nokv/src/main.rs
@@ -294,7 +294,7 @@ OWNER:
   --root-id HEX32 --etcd-endpoint URL --node-id ID
   --advertise-endpoint HOST:PORT --bind HOST:PORT
   --metadata-create PATH starts the first standalone local-WAL owner
-  --metadata-reopen PATH is recovery admission only; standalone successors currently fail closed
+  --metadata-reopen PATH restarts the same exclusive local-WAL authority after lease loss
 
 OBJECT DATA:
   --object-bucket NAME [--object-endpoint URL] [--object-root PREFIX]

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -316,11 +316,19 @@ outbox. Remote outbox consumption/ACK, shared-log replication, checkpoint
 installation/replay, and fsck remain qualification work. Until those are
 implemented and verified, bootstrap rejects any non-zero or referenced Control
 recovery frontier before acquiring an owner or installing a route; it cannot
-mark such a shard `Serving` from an arbitrary local directory. Even while the
-frontier is empty, the local-WAL profile permits only first-owner `Create` and
-an epoch-zero `Reopen` retry, or exact current-lease `Resume` with `Reopen`. It
-refuses every successor acquisition rather than risk serving a replacement
-empty Holt store.
+mark such a shard `Serving` from an arbitrary local directory. With an empty
+shared frontier, `Reopen` can restart the same exclusive Holt namespace after
+the prior etcd session is gone. Startup first opens Holt under its lifetime
+directory lock, replays the WAL, validates schema/shard identity and the full
+recovery-outbox chain, and compares the local owner fence with the control
+record. A completed owner gets the next epoch. A crash while the control record
+is `Recovering` rebinds that same recovery epoch whether the local fence is its
+predecessor or already exact, so repeated crashes cannot create an epoch gap.
+A live session, stale local epoch, corrupt or uninitialized replacement, or
+non-empty shared recovery frontier remains fail-closed. A byte-for-byte copy
+may carry the same shard and epoch bits and cannot yet be distinguished from
+the original without a persistent provider identity; copied-directory and
+cross-host failover remain outside this qualification.
 
 Durable ledgers, not object listing, recover:
 

--- a/docs/development/metadata-store-interface.md
+++ b/docs/development/metadata-store-interface.md
@@ -267,9 +267,11 @@ identify one failed check because some stores cannot report it after an atomic
 conflict.
 
 Any successor that the profile permits to serve must first observe every
-`Applied` commit under the same authority. `Local` forbids a successor from
-claiming another local authority. Shared and replicated profiles must complete
-their open or catch-up boundary before route admission.
+`Applied` commit under the same authority. `Local` permits an owner restart
+only after the exact exclusive namespace is explicitly reopened and its WAL,
+schema, recovery chain, and owner fence validate; it never permits a different
+local authority to substitute for it. Shared and replicated profiles must
+complete their open or catch-up boundary before route admission.
 
 `MetaShard` translates one validated `MetadataCommand` into a `WriteTxn`.
 Command deduplication, history, events, root fences, and deterministic results
@@ -300,8 +302,12 @@ reached its advertised acknowledgement boundary.
 An adapter can keep a physical transaction or log identifier for diagnostics
 and recovery, but it cannot expose that identifier as a NoKV receipt or
 `ReadVersion`. Before a shard can serve, the runtime must bind the domain
-receipt namespace to the admitted physical store identity and owner epoch.
-That admission binding is still pending.
+receipt namespace to the admitted physical authority and owner epoch. The
+current local profile does this narrowly through an explicit `Existing` path,
+Holt's lifetime exclusive directory lock, the durable shard identity and owner
+fence, and full recovery-chain validation. A provider-neutral persistent store
+identity and configuration digest remain pending; without them, another
+directory, copy/rollback, or cross-host failover is not qualified.
 
 ## Error Contract
 
@@ -394,10 +400,10 @@ projection. A separate successful replacement changes all 60 index fields at
 once: the before/after event is 61,323 bytes and the fully derived transaction
 is 9,859,091 bytes. The short-path replace-to-empty and remove transactions are
 also pinned at 11,797,794 and 11,791,459 bytes. These are characterized storage
-and metadata-engine compatibility results, not a universal domain-size proof
-or a qualified `nokv serve` restart/rolling-upgrade path. The local-WAL server
-still refuses successor admission until its checkpoint/log recovery and exact
-lease-resume workflow are implemented.
+and metadata-engine compatibility results, not a universal domain-size proof.
+The local-WAL server qualifies restart of the same exclusive namespace with an
+empty shared recovery frontier. It does not qualify rolling upgrade onto
+another store, copied-directory recovery, or checkpoint/log failover.
 
 The envelope exceeds FoundationDB's
 [10,000,000-byte hard transaction limit](https://apple.github.io/foundationdb/known-limitations.html),
@@ -464,15 +470,19 @@ attach_root
 
 `bootstrap_shard` performs these steps:
 
-1. Validate the open mode, lease admission, and store failover profile.
-2. For the first owner, initialize a `New` namespace or reopen a prepared
-   `Existing` namespace. Validate that its durable owner fence remains epoch
-   zero and records no owner.
-3. Acquire one first-owner lease or renew the exact resumed lease. An existing
-   store with a nonzero owner fence opens only with that resumed lease.
-4. Validate the schema and logical-shard identity.
-5. Advance the shard owner epoch in the metadata transaction store before any
-   route is installed.
+1. Validate the open mode, root placements, control record, and shared recovery
+   frontier.
+2. Before any new acquisition, initialize or exclusively reopen the explicit
+   local namespace. Holt replays its WAL; `MetaShard` validates the catalog,
+   schema, logical-shard identity, system rows, and full recovery-outbox chain.
+3. Compare the local owner fence with the durable control state. A normal
+   successor requires the exact previous epoch. An interrupted `Recovering`
+   attempt accepts only that recovery epoch or its immediate predecessor.
+4. Atomically acquire the first/next epoch, or rebind an unfinished recovery
+   attempt at the same epoch after proving its previous session key is absent.
+   An exact live-session `Resume` still renews before reopening.
+5. Advance the local owner fence idempotently before any route is installed,
+   attach roots, renew once, and publish `Serving`.
 
 `attach_root` then:
 
@@ -485,24 +495,24 @@ The server publishes the logical shard as serving only after its initial root
 routes are ready. It renews and releases the shard lease once per shard, not
 once per root.
 
-A physical initialization failure for the first `New` owner occurs before
-control-plane acquisition and does not consume an owner epoch. If subsequent
-owner acquisition fails, bootstrap closes and preserves the prepared epoch-zero
-store. A failure known not to have applied reports an exact corrected
-`Existing` retry. When the control backend cannot classify acquisition,
-bootstrap explicitly reports that automatic ownership reconciliation is not
-implemented. The operator must inspect the configured control backend; only a
-proven-not-applied acquisition may retry with the reported `--metadata-reopen`
-path. An acquisition that may have applied remains fail-closed and retains both
-the prepared store and owner record for operator recovery.
-Bootstrap never infers directory ownership from a path precheck or recursively
-deletes a prepared store; both would be unsafe under a concurrent path change.
+A physical initialization or reopen validation failure occurs before control
+acquisition and consumes no epoch. A first-owner admission failure preserves
+the prepared epoch-zero store and reports an `Existing` retry. If the control
+outcome was unknown, that retry reconciles either result after the session
+settles: it acquires epoch one if the transaction did not apply, or rebinds the
+durable `Recovering` epoch one if it did. Bootstrap never infers directory
+ownership from a path precheck or recursively deletes a prepared store; both
+would be unsafe under a concurrent path change.
 
-The local profile still needs an explicit recovering ownership token for a
-failure after acquisition but before `Serving`. Releasing that lease is
-fail-closed, but it can strand the local authority because successor
-acquisition is not qualified. Unknown control acquisition needs the same typed
-recovery treatment after the immediate preserve-and-report boundary.
+The control record and the lease-backed session key have separate lifetimes.
+`Recovering` is a durable attempt token. A bootstrap rollback removes only its
+session (`suspend_recovery`) and retains the record; an ungraceful process loss
+gets the same result when etcd expires the session key. Control refuses to
+increment past a `Recovering` record. The next bootstrap must rebind that exact
+epoch, then tolerate only two local states: the predecessor when the crash was
+before local fence installation, or the exact epoch when it was after. This
+keeps retries idempotent and prevents the epoch-gap strand where control moves
+to `E+2` while the local authority remains at `E`.
 
 Lifecycle work remains root-scoped because each runner owns root-specific
 cursors. Every attached root gets one supervised lifecycle runner. Runtime
@@ -514,9 +524,11 @@ that becomes Active later requires an owner restart until runtime attachment is
 implemented.
 
 The current Holt-only bootstrap admits a first `New` owner, an epoch-zero
-`Existing` store that retries a settled first-owner acquisition, or an exact
-`Existing` lease resume. It hard-codes refusal of every successor acquisition.
-It does not yet select admission from `StoreProfile`.
+`Existing` retry, an exact live-session `Resume`, and same-namespace
+`Existing` restart after owner loss. A live session, non-empty shared recovery
+frontier, local/control epoch mismatch, or store validation failure remains
+fail-closed. Bootstrap does not yet select provider construction from a
+provider-neutral persistent configuration.
 
 In the target runtime, open mode does not decide successor admission.
 `StoreProfile::authority` and the server's qualification policy decide whether
@@ -533,7 +545,7 @@ The initial profiles are:
 
 | Store | `Authority` | `AckBoundary` | Successor status |
 | --- | --- | --- | --- |
-| `HoltStore` | `Local` | `LocalSync` | Refused until checkpoint and log recovery qualify |
+| `HoltStore` | `Local` | `LocalSync` | Same exclusive namespace restart qualified; replacement/cross-host failover refused |
 | `FdbStore` | `Shared` | `SharedCommit` | Proposed, not qualified |
 | `HoltClusterStore` | `Replicated` | `QuorumCommit` | Proposed, not implemented |
 
@@ -569,7 +581,7 @@ logical shard, owner epoch, physical store identity, store profile, and
 configuration digest. The current registry now closes the complete shard
 route set and holds a response permit through socket delivery when lease loss
 or adapter poison occurs. Durable provider admission and restart-time
-unknown-outcome reconciliation remain
+metadata-transaction unknown-outcome reconciliation remain
 [Issue #436](https://github.com/NoKV-Lab/NoKV/issues/436) requirements, not
 `TxnStore` methods.
 
@@ -618,11 +630,13 @@ Completed in the local Holt cutover:
 6. Enforce the serving logical limits before physical I/O.
 7. Fence shard admission and response delivery immediately on lease loss or a
    poisoned store outcome.
+8. Reopen the same exclusive local authority as a successor and retain/rebind
+   interrupted control-plane recovery epochs without creating an epoch gap.
 
 Remaining work:
 
 1. Add provider-neutral configuration, persistent runtime binding, admission,
-   and unknown-outcome recovery orchestration.
+   and metadata-transaction unknown-outcome recovery orchestration.
 2. Replace the synchronous store and server path with one async path.
 3. Add a non-default `nokv-meta-fdb` adapter and keep it `NOT QUALIFIED` until
    its workspace, failure, failover, and benchmark gates pass.

--- a/docs/development/workspace-acceptance.md
+++ b/docs/development/workspace-acceptance.md
@@ -175,6 +175,11 @@ Required evidence:
 
 ## Gate 6: Routing, Ownership, And Durability
 
+The real-etcd local-WAL epoch runner is
+[`scripts/workbench/local_wal_recovery_gate.py`](../../scripts/workbench/local_wal_recovery_gate.py).
+Its bench-owned fault process acquires the real control lease and holds the
+same Holt authority; the production CLI contains no fault-only admission path.
+
 Required evidence:
 
 - root placement is persisted before the first write;
@@ -189,6 +194,12 @@ Required evidence:
 - checkpoint plus logical-log replay recovers the exact committed command
   sequence and deterministic results;
 - failover tests inject loss before and after each durability boundary.
+- local-WAL restart kills `Recovering(E+1)` both before and after the local
+  owner fence advances, waits for the lease-attached etcd session to disappear,
+  and proves retry reaches `Serving(E+1)` without allocating `E+2`;
+- the epoch kill/retry record names the exact NoKV commit and dirty state,
+  binary digests, etcd version, control records, local crash epoch, commands,
+  process exits, and terminal metadata probe.
 
 ## Gate 7: SDK, CLI, MCP, And Package Boundaries
 

--- a/docs/workbench-preflight.md
+++ b/docs/workbench-preflight.md
@@ -59,6 +59,10 @@ the local/control owner-epoch relation before consuming a new epoch. An
 unfinished `Recovering` epoch is rebound rather than skipped. This remains
 restart evidence, not copied-directory, cross-host, shared-log, or rolling
 upgrade failover evidence.
+The release-level epoch proof is the real-etcd fence-before/fence-after
+`SIGKILL` runner in
+[`scripts/workbench/local_wal_recovery_gate.py`](../scripts/workbench/local_wal_recovery_gate.py);
+a normal reopen alone does not cover interrupted `Recovering` retries.
 The selected `--workbench-root` is durable presentation configuration because
 canonical v1 manifests contain its projected paths. Keep it identical across
 restart/replay; it never replaces `RootId` as the storage or routing identity.

--- a/docs/workbench-preflight.md
+++ b/docs/workbench-preflight.md
@@ -52,9 +52,13 @@ starts `nokv serve` with explicit metadata create/reopen intent, starts
 `nokv ... --workbench-root /agents/{agent}/wb mcp`, exercises all 18 tools, and
 retains exact requests/responses plus materialize/collect evidence. Run
 `--dry-run` first to inspect the redacted command and normalized-input plan.
-In the current local-WAL profile, `reopen` is a negative qualification run:
-standalone successor admission fails closed until verified checkpoint/log
-recovery and fsck exist. A successful `create` run is not failover evidence.
+In the local-WAL profile, `reopen` qualifies only a restart of the same
+exclusive Holt namespace. Admission validates Holt WAL recovery, the exact
+workspace schema and shard identity, the complete recovery-outbox chain, and
+the local/control owner-epoch relation before consuming a new epoch. An
+unfinished `Recovering` epoch is rebound rather than skipped. This remains
+restart evidence, not copied-directory, cross-host, shared-log, or rolling
+upgrade failover evidence.
 The selected `--workbench-root` is durable presentation configuration because
 canonical v1 manifests contain its projected paths. Keep it identical across
 restart/replay; it never replaces `RootId` as the storage or routing identity.

--- a/scripts/workbench/README.md
+++ b/scripts/workbench/README.md
@@ -128,6 +128,12 @@ The two mandatory boundaries are:
 1. etcd is `Recovering(2)` while the local Holt fence is still epoch 1;
 2. etcd is `Recovering(2)` after the local Holt fence has committed epoch 2.
 
+The `nokv-workspace` GitHub Actions check runs both boundaries against a
+checksum-pinned real etcd release. It uploads the complete evidence directory
+for seven days even when the gate fails, so a failed retry retains its control
+records, process logs, and terminal `qualification.json` instead of exposing
+only a transient CI error line.
+
 For each boundary the driver holds a live lease and the same exclusive Holt
 path until the gate sends `SIGKILL`. Retry begins only after the lease-attached
 session key disappears. The real CLI must reopen the path, preserve the

--- a/scripts/workbench/README.md
+++ b/scripts/workbench/README.md
@@ -72,16 +72,19 @@ python3 scripts/workbench/live_workbench.py \
   --evidence-dir target/workbench-live/evidence/live-01
 ```
 
-`--metadata-mode reopen` is currently a negative qualification path, not a
-supported standalone restart: local-WAL bootstrap refuses successor ownership
-until checkpoint/log recovery and fsck are verified. The harness always calls
-`nokv provision`, starts `nokv serve` with exactly one of `--metadata-create`
-or `--metadata-reopen`, and starts
-`nokv ... --workbench-root /agents/{agent}/wb mcp`. The scientific step uses the
-explicit `materialize` and `collect` commands; its local sandbox is not a NoKV
-namespace. Keep the configured Workbench root stable across restarts because
-canonical v1 manifest presentation paths are replay-bound; `RootId`, not this
-display root, remains the storage/routing identity.
+`--metadata-mode reopen` restarts the same explicit local-WAL namespace after
+the prior owner session is gone. Startup exclusively opens Holt, replays and
+validates its WAL, checks the workspace schema, shard identity, recovery chain,
+and local/control owner epochs, then either acquires the next epoch or resumes
+an interrupted `Recovering` epoch. It does not qualify another directory, a
+copied/rolled-back namespace, cross-host failover, or a non-empty shared
+checkpoint/log frontier. The harness always calls `nokv provision`, starts
+`nokv serve` with exactly one of `--metadata-create` or `--metadata-reopen`,
+and starts `nokv ... --workbench-root /agents/{agent}/wb mcp`. The scientific
+step uses the explicit `materialize` and `collect` commands; its local sandbox
+is not a NoKV namespace. Keep the configured Workbench root stable across
+restarts because canonical v1 manifest presentation paths are replay-bound;
+`RootId`, not this display root, remains the storage/routing identity.
 
 The deterministic evidence directory contains `plan.json`, exact paired
 requests/responses in `mcp-transcript.jsonl`, `processes.jsonl` and process

--- a/scripts/workbench/README.md
+++ b/scripts/workbench/README.md
@@ -21,6 +21,12 @@ The checked-in integration assets are deliberately small:
   scientific reconstruction workflow through all 18 tools.
 - `live_workbench_test.py` checks exact coverage/order, flat commands,
   secret redaction, dry-run evidence, and fail-closed qualification.
+- `local_wal_recovery_gate.py` starts an isolated real etcd process and proves
+  that a killed `Recovering(2)` owner is retried at epoch 2 both before and
+  after the local Holt fence advances.
+- `local_wal_recovery_gate_test.py` freezes the gate's crash-stage and terminal
+  evidence contract. Its fault process is the bench-owned
+  `nokv-local-wal-recovery-fault` binary, not a production CLI test hook.
 - `start_rustfs.sh` starts the optional local S3-compatible artifact backend.
 
 Build and validate the product directly:
@@ -30,6 +36,7 @@ cargo build -p nokv --bin nokv
 cargo test --workspace
 python3 scripts/workbench/workbench_contract_test.py
 python3 scripts/workbench/live_workbench_test.py
+python3 scripts/workbench/local_wal_recovery_gate_test.py
 ```
 
 Register the built binary in any MCP-compatible Agent runtime as a stdio MCP
@@ -101,3 +108,32 @@ Live durability, failover, object-provider, and end-to-end Workbench
 qualification must be reported separately according to
 `docs/development/workspace-acceptance.md`. Unit tests or schema checks are not
 substitutes for those gates.
+
+## Local-WAL epoch recovery evidence
+
+The release recovery gate requires local `etcd` and `etcdctl` binaries. It
+starts a fresh single-member etcd under the evidence directory, builds the real
+`nokv` CLI plus the bench fault driver, and retains every control record,
+process log, crash-boundary record, binary digest, and terminal result:
+
+```bash
+python3 scripts/workbench/local_wal_recovery_gate.py \
+  --build \
+  --target-dir target/local-wal-recovery-gate/build \
+  --evidence-dir target/local-wal-recovery-gate/evidence/run-01
+```
+
+The two mandatory boundaries are:
+
+1. etcd is `Recovering(2)` while the local Holt fence is still epoch 1;
+2. etcd is `Recovering(2)` after the local Holt fence has committed epoch 2.
+
+For each boundary the driver holds a live lease and the same exclusive Holt
+path until the gate sends `SIGKILL`. Retry begins only after the lease-attached
+session key disappears. The real CLI must reopen the path, preserve the
+metadata probe, and publish `Serving(2)`; observing epoch 3 is a hard `FAIL`.
+
+This gate isolates control/local-WAL recovery and intentionally performs no
+object I/O. RustFS/S3 publication and reads remain the responsibility of
+`live_workbench.py`. Missing local etcd dependencies report `NOT QUALIFIED`;
+an invariant violation reports `FAIL`.

--- a/scripts/workbench/local_wal_recovery_gate.py
+++ b/scripts/workbench/local_wal_recovery_gate.py
@@ -1,0 +1,671 @@
+#!/usr/bin/env python3
+"""Real-etcd kill/retry qualification for one local-WAL metadata authority.
+
+The gate creates durable metadata under owner epoch one, then uses the
+bench-owned fault driver to stop at both non-terminal epoch-two boundaries:
+before and after the local Holt owner fence is advanced. The driver is killed,
+its lease-backed etcd session is allowed to expire, and the real ``nokv`` CLI
+must reopen the same metadata path without consuming epoch three.
+
+Artifact storage is deliberately not exercised here; the object arguments are
+an unreachable, unsigned S3 configuration used only to compose the CLI. The
+separate live Workbench gate owns RustFS/S3 qualification.
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import hashlib
+import json
+import os
+import platform
+import shutil
+import signal
+import socket
+import subprocess
+import sys
+import time
+from pathlib import Path
+from typing import Any, Sequence, TextIO
+
+
+SCHEMA = "nokv.local_wal_recovery_gate.v1"
+CRASH_STAGES = ("before-local-fence", "after-local-fence")
+
+
+class NotQualified(RuntimeError):
+    pass
+
+
+class WorkflowFailure(RuntimeError):
+    pass
+
+
+def now() -> str:
+    return dt.datetime.now(dt.timezone.utc).isoformat()
+
+
+def canonical_json(value: Any) -> str:
+    return json.dumps(value, ensure_ascii=False, separators=(",", ":"), sort_keys=True)
+
+
+def digest_file(path: Path) -> str:
+    state = hashlib.sha256()
+    with path.open("rb") as source:
+        for block in iter(lambda: source.read(1024 * 1024), b""):
+            state.update(block)
+    return state.hexdigest()
+
+
+def fixed_id(seed: str, label: str) -> str:
+    return hashlib.sha256(f"{seed}:{label}".encode()).hexdigest()[:32]
+
+
+def validate_stage_evidence(evidence: dict[str, object]) -> None:
+    stage = evidence.get("stage")
+    if stage not in CRASH_STAGES:
+        raise WorkflowFailure(f"unknown crash stage {stage!r}")
+
+    previous = evidence.get("previous_owner_epoch")
+    recovery = evidence.get("recovery_owner_epoch")
+    final = evidence.get("final_owner_epoch")
+    if previous != 1 or recovery != 2:
+        raise WorkflowFailure(
+            f"{stage} expected owner epochs 1 -> Recovering(2), got {previous!r} -> {recovery!r}"
+        )
+    if final != recovery:
+        raise WorkflowFailure(
+            f"{stage} retry advanced from recovery epoch {recovery} to {final}"
+        )
+
+    expected_local = 1 if stage == "before-local-fence" else 2
+    if evidence.get("local_epoch_at_crash") != expected_local:
+        raise WorkflowFailure(
+            f"{stage} must stop at local epoch {expected_local}, got "
+            f"{evidence.get('local_epoch_at_crash')!r}"
+        )
+    if evidence.get("fault_exit_code") != -signal.SIGKILL:
+        raise WorkflowFailure(
+            f"{stage} boundary process was not terminated by SIGKILL: "
+            f"{evidence.get('fault_exit_code')!r}"
+        )
+    if evidence.get("session_absent_before_retry") is not True:
+        raise WorkflowFailure(f"{stage} killed owner session remained live before retry")
+    if evidence.get("final_state") != "Serving":
+        raise WorkflowFailure(
+            f"{stage} retry ended in {evidence.get('final_state')!r}, expected Serving"
+        )
+    probe = evidence.get("metadata_probe")
+    if not isinstance(probe, dict) or probe.get("status") != "success":
+        raise WorkflowFailure(f"{stage} terminal metadata probe did not succeed")
+
+
+def run(
+    argv: Sequence[os.PathLike[str] | str],
+    *,
+    cwd: Path,
+    timeout: float,
+    check: bool = True,
+) -> subprocess.CompletedProcess[str]:
+    result = subprocess.run(
+        [str(item) for item in argv],
+        cwd=cwd,
+        text=True,
+        capture_output=True,
+        timeout=timeout,
+        check=False,
+    )
+    if check and result.returncode != 0:
+        rendered = " ".join(str(item) for item in argv)
+        output = (result.stderr or result.stdout).strip()
+        raise WorkflowFailure(f"command failed ({result.returncode}): {rendered}\n{output}")
+    return result
+
+
+def free_port() -> int:
+    with socket.socket() as probe:
+        probe.bind(("127.0.0.1", 0))
+        return int(probe.getsockname()[1])
+
+
+def stop(process: subprocess.Popen[bytes] | None, sig: signal.Signals = signal.SIGKILL) -> None:
+    if process is None or process.poll() is not None:
+        return
+    os.kill(process.pid, sig)
+    try:
+        process.wait(timeout=10)
+    except subprocess.TimeoutExpired:
+        process.kill()
+        process.wait(timeout=10)
+
+
+def wait_tcp(process: subprocess.Popen[bytes], port: int, timeout: float) -> None:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if process.poll() is not None:
+            raise WorkflowFailure(f"server exited before readiness with {process.returncode}")
+        try:
+            with socket.create_connection(("127.0.0.1", port), timeout=0.2):
+                return
+        except OSError:
+            time.sleep(0.05)
+    raise WorkflowFailure(f"server did not listen on 127.0.0.1:{port}")
+
+
+def wait_json(path: Path, process: subprocess.Popen[bytes], timeout: float) -> dict[str, Any]:
+    deadline = time.monotonic() + timeout
+    last_error: Exception | None = None
+    while time.monotonic() < deadline:
+        if process.poll() is not None:
+            raise WorkflowFailure(
+                f"fault driver exited before boundary with {process.returncode}"
+            )
+        if path.exists():
+            try:
+                value = json.loads(path.read_text())
+                if isinstance(value, dict):
+                    return value
+                last_error = WorkflowFailure("ready record is not an object")
+            except (OSError, json.JSONDecodeError) as error:
+                last_error = error
+        time.sleep(0.05)
+    detail = f": {last_error}" if last_error is not None else ""
+    raise WorkflowFailure(f"fault driver did not publish {path}{detail}")
+
+
+def etcd_value(
+    etcdctl: Path,
+    endpoint: str,
+    key: str,
+    *,
+    cwd: Path,
+    timeout: float,
+) -> str:
+    return run(
+        [etcdctl, f"--endpoints={endpoint}", "get", key, "--print-value-only"],
+        cwd=cwd,
+        timeout=timeout,
+    ).stdout.strip()
+
+
+def wait_session_absent(
+    etcdctl: Path,
+    endpoint: str,
+    key: str,
+    *,
+    cwd: Path,
+    timeout: float,
+) -> None:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if not etcd_value(etcdctl, endpoint, key, cwd=cwd, timeout=timeout):
+            return
+        time.sleep(0.1)
+    raise WorkflowFailure(f"owner session key remained live after SIGKILL: {key}")
+
+
+def wait_etcd(
+    etcdctl: Path,
+    endpoint: str,
+    process: subprocess.Popen[bytes],
+    *,
+    cwd: Path,
+    timeout: float,
+) -> None:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if process.poll() is not None:
+            raise WorkflowFailure(f"etcd exited before readiness with {process.returncode}")
+        result = run(
+            [etcdctl, f"--endpoints={endpoint}", "endpoint", "health"],
+            cwd=cwd,
+            timeout=timeout,
+            check=False,
+        )
+        if result.returncode == 0:
+            return
+        time.sleep(0.1)
+    raise WorkflowFailure(f"etcd did not become healthy at {endpoint}")
+
+
+def start_process(argv: Sequence[os.PathLike[str] | str], cwd: Path, log: TextIO) -> subprocess.Popen[bytes]:
+    return subprocess.Popen(
+        [str(item) for item in argv],
+        cwd=cwd,
+        stdin=subprocess.DEVNULL,
+        stdout=log,
+        stderr=subprocess.STDOUT,
+    )
+
+
+def control_args(binary: Path, root_id: str, endpoint: str, prefix: str) -> list[str]:
+    return [
+        str(binary),
+        "--root-id",
+        root_id,
+        "--etcd-endpoint",
+        endpoint,
+        "--etcd-key-prefix",
+        prefix,
+        "--etcd-lease-ttl-seconds",
+        "2",
+    ]
+
+
+def object_args(stage: str) -> list[str]:
+    # These arguments compose the product CLI but no gate operation performs
+    # object I/O. RustFS/S3 behavior belongs to the separate live Workbench gate.
+    return [
+        "--object-bucket",
+        "nokv-local-wal-recovery-gate",
+        "--object-endpoint",
+        "http://127.0.0.1:1",
+        "--object-root",
+        f"local-wal-recovery/{stage}",
+        "--object-skip-signature",
+    ]
+
+
+def decode_control_record(
+    etcdctl: Path,
+    endpoint: str,
+    key: str,
+    *,
+    cwd: Path,
+    timeout: float,
+) -> dict[str, Any]:
+    raw = etcd_value(etcdctl, endpoint, key, cwd=cwd, timeout=timeout)
+    if not raw:
+        raise WorkflowFailure(f"logical-shard control record is absent: {key}")
+    try:
+        value = json.loads(raw)
+    except json.JSONDecodeError as error:
+        raise WorkflowFailure(f"decode logical-shard control record: {error}") from error
+    if not isinstance(value, dict):
+        raise WorkflowFailure("logical-shard control record is not an object")
+    return value
+
+
+def run_stage(
+    stage: str,
+    *,
+    repo: Path,
+    binary: Path,
+    driver: Path,
+    etcdctl: Path,
+    etcd_endpoint: str,
+    evidence: Path,
+    seed: str,
+    timeout: float,
+) -> dict[str, object]:
+    stage_dir = evidence / stage
+    stage_dir.mkdir(parents=True)
+    metadata = stage_dir / "metadata"
+    ready_path = stage_dir / "fault-ready.json"
+    config_path = stage_dir / "fault-config.json"
+    root_id = fixed_id(seed, f"{stage}:root")
+    shard_id = fixed_id(seed, f"{stage}:shard")
+    prefix = f"/nokv/local-wal-recovery/{fixed_id(seed, stage)}"
+    record_key = f"{prefix}/logical-shards/{shard_id}"
+    session_key = f"{prefix}/sessions/{shard_id}"
+    common = control_args(binary, root_id, etcd_endpoint, prefix)
+    objects = object_args(stage)
+    processes: list[subprocess.Popen[bytes]] = []
+    logs: list[TextIO] = []
+
+    try:
+        provision_command = [*common, "provision", shard_id]
+        provision = run(provision_command, cwd=repo, timeout=timeout)
+        (stage_dir / "provision.stdout.log").write_text(provision.stdout)
+        (stage_dir / "provision.stderr.log").write_text(provision.stderr)
+
+        first_port = free_port()
+        first_log = (stage_dir / "owner-e1.log").open("w")
+        logs.append(first_log)
+        first_command = [
+            *common,
+            *objects,
+            "--bind",
+            f"127.0.0.1:{first_port}",
+            "--advertise-endpoint",
+            f"127.0.0.1:{first_port}",
+            "--node-id",
+            f"gate-{stage}-e1",
+            "--metadata-create",
+            metadata,
+            "serve",
+        ]
+        first = start_process(first_command, repo, first_log)
+        processes.append(first)
+        wait_tcp(first, first_port, timeout)
+
+        client = [*common, "--workbench-root", "/agents/issue450/wb", *objects]
+        create_command = [
+            *client,
+            "workbench",
+            "workbench_create",
+            canonical_json({"id": "restart-proof"}),
+        ]
+        create = run(create_command, cwd=repo, timeout=timeout)
+        create_result = json.loads(create.stdout)
+        initial = decode_control_record(
+            etcdctl, etcd_endpoint, record_key, cwd=repo, timeout=timeout
+        )
+        if initial.get("owner_epoch") != 1 or initial.get("state") != 3:
+            raise WorkflowFailure(f"initial owner did not reach Serving(1): {initial}")
+
+        stop(first)
+        first_exit_code = first.returncode
+        wait_session_absent(
+            etcdctl, etcd_endpoint, session_key, cwd=repo, timeout=timeout
+        )
+
+        config = {
+            "etcd_endpoints": [etcd_endpoint],
+            "etcd_key_prefix": prefix,
+            "lease_ttl_seconds": 2,
+            "logical_shard_id": shard_id,
+            "metadata_path": str(metadata),
+            "previous_owner_epoch": 1,
+            "node_id": f"gate-{stage}-fault",
+            "endpoint": "127.0.0.1:1",
+            "stage": stage,
+            "ready_path": str(ready_path),
+        }
+        config_path.write_text(json.dumps(config, indent=2, sort_keys=True) + "\n")
+        fault_log = (stage_dir / "fault-driver.log").open("w")
+        logs.append(fault_log)
+        fault_command = [str(driver), str(config_path)]
+        fault = start_process(fault_command, repo, fault_log)
+        processes.append(fault)
+        boundary = wait_json(ready_path, fault, timeout)
+        recovering = decode_control_record(
+            etcdctl, etcd_endpoint, record_key, cwd=repo, timeout=timeout
+        )
+        if recovering.get("owner_epoch") != 2 or recovering.get("state") != 2:
+            raise WorkflowFailure(f"fault driver did not retain Recovering(2): {recovering}")
+        if not etcd_value(etcdctl, etcd_endpoint, session_key, cwd=repo, timeout=timeout):
+            raise WorkflowFailure("fault driver published its boundary without a live session")
+
+        stop(fault)
+        fault_exit_code = fault.returncode
+        wait_session_absent(
+            etcdctl, etcd_endpoint, session_key, cwd=repo, timeout=timeout
+        )
+        session_absent = True
+
+        retry_port = free_port()
+        retry_log = (stage_dir / "owner-e2-retry.log").open("w")
+        logs.append(retry_log)
+        retry_command = [
+            *common,
+            *objects,
+            "--bind",
+            f"127.0.0.1:{retry_port}",
+            "--advertise-endpoint",
+            f"127.0.0.1:{retry_port}",
+            "--node-id",
+            f"gate-{stage}-retry",
+            "--metadata-reopen",
+            metadata,
+            "serve",
+        ]
+        retry = start_process(retry_command, repo, retry_log)
+        processes.append(retry)
+        wait_tcp(retry, retry_port, timeout)
+        catalog_command = [
+            *client,
+            "workbench",
+            "workbench_catalog",
+            canonical_json({"id": "restart-proof", "include_facets": True}),
+        ]
+        catalog = run(catalog_command, cwd=repo, timeout=timeout)
+        metadata_probe = json.loads(catalog.stdout)
+        final = decode_control_record(
+            etcdctl, etcd_endpoint, record_key, cwd=repo, timeout=timeout
+        )
+        stop(retry)
+        retry_exit_code = retry.returncode
+        state_name = "Serving" if final.get("state") == 3 else f"state-{final.get('state')}"
+        result: dict[str, object] = {
+            "stage": stage,
+            "previous_owner_epoch": 1,
+            "recovery_owner_epoch": boundary.get("recovery_owner_epoch"),
+            "local_epoch_at_crash": boundary.get("local_epoch_at_crash"),
+            "fault_exit_code": fault_exit_code,
+            "session_absent_before_retry": session_absent,
+            "final_owner_epoch": final.get("owner_epoch"),
+            "final_state": state_name,
+            "metadata_probe": metadata_probe,
+            "initial_control_record": initial,
+            "recovering_control_record": recovering,
+            "final_control_record": final,
+            "create_result": create_result,
+            "etcd_prefix": prefix,
+            "logical_shard_id": shard_id,
+            "metadata_path": str(metadata),
+            "fault_driver_boundary": boundary,
+            "process_exit_codes": {
+                "owner_e1": first_exit_code,
+                "fault_driver": fault_exit_code,
+                "owner_e2_retry": retry_exit_code,
+            },
+            "commands": {
+                "provision": [str(item) for item in provision_command],
+                "owner_e1": [str(item) for item in first_command],
+                "create_metadata_probe": [str(item) for item in create_command],
+                "fault_driver": fault_command,
+                "owner_e2_retry": [str(item) for item in retry_command],
+                "terminal_metadata_probe": [str(item) for item in catalog_command],
+            },
+        }
+        validate_stage_evidence(result)
+        return result
+    finally:
+        for process in reversed(processes):
+            stop(process)
+        for log in logs:
+            log.close()
+
+
+def build_binaries(repo: Path, target: Path, timeout: float) -> tuple[Path, Path]:
+    environment = os.environ.copy()
+    environment["CARGO_TARGET_DIR"] = str(target)
+    for command in (
+        ["cargo", "build", "-p", "nokv", "--bin", "nokv"],
+        [
+            "cargo",
+            "build",
+            "-p",
+            "nokv-bench",
+            "--bin",
+            "nokv-local-wal-recovery-fault",
+        ],
+    ):
+        result = subprocess.run(
+            command,
+            cwd=repo,
+            text=True,
+            capture_output=True,
+            timeout=timeout,
+            check=False,
+            env=environment,
+        )
+        if result.returncode != 0:
+            raise WorkflowFailure(
+                f"command failed ({result.returncode}): {' '.join(command)}\n"
+                f"{result.stderr or result.stdout}"
+            )
+    return target / "debug" / "nokv", target / "debug" / "nokv-local-wal-recovery-fault"
+
+
+def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    repo_default = Path(__file__).resolve().parents[2]
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--repo", type=Path, default=repo_default)
+    parser.add_argument("--evidence-dir", type=Path, required=True)
+    parser.add_argument("--target-dir", type=Path)
+    parser.add_argument("--binary", type=Path)
+    parser.add_argument("--fault-driver", type=Path)
+    parser.add_argument("--build", action="store_true")
+    parser.add_argument("--etcd-bin", type=Path, default=shutil.which("etcd"))
+    parser.add_argument("--etcdctl-bin", type=Path, default=shutil.which("etcdctl"))
+    parser.add_argument("--seed", default="issue450-e2-kill-retry-v1")
+    parser.add_argument("--timeout", type=float, default=30.0)
+    return parser.parse_args(argv)
+
+
+def execute(args: argparse.Namespace) -> dict[str, object]:
+    repo = args.repo.resolve()
+    evidence = args.evidence_dir.resolve()
+    if evidence.exists() and any(evidence.iterdir()):
+        raise WorkflowFailure(f"evidence directory is not empty: {evidence}")
+    evidence.mkdir(parents=True, exist_ok=True)
+    if args.etcd_bin is None or not Path(args.etcd_bin).is_file():
+        raise NotQualified("a real etcd binary is required")
+    if args.etcdctl_bin is None or not Path(args.etcdctl_bin).is_file():
+        raise NotQualified("etcdctl is required")
+    if args.timeout <= 0:
+        raise WorkflowFailure("--timeout must be positive")
+
+    target = (args.target_dir or repo / "target").resolve()
+    binary = args.binary.resolve() if args.binary else target / "debug" / "nokv"
+    driver = (
+        args.fault_driver.resolve()
+        if args.fault_driver
+        else target / "debug" / "nokv-local-wal-recovery-fault"
+    )
+    if args.build:
+        binary, driver = build_binaries(repo, target, max(args.timeout, 600.0))
+    if not binary.is_file() or not driver.is_file():
+        raise NotQualified("built nokv and recovery fault-driver binaries are required")
+
+    client_port = free_port()
+    peer_port = free_port()
+    endpoint = f"http://127.0.0.1:{client_port}"
+    peer = f"http://127.0.0.1:{peer_port}"
+    etcd_data = evidence / "etcd-data"
+    etcd_log = (evidence / "etcd.log").open("w")
+    etcd: subprocess.Popen[bytes] | None = None
+    started_at = now()
+    stages: list[dict[str, object]] = []
+    try:
+        etcd = start_process(
+            [
+                args.etcd_bin,
+                "--name",
+                "nokv-local-wal-recovery",
+                "--data-dir",
+                etcd_data,
+                "--listen-client-urls",
+                endpoint,
+                "--advertise-client-urls",
+                endpoint,
+                "--listen-peer-urls",
+                peer,
+                "--initial-advertise-peer-urls",
+                peer,
+                "--initial-cluster",
+                f"nokv-local-wal-recovery={peer}",
+                "--initial-cluster-state",
+                "new",
+                "--log-level",
+                "warn",
+            ],
+            repo,
+            etcd_log,
+        )
+        wait_etcd(
+            Path(args.etcdctl_bin), endpoint, etcd, cwd=repo, timeout=args.timeout
+        )
+        for stage in CRASH_STAGES:
+            stages.append(
+                run_stage(
+                    stage,
+                    repo=repo,
+                    binary=binary,
+                    driver=driver,
+                    etcdctl=Path(args.etcdctl_bin),
+                    etcd_endpoint=endpoint,
+                    evidence=evidence,
+                    seed=args.seed,
+                    timeout=args.timeout,
+                )
+            )
+    finally:
+        stop(etcd, signal.SIGTERM)
+        etcd_log.close()
+
+    git_head = run(["git", "rev-parse", "HEAD"], cwd=repo, timeout=args.timeout).stdout.strip()
+    git_status = run(
+        ["git", "status", "--porcelain=v1"], cwd=repo, timeout=args.timeout
+    ).stdout.splitlines()
+    etcd_version = run(
+        [args.etcd_bin, "--version"], cwd=repo, timeout=args.timeout
+    ).stdout.splitlines()
+    return {
+        "schema": SCHEMA,
+        "status": "PASS",
+        "started_at": started_at,
+        "finished_at": now(),
+        "source": {"commit": git_head, "dirty": git_status},
+        "environment": {
+            "platform": platform.platform(),
+            "python": platform.python_version(),
+            "etcd": etcd_version,
+            "object_profile": "not exercised; unreachable unsigned S3 composition only",
+        },
+        "binaries": {
+            "nokv": {"path": str(binary), "sha256": digest_file(binary)},
+            "fault_driver": {"path": str(driver), "sha256": digest_file(driver)},
+        },
+        "invariants": {
+            "recovery_epoch": 2,
+            "retry_must_not_allocate_epoch": 3,
+            "session_must_expire_before_retry": True,
+            "stages": list(CRASH_STAGES),
+        },
+        "stages": stages,
+    }
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = parse_args(argv)
+    evidence = args.evidence_dir.resolve()
+    try:
+        result = execute(args)
+        evidence.mkdir(parents=True, exist_ok=True)
+        (evidence / "qualification.json").write_text(
+            json.dumps(result, indent=2, sort_keys=True) + "\n"
+        )
+        print(evidence / "qualification.json")
+        return 0
+    except NotQualified as error:
+        status = "NOT QUALIFIED"
+        code = 3
+        failure = str(error)
+    except Exception as error:  # Preserve a reviewable terminal gate result.
+        status = "FAIL"
+        code = 2
+        failure = str(error)
+    evidence.mkdir(parents=True, exist_ok=True)
+    (evidence / "qualification.json").write_text(
+        json.dumps(
+            {
+                "schema": SCHEMA,
+                "status": status,
+                "finished_at": now(),
+                "error": failure,
+            },
+            indent=2,
+            sort_keys=True,
+        )
+        + "\n"
+    )
+    print(f"{status}: {failure}", file=sys.stderr)
+    return code
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/workbench/local_wal_recovery_gate_test.py
+++ b/scripts/workbench/local_wal_recovery_gate_test.py
@@ -1,0 +1,119 @@
+#!/usr/bin/env python3
+"""Contract tests for the real-etcd local-WAL recovery gate."""
+
+from __future__ import annotations
+
+import copy
+import contextlib
+import io
+import json
+import signal
+import tempfile
+import unittest
+from pathlib import Path
+
+from local_wal_recovery_gate import (
+    CRASH_STAGES,
+    WorkflowFailure,
+    main,
+    validate_stage_evidence,
+)
+
+
+def valid_evidence(stage: str) -> dict[str, object]:
+    local_epoch = 1 if stage == "before-local-fence" else 2
+    return {
+        "stage": stage,
+        "previous_owner_epoch": 1,
+        "recovery_owner_epoch": 2,
+        "local_epoch_at_crash": local_epoch,
+        "fault_exit_code": -signal.SIGKILL,
+        "session_absent_before_retry": True,
+        "final_owner_epoch": 2,
+        "final_state": "Serving",
+        "metadata_probe": {
+            "status": "success",
+            "path": "/agents/issue450/wb/restart-proof",
+        },
+    }
+
+
+class LocalWalRecoveryGateContractTests(unittest.TestCase):
+    def test_gate_has_exactly_the_two_epoch_two_crash_boundaries(self) -> None:
+        self.assertEqual(
+            CRASH_STAGES,
+            ("before-local-fence", "after-local-fence"),
+        )
+
+    def test_each_stage_converges_to_the_same_recovery_epoch(self) -> None:
+        for stage in CRASH_STAGES:
+            with self.subTest(stage=stage):
+                validate_stage_evidence(valid_evidence(stage))
+
+    def test_epoch_three_is_a_release_failure(self) -> None:
+        evidence = valid_evidence("before-local-fence")
+        evidence["final_owner_epoch"] = 3
+
+        with self.assertRaisesRegex(WorkflowFailure, "advanced from recovery epoch 2 to 3"):
+            validate_stage_evidence(evidence)
+
+    def test_pre_fence_crash_must_leave_local_epoch_one(self) -> None:
+        evidence = valid_evidence("before-local-fence")
+        evidence["local_epoch_at_crash"] = 2
+
+        with self.assertRaisesRegex(WorkflowFailure, "before-local-fence.*local epoch 1"):
+            validate_stage_evidence(evidence)
+
+    def test_post_fence_crash_must_persist_local_epoch_two(self) -> None:
+        evidence = valid_evidence("after-local-fence")
+        evidence["local_epoch_at_crash"] = 1
+
+        with self.assertRaisesRegex(WorkflowFailure, "after-local-fence.*local epoch 2"):
+            validate_stage_evidence(evidence)
+
+    def test_retry_waits_for_the_killed_session_to_disappear(self) -> None:
+        evidence = valid_evidence("after-local-fence")
+        evidence["session_absent_before_retry"] = False
+
+        with self.assertRaisesRegex(WorkflowFailure, "owner session remained live"):
+            validate_stage_evidence(evidence)
+
+    def test_boundary_process_must_be_killed_not_cleanly_released(self) -> None:
+        evidence = valid_evidence("after-local-fence")
+        evidence["fault_exit_code"] = 0
+
+        with self.assertRaisesRegex(WorkflowFailure, "was not terminated by SIGKILL"):
+            validate_stage_evidence(evidence)
+
+    def test_terminal_metadata_probe_is_required(self) -> None:
+        evidence = copy.deepcopy(valid_evidence("after-local-fence"))
+        evidence["metadata_probe"]["status"] = "error"  # type: ignore[index]
+
+        with self.assertRaisesRegex(WorkflowFailure, "metadata probe did not succeed"):
+            validate_stage_evidence(evidence)
+
+    def test_not_qualified_dependency_failure_retains_terminal_evidence(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            evidence = Path(temporary) / "evidence"
+            missing = Path(temporary) / "missing-etcd"
+
+            with contextlib.redirect_stderr(io.StringIO()):
+                code = main(
+                    [
+                        "--evidence-dir",
+                        str(evidence),
+                        "--etcd-bin",
+                        str(missing),
+                        "--etcdctl-bin",
+                        str(missing),
+                    ]
+                )
+
+            self.assertEqual(code, 3)
+            terminal = json.loads((evidence / "qualification.json").read_text())
+            self.assertEqual(terminal["status"], "NOT QUALIFIED")
+            self.assertIn("real etcd binary", terminal["error"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/workbench/local_wal_recovery_gate_test.py
+++ b/scripts/workbench/local_wal_recovery_gate_test.py
@@ -20,6 +20,9 @@ from local_wal_recovery_gate import (
 )
 
 
+REPO = Path(__file__).resolve().parents[2]
+
+
 def valid_evidence(stage: str) -> dict[str, object]:
     local_epoch = 1 if stage == "before-local-fence" else 2
     return {
@@ -39,6 +42,26 @@ def valid_evidence(stage: str) -> dict[str, object]:
 
 
 class LocalWalRecoveryGateContractTests(unittest.TestCase):
+    def test_rust_ci_runs_the_real_gate_and_retains_failure_evidence(self) -> None:
+        workflow = (REPO / ".github/workflows/rust.yml").read_text()
+
+        for required in (
+            "python3 scripts/workbench/local_wal_recovery_gate_test.py",
+            "id: local_wal_recovery",
+            "python3 scripts/workbench/local_wal_recovery_gate.py",
+            "--build",
+            "--evidence-dir \"$RECOVERY_EVIDENCE_DIR\"",
+            "sha256sum --check",
+            "if: ${{ always() && steps.local_wal_recovery.outcome != 'skipped' }}",
+            "if-no-files-found: error",
+        ):
+            with self.subTest(required=required):
+                self.assertIn(required, workflow)
+        self.assertRegex(
+            workflow,
+            r"ETCD_LINUX_AMD64_SHA256: [0-9a-f]{64}",
+        )
+
     def test_gate_has_exactly_the_two_epoch_two_crash_boundaries(self) -> None:
         self.assertEqual(
             CRASH_STAGES,


### PR DESCRIPTION
## Related Issue

Fixes #450

## Summary

- Reopen and validate the same exclusive Holt authority before acquiring a successor epoch, so the CLI can restart after its previous etcd lease expires.
- Retain `Recovering(E+1)` as a durable retry token and rebind that exact epoch after session loss. A crash before or after the local fence advances therefore converges to `Serving(E+1)` without consuming `E+2`.
- Keep stale authorities, live owners, corrupt recovery chains, and unverified shared frontiers fail-closed.
- Add a real-etcd release gate that sends `SIGKILL` on both sides of the local fence boundary and requires the durable metadata probe to survive retry.
- Run that gate inside the existing `nokv-workspace` CI check with a checksum-pinned etcd release and always retain its evidence artifact after an executed gate.

The agent-native cutover removed the earlier explicit failover route. The replacement bootstrap then refused every successor open, so healthy etcd and object storage could not make a stopped local-WAL shard serve again.

## Scope

- [x] This PR changes one logical boundary only.
- [x] No unrelated refactor, benchmark, metadata model, Holt layout, object-store, agent interface, or docs change is mixed in.
- [x] The linked issue describes the user-visible problem and design decision.
- [x] No public Workbench or storage-format break is introduced.
- [x] No compatibility shim, deprecated alias, or forwarding wrapper was added.

The qualified mode is a restart against the same exclusive Holt metadata directory. Copied-directory, cross-host, shared-log, and rolling-upgrade failover remain out of scope and fail closed.

## Code Contract

- [x] Package boundaries follow `docs/development/code_contract.md`.
- [x] Control-plane state remains in `nokv-control`; bootstrap composition remains in `nokv-server`.
- [x] The fault workload lives in `bench/`; the production CLI has no test-only admission path.
- [x] Errors and recovery states are owned by their domain packages.
- [x] Persisted root placement, one active writer, and owner-epoch fencing are preserved.
- [x] Metadata durability and recovery boundaries are documented and tested.

## Claims and Evidence

- [x] Documentation distinguishes qualified local restart from unsupported failover modes.
- [x] No security, authorization, or performance claim is introduced.
- [x] Benchmark-only behavior does not alter product semantics.

Local real-etcd qualification on commit `631877794bc663515b6182ac22ff532f217f8196`, with a clean worktree and etcd 3.7.1:

- before fence: local E1 + `Recovering(E2)` -> `SIGKILL` -> expired session -> `Serving(E2)`;
- after fence: local E2 + `Recovering(E2)` -> `SIGKILL` -> expired session -> `Serving(E2)`;
- both metadata probes succeeded and neither retry allocated E3.

The GitHub Ubuntu runner independently passed the same gate on clean PR merge SHA `deb2316b85b13531e0212013ea57c9d4da7ddbc3` with etcd 3.7.1 on Linux amd64. Run [31873334723](https://github.com/NoKV-Lab/NoKV/actions/runs/31873334723) uploaded `local-wal-recovery-deb2316b85b13531e0212013ea57c9d4da7ddbc3` with both control records, process logs, Holt metadata, and terminal `qualification.json`.

`main` branch protection now strictly requires both `nokv-workspace` and `workbench-contract`, so an epoch-gate failure or accidental removal of its CI contract blocks ordinary PR merges.

## Validation

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace`
- [x] `actionlint .github/workflows/rust.yml` (v1.7.12)
- [x] `python3 scripts/workbench/workbench_contract_test.py`
- [x] `python3 scripts/workbench/live_workbench_test.py`
- [x] `python3 scripts/workbench/local_wal_recovery_gate_test.py`
- [x] `python3 scripts/workbench/local_wal_recovery_gate.py --build --target-dir target --evidence-dir /private/tmp/nokv-issue450-e2-gate-631877794b --timeout 45`
- [x] `git diff --check origin/main...HEAD`

The E2 epoch gate intentionally performs no object I/O; RustFS/S3 publication remains the separate live Workbench qualification boundary.

## Contributor Sign-off

- [x] Every commit in this PR includes a DCO `Signed-off-by` trailer.
