### PR TITLE
fix(cli): default recovery publication to local-only

### DIFF
--- a/crates/nokv/src/cli.rs
+++ b/crates/nokv/src/cli.rs
@@ -86,15 +86,16 @@ pub enum MetadataStoreConfig {
 
 /// `serve --recovery-publication` selection.
 ///
-/// `Shared` uploads every applied outbox tail as immutable log segments plus
-/// control references before a response leaves the shard. `LocalOnly` keeps
-/// the exclusive local WAL as the only recovery authority and publishes
-/// nothing; it is the deployment shape to use until shared checkpoint
-/// compaction bounds the segment chain.
+/// `LocalOnly` is the resting state: the exclusive local Holt WAL is the only
+/// recovery authority and nothing is published to Control. `Shared` uploads
+/// every applied outbox tail as immutable log segments plus control
+/// references before a response leaves the shard; until shared checkpoint
+/// compaction bounds that segment chain it is an opt-in, and it is implied by
+/// `--metadata-recover-log`, which can only resume from a shared frontier.
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
 pub enum RecoveryPublicationConfig {
-    #[default]
     Shared,
+    #[default]
     LocalOnly,
 }
 
@@ -291,7 +292,7 @@ impl Default for ServerConfig {
             node_id: None,
             metadata_store: None,
             lifecycle_interval_millis: DEFAULT_LIFECYCLE_INTERVAL_MILLIS,
-            recovery_publication: RecoveryPublicationConfig::Shared,
+            recovery_publication: RecoveryPublicationConfig::LocalOnly,
         }
     }
 }
@@ -300,6 +301,7 @@ pub fn parse(arguments: impl IntoIterator<Item = String>) -> Result<Invocation, 
     let mut arguments = arguments.into_iter();
     let mut client = ClientConfig::default();
     let mut server = ServerConfig::default();
+    let mut recovery_publication_explicit = false;
     let mut static_routing = StaticRoutingConfig::default();
     let mut etcd_routing = EtcdRoutingConfig::default();
     let mut routing_kind = None;
@@ -453,6 +455,7 @@ pub fn parse(arguments: impl IntoIterator<Item = String>) -> Result<Invocation, 
             }
             "--recovery-publication" => {
                 let value = next_value(&mut arguments, &argument)?;
+                recovery_publication_explicit = true;
                 server.recovery_publication = match value.as_str() {
                     "shared" => RecoveryPublicationConfig::Shared,
                     "local-only" => RecoveryPublicationConfig::LocalOnly,
@@ -469,13 +472,20 @@ pub fn parse(arguments: impl IntoIterator<Item = String>) -> Result<Invocation, 
             _ => return Err(CliError::UnknownOption(argument)),
         }
     };
