### PR TITLE
release: raise nokv line to 0.11.0

### DIFF
--- a/.github/workflows/release-homebrew.yml
+++ b/.github/workflows/release-homebrew.yml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
     inputs:
       tag:
-        description: "Canonical stable tag, for example v0.10.0"
+        description: "Canonical stable tag, for example v0.11.0"
         required: true
         type: string
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1270,7 +1270,7 @@ checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
 
 [[package]]
 name = "nokv"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "base64 0.23.0",
  "nokv-agent",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ nokv-object = { path = "crates/nokv-object", version = "0.1.0" }
 nokv-client = { path = "crates/nokv-client", version = "0.1.0" }
 nokv-agent = { path = "crates/nokv-agent", version = "0.1.0" }
 nokv-server = { path = "crates/nokv-server", version = "0.1.0" }
-nokv = { path = "crates/nokv", version = "0.10.0" }
+nokv = { path = "crates/nokv", version = "0.11.0" }
 nokv-python = { path = "crates/nokv-python", version = "0.1.0" }
 nokv-bench = { path = "bench", version = "0.1.0" }
 holt = { version = "=0.8.5", default-features = false }

--- a/crates/nokv/Cargo.toml
+++ b/crates/nokv/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nokv"
-version = "0.10.0"
+version = "0.11.0"
 description = "Custom CLI and MCP wiring for NoKV Agent workspaces."
 edition.workspace = true
 rust-version.workspace = true

--- a/crates/nokv/src/build_info.rs
+++ b/crates/nokv/src/build_info.rs
@@ -35,7 +35,7 @@ mod tests {
 
     #[test]
     fn compiled_identity_is_complete() {
-        assert_eq!(VERSION, "0.10.0");
+        assert_eq!(VERSION, "0.11.0");
         assert!(GIT_COMMIT == "unknown" || GIT_COMMIT.len() == 40);
         assert_eq!(CARGO_LOCK_SHA256.len(), 64);
         assert_eq!(HOLT_VERSION, "0.8.5");


### PR DESCRIPTION
Raises the `crates/nokv` line from 0.10.0 to 0.11.0 so the public Homebrew tap can be updated to the current `main`.

## Why minor, not patch

`v0.10.0..main` carries additive contract work, not only fixes:

- `feat(server)`: recovery publication became an explicit `serve` choice, with `--recovery-publication local-only` as the default.
- `feat(workspace)` / `feat(runtime)`: v9 Agent and lifecycle contracts, shared recovery.
- `feat(python)`: bounded Workbench adapters.
- `feat(metadata)` / `feat(control)` / `feat(meta-store)` / `feat(meta-holt)` / `feat(object)`: recovery outbox, checkpoint exchange, retained Generic index generations.

A patch number would understate that. `version_scheme 1` is unchanged, so the `0.x` upgrade ordering established in 0.10.0 still holds.

## Scope

Five lines, version identity only:

- `crates/nokv/Cargo.toml`, workspace `nokv` dependency, and `Cargo.lock` package version.
- `crates/nokv/src/build_info.rs` compiled identity assertion.
- The `release-homebrew.yml` dispatch example tag.

The Workbench contract stays frozen at 18 tools and Holt stays pinned at `=0.8.5`; neither is touched by this change.

## Local qualification

- `python3 scripts/release/test_homebrew_source_release.py` — 15 tests, OK.
- `python3 scripts/workbench/workbench_contract_test.py` — 8 tests, OK.
- `python3 scripts/workbench/pre423_contract_ledger.py` + its test — PASS, 26 tests OK.
- `cargo fmt --all -- --check` — clean.
- `cargo check --locked --workspace` — clean.
- `cargo test --locked -p nokv --bins build_info` — compiled identity reports 0.11.0.
- Disposable-clone dry run of `prepare` + `render-formula` against a local `v0.11.0` tag produced a well-formed manifest and Formula (18 tools, Holt 0.8.5). The published archive and checksums are regenerated by CI from the tag commit.

## After merge

1. Tag the merge commit `v0.11.0`.
2. Dispatch **Release Homebrew Source Formula** with `v0.11.0`.
3. Merge the tap PR the workflow opens against `NoKV-Lab/homebrew-tap`.
