### PR TITLE
fix: make static route snapshots explicit

### DIFF
--- a/crates/nokv-client/src/lib.rs
+++ b/crates/nokv-client/src/lib.rs
@@ -26,7 +26,7 @@ pub use error::{ArtifactPublishStage, ClientError, TransportError};
 pub use route::ControlRouteResolver;
 #[cfg(feature = "etcd")]
 pub use route::EtcdRouteOptions;
-pub use route::{ResolvedRoute, RouteResolver, StaticRouteResolver};
+pub use route::{ResolvedRoute, RouteRefreshMode, RouteResolver, StaticRouteResolver};
 pub use sdk::{ClientCall, ClientOptions, WorkspaceClient};
 pub use snapshot_workflow::{
     SnapshotMintOptions, SnapshotRenewOptions, SnapshotRetireOptions, SnapshotRetireOutcome,

--- a/crates/nokv-client/src/route.rs
+++ b/crates/nokv-client/src/route.rs
@@ -20,6 +20,16 @@ use nokv_types::RootId;
 
 use crate::ClientError;
 
+/// Describes where a resolver obtains a route after a refresh request.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum RouteRefreshMode {
+    /// Reloads route state from an authoritative control source.
+    Authoritative,
+    /// Observes only caller-supplied replacement snapshots.
+    CallerManaged,
+}
+
 /// One persisted routing fence plus the current physical owner endpoint.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct ResolvedRoute {