-    if server.recovery_publication == RecoveryPublicationConfig::LocalOnly
-        && matches!(
-            server.metadata_store,
-            Some(MetadataStoreConfig::RecoverLog(_))
-        )
-    {
-        return Err(CliError::LocalOnlyRecoverLog);
+    if matches!(
+        server.metadata_store,
+        Some(MetadataStoreConfig::RecoverLog(_))
+    ) {
+        // A shared-log successor resumes from a shared frontier, so shared
+        // publication is the only coherent choice: imply it when the caller
+        // said nothing, refuse it when the caller asked for local-only.
+        match (recovery_publication_explicit, server.recovery_publication) {
+            (false, _) => server.recovery_publication = RecoveryPublicationConfig::Shared,
+            (true, RecoveryPublicationConfig::LocalOnly) => {
+                return Err(CliError::LocalOnlyRecoverLog);
+            }
+            (true, RecoveryPublicationConfig::Shared) => {}
+        }
     }
     client.routing = match routing_kind.unwrap_or(RoutingKind::Static) {
         RoutingKind::Static => RoutingConfig::Static(static_routing),
@@ -1152,10 +1162,24 @@ mod tests {
     }
 
     #[test]
-    fn server_recovery_publication_defaults_to_shared_and_local_only_is_explicit() {
+    fn server_recovery_publication_defaults_to_local_only_and_shared_is_explicit() {
+        // A fresh or reopened owner runs on its exclusive Holt WAL alone unless
+        // shared publication is asked for. Publishing to Control is a switch,
+        // not the resting state.
+        for open in ["--metadata-create", "--metadata-reopen"] {
+            let parsed = parse(args(&[open, "/var/lib/nokv/shard.holt", "serve"])).unwrap();
+            assert_eq!(
+                parsed.server.recovery_publication,
+                RecoveryPublicationConfig::LocalOnly,
+                "{open} without --recovery-publication must be local-only"
+            );
+        }
+
         let shared = parse(args(&[
             "--metadata-reopen",
             "/var/lib/nokv/shard.holt",
+            "--recovery-publication",
+            "shared",
             "serve",
         ]))
         .unwrap();
@@ -1189,6 +1213,37 @@ mod tests {
                 option: "--recovery-publication",
                 value: "sometimes".to_owned(),
             })
+        );
+    }
+
+    #[test]
+    fn recover_log_implies_shared_publication_unless_contradicted() {
+        // Recovering from the shared log installs a shared frontier, so the
+        // only coherent publication mode is shared. Leaving the option out
+        // must select it rather than trip over the local-only default.
+        let recovered = parse(args(&[
+            "--metadata-recover-log",
+            "/var/lib/nokv/recovered.holt",
+            "serve",
+        ]))
+        .unwrap();
+        assert_eq!(
+            recovered.server.recovery_publication,
+            RecoveryPublicationConfig::Shared
+        );
+
+        // Saying so explicitly is fine.
+        let explicit = parse(args(&[
+            "--metadata-recover-log",
+            "/var/lib/nokv/recovered.holt",
+            "--recovery-publication",
+            "shared",
+            "serve",
+        ]))
+        .unwrap();
+        assert_eq!(
+            explicit.server.recovery_publication,
+            RecoveryPublicationConfig::Shared
         );
 
         // A shared-log successor cannot be a local-only owner.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -376,14 +376,23 @@ Because no checkpoint publisher exists yet, the shared log chain only grows:
 every acknowledged mutation appends one segment reference to the Control
 logical-shard record, and Control bounds that record (`MAX_LOGICAL_SHARD_RECORD_BYTES`)
 and the chain length (`MAX_RECOVERY_LOG_SEGMENTS`). A shard that reaches either
-bound stops accepting writes until compaction exists. `nokv serve
---recovery-publication` selects the recovery authority explicitly: `shared`
-(default) is the object-first boundary described above; `local-only` keeps the
-exclusive Holt WAL as the only recovery authority, publishes no segments, leaves
-any earlier shared frontier frozen, still proves owner liveness before every
-acknowledgement, and cannot combine with `--metadata-recover-log`. A
-`local-only` shard has no shared-log successor path: losing its Holt directory
-loses the metadata, exactly as with the `local` mode above.
+bound loses its owner fence and stops serving; on the current record size that
+happens after roughly a hundred acknowledged publications. Shared publication
+is therefore an opt-in, not the resting state.
+
+`nokv serve --recovery-publication` selects the recovery authority:
+
+- `local-only` (**default**) keeps the exclusive Holt WAL as the only recovery
+  authority, publishes no segments, leaves any earlier shared frontier frozen,
+  and still proves owner liveness before every acknowledgement. Control (etcd)
+  is used for routing and the owner lease only. A `local-only` shard has no
+  shared-log successor path: losing its Holt directory loses the metadata,
+  exactly as with the `local` mode above.
+- `shared` is the object-first boundary described above. It is implied by
+  `--metadata-recover-log`, which can only resume from a shared frontier, and
+  it cannot be combined with `local-only` on that open mode. Do not select it
+  for a shard that will accept more than a bounded burst of writes until
+  checkpoint compaction lands.
 
 Durable ledgers, not object listing, recover:
 

--- a/docs/workbench-preflight.md
+++ b/docs/workbench-preflight.md
@@ -42,6 +42,27 @@ git diff --check
 The contract check proves only the exact 18 names and normalized input schemas.
 It does not qualify persistence, object I/O, failover, restore, or latency.
 
+## Default Deployment Shape
+
+A serving shard is one `nokv serve` process over one exclusive Holt store. That
+process is the metadata authority: it holds the owner lease, applies every
+metadata command to its local Holt WAL, and acknowledges once that WAL is
+durable. Nothing else has to be running for reads and writes to work.
+
+Control (etcd) is required, but for two narrow jobs: resolving which process
+owns a root, and fencing that ownership with an epoch. It is not on the write
+path and it does not hold metadata.
+
+Publishing the recovery log to Control (`--recovery-publication shared`) is
+an option, and an immature one: without checkpoint compaction the shared log
+chain grows without bound and the shard stops serving after roughly a hundred
+acknowledged publications. Leave it off unless you are qualifying the shared
+recovery path itself. It is switched on implicitly by
+`--metadata-recover-log`, which resumes a shard from a shared frontier.
+
+The corresponding invariant for operators: back up the Holt directory. In the
+default shape it is the only copy of the metadata.
+
 ## Live Contract Check
 
 Start `nokv mcp` with the same root, route, owner, and object configuration that


### PR DESCRIPTION
## What changed

`serve --recovery-publication` now defaults to **`local-only`**. `shared` becomes an explicit opt-in, and is implied by `--metadata-recover-log` (which can only resume from a shared frontier). Asking for `local-only` together with `--metadata-recover-log` is still refused.

Docs updated to match: `docs/architecture.md` corrects the default and marks shared publication as an option; `docs/workbench-preflight.md` gains a "Default Deployment Shape" section stating that a serving shard is one `nokv serve` over one exclusive Holt store, that Control (etcd) is for routing and the owner lease only, and that shared publication is immature until checkpoint compaction lands.

## Why

With `shared` as the default, a shard nobody asked to publish did so on every acknowledged mutation, appending a segment reference to the Control logical-shard record. There is no checkpoint publisher, so that record only grows, and it crosses `MAX_LOGICAL_SHARD_RECORD_BYTES` after roughly a hundred publications:

```
lifecycle owner fence lost ... recovery publication failed:
encoded logical shard record is 459568 bytes; maximum is 458752
```

The owner fence is lost and the RPC server stops. Measured on a fresh shard: **36 published objects** were enough to bring the record to 456,944 bytes. That is below the size of any real workload, and it hit during a 60-document ingest run.

The doc comment on `RecoveryPublicationConfig` already described `LocalOnly` as "the deployment shape to use until shared checkpoint compaction bounds the segment chain". The default now agrees with it.

## Validation

- `cargo test -p nokv --bin nokv`: 132 passed, including two new tests (`server_recovery_publication_defaults_to_local_only_and_shared_is_explicit`, `recover_log_implies_shared_publication_unless_contradicted`)
- `cargo test -p nokv-server`: 157 passed
- `cargo fmt --all -- --check`, `cargo clippy -p nokv --all-targets -- -D warnings`, `git diff --check`: clean
- Live stack, `nokv serve` started with **no** `--recovery-publication` flag: 240+ publications through the Python SDK, control record stayed at **244 bytes**, server up throughout, full lifecycle (commit → snapshot → as-of read → restore) verified. The identical run on the previous default stopped serving before publication 40.

## Compatibility

Anyone relying on the old default gets local-only publication after upgrading and must pass `--recovery-publication shared` explicitly. Given that the old default stopped serving after ~100 publications, no working deployment can have been depending on it beyond a bounded burst.