### PR TITLE
test(ci): qualify the wire-compatibility matrix on the #465 handshake

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -54,7 +54,8 @@ jobs:
             scripts/workbench/local_wal_recovery_gate.py \
             scripts/workbench/object_namespace_recovery_gate.py \
             scripts/workbench/restore_composition_gate.py \
-            scripts/workbench/fork_restore_recovery_gate.py
+            scripts/workbench/fork_restore_recovery_gate.py \
+            scripts/workbench/wire_compat_gate.py
           python3 scripts/workbench/pre423_contract_ledger.py
           python3 scripts/workbench/pre423_contract_ledger_test.py
           python3 scripts/workbench/workbench_contract_test.py
@@ -63,6 +64,7 @@ jobs:
           python3 scripts/workbench/object_namespace_recovery_gate_test.py
           python3 scripts/workbench/restore_composition_gate_test.py
           python3 scripts/workbench/fork_restore_recovery_gate_test.py
+          python3 scripts/workbench/wire_compat_gate_test.py
           bash -n scripts/workbench/start_rustfs.sh
 
       - name: Check Phase 1 qualification framework
@@ -459,6 +461,103 @@ jobs:
         with:
           name: local-wal-recovery-${{ github.sha }}
           path: ${{ runner.temp }}/local-wal-recovery-evidence