@@ -38,6 +48,12 @@ impl ResolvedRoute {
 
 /// Resolves a root to its persisted logical-shard placement.
 pub trait RouteResolver: Send + Sync {
+    /// Existing resolvers are authoritative by contract unless they explicitly
+    /// identify themselves as caller-managed snapshots.
+    fn refresh_mode(&self) -> RouteRefreshMode {
+        RouteRefreshMode::Authoritative
+    }
+
     fn resolve(&self, root_id: RootIdentity, refresh: bool) -> Result<ResolvedRoute, ClientError>;
 }
 
@@ -45,12 +61,20 @@ impl<T> RouteResolver for Arc<T>
 where
     T: RouteResolver + ?Sized,
 {
+    fn refresh_mode(&self) -> RouteRefreshMode {
+        (**self).refresh_mode()
+    }
+
     fn resolve(&self, root_id: RootIdentity, refresh: bool) -> Result<ResolvedRoute, ClientError> {
         (**self).resolve(root_id, refresh)
     }
 }
 
-/// Resolver for single-route deployments and tests.
+/// Caller-managed point-in-time route for single-owner deployments and tests.
+///
+/// Resolving with `refresh = true` observes a concurrent [`Self::replace`], but
+/// never discovers placement or ownership by itself. Long-running clients need
+/// a control-plane-backed resolver.
 #[derive(Clone, Debug)]
 pub struct StaticRouteResolver {
     resolved: Arc<RwLock<ResolvedRoute>>,
@@ -81,6 +105,10 @@ impl StaticRouteResolver {
 }
 
 impl RouteResolver for StaticRouteResolver {
+    fn refresh_mode(&self) -> RouteRefreshMode {
+        RouteRefreshMode::CallerManaged
+    }
+
     fn resolve(&self, root_id: RootIdentity, _refresh: bool) -> Result<ResolvedRoute, ClientError> {
         let resolved = *self
             .resolved
@@ -194,6 +222,10 @@ impl ControlRouteResolver {
 
 #[cfg(feature = "control")]
 impl RouteResolver for ControlRouteResolver {
+    fn refresh_mode(&self) -> RouteRefreshMode {
+        RouteRefreshMode::Authoritative
+    }
+
     fn resolve(&self, root_id: RootIdentity, refresh: bool) -> Result<ResolvedRoute, ClientError> {
         if refresh {
             self.cached

--- a/crates/nokv-client/src/sdk.rs
+++ b/crates/nokv-client/src/sdk.rs
@@ -781,14 +781,18 @@ mod tests {
         }
     }
 
-    fn route(owner_epoch: u64) -> RootRoute {
+    fn route_with_fences(placement_generation: u64, owner_epoch: u64) -> RootRoute {
         RootRoute {
             root_id: RootIdentity([1; 16]),
             logical_shard_id: LogicalShardIdentity([2; 16]),
             object_namespace_id: nokv_protocol::ObjectNamespaceIdentity([8; 16]),
-            placement_generation: 3,
+            placement_generation,
             owner_epoch,
         }
+    }
+
+    fn route(owner_epoch: u64) -> RootRoute {
+        route_with_fences(3, owner_epoch)
     }
 
     fn resolved(owner_epoch: u64, port: u16) -> ResolvedRoute {
@@ -941,6 +945,55 @@ mod tests {
                  configured \
                  placement_generation=3 owner_epoch=7, owner hint requires \
                  placement_generation=3 owner_epoch=8; replace the route snapshot or use an \
+                 authoritative control-plane resolver"
+                    .to_owned()
+            )
+        );
+        assert_eq!(client.transport.requests.lock().unwrap().len(), 1);
+    }
+
+    #[test]
+    fn unchanged_static_route_reports_fresh_placement_generation_mismatch() {
+        let request_id = RequestIdentity([13; 16]);
+        let configured = route_with_fences(1, 1);
+        let hint = route_with_fences(2, 1);
+        let endpoint = SocketAddr::from(([127, 0, 0, 1], 4107));
+        let response = WorkspaceRpcResponse {
+            route: configured,
+            request_id,
+            commit_version: None,
+            replayed: false,
+            outcome: WorkspaceRpcOutcome::Failure(RpcFailure {
+                code: ErrorCode::NotOwner,
+                message: "placement activated".to_owned(),
+                retryable: true,
+                conflict: Some(ConflictKind::RootPlacement),
+                current_generation: None,
+                route_hint: Some(hint),
+            }),
+        };
+        let transport = ScriptedTransport::new(vec![response]);
+        let resolver: Arc<dyn RouteResolver> =
+            Arc::new(StaticRouteResolver::new(configured, endpoint).unwrap());
+        let client = WorkspaceClient::new(
+            configured.root_id,
+            transport,
+            resolver,
+            ClientOptions::default(),
+        )
+        .unwrap();
+
+        let error = client
+            .create_workspace(request_id, create_request())
+            .expect_err("the pre-activation generation cannot refresh itself");
+
+        assert_eq!(
+            error,
+            ClientError::InvalidRoute(
+                "NotOwner refresh returned the unchanged caller-managed route and endpoint; \
+                 configured \
+                 placement_generation=1 owner_epoch=1, owner hint requires \
+                 placement_generation=2 owner_epoch=1; replace the route snapshot or use an \
                  authoritative control-plane resolver"
                     .to_owned()
             )

--- a/crates/nokv-client/src/sdk.rs
+++ b/crates/nokv-client/src/sdk.rs
@@ -24,7 +24,7 @@ use nokv_protocol::{
 };
 use sha2::{Digest as _, Sha256};
 
-use crate::{ClientError, ResolvedRoute, RouteResolver, RpcTransport};
+use crate::{ClientError, ResolvedRoute, RouteRefreshMode, RouteResolver, RpcTransport};
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct ClientOptions {
@@ -181,6 +181,7 @@ where
     ) -> Result<ClientCall<WorkspaceResult>, ClientError> {
         let mut resolved = self.routes.resolve(self.root_id, false)?;
         validate_resolved_route(resolved, self.root_id, expected_shard)?;
+        let refresh_mode = self.routes.refresh_mode();
 
         for attempt in 1..=self.options.max_attempts {
             let request = WorkspaceRpcRequest {
@@ -251,6 +252,14 @@ where
                                 resolved.route,
                                 "refreshed route",
                             )?;
+                            if refreshed == resolved
+                                && refresh_mode == RouteRefreshMode::CallerManaged
+                            {
+                                return Err(unchanged_not_owner_route(
+                                    resolved.route,
+                                    failure.route_hint,
+                                ));
+                            }
                             if let Some(hint) = failure.route_hint {
                                 validate_refreshed_route(refreshed.route, hint)?;
                             }
@@ -573,6 +582,23 @@ fn validate_refreshed_route(refreshed: RootRoute, hint: RootRoute) -> Result<(),
     Ok(())
 }
 
+fn unchanged_not_owner_route(configured: RootRoute, hint: Option<RootRoute>) -> ClientError {
+    let mismatch = hint.map_or_else(String::new, |hint| {
+        format!(
+            "; configured placement_generation={} owner_epoch={}, owner hint requires \
+             placement_generation={} owner_epoch={}",
+            configured.placement_generation,
+            configured.owner_epoch,
+            hint.placement_generation,
+            hint.owner_epoch
+        )
+    });
+    ClientError::InvalidRoute(format!(
+        "NotOwner refresh returned the unchanged caller-managed route and endpoint{mismatch}; \
+         replace the route snapshot or use an authoritative control-plane resolver"
+    ))
+}
+
 fn validate_route_continuity(
     candidate: RootRoute,
     current: RootRoute,
@@ -702,6 +728,28 @@ mod tests {
                 .expect("script contains one response per request");
             encode_response(&response)
                 .map_err(|error| crate::TransportError::new(error.to_string(), false))
+        }
+    }
+
+    struct ReplacingTransport {
+        inner: ScriptedTransport,
+        resolver: StaticRouteResolver,
+        replacement: Mutex<Option<ResolvedRoute>>,
+    }
+
+    impl RpcTransport for ReplacingTransport {
+        fn round_trip(
+            &self,
+            endpoint: SocketAddr,
+            request: &[u8],
+        ) -> Result<Vec<u8>, crate::TransportError> {
+            let response = self.inner.round_trip(endpoint, request)?;
+            if let Some(replacement) = self.replacement.lock().unwrap().take() {
+                self.resolver
+                    .replace(replacement.route, replacement.endpoint)
+                    .map_err(|error| crate::TransportError::new(error.to_string(), false))?;
+            }
+            Ok(response)
         }
     }
 
@@ -852,6 +900,152 @@ mod tests {
             vec![resolved(7, 4107).endpoint, resolved(8, 4108).endpoint]
         );
         assert_eq!(*refreshes.lock().unwrap(), vec![false, true]);
+    }
+
+    #[test]
+    fn unchanged_static_route_reports_the_not_owner_fence_mismatch() {
+        let request_id = RequestIdentity([10; 16]);
+        let response = WorkspaceRpcResponse {
+            route: route(7),
+            request_id,
+            commit_version: None,
+            replayed: false,
+            outcome: WorkspaceRpcOutcome::Failure(RpcFailure {
+                code: ErrorCode::NotOwner,
+                message: "owner changed".to_owned(),
+                retryable: true,
+                conflict: Some(ConflictKind::RootPlacement),
+                current_generation: None,
+                route_hint: Some(route(8)),
+            }),
+        };
+        let transport = ScriptedTransport::new(vec![response]);
+        let resolver: Arc<dyn RouteResolver> =
+            Arc::new(StaticRouteResolver::new(route(7), resolved(7, 4107).endpoint).unwrap());
+        let client = WorkspaceClient::new(
+            route(7).root_id,
+            transport,
+            resolver,
+            ClientOptions::default(),
+        )
+        .unwrap();
+
+        let error = client
+            .create_workspace(request_id, create_request())
+            .expect_err("a pinned stale route cannot refresh itself");
+
+        assert_eq!(
+            error,
+            ClientError::InvalidRoute(
+                "NotOwner refresh returned the unchanged caller-managed route and endpoint; \
+                 configured \
+                 placement_generation=3 owner_epoch=7, owner hint requires \
+                 placement_generation=3 owner_epoch=8; replace the route snapshot or use an \
+                 authoritative control-plane resolver"
+                    .to_owned()
+            )
+        );
+        assert_eq!(client.transport.requests.lock().unwrap().len(), 1);
+    }
+
+    #[test]
+    fn unchanged_authoritative_route_preserves_the_older_hint_diagnostic() {
+        let request_id = RequestIdentity([11; 16]);
+        let response = WorkspaceRpcResponse {
+            route: route(7),
+            request_id,
+            commit_version: None,
+            replayed: false,
+            outcome: WorkspaceRpcOutcome::Failure(RpcFailure {
+                code: ErrorCode::NotOwner,
+                message: "owner changed".to_owned(),
+                retryable: true,
+                conflict: Some(ConflictKind::RootPlacement),
+                current_generation: None,
+                route_hint: Some(route(8)),
+            }),
+        };
+        let transport = ScriptedTransport::new(vec![response]);
+        let refreshes = Arc::new(Mutex::new(Vec::new()));
+        let resolver = ScriptedResolver {
+            initial: resolved(7, 4107),
+            refreshed: resolved(7, 4107),
+            refreshes: Arc::clone(&refreshes),
+        };
+        let client = WorkspaceClient::new(
+            route(7).root_id,
+            transport,
+            resolver,
+            ClientOptions::default(),
+        )
+        .unwrap();
+
+        let error = client
+            .create_workspace(request_id, create_request())
+            .expect_err("an authoritative resolver behind the owner hint must fail closed");
+
+        assert_eq!(
+            error,
+            ClientError::InvalidRoute(
+                "refreshed route is older than the NotOwner placement hint".to_owned()
+            )
+        );
+        assert_eq!(client.transport.requests.lock().unwrap().len(), 1);
+        assert_eq!(*refreshes.lock().unwrap(), vec![false, true]);
+    }
+
+    #[test]
+    fn caller_managed_route_can_observe_a_concurrent_replacement() {
+        let request_id = RequestIdentity([12; 16]);
+        let first = WorkspaceRpcResponse {
+            route: route(7),
+            request_id,
+            commit_version: None,
+            replayed: false,
+            outcome: WorkspaceRpcOutcome::Failure(RpcFailure {
+                code: ErrorCode::NotOwner,
+                message: "owner changed".to_owned(),
+                retryable: true,
+                conflict: Some(ConflictKind::RootPlacement),
+                current_generation: None,
+                route_hint: Some(route(8)),
+            }),
+        };
+        let second = WorkspaceRpcResponse {
+            route: route(8),
+            request_id,
+            commit_version: Some(12),
+            replayed: true,
+            outcome: WorkspaceRpcOutcome::Success(Box::new(workspace_result())),
+        };
+        let resolver = StaticRouteResolver::new(route(7), resolved(7, 4107).endpoint).unwrap();
+        let transport = ReplacingTransport {
+            inner: ScriptedTransport::new(vec![first, second]),
+            resolver: resolver.clone(),
+            replacement: Mutex::new(Some(resolved(8, 4108))),
+        };
+        let client = WorkspaceClient::new(
+            route(7).root_id,
+            transport,
+            resolver,
+            ClientOptions::default(),
+        )
+        .unwrap();
+
+        let result = client
+            .create_workspace(request_id, create_request())
+            .unwrap();
+
+        assert!(result.replayed);
+        let requests = client.transport.inner.requests.lock().unwrap();
+        assert_eq!(requests.len(), 2);
+        assert_eq!(requests[0].request_id, requests[1].request_id);
+        assert_eq!(requests[0].route.owner_epoch, 7);
+        assert_eq!(requests[1].route.owner_epoch, 8);
+        assert_eq!(
+            *client.transport.inner.endpoints.lock().unwrap(),
+            vec![resolved(7, 4107).endpoint, resolved(8, 4108).endpoint]
+        );
     }
 
     #[test]

--- a/crates/nokv/src/cli.rs
+++ b/crates/nokv/src/cli.rs
@@ -37,8 +37,8 @@ pub struct StaticRoutingConfig {
     pub metadata_address: SocketAddr,
     pub logical_shard_id: Option<String>,
     pub object_namespace_id: Option<String>,
-    pub placement_generation: u64,
-    pub owner_epoch: u64,
+    pub placement_generation: Option<u64>,
+    pub owner_epoch: Option<u64>,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -181,8 +181,8 @@ impl Default for StaticRoutingConfig {
                 .expect("default metadata address is valid"),
             logical_shard_id: None,
             object_namespace_id: None,
-            placement_generation: 1,
-            owner_epoch: 1,
+            placement_generation: None,
+            owner_epoch: None,
         }
     }
 }
@@ -264,15 +264,17 @@ pub fn parse(arguments: impl IntoIterator<Item = String>) -> Result<Invocation, 
             }
             "--placement-generation" => {
                 select_routing(&mut routing_kind, RoutingKind::Static)?;
-                static_routing.placement_generation = parse_number(
+                static_routing.placement_generation = Some(parse_number(
                     "--placement-generation",
                     next_value(&mut arguments, &argument)?,
-                )?;
+                )?);
             }
             "--owner-epoch" => {
                 select_routing(&mut routing_kind, RoutingKind::Static)?;
-                static_routing.owner_epoch =
-                    parse_number("--owner-epoch", next_value(&mut arguments, &argument)?)?;
+                static_routing.owner_epoch = Some(parse_number(
+                    "--owner-epoch",
+                    next_value(&mut arguments, &argument)?,
+                )?);
             }
             "--etcd-endpoint" => {
                 select_routing(&mut routing_kind, RoutingKind::Etcd)?;
@@ -577,8 +579,8 @@ mod tests {
             panic!("static route expected");
         };
         assert_eq!(route.logical_shard_id.as_deref(), Some("02"));
-        assert_eq!(route.placement_generation, 7);
-        assert_eq!(route.owner_epoch, 9);
+        assert_eq!(route.placement_generation, Some(7));
+        assert_eq!(route.owner_epoch, Some(9));
         assert_eq!(
             parsed.command,
             Command::Workbench {

--- a/crates/nokv/src/connection.rs
+++ b/crates/nokv/src/connection.rs
@@ -142,13 +142,19 @@ fn static_route_resolver(
         "--object-namespace-id",
         config.object_namespace_id.as_deref(),
     )?);
+    let placement_generation = config
+        .placement_generation
+        .ok_or(ConnectionError::MissingOption("--placement-generation"))?;
+    let owner_epoch = config
+        .owner_epoch
+        .ok_or(ConnectionError::MissingOption("--owner-epoch"))?;
     let resolver = StaticRouteResolver::new(
         RootRoute {
             root_id,
             logical_shard_id,
             object_namespace_id,
-            placement_generation: config.placement_generation,
-            owner_epoch: config.owner_epoch,
+            placement_generation,
+            owner_epoch,
         },
         config.metadata_address,
     )?;
@@ -236,8 +242,8 @@ mod tests {
                 metadata_address: "127.0.0.1:17750".parse().expect("test address is valid"),
                 logical_shard_id: Some(identity(0x22)),
                 object_namespace_id: Some(identity(0x33)),
-                placement_generation: 7,
-                owner_epoch: 9,
+                placement_generation: Some(7),
+                owner_epoch: Some(9),
             }),
             ..ClientConfig::default()
         }
@@ -288,6 +294,48 @@ mod tests {
         assert!(matches!(
             connect(&config),
             Err(ConnectionError::MissingOption("--logical-shard-id"))
+        ));
+    }
+
+    #[test]
+    fn parsed_static_route_requires_explicit_fences_before_connecting() {
+        let root_id = identity(0x11);
+        let logical_shard_id = identity(0x22);
+        let object_namespace_id = identity(0x33);
+        let parse = |extra: &[&str]| {
+            crate::cli::parse(
+                [
+                    "--root-id",
+                    root_id.as_str(),
+                    "--metadata-address",
+                    "127.0.0.1:17750",
+                    "--logical-shard-id",
+                    logical_shard_id.as_str(),
+                    "--object-namespace-id",
+                    object_namespace_id.as_str(),
+                ]
+                .into_iter()
+                .chain(extra.iter().copied())
+                .chain([
+                    "--workbench-root",
+                    "/agents/test/wb",
+                    "workbench",
+                    "workbench_create",
+                    r#"{"id":"run-1"}"#,
+                ])
+                .map(str::to_owned),
+            )
+            .unwrap()
+            .client
+        };
+
+        assert!(matches!(
+            connect(&parse(&["--owner-epoch", "1"])),
+            Err(ConnectionError::MissingOption("--placement-generation"))
+        ));
+        assert!(matches!(
+            connect(&parse(&["--placement-generation", "2"])),
+            Err(ConnectionError::MissingOption("--owner-epoch"))
         ));
     }
 

--- a/crates/nokv/src/main.rs
+++ b/crates/nokv/src/main.rs
@@ -291,6 +291,9 @@ USAGE:
 CLIENT ROUTING:
   --root-id HEX32
   --metadata-address HOST:PORT --logical-shard-id HEX32 --object-namespace-id HEX32
+    --placement-generation N --owner-epoch N
+  static routing is a point-in-time pin and cannot refresh after placement changes or owner restarts
+  use --etcd-endpoint for self-refreshing routing
   --etcd-endpoint URL [--etcd-endpoint URL ...]
 
 AGENT PRESENTATION:

--- a/crates/nokv/tests/cli_help.rs
+++ b/crates/nokv/tests/cli_help.rs
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2024-2026 The NoKV Authors.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+use std::process::Command;
+
+#[test]
+fn static_route_help_exposes_required_fences_and_refresh_limit() {
+    let output = Command::new(env!("CARGO_BIN_EXE_nokv"))
+        .arg("--help")
+        .output()
+        .expect("nokv help must execute");
+    assert!(output.status.success());
+    let help = String::from_utf8(output.stdout).expect("nokv help must be UTF-8");
+
+    assert!(help.contains("--placement-generation"));
+    assert!(help.contains("--owner-epoch"));
+    assert!(help.contains("static routing is a point-in-time pin"));
+    assert!(help.contains("cannot refresh after placement changes or owner restarts"));
+    assert!(help.contains("use --etcd-endpoint for self-refreshing routing"));
+}


### PR DESCRIPTION
## Related Issue

Fixes #459

## Summary

- Remove the hidden `placement_generation=1` / `owner_epoch=1` static-route defaults and require both fences before any network access.
- Distinguish caller-managed route snapshots from authoritative control-plane resolvers, so a stale static snapshot produces an actionable error without weakening etcd refresh or route-continuity checks.
- Document the static point-in-time contract in CLI help and retain explicit concurrent snapshot replacement.

Fresh provisioning activates generation 2, so the old generation 1 default could not describe a real active placement. After `NotOwner`, the static resolver returned the same snapshot and the client incorrectly reported that a supposedly refreshed route was older than the server hint.

The server hint remains diagnostic evidence, not new placement authority: it has no endpoint and is never adopted automatically.

Regression coverage locks both real stale-fence shapes: fresh activation from `G1/E1` to `G2/E1`, and owner restart from `G3/E7` to `G3/E8`.

## Scope

- [x] This PR changes one logical boundary only: static client routing admission and retry diagnostics.
- [x] No unrelated refactor, benchmark, metadata model, Holt layout, object-store, agent interface, or docs change is mixed in.
- [x] The linked issue describes the user-visible problem and design decision.
- [x] The breaking removal of hidden fence defaults is intentional and documented.
- [x] No compatibility shim, deprecated alias, or forwarding wrapper was added.

## Change Size And Review

- [x] GitHub additions plus deletions are below 5,000 lines.
- [x] Additional large-change approval is not required.
- [x] The change remains focused and reviewable.

## Code Contract

- [x] Package boundaries, naming, error ownership, and public Rustdoc follow `docs/development/code_contract.md`.
- [x] No metadata format, protocol schema, server fencing, Holt transaction, object-store, or Agent facade behavior changes.
- [x] Routing still preserves root, shard, object namespace, placement generation, and owner epoch continuity.
- [x] Existing custom resolvers remain source-compatible through an additive default method; `Arc<dyn RouteResolver>` forwards the declared refresh mode.

## User Impact

Static CLI users must now supply both `--placement-generation` and `--owner-epoch`. Long-running clients should use `--etcd-endpoint`. Explicit static configurations keep their existing behavior, including caller-driven `replace()`.

## Validation

- [x] `cargo test --workspace` — passed.
- [x] `cargo test -p nokv-client` — 58 passed.
- [x] `cargo test -p nokv-client --no-default-features` — 58 passed.
- [x] `cargo test -p nokv-client --features etcd` — 62 passed.
- [x] `cargo test -p nokv` — 58 unit and 1 CLI integration test passed.
- [x] `cargo test -p nokv --no-default-features` — 56 unit and 1 CLI integration test passed.
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — passed.
- [x] `python3 scripts/workbench/workbench_contract_test.py` — 8 passed.
- [x] `cargo fmt --all -- --check` and `git diff --check` — passed.

Not run: a live etcd/RustFS deployment gate. The changed static-route admission and diagnostic path is covered deterministically, while the unchanged control, server, Holt, object, Python, and Workbench paths are covered by the full workspace and contract suites.

## Contributor Sign-off

- [x] Every commit includes a DCO `Signed-off-by` trailer.
