### PR TITLE
release: reset nokv line to 0.10.0

### DIFF
--- a/.github/workflows/release-homebrew.yml
+++ b/.github/workflows/release-homebrew.yml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
     inputs:
       tag:
-        description: "Canonical stable tag, for example v1.0.0"
+        description: "Canonical stable tag, for example v0.10.0"
         required: true
         type: string
 
@@ -249,6 +249,7 @@ jobs:
               "$RELEASE_DIR/$manifest" \
               "$RELEASE_DIR/SHA256SUMS" \
               --verify-tag \
+              --latest \
               --title "NoKV $RELEASE_VERSION" \
               --notes "Source-only Homebrew release for commit $EXPECTED_COMMIT."
           fi

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1270,7 +1270,7 @@ checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
 
 [[package]]
 name = "nokv"
-version = "1.0.0"
+version = "0.10.0"
 dependencies = [
  "base64 0.23.0",
  "nokv-agent",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ nokv-object = { path = "crates/nokv-object", version = "0.1.0" }
 nokv-client = { path = "crates/nokv-client", version = "0.1.0" }
 nokv-agent = { path = "crates/nokv-agent", version = "0.1.0" }
 nokv-server = { path = "crates/nokv-server", version = "0.1.0" }
-nokv = { path = "crates/nokv", version = "1.0.0" }
+nokv = { path = "crates/nokv", version = "0.10.0" }
 nokv-python = { path = "crates/nokv-python", version = "0.1.0" }
 nokv-bench = { path = "bench", version = "0.1.0" }
 holt = { version = "=0.8.5", default-features = false }

--- a/README.md
+++ b/README.md
@@ -329,6 +329,9 @@ brew upgrade nokv
 nokv version --json
 ```
 
+The Formula keeps Homebrew `version_scheme 1` so the corrected pre-1.0 release
+line upgrades cleanly from the earlier `1.0.0` Formula.
+
 The Formula version follows the stable NoKV release tag and the `crates/nokv`
 package version, not Holt, Rust, or protobuf. Every NoKV release carries its
 own `Cargo.lock` and embeds the exact Holt version, source, and checksum in the

--- a/crates/nokv/Cargo.toml
+++ b/crates/nokv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nokv"
-version = "1.0.0"
+version = "0.10.0"
 description = "Custom CLI and MCP wiring for NoKV Agent workspaces."
 edition.workspace = true
 rust-version.workspace = true

--- a/crates/nokv/src/build_info.rs
+++ b/crates/nokv/src/build_info.rs
@@ -35,7 +35,7 @@ mod tests {
 
     #[test]
     fn compiled_identity_is_complete() {
-        assert_eq!(VERSION, "1.0.0");
+        assert_eq!(VERSION, "0.10.0");
         assert!(GIT_COMMIT == "unknown" || GIT_COMMIT.len() == 40);
         assert_eq!(CARGO_LOCK_SHA256.len(), 64);
         assert_eq!(HOLT_VERSION, "0.8.5");

--- a/scripts/release/README.md
+++ b/scripts/release/README.md
@@ -35,6 +35,11 @@ brew update
 brew upgrade nokv
 ```
 
+The generated Formula keeps `version_scheme 1`. This is the permanent Homebrew
+ordering boundary for the corrected pre-1.0 release line, so an existing
+`1.0.0` installation is eligible to upgrade to `0.10.0` and later `0.x`
+releases. Future Formula updates must not remove or decrease it.
+
 The Formula declares Homebrew `rust` and `protobuf` as build-only dependencies.
 The Rust dependency graph is resolved exclusively from the release
 `Cargo.lock`; the installed binary reports its NoKV version, exact source

--- a/scripts/release/homebrew_source_release.py
+++ b/scripts/release/homebrew_source_release.py
@@ -26,6 +26,7 @@ TAP_MARKER_SCHEMA = "nokv.homebrew.public_tap.v1"
 SOURCE_REPOSITORY = "NoKV-Lab/NoKV"
 TAP_REPOSITORY = "NoKV-Lab/homebrew-tap"
 WORKBENCH_TOOL_COUNT = 18
+HOMEBREW_VERSION_SCHEME = 1
 STABLE_TAG = re.compile(
     r"v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)",
     re.ASCII,
@@ -490,6 +491,7 @@ class Nokv < Formula
   url {_ruby_string(values["url"])}
   sha256 {_ruby_string(values["source_sha"])}
   license "Apache-2.0"
+  version_scheme {HOMEBREW_VERSION_SCHEME}
 
   depends_on "protobuf" => :build
   depends_on "rust" => :build

--- a/scripts/release/test_homebrew_source_release.py
+++ b/scripts/release/test_homebrew_source_release.py
@@ -23,7 +23,7 @@ sys.path.insert(0, str(SCRIPT_DIR))
 import homebrew_source_release as release  # noqa: E402
 
 
-HOLT_CHECKSUM = "c0e62dad7ce341d1e1995cc0034cb347d0e562e444b2354f8418410e2ba770e4"
+HOLT_CHECKSUM = "de964ee5f86d1ffba48f3213c97754bf80ea4289d5084419a4385a687c6818a4"
 REGISTRY = "registry+https://github.com/rust-lang/crates.io-index"
 
 
@@ -53,7 +53,7 @@ resolver = "2"
 
 [workspace.dependencies]
 nokv = { path = "crates/nokv", version = "1.0.0" }
-holt = { version = "=0.8.4", default-features = false }
+holt = { version = "=0.8.5", default-features = false }
 """,
     )
     write(
@@ -73,7 +73,7 @@ version = 4
 
 [[package]]
 name = "holt"
-version = "0.8.4"
+version = "0.8.5"
 source = "{REGISTRY}"
 checksum = "{HOLT_CHECKSUM}"
 
@@ -111,6 +111,7 @@ class StableTagTest(unittest.TestCase):
     def test_accepts_only_canonical_stable_tags(self) -> None:
         for tag, version in {
             "v0.1.0": "0.1.0",
+            "v0.10.0": "0.10.0",
             "v1.0.0": "1.0.0",
             "v12.345.6789": "12.345.6789",
         }.items():
@@ -154,7 +155,7 @@ class RepositoryValidationTest(unittest.TestCase):
         self.assertRegex(metadata.commit, r"^[0-9a-f]{40}$")
         self.assertRegex(metadata.tree, r"^[0-9a-f]{40}$")
         self.assertRegex(metadata.cargo_lock_sha256, r"^[0-9a-f]{64}$")
-        self.assertEqual(metadata.holt.version, "0.8.4")
+        self.assertEqual(metadata.holt.version, "0.8.5")
         self.assertEqual(metadata.holt.source, REGISTRY)
         self.assertEqual(metadata.holt.checksum, HOLT_CHECKSUM)
         self.assertEqual(metadata.workbench.tool_count, 18)
@@ -194,7 +195,7 @@ class RepositoryValidationTest(unittest.TestCase):
             root = repository_fixture(Path(directory))
             manifest = root / "Cargo.toml"
             manifest.write_text(
-                manifest.read_text(encoding="utf-8").replace("=0.8.4", "=0.8.3"),
+                manifest.read_text(encoding="utf-8").replace("=0.8.5", "=0.8.4"),
                 encoding="utf-8",
             )
             run("git", "add", ".", cwd=root)
@@ -265,6 +266,7 @@ class SourceArchiveTest(unittest.TestCase):
         self.assertNotIn("on_arm", formula)
         self.assertNotIn("on_intel", formula)
         self.assertNotIn('  version "1.0.0"', formula)
+        self.assertIn("  version_scheme 1", formula)
         self.assertIn('depends_on "rust" => :build', formula)
         self.assertIn('depends_on "protobuf" => :build', formula)
         self.assertIn('"cargo", "install", *std_cargo_args(path: "crates/nokv")', formula)
@@ -303,7 +305,7 @@ class InstalledIdentityTest(unittest.TestCase):
             "commit": "a" * 40,
             "cargo_lock_sha256": "b" * 64,
             "holt": {
-                "version": "0.8.4",
+                "version": "0.8.5",
                 "source": REGISTRY,
                 "checksum": HOLT_CHECKSUM,
             },
@@ -403,6 +405,7 @@ class PublicTapAndWorkflowTest(unittest.TestCase):
         self.assertIn("NoKV-Lab/homebrew-tap", workflow)
         self.assertIn("create-github-app-token", workflow)
         self.assertIn("gh pr create", workflow)
+        self.assertIn("--latest", workflow)
         self.assertIn("Fail closed unless the tap is public", workflow)
         self.assertIn('"$private" != "false"', workflow)
         self.assertIn('"$visibility" != "public"', workflow)


### PR DESCRIPTION
## Related Issue

Release chore; no issue is required for this focused version-line correction.

## Summary

- Reset the public NoKV CLI release line from the premature `1.0.0` to `0.10.0`.
- Keep the exact Holt `0.8.5` registry pin and lockfile identity from current `main`.
- Add permanent Homebrew `version_scheme 1` ordering so existing `1.0.0` installations upgrade to the corrected `0.x` line.
- Mark the newly published GitHub release as Latest.

## Scope

- [x] This PR changes one logical release boundary only.
- [x] No metadata, object-store, Agent interface, or Workbench behavior changes are included.
- [x] The version-line reset and Homebrew migration are intentional and documented.
- [x] No compatibility shim or parallel implementation is added.

## Code Contract

- [x] Package boundaries remain unchanged.
- [x] The stable 18-tool Workbench contract remains unchanged.

## Validation

- `python3 scripts/release/test_homebrew_source_release.py` — 15 passed.
- `python3 scripts/workbench/workbench_contract_test.py` — 8 passed.
- `actionlint .github/workflows/release-homebrew.yml` — passed with actionlint 1.7.12.
- `cargo fmt --all -- --check` — passed.
- `cargo clippy --locked --workspace --all-targets -- -D warnings` — passed.
- `cargo test --locked --workspace` — passed.
- `git diff --check` — passed.
- Local source Formula migration — Homebrew reported and completed `nokv 1.0.0 -> 0.10.0`.
- Installed identity verification — version `0.10.0`, Holt `0.8.5`, exact commit and `Cargo.lock` checksum, and 18 Workbench tools all matched the generated manifest.

## Contributor Sign-off

- [x] Every commit includes a DCO `Signed-off-by` trailer.