+          if-no-files-found: error
+          retention-days: 7
+
+      - name: Build pinned legacy v0.10.0 binary for wire compatibility
+        shell: bash
+        env:
+          LEGACY_NOKV_SOURCE_SHA256: 4b486c18bd4c6c0d07e3a55834bf50bb97cc6085c46bdd405101530ad89ad4c1
+        run: |
+          set -euo pipefail
+          archive="$RUNNER_TEMP/nokv-0.10.0-source.tar.gz"
+          legacy_dir="$RUNNER_TEMP/nokv-0.10.0"
+          curl --fail --location --retry 5 --retry-all-errors --retry-delay 5 \
+            --connect-timeout 30 --max-time 600 \
+            --output "$archive" \
+            "https://github.com/NoKV-Lab/NoKV/releases/download/v0.10.0/nokv-0.10.0-source.tar.gz"
+          # Frozen from the v0.10.0 release's SHA256SUMS asset. The matrix
+          # must never qualify an unverified archive merely because its URL
+          # names a release tag.
+          echo "$LEGACY_NOKV_SOURCE_SHA256  $archive" | sha256sum --check
+          mkdir -p "$legacy_dir"
+          tar -xzf "$archive" -C "$legacy_dir" --strip-components=1
+          cargo build --locked --manifest-path "$legacy_dir/Cargo.toml" -p nokv
+          legacy_binary="$legacy_dir/target/debug/nokv"
+          test -x "$legacy_binary"
+          legacy_binary_sha256=$(sha256sum "$legacy_binary" | awk '{print $1}')
+          printf 'legacy source sha256: %s\nlegacy binary sha256: %s\n' \
+            "$LEGACY_NOKV_SOURCE_SHA256" "$legacy_binary_sha256"
+          {
+            echo "LEGACY_NOKV_SOURCE=$archive"
+            echo "LEGACY_NOKV_SOURCE_SHA256=$LEGACY_NOKV_SOURCE_SHA256"
+            echo "LEGACY_NOKV_BINARY=$legacy_binary"
+            echo "LEGACY_NOKV_BINARY_SHA256=$legacy_binary_sha256"
+          } >>"$GITHUB_ENV"
+
+      - name: Qualify the wire-compatibility matrix
+        id: wire_compat
+        shell: bash
+        env:
+          WIRE_COMPAT_ETCD_ROOT: ${{ runner.temp }}/wire-compat-etcd
+          WIRE_COMPAT_EVIDENCE_DIR: ${{ runner.temp }}/wire-compat-evidence
+          AWS_ACCESS_KEY_ID: rustfsadmin
+          AWS_SECRET_ACCESS_KEY: rustfsadmin
+          AWS_DEFAULT_REGION: us-east-1
+          AWS_EC2_METADATA_DISABLED: "true"
+        run: |
+          set -euo pipefail
+          endpoint=http://127.0.0.1:22390
+          peer=http://127.0.0.1:22391
+          mkdir -p "$WIRE_COMPAT_ETCD_ROOT"
+          etcd \
+            --name nokv-wire-compat \
+            --data-dir "$WIRE_COMPAT_ETCD_ROOT/data" \
+            --listen-client-urls "$endpoint" \
+            --advertise-client-urls "$endpoint" \
+            --listen-peer-urls "$peer" \
+            --initial-advertise-peer-urls "$peer" \
+            --initial-cluster "nokv-wire-compat=$peer" \
+            --initial-cluster-state new \
+            --log-level warn \
+            >"$WIRE_COMPAT_ETCD_ROOT/etcd.log" 2>&1 &
+          etcd_pid=$!
+          trap 'kill "$etcd_pid" >/dev/null 2>&1 || true; wait "$etcd_pid" >/dev/null 2>&1 || true' EXIT
+          ready=false
+          for _ in $(seq 1 60); do
+            if etcdctl --endpoints "$endpoint" endpoint health >/dev/null 2>&1; then
+              ready=true
+              break
+            fi
+            if ! kill -0 "$etcd_pid" >/dev/null 2>&1; then
+              break
+            fi
+            sleep 0.25
+          done
+          if [[ "$ready" != true ]]; then
+            cat "$WIRE_COMPAT_ETCD_ROOT/etcd.log"
+            exit 1
+          fi
+          cargo build -p nokv --bin nokv
+          python3 scripts/workbench/wire_compat_gate.py \
+            --new-binary target/debug/nokv \
+            --old-binary "$LEGACY_NOKV_BINARY" \
+            --legacy-source "$LEGACY_NOKV_SOURCE" \
+            --legacy-source-sha256 "$LEGACY_NOKV_SOURCE_SHA256" \
+            --legacy-binary-sha256 "$LEGACY_NOKV_BINARY_SHA256" \
+            --etcd-endpoint "$endpoint" \
+            --object-bucket nokv-local-wal-recovery-gate \
+            --object-root-new local-wire-new \
+            --object-root-old local-wire-old \
+            --agent-id "$(openssl rand -hex 16)" \
+            --evidence-dir "$WIRE_COMPAT_EVIDENCE_DIR"
+
+      - name: Upload wire-compatibility evidence
+        if: ${{ always() && steps.wire_compat.outcome != 'skipped' }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+        with:
+          name: wire-compat-${{ github.sha }}
+          path: ${{ runner.temp }}/wire-compat-evidence
           if-no-files-found: error
           retention-days: 7
 

--- a/scripts/workbench/wire_compat_gate.py
+++ b/scripts/workbench/wire_compat_gate.py
@@ -1,0 +1,660 @@
+#!/usr/bin/env python3
+# Copyright 2024-2026 The NoKV Authors.
+# SPDX-License-Identifier: Apache-2.0
+"""Wire-compatibility matrix gate: qualify the pre-operation handshake.
+
+Drives one bounded release-binary matrix against a real etcd and S3-compatible
+object store:
+
+  * new client <-> new server  (same-version control)
+  * old client  -> new server  (a valid v2 request receives the exact
+    schema-upgrade rejection, then the legacy CLI reports that rejection)
+  * old client <-> old server  (same-version control)
+  * new client  -> old server  (first an unadopted Agent-binding guard, then
+    an adopted client that reaches the old server and observes its
+    fail-closed handshake behavior)
+
+Wire-level assertions use hand-encoded frames over a raw socket so the matrix
+does not depend on internal crate APIs:
+
+  * a ClientHello declaring a foreign schema receives an Incompatible
+    handshake that advertises the server's exact schema, without any request
+    dispatch;
+  * a structurally valid legacy v2 request receives the exact v2
+    PreconditionFailed upgrade response and leaves the server healthy.
+
+The legacy source archive is content-pinned; the gate verifies its digest and
+the declared legacy binary digest before execution, records both identities,
+and verifies that neither artifact drifts during the matrix.
+
+Every scenario writes one evidence entry; any failure exits nonzero.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import re
+import socket
+import struct
+import subprocess
+import sys
+import time
+
+MAGIC = b"NOKVHS1\0"
+KIND_CLIENT_HELLO = 1
+KIND_ACCEPTED = 2
+KIND_INCOMPATIBLE = 3
+HANDSHAKE_PAYLOAD_BYTES = 48
+LEGACY_V2_SCHEMA = "nokv.workspace.rpc.v2"
+LEGACY_CLIENT_UPGRADE_MESSAGE = (
+    "this NoKV client uses an unsupported workspace RPC schema; "
+    "upgrade the NoKV client"
+)
+SHA256_HEX = re.compile(r"[0-9a-f]{64}")
+
+
+def encode_handshake(kind: int, schema: str) -> bytes:
+    schema_bytes = schema.encode("ascii")
+    assert len(schema_bytes) <= 32, "schema must fit the fixed handshake width"
+    payload = bytearray(HANDSHAKE_PAYLOAD_BYTES)
+    payload[0:8] = MAGIC
+    payload[8] = kind
+    payload[9] = len(schema_bytes)
+    payload[16 : 16 + len(schema_bytes)] = schema_bytes
+    return struct.pack(">I", HANDSHAKE_PAYLOAD_BYTES) + bytes(payload)
+
+
+def decode_handshake(frame: bytes) -> tuple[int, str]:
+    assert len(frame) == 4 + HANDSHAKE_PAYLOAD_BYTES, "unexpected handshake frame"
+    payload = frame[4:]
+    assert payload[0:8] == MAGIC, "handshake magic missing"
+    kind = payload[8]
+    schema_len = payload[9]
+    schema = payload[16 : 16 + schema_len].decode("ascii")
+    return kind, schema
+
+
+def encode_messagepack_string(value: str) -> bytes:
+    encoded = value.encode("utf-8")
+    if len(encoded) <= 31:
+        return bytes([0xA0 | len(encoded)]) + encoded
+    if len(encoded) <= 0xFF:
+        return b"\xD9" + bytes([len(encoded)]) + encoded
+    if len(encoded) <= 0xFFFF:
+        return b"\xDA" + struct.pack(">H", len(encoded)) + encoded
+    raise ValueError("messagepack string is too large for the compatibility gate")
+
+
+def encode_messagepack_uint(value: int) -> bytes:
+    if value < 0:
+        raise ValueError("messagepack unsigned integer must not be negative")
+    if value <= 0x7F:
+        return bytes([value])
+    if value <= 0xFF:
+        return b"\xCC" + bytes([value])
+    if value <= 0xFFFF:
+        return b"\xCD" + struct.pack(">H", value)
+    if value <= 0xFFFFFFFF:
+        return b"\xCE" + struct.pack(">I", value)
+    if value <= 0xFFFFFFFFFFFFFFFF:
+        return b"\xCF" + struct.pack(">Q", value)
+    raise ValueError("messagepack unsigned integer exceeds u64")
+
+
+def encode_messagepack_u8_array(value: bytes) -> bytes:
+    if len(value) <= 15:
+        prefix = bytes([0x90 | len(value)])
+    elif len(value) <= 0xFFFF:
+        prefix = b"\xDC" + struct.pack(">H", len(value))
+    else:
+        raise ValueError("messagepack byte array is too large for the compatibility gate")
+    return prefix + b"".join(encode_messagepack_uint(item) for item in value)
+
+
+def encode_messagepack_map(items: list[tuple[str, bytes]]) -> bytes:
+    if len(items) > 15:
+        raise ValueError("messagepack map is too large for the compatibility gate")
+    return bytes([0x80 | len(items)]) + b"".join(
+        encode_messagepack_string(key) + value for key, value in items
+    )
+
+
+def encode_legacy_v2_route(
+    root_id: bytes,
+    logical_shard_id: bytes,
+    placement_generation: int,
+    owner_epoch: int,
+) -> bytes:
+    if len(root_id) != 16 or len(logical_shard_id) != 16:
+        raise ValueError("legacy v2 route ids must be exactly 16 bytes")
+    if placement_generation == 0 or owner_epoch == 0:
+        raise ValueError("legacy v2 route generation and epoch must be nonzero")
+    return encode_messagepack_map([
+        ("root_id", encode_messagepack_u8_array(root_id)),
+        ("logical_shard_id", encode_messagepack_u8_array(logical_shard_id)),
+        ("placement_generation", encode_messagepack_uint(placement_generation)),
+        ("owner_epoch", encode_messagepack_uint(owner_epoch)),
+    ])
+
+
+def encode_legacy_v2_business_frame(
+    root_id: bytes,
+    logical_shard_id: bytes,
+    placement_generation: int,
+    owner_epoch: int,
+    request_id: bytes,
+) -> bytes:
+    """Encode a complete public v2 CreateWorkspace request.
+
+    The server deliberately parses only the public envelope before rejecting
+    it, but every route, request-id, and operation field is valid so this is
+    not a malformed-frame probe.
+    """
+    if len(request_id) != 16:
+        raise ValueError("legacy v2 request id must be exactly 16 bytes")
+    operation = encode_messagepack_map([
+        ("operation", encode_messagepack_string("create_workspace")),
+        ("request", encode_messagepack_map([
+            ("workbench", encode_messagepack_string("wire-compat-legacy-probe")),
+            ("workspace_incarnation_id", encode_messagepack_u8_array(bytes([0x55]) * 16)),
+        ])),
+    ])
+    body = encode_messagepack_map([
+        ("schema", encode_messagepack_string(LEGACY_V2_SCHEMA)),
+        ("payload", encode_messagepack_map([
+            ("route", encode_legacy_v2_route(
+                root_id, logical_shard_id, placement_generation, owner_epoch
+            )),
+            ("request_id", encode_messagepack_u8_array(request_id)),
+            ("operation", operation),
+        ])),
+    ])
+    return struct.pack(">I", len(body)) + body
+
+
+def encode_legacy_v2_upgrade_response(
+    root_id: bytes,
+    logical_shard_id: bytes,
+    placement_generation: int,
+    owner_epoch: int,
+    request_id: bytes,
+) -> bytes:
+    """Encode the exact public v2 rejection emitted by the current server."""
+    body = encode_messagepack_map([
+        ("schema", encode_messagepack_string(LEGACY_V2_SCHEMA)),
+        ("payload", encode_messagepack_map([
+            ("route", encode_legacy_v2_route(
+                root_id, logical_shard_id, placement_generation, owner_epoch
+            )),
+            ("request_id", encode_messagepack_u8_array(request_id)),
+            ("commit_version", b"\xC0"),
+            ("replayed", b"\xC2"),
+            ("outcome", encode_messagepack_map([
+                ("status", encode_messagepack_string("failure")),
+                ("body", encode_messagepack_map([
+                    ("code", encode_messagepack_string("precondition_failed")),
+                    ("message", encode_messagepack_string(LEGACY_CLIENT_UPGRADE_MESSAGE)),
+                    ("retryable", b"\xC2"),
+                    ("conflict", b"\xC0"),
+                    ("current_generation", b"\xC0"),
+                    ("route_hint", b"\xC0"),
+                ])),
+            ])),
+        ])),
+    ])
+    return struct.pack(">I", len(body)) + body
+
+
+def read_exact(sock: socket.socket, count: int, timeout: float) -> bytes:
+    sock.settimeout(timeout)
+    chunks = []
+    remaining = count
+    while remaining > 0:
+        chunk = sock.recv(remaining)
+        if not chunk:
+            raise ConnectionError("peer closed with zero bytes")
+        chunks.append(chunk)
+        remaining -= len(chunk)
+    return b"".join(chunks)
+
+
+def read_frame(sock: socket.socket, timeout: float) -> bytes:
+    head = read_exact(sock, 4, timeout)
+    length = struct.unpack(">I", head)[0]
+    return head + read_exact(sock, length, timeout)
+
+
+def run_cli(binary: str, args: list[str], timeout: float) -> tuple[int, str, str]:
+    proc = subprocess.run(
+        [binary, *args],
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+    )
+    return proc.returncode, proc.stdout, proc.stderr
+
+
+def digest_file(path: str) -> str:
+    digest = hashlib.sha256()
+    with open(path, "rb") as source:
+        for chunk in iter(lambda: source.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def verify_pinned_digest(path: str, expected: str, label: str) -> str:
+    if SHA256_HEX.fullmatch(expected) is None:
+        raise ValueError(f"{label} digest must be 64 lowercase hexadecimal characters")
+    if not os.path.isfile(path):
+        raise ValueError(f"{label} is missing: {path}")
+    actual = digest_file(path)
+    if actual != expected:
+        raise ValueError(
+            f"{label} digest mismatch: expected {expected}, observed {actual}"
+        )
+    return actual
+
+
+class Evidence:
+    def __init__(self, path: str):
+        self.path = path
+        self.entries: list[dict] = []
+        self.artifacts: dict[str, dict[str, str]] = {}
+
+    def record(self, scenario: str, passed: bool, detail: str) -> None:
+        self.entries.append(
+            {"scenario": scenario, "passed": passed, "detail": detail[:2000]}
+        )
+
+    def record_artifact(
+        self,
+        name: str,
+        path: str,
+        sha256: str,
+        expected_sha256: str,
+    ) -> None:
+        self.artifacts[name] = {
+            "path": os.path.basename(path),
+            "sha256": sha256,
+            "expected_sha256": expected_sha256,
+        }
+
+    def payload(self) -> dict:
+        return {
+            "wire_compat_matrix": self.entries,
+            "legacy_artifacts": self.artifacts,
+        }
+
+    def write(self) -> None:
+        with open(self.path, "w", encoding="utf-8") as handle:
+            json.dump(self.payload(), handle, indent=2)
+
+
+def wait_for_port(port: int, seconds: float) -> bool:
+    deadline = time.time() + seconds
+    while time.time() < deadline:
+        try:
+            with socket.create_connection(("127.0.0.1", port), timeout=1):
+                return True
+        except OSError:
+            time.sleep(0.5)
+    return False
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--new-binary", required=True)
+    parser.add_argument("--old-binary", required=True)
+    parser.add_argument("--legacy-source", required=True)
+    parser.add_argument("--legacy-source-sha256", required=True)
+    parser.add_argument("--legacy-binary-sha256", required=True)
+    parser.add_argument("--etcd-endpoint", default="http://127.0.0.1:2379")
+    parser.add_argument("--object-bucket", required=True)
+    parser.add_argument("--object-endpoint", default="http://127.0.0.1:9000")
+    parser.add_argument("--object-region", default="us-east-1")
+    parser.add_argument("--object-access-key-id", default="rustfsadmin")
+    parser.add_argument("--object-secret-access-key", default="rustfsadmin")
+    parser.add_argument("--object-root-new", required=True)
+    parser.add_argument("--object-root-old", required=True)
+    parser.add_argument("--agent-id", required=True)
+    parser.add_argument("--evidence-dir", required=True)
+    parser.add_argument("--port", type=int, default=7750)
+    args = parser.parse_args()
+
+    os.makedirs(args.evidence_dir, exist_ok=True)
+    evidence = Evidence(os.path.join(args.evidence_dir, "wire_compat_evidence.json"))
+    endpoint = f"127.0.0.1:{args.port}"
+
+    try:
+        legacy_source_sha256 = verify_pinned_digest(
+            args.legacy_source,
+            args.legacy_source_sha256,
+            "legacy source archive",
+        )
+        legacy_binary_sha256 = verify_pinned_digest(
+            args.old_binary,
+            args.legacy_binary_sha256,
+            "legacy binary",
+        )
+    except ValueError as error:
+        evidence.record("legacy_artifact_identity", False, str(error))
+        evidence.write()
+        print(json.dumps(evidence.payload(), indent=2))
+        return 1
+    evidence.record_artifact(
+        "source",
+        args.legacy_source,
+        legacy_source_sha256,
+        args.legacy_source_sha256,
+    )
+    evidence.record_artifact(
+        "binary",
+        args.old_binary,
+        legacy_binary_sha256,
+        args.legacy_binary_sha256,
+    )
+    evidence.record(
+        "legacy_artifact_identity",
+        True,
+        "pinned legacy source and declared legacy binary digests verified before execution",
+    )
+
+    def base_args(root_id: str, object_root: str, agent: bool) -> list[str]:
+        common = [
+            "--root-id", root_id,
+            "--etcd-endpoint", args.etcd_endpoint,
+            "--object-bucket", args.object_bucket,
+            "--object-endpoint", args.object_endpoint,
+            "--object-region", args.object_region,
+            "--object-root", object_root,
+            "--object-access-key-id", args.object_access_key_id,
+            "--object-secret-access-key", args.object_secret_access_key,
+        ]
+        if agent:
+            common += ["--agent-id", args.agent_id]
+        return common
+
+    new_root = os.urandom(16).hex()
+    new_shard = os.urandom(16).hex()
+    old_root = os.urandom(16).hex()
+    old_shard = os.urandom(16).hex()
+    server_log = os.path.join(args.evidence_dir, "server.log")
+
+    # --- provision the new deployment and start the new server ------------
+    provision = subprocess.run(
+        [args.new_binary, *base_args(new_root, args.object_root_new, True), "provision", new_shard],
+        capture_output=True, text=True, timeout=30,
+    )
+    if provision.returncode != 0:
+        evidence.record("new_provision", False, provision.stderr[-400:])
+        evidence.write()
+        print(json.dumps(evidence.payload(), indent=2))
+        return 1
+    evidence.record("new_provision", True, "new deployment provisioned")
+
+    server = subprocess.Popen(
+        [args.new_binary,
+         *base_args(new_root, args.object_root_new, True),
+         "--node-id", "wire-compat-new",
+         "--advertise-endpoint", endpoint,
+         "--metadata-create", os.path.join(args.evidence_dir, "meta-new"),
+         "serve"],
+        stdout=open(server_log, "a", encoding="utf-8"),
+        stderr=subprocess.STDOUT,
+    )
+    if not wait_for_port(args.port, 20.0):
+        evidence.record("new_server_start", False, "server never listened on the port")
+        evidence.write()
+        print(json.dumps(evidence.payload(), indent=2))
+        return 1
+
+    def new_find(root_id: str, object_root: str) -> tuple[int, str, str]:
+        return run_cli(
+            args.new_binary,
+            [*base_args(root_id, object_root, True),
+             "--workbench-root", "/agents/wire-compat/wb",
+             "workbench", "workbench_find",
+             '{"committed":null,"manifest_pattern":null,"include_manifest":false}'],
+            timeout=30,
+        )
+
+    def old_find(root_id: str, object_root: str) -> tuple[int, str, str]:
+        return run_cli(
+            args.old_binary,
+            [*base_args(root_id, object_root, False),
+             "--workbench-root", "/agents/wire-compat/wb",
+             "workbench", "workbench_find",
+             '{"committed":null,"manifest_pattern":null,"include_manifest":false}'],
+            timeout=30,
+        )
+
+    # --- 1. same-version control: new <-> new -----------------------------
+    code, out, err = new_find(new_root, args.object_root_new)
+    if code != 0 or "match_count" not in out:
+        evidence.record("new_client_new_server", False, f"exit {code}: {out[:200]} {err[:200]}")
+    else:
+        evidence.record("new_client_new_server", True, "find succeeded against the new server")
+
+    # --- 2. foreign ClientHello -> Incompatible, no dispatch ---------------
+    try:
+        with socket.create_connection(("127.0.0.1", args.port), timeout=5) as sock:
+            sock.sendall(encode_handshake(KIND_CLIENT_HELLO, "nokv.workspace.rpc.v2"))
+            frame = read_frame(sock, timeout=5)
+        kind, schema = decode_handshake(frame)
+        if kind != KIND_INCOMPATIBLE or schema != "nokv.workspace.rpc.v9":
+            evidence.record("handshake_incompatible", False,
+                            f"kind={kind} schema={schema!r}, expected Incompatible + v9")
+        else:
+            evidence.record("handshake_incompatible", True,
+                            "foreign ClientHello answered Incompatible advertising v9")
+    except Exception as error:  # noqa: BLE001 - evidence, not control flow
+        evidence.record("handshake_incompatible", False, f"{type(error).__name__}: {error}")
+
+    # --- 3. valid legacy v2 request -> exact upgrade rejection -------------
+    legacy_request_id = bytes([0x44]) * 16
+    legacy_root_id = bytes.fromhex(new_root)
+    legacy_shard_id = bytes.fromhex(new_shard)
+    legacy_request = encode_legacy_v2_business_frame(
+        legacy_root_id,
+        legacy_shard_id,
+        placement_generation=2,
+        owner_epoch=1,
+        request_id=legacy_request_id,
+    )
+    expected_rejection = encode_legacy_v2_upgrade_response(
+        legacy_root_id,
+        legacy_shard_id,
+        placement_generation=2,
+        owner_epoch=1,
+        request_id=legacy_request_id,
+    )
+    try:
+        with socket.create_connection(("127.0.0.1", args.port), timeout=5) as sock:
+            sock.sendall(legacy_request)
+            frame = read_frame(sock, timeout=5)
+        if frame != expected_rejection:
+            evidence.record(
+                "legacy_v2_request_upgrade_rejection",
+                False,
+                "legacy rejection differed from the exact v2 schema-upgrade response: "
+                f"expected_sha256={hashlib.sha256(expected_rejection).hexdigest()} "
+                f"actual_sha256={hashlib.sha256(frame).hexdigest()}",
+            )
+        else:
+            code, out, err = new_find(new_root, args.object_root_new)
+            if code != 0 or "match_count" not in out:
+                evidence.record(
+                    "legacy_v2_request_upgrade_rejection",
+                    False,
+                    f"server unhealthy after legacy rejection: exit {code}: {out[:200]} {err[:200]}",
+                )
+            else:
+                evidence.record(
+                    "legacy_v2_request_upgrade_rejection",
+                    True,
+                    "valid v2 request reached the server, received the exact upgrade rejection, "
+                    "and left the server healthy",
+                )
+    except Exception as error:  # noqa: BLE001
+        evidence.record(
+            "legacy_v2_request_upgrade_rejection",
+            False,
+            f"{type(error).__name__}: {error}",
+        )
+
+    # --- 4. old CLI reaches the new server and reports its rejection -------
+    code, out, err = run_cli(
+        args.old_binary,
+        [*base_args(new_root, args.object_root_new, False),
+         "--workbench-root", "/agents/wire-compat/wb",
+         "workbench", "workbench_find",
+         '{"committed":null,"manifest_pattern":null,"include_manifest":false}'],
+        timeout=30,
+    )
+    schema_upgrade = LEGACY_CLIENT_UPGRADE_MESSAGE in (out + err)
+    if code == 0 or not schema_upgrade:
+        evidence.record(
+            "old_client_new_server",
+            False,
+            f"exit {code}, exact-schema-upgrade={schema_upgrade}: {(out + err)[:200]}",
+        )
+    else:
+        evidence.record(
+            "old_client_new_server",
+            True,
+            "old CLI reached the new server and rendered the exact schema-upgrade rejection",
+        )
+
+    server.terminate()
+    server.wait(timeout=10)
+
+    # --- 5. old <-> old control (same-version) ----------------------------
+    provision_old = subprocess.run(
+        [args.old_binary, *base_args(old_root, args.object_root_old, False), "provision", old_shard],
+        capture_output=True, text=True, timeout=30,
+    )
+    if provision_old.returncode != 0:
+        evidence.record("old_provision", False, provision_old.stderr[-400:])
+        evidence.write()
+        print(json.dumps(evidence.payload(), indent=2))
+        return 1
+    evidence.record("old_provision", True, "old deployment provisioned")
+
+    server_old = subprocess.Popen(
+        [args.old_binary,
+         *base_args(old_root, args.object_root_old, False),
+         "--node-id", "wire-compat-old",
+         "--advertise-endpoint", endpoint,
+         "--metadata-create", os.path.join(args.evidence_dir, "meta-old"),
+         "serve"],
+        stdout=open(server_log, "a", encoding="utf-8"),
+        stderr=subprocess.STDOUT,
+    )
+    if not wait_for_port(args.port, 20.0):
+        evidence.record("old_server_start", False, "old server never listened on the port")
+        evidence.write()
+        print(json.dumps(evidence.payload(), indent=2))
+        return 1
+
+    code, out, err = old_find(old_root, args.object_root_old)
+    if code != 0 or "match_count" not in out:
+        evidence.record("old_client_old_server", False, f"exit {code}: {out[:200]} {err[:200]}")
+    else:
+        evidence.record("old_client_old_server", True, "old CLI served by the old server")
+
+    # --- 6a. current client -> unadopted old deployment --------------------
+    code, out, err = new_find(old_root, args.object_root_old)
+    unadopted_guard = "no durable Agent binding" in (out + err)
+    if code == 0 or not unadopted_guard:
+        evidence.record(
+            "new_client_old_server_unadopted_guard",
+            False,
+            f"exit {code}, Agent-binding-guard={unadopted_guard}: {(out + err)[:200]}",
+        )
+    else:
+        evidence.record(
+            "new_client_old_server_unadopted_guard",
+            True,
+            "unadopted legacy root was rejected before routing by the Agent-binding guard",
+        )
+
+    # --- 6b. adopted current client reaches the old server -----------------
+    adoption = subprocess.run(
+        [args.new_binary,
+         *base_args(old_root, args.object_root_old, True),
+         "provision", old_shard,
+         "--adopt-legacy-object-namespace",
+         "--adopt-legacy-agent-binding"],
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    if adoption.returncode != 0:
+        evidence.record(
+            "new_client_old_server_adopted_reaches_server",
+            False,
+            f"legacy-root adoption failed: exit {adoption.returncode}: "
+            f"{adoption.stdout[-200:]} {adoption.stderr[-200:]}",
+        )
+    else:
+        code, out, err = new_find(old_root, args.object_root_old)
+        combined = out + err
+        reached_old_server = "workspace RPC handshake ended early" in combined
+        if code == 0 or not reached_old_server or "no durable Agent binding" in combined:
+            evidence.record(
+                "new_client_old_server_adopted_reaches_server",
+                False,
+                f"exit {code}, handshake-ended-early={reached_old_server}: {combined[:200]}",
+            )
+        else:
+            old_code, old_out, old_err = old_find(old_root, args.object_root_old)
+            if old_code != 0 or "match_count" not in old_out:
+                evidence.record(
+                    "new_client_old_server_adopted_reaches_server",
+                    False,
+                    "old server was unhealthy after receiving the adopted current client's "
+                    f"ClientHello: exit {old_code}: {old_out[:200]} {old_err[:200]}",
+                )
+            else:
+                evidence.record(
+                    "new_client_old_server_adopted_reaches_server",
+                    True,
+                    "adopted current client reached the old server, whose v2 decoder "
+                    "fail-closed after the ClientHello while remaining healthy",
+                )
+
+    server_old.terminate()
+    server_old.wait(timeout=10)
+
+    try:
+        final_source_sha256 = digest_file(args.legacy_source)
+        final_binary_sha256 = digest_file(args.old_binary)
+        if (
+            final_source_sha256 != legacy_source_sha256
+            or final_binary_sha256 != legacy_binary_sha256
+        ):
+            evidence.record(
+                "legacy_artifact_digest_stability",
+                False,
+                "legacy artifacts changed during qualification: "
+                f"source={final_source_sha256}, binary={final_binary_sha256}",
+            )
+        else:
+            evidence.record(
+                "legacy_artifact_digest_stability",
+                True,
+                "legacy source and binary digests remained unchanged throughout qualification",
+            )
+    except OSError as error:
+        evidence.record("legacy_artifact_digest_stability", False, str(error))
+
+    evidence.write()
+    print(json.dumps(evidence.payload(), indent=2))
+    return 0 if all(entry["passed"] for entry in evidence.entries) else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/workbench/wire_compat_gate_test.py
+++ b/scripts/workbench/wire_compat_gate_test.py
@@ -1,0 +1,163 @@
+#!/usr/bin/env python3
+# Copyright 2024-2026 The NoKV Authors.
+# SPDX-License-Identifier: Apache-2.0
+"""Unit tests for the wire-compatibility matrix gate helpers."""
+
+import io
+import struct
+import sys
+import unittest
+from contextlib import redirect_stdout
+
+sys.path.insert(0, __import__("os").path.dirname(__file__))
+import wire_compat_gate as gate  # noqa: E402
+
+
+class FrameEncodingTests(unittest.TestCase):
+    def test_handshake_round_trips_exact_fields(self) -> None:
+        frame = gate.encode_handshake(gate.KIND_CLIENT_HELLO, "nokv.workspace.rpc.v9")
+        self.assertEqual(len(frame), 4 + gate.HANDSHAKE_PAYLOAD_BYTES)
+        self.assertEqual(struct.unpack(">I", frame[:4])[0], gate.HANDSHAKE_PAYLOAD_BYTES)
+        kind, schema = gate.decode_handshake(frame)
+        self.assertEqual(kind, gate.KIND_CLIENT_HELLO)
+        self.assertEqual(schema, "nokv.workspace.rpc.v9")
+
+    def test_handshake_rejects_oversized_schema(self) -> None:
+        with self.assertRaises(AssertionError):
+            gate.encode_handshake(gate.KIND_CLIENT_HELLO, "x" * 33)
+
+    def test_incompatible_handshake_decodes_kind_and_advertised_schema(self) -> None:
+        frame = gate.encode_handshake(gate.KIND_INCOMPATIBLE, "nokv.workspace.rpc.v9")
+        kind, schema = gate.decode_handshake(frame)
+        self.assertEqual(kind, gate.KIND_INCOMPATIBLE)
+        self.assertEqual(schema, "nokv.workspace.rpc.v9")
+
+    def test_legacy_v2_frame_is_a_complete_public_request(self) -> None:
+        root_id = bytes([1]) * 16
+        shard_id = bytes([2]) * 16
+        request_id = bytes([4]) * 16
+        frame = gate.encode_legacy_v2_business_frame(
+            root_id,
+            shard_id,
+            placement_generation=7,
+            owner_epoch=11,
+            request_id=request_id,
+        )
+        length = struct.unpack(">I", frame[:4])[0]
+        self.assertEqual(len(frame), 4 + length)
+        body = frame[4:]
+        # Top-level schema/payload map, with a nonempty payload carrying the
+        # complete v2 route, request id, and a real CreateWorkspace operation.
+        self.assertEqual(body[0], 0x82)
+        self.assertIn(b"schema", body)
+        self.assertIn(gate.LEGACY_V2_SCHEMA.encode(), body)
+        self.assertIn(b"route", body)
+        self.assertIn(b"request_id", body)
+        self.assertIn(b"create_workspace", body)
+        self.assertIn(b"\xDC\x00\x10" + request_id, body)
+
+    def test_legacy_v2_upgrade_response_is_exactly_framed(self) -> None:
+        root_id = bytes([1]) * 16
+        shard_id = bytes([2]) * 16
+        request_id = bytes([4]) * 16
+        response = gate.encode_legacy_v2_upgrade_response(
+            root_id,
+            shard_id,
+            placement_generation=7,
+            owner_epoch=11,
+            request_id=request_id,
+        )
+        self.assertEqual(len(response), 4 + struct.unpack(">I", response[:4])[0])
+        body = response[4:]
+        self.assertEqual(body[0], 0x82)
+        self.assertIn(gate.LEGACY_V2_SCHEMA.encode(), body)
+        self.assertIn(b"precondition_failed", body)
+        self.assertIn(gate.LEGACY_CLIENT_UPGRADE_MESSAGE.encode(), body)
+        self.assertIn(b"\xDC\x00\x10" + request_id, body)
+
+
+class EvidenceTests(unittest.TestCase):
+    def test_evidence_records_and_writes_all_scenarios(self) -> None:
+        import json
+        import os
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as tmp:
+            path = os.path.join(tmp, "evidence.json")
+            evidence = gate.Evidence(path)
+            evidence.record("a", True, "ok")
+            evidence.record("b", False, "boom")
+            evidence.record_artifact("source", "/tmp/source.tar.gz", "11" * 32, "11" * 32)
+            evidence.write()
+            with open(path, encoding="utf-8") as handle:
+                data = json.load(handle)
+            self.assertEqual(len(data["wire_compat_matrix"]), 2)
+            self.assertEqual(data["wire_compat_matrix"][0]["scenario"], "a")
+            self.assertTrue(data["wire_compat_matrix"][0]["passed"])
+            self.assertFalse(data["wire_compat_matrix"][1]["passed"])
+            self.assertEqual(data["legacy_artifacts"]["source"]["path"], "source.tar.gz")
+            self.assertEqual(data["legacy_artifacts"]["source"]["sha256"], "11" * 32)
+
+
+class DigestTests(unittest.TestCase):
+    def test_verify_pinned_digest_accepts_matching_file(self) -> None:
+        import hashlib
+        import os
+        import tempfile
+
+        with tempfile.NamedTemporaryFile(delete=False) as handle:
+            handle.write(b"legacy source")
+            path = handle.name
+        try:
+            expected = hashlib.sha256(b"legacy source").hexdigest()
+            self.assertEqual(
+                gate.verify_pinned_digest(path, expected, "legacy source"),
+                expected,
+            )
+        finally:
+            os.unlink(path)
+
+    def test_verify_pinned_digest_rejects_mismatch_and_invalid_pin(self) -> None:
+        import os
+        import tempfile
+
+        with tempfile.NamedTemporaryFile(delete=False) as handle:
+            handle.write(b"legacy binary")
+            path = handle.name
+        try:
+            with self.assertRaisesRegex(ValueError, "digest mismatch"):
+                gate.verify_pinned_digest(path, "00" * 32, "legacy binary")
+            with self.assertRaisesRegex(ValueError, "lowercase hexadecimal"):
+                gate.verify_pinned_digest(path, "not-a-digest", "legacy binary")
+        finally:
+            os.unlink(path)
+
+
+class SocketHelperTests(unittest.TestCase):
+    def test_read_exact_surfaces_early_close_as_connection_error(self) -> None:
+        import socket
+
+        left, right = socket.socketpair()
+        try:
+            right.sendall(b"ab")
+            right.close()
+            with self.assertRaises(ConnectionError):
+                gate.read_exact(left, 4, timeout=1.0)
+        finally:
+            left.close()
+
+    def test_read_frame_round_trips_a_length_prefixed_frame(self) -> None:
+        import socket
+
+        payload = gate.encode_handshake(gate.KIND_ACCEPTED, "nokv.workspace.rpc.v9")
+        left, right = socket.socketpair()
+        try:
+            right.sendall(payload)
+            self.assertEqual(gate.read_frame(left, timeout=1.0), payload)
+        finally:
+            left.close()
+            right.close()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
<!--
Copyright 2024-2026 The NoKV Authors.
SPDX-License-Identifier: Apache-2.0
-->

## Related Issue

Closes #463

## Summary

This PR retains the real release-binary compatibility qualification requested
for the #465 pre-operation handshake, without reintroducing a second product
wire-rejection path.

`scripts/workbench/wire_compat_gate.py` runs a bounded current ↔ v0.10.0
matrix against real etcd and RustFS. It uses raw sockets only for wire-level
assertions, so the checks do not rely on current internal protocol APIs.

- A foreign `ClientHello` receives `Incompatible` with the exact current
  schema before request dispatch.
- A complete, structurally valid legacy v2 `CreateWorkspace` MessagePack
  request receives the exact v2 `PreconditionFailed` schema-upgrade response,
  byte-for-byte; a current-client control request then confirms that the
  server remains healthy.
- The v0.10.0 CLI must reach the current server and render the exact
  actionable schema-upgrade message. A control-store codec error is not
  accepted as a passing result.
- Current → v0.10.0 is split into an unadopted durable-Agent-binding guard
  and an explicitly adopted legacy root. The adopted client reaches the old
  server, which fail-closes its v2 decoder after the current `ClientHello`;
  an old-client control request then confirms the old server remains healthy.
- Same-version current ↔ current and v0.10.0 ↔ v0.10.0 controls remain in the
  matrix.

The CI job content-pins the v0.10.0 source archive to:

```text
4b486c18bd4c6c0d07e3a55834bf50bb97cc6085c46bdd405101530ad89ad4c1
```

It verifies that archive before extracting it, builds the legacy CLI with
`cargo build --locked`, binds the resulting binary SHA-256 to the gate, and
the gate verifies and records source/binary identities before and after the
matrix. The release publishes a source archive rather than a Linux binary, so
the binary identity is necessarily the locked-build artifact recorded by each
qualification run.

CI integration adds unit-test coverage, builds the pinned legacy artifact,
starts an isolated etcd instance, runs the matrix against the existing
job-owned RustFS service, and uploads evidence.

## Scope

- [x] This PR changes one logical boundary only: wire-compatibility
      qualification for the #465 handshake.
- [x] No product protocol, metadata, object-store, Agent interface, benchmark,
      or documentation behavior is changed.
- [x] No compatibility shim, deprecated alias, or forwarding wrapper is added.
- [x] This focused change is below the 5,000-line review threshold.

## Code Contract

- [x] No product package boundary changes or new product errors/metrics.
- [x] The gate and its tests are placed under `scripts/workbench/`, alongside
      the existing qualification gates.
- [x] CI evidence is uploaded as a bounded artifact with seven-day retention.

## Validation

- `python3 -m py_compile scripts/workbench/wire_compat_gate.py
  scripts/workbench/wire_compat_gate_test.py` → OK
- `python3 scripts/workbench/wire_compat_gate_test.py` → 10 passed
- `python3 scripts/workbench/workbench_contract_test.py` → 8 passed
- Full matrix with a current local binary, a v0.10.0 binary built from the
  pinned source archive with `--locked`, real etcd, and RustFS → **11/11
  evidence scenarios passed**
- A deliberately incorrect legacy source SHA-256 failed closed before matrix
  startup
- `cargo fmt --all -- --check` → pass
- `cargo clippy --workspace --all-targets -- -D warnings` → pass (local Rust
  1.97.1)
- `cargo test --workspace` → 1,070 passed, 0 failed
- Workflow YAML parsing and `git diff --check` → pass

## Contributor Sign-off

- [x] Every commit in this PR includes a DCO `Signed-off-by` trailer.
