### PR TITLE
docs(cli): describe the local-only recovery default in --help

### DIFF
--- a/crates/nokv/src/main.rs
+++ b/crates/nokv/src/main.rs
@@ -614,12 +614,13 @@ OWNER:
   --metadata-create PATH starts the first standalone local-WAL owner
   --metadata-reopen PATH restarts the same exclusive local-WAL authority after lease loss
   --metadata-recover-log PATH installs or resumes one exact receipt-directed shared-log frontier
-  --recovery-publication shared|local-only (default shared)
+  --recovery-publication local-only|shared (default local-only)
+    local-only keeps the exclusive local WAL as the only recovery authority and publishes nothing;
+    Control (etcd) is used for routing and the owner lease only
     shared publishes every applied outbox tail as immutable log segments plus control references
     before a response leaves the shard; without checkpoint compaction the chain is bounded by the
-    control record size, and a shard that reaches that bound stops accepting writes
-    local-only keeps the exclusive local WAL as the only recovery authority, publishes nothing,
-    and cannot combine with --metadata-recover-log
+    control record size, and a shard that reaches that bound loses its owner fence and stops serving
+    --metadata-recover-log implies shared when this option is omitted and refuses local-only
 
 OBJECT DATA:
   --object-bucket NAME [--object-endpoint URL] [--object-root PREFIX]


### PR DESCRIPTION
Follow-up to #466. The `serve` help text still said `--recovery-publication ... (default shared)` and that local-only "cannot combine with --metadata-recover-log" unconditionally. Both are stale after #466: the default is `local-only`, and `--metadata-recover-log` implies `shared` when the option is omitted (only an explicit `local-only` is refused). The help now matches the parser and describes the consequence of hitting the shared control-record bound as it actually behaves.

Text-only change to `crates/nokv/src/main.rs`; `cargo test -p nokv --bin nokv` 132 passed, fmt clean.