### PR TITLE
fix(control): keep the logical shard routing record readable by every released client

### DIFF
--- a/crates/nokv-control/src/codec.rs
+++ b/crates/nokv-control/src/codec.rs
@@ -5,15 +5,30 @@ use crate::store::{validate_logical_shard_record, MAX_LOGICAL_SHARD_RECORD_BYTES
 use crate::LogicalShardLease;
 use crate::{
     AgentId, CheckpointRef, ControlError, LogRef, LogSegmentRef, LogicalShardId,
-    LogicalShardRecord, LogicalShardState, NodeId, ObjectNamespaceId, OwnerEpoch,
-    PlacementGeneration, RecoveryUploadIntent, RootAgentBinding, RootId,
+    LogicalShardRecord, LogicalShardRecoveryState, LogicalShardState, NodeId, ObjectNamespaceId,
+    OwnerEpoch, PlacementGeneration, RecoveryUploadIntent, RootAgentBinding, RootId,
     RootObjectNamespaceBinding, RootPlacement, RootPlacementLifecycle,
 };
 
 const ROOT_PLACEMENT_CODEC_VERSION: u8 = 1;
 const ROOT_AGENT_BINDING_CODEC_VERSION: u8 = 1;
 const ROOT_OBJECT_NAMESPACE_CODEC_VERSION: u8 = 1;
-const LOGICAL_SHARD_RECORD_CODEC_VERSION: u8 = 3;
+/// Wire version of the client-facing logical shard routing record.
+///
+/// This is a compatibility contract, not a counter: every reader that
+/// understands version 1 (every released NoKV client) must keep decoding the
+/// value stored at the logical shard record key. Owner-side recovery state is
+/// persisted under its own key and codec version so that it can evolve
+/// without touching this schema. Bumping this version is a deliberate,
+/// client-breaking release decision.
+pub const LOGICAL_SHARD_ROUTING_CODEC_VERSION: u8 = 1;
+/// Wire version of the owner-only logical shard recovery state.
+pub const LOGICAL_SHARD_RECOVERY_CODEC_VERSION: u8 = 1;
+/// Highest legacy combined record version still readable at the routing key.
+///
+/// Versions 2 and 3 folded recovery state into the routing record; owners
+/// that still write them are read but never written by this crate.
+const LEGACY_COMBINED_LOGICAL_SHARD_RECORD_MAX_VERSION: u8 = 3;
 #[cfg(any(feature = "etcd", test))]
 const OWNER_SESSION_CODEC_VERSION: u8 = 1;
 
@@ -88,6 +103,17 @@ struct LogicalShardRecordWireV1 {
     checkpoint: Option<CheckpointRefWireV2>,
     log: Option<LogRefWireV1>,
     durable_lsn: u64,
+}
+
+#[derive(Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct LogicalShardRecoveryWireV1 {
+    version: u8,
+    logical_shard_id: String,
+    checkpoint: Option<CheckpointRefWire>,
+    log: Option<LogRefWire>,
+    durable_lsn: u64,
+    pending_recovery_upload: Option<RecoveryUploadIntentWire>,
 }
 
 #[derive(Serialize, Deserialize)]
@@ -275,74 +301,195 @@ pub fn decode_root_object_namespace_binding(
     Ok(binding)
 }
 
-pub fn encode_logical_shard_record(record: &LogicalShardRecord) -> Result<Vec<u8>, ControlError> {
+/// Encode the client-facing routing record stored at the logical shard key.
+///
+/// The value is always the version-1 wire schema with every recovery field
+/// cleared: checkpoint and log are `null` and `durable_lsn` is zero, which is
+/// the only recovery frontier a version-1 reader can validate. The full
+/// record is validated first so an inconsistent owner state never reaches
+/// either key.
+pub fn encode_logical_shard_routing_record(
+    record: &LogicalShardRecord,
+) -> Result<Vec<u8>, ControlError> {
     validate_logical_shard_record(record)?;
-    encode_logical_shard_record_wire(record)
+    encode_logical_shard_routing_record_wire(record)
+}
+
+/// Encode the owner-side recovery state stored next to the routing record.
+///
+/// Returns `None` when the record carries no recovery state at all; the
+/// backend then removes the recovery key so that absence and emptiness are
+/// the same durable fact.
+pub fn encode_logical_shard_recovery_state(
+    record: &LogicalShardRecord,
+) -> Result<Option<Vec<u8>>, ControlError> {
+    validate_logical_shard_record(record)?;
+    encode_logical_shard_recovery_state_wire(record)
 }
 
 pub(crate) fn validate_logical_shard_record_encoded_size(
     record: &LogicalShardRecord,
 ) -> Result<(), ControlError> {
-    let encoded = encode_logical_shard_record_wire(record)?;
-    if encoded.len() > MAX_LOGICAL_SHARD_RECORD_BYTES {
+    let routing = encode_logical_shard_routing_record_wire(record)?;
+    if routing.len() > MAX_LOGICAL_SHARD_RECORD_BYTES {
         return Err(ControlError::InvalidRecord(format!(
-            "encoded logical shard record is {} bytes; maximum is {MAX_LOGICAL_SHARD_RECORD_BYTES}",
-            encoded.len()
+            "encoded logical shard routing record is {} bytes; maximum is {MAX_LOGICAL_SHARD_RECORD_BYTES}",
+            routing.len()
         )));
+    }
+    if let Some(recovery) = encode_logical_shard_recovery_state_wire(record)? {
+        if recovery.len() > MAX_LOGICAL_SHARD_RECORD_BYTES {
+            return Err(ControlError::InvalidRecord(format!(
+                "encoded logical shard recovery state is {} bytes; maximum is {MAX_LOGICAL_SHARD_RECORD_BYTES}",
+                recovery.len()
+            )));
+        }
     }
     Ok(())
 }
 
-fn encode_logical_shard_record_wire(record: &LogicalShardRecord) -> Result<Vec<u8>, ControlError> {
-    serde_json::to_vec(&LogicalShardRecordWireV3 {
-        version: LOGICAL_SHARD_RECORD_CODEC_VERSION,
+fn encode_logical_shard_routing_record_wire(
+    record: &LogicalShardRecord,
+) -> Result<Vec<u8>, ControlError> {
+    serde_json::to_vec(&LogicalShardRecordWireV1 {
+        version: LOGICAL_SHARD_ROUTING_CODEC_VERSION,
         logical_shard_id: encode_fixed_id(record.logical_shard_id.as_bytes()),
         owner: record.owner.as_ref().map(|owner| owner.as_str().to_owned()),
         owner_epoch: record.owner_epoch.map(OwnerEpoch::get),
         lease_id: record.lease_id,
         state: record.state.into(),
         endpoint: record.endpoint.clone(),
+        checkpoint: None,
+        log: None,
+        durable_lsn: 0,
+    })
+    .map_err(codec_error)
+}
+
+fn encode_logical_shard_recovery_state_wire(
+    record: &LogicalShardRecord,
+) -> Result<Option<Vec<u8>>, ControlError> {
+    if !record.has_recovery_state() {
+        return Ok(None);
+    }
+    serde_json::to_vec(&LogicalShardRecoveryWireV1 {
+        version: LOGICAL_SHARD_RECOVERY_CODEC_VERSION,
+        logical_shard_id: encode_fixed_id(record.logical_shard_id.as_bytes()),
         checkpoint: record.checkpoint.clone().map(Into::into),
         log: record.log.clone().map(Into::into),
         durable_lsn: record.durable_lsn,
         pending_recovery_upload: record.pending_recovery_upload.clone().map(Into::into),
     })
+    .map(Some)
     .map_err(codec_error)
 }
 
-pub fn decode_logical_shard_record(bytes: &[u8]) -> Result<LogicalShardRecord, ControlError> {
+/// How the value at the logical shard record key was written.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum LogicalShardRecordWireKind {
+    /// The current version-1 routing record; recovery state lives separately.
+    Routing,
+    /// A legacy version-2 or version-3 record that folds recovery state in.
+    LegacyCombined { version: u8 },
+}
+
+/// One decoded logical shard record value plus how it was written.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct DecodedLogicalShardRecord {
+    pub record: LogicalShardRecord,
+    pub wire: LogicalShardRecordWireKind,
+}
+
+/// Decode the value stored at the logical shard record key.
+///
+/// A version-1 value is a routing record whose recovery fields are absent by
+/// construction; the backend reattaches the separately stored recovery state.
+/// Legacy version-2/3 values written by owners before the split are complete
+/// records and take precedence over any recovery key left next to them.
+pub fn decode_logical_shard_record_value(
+    bytes: &[u8],
+) -> Result<DecodedLogicalShardRecord, ControlError> {
     let version: VersionWire = serde_json::from_slice(bytes).map_err(codec_error)?;
-    let record = match version.version {
-        1 => decode_logical_shard_record_v1(bytes)?,
-        2 => decode_logical_shard_record_v2(bytes)?,
-        LOGICAL_SHARD_RECORD_CODEC_VERSION => decode_logical_shard_record_v3(bytes)?,
+    let (record, wire) = match version.version {
+        LOGICAL_SHARD_ROUTING_CODEC_VERSION => (
+            decode_logical_shard_record_v1(bytes)?,
+            LogicalShardRecordWireKind::Routing,
+        ),
+        2 => (
+            decode_logical_shard_record_v2(bytes)?,
+            LogicalShardRecordWireKind::LegacyCombined { version: 2 },
+        ),
+        3 => (
+            decode_logical_shard_record_v3(bytes)?,
+            LogicalShardRecordWireKind::LegacyCombined { version: 3 },
+        ),
         actual => {
-            require_version(
-                "logical shard record",
-                actual,
-                LOGICAL_SHARD_RECORD_CODEC_VERSION,
-            )?;
-            unreachable!("version validator returned Ok for an unsupported version")
+            return Err(ControlError::UnsupportedRecordVersion {
+                record: "logical shard record",
+                version: actual,
+                supported: LEGACY_COMBINED_LOGICAL_SHARD_RECORD_MAX_VERSION,
+            });
         }
     };
     validate_logical_shard_record(&record)?;
-    if version.version == LOGICAL_SHARD_RECORD_CODEC_VERSION
-        && encode_logical_shard_record(&record)?.as_slice() != bytes
-    {
+    Ok(DecodedLogicalShardRecord { record, wire })
+}
+
+/// Decode the value stored at the logical shard record key into a record.
+pub fn decode_logical_shard_record(bytes: &[u8]) -> Result<LogicalShardRecord, ControlError> {
+    decode_logical_shard_record_value(bytes).map(|decoded| decoded.record)
+}
+
+/// Decode the owner-side recovery state stored next to a routing record.
+pub fn decode_logical_shard_recovery_state(
+    bytes: &[u8],
+) -> Result<LogicalShardRecoveryState, ControlError> {
+    let version: VersionWire = serde_json::from_slice(bytes).map_err(codec_error)?;
+    if version.version != LOGICAL_SHARD_RECOVERY_CODEC_VERSION {
+        return Err(ControlError::UnsupportedRecordVersion {
+            record: "logical shard recovery state",
+            version: version.version,
+            supported: LOGICAL_SHARD_RECOVERY_CODEC_VERSION,
+        });
+    }
+    let wire: LogicalShardRecoveryWireV1 = serde_json::from_slice(bytes).map_err(codec_error)?;
+    if serde_json::to_vec(&wire).map_err(codec_error)?.as_slice() != bytes {
         return Err(ControlError::Codec(
-            "logical shard record input is not canonical".to_owned(),
+            "logical shard recovery state input is not canonical".to_owned(),
         ));
     }
-    Ok(record)
+    let state = LogicalShardRecoveryState {
+        logical_shard_id: LogicalShardId::from_bytes(decode_fixed_id(
+            &wire.logical_shard_id,
+            "logical shard id",
+        )?),
+        checkpoint: wire.checkpoint.map(Into::into),
+        log: wire.log.map(Into::into),
+        durable_lsn: wire.durable_lsn,
+        pending_recovery_upload: wire
+            .pending_recovery_upload
+            .map(RecoveryUploadIntent::try_from)
+            .transpose()?,
+    };
+    if !LogicalShardRecord::unassigned(state.logical_shard_id)
+        .with_recovery_state(state.clone())?
+        .has_recovery_state()
+    {
+        return Err(ControlError::Codec(
+            "logical shard recovery state must not be stored when it is empty".to_owned(),
+        ));
+    }
+    Ok(state)
 }
 
 fn decode_logical_shard_record_v3(bytes: &[u8]) -> Result<LogicalShardRecord, ControlError> {
     let wire: LogicalShardRecordWireV3 = serde_json::from_slice(bytes).map_err(codec_error)?;
-    require_version(
-        "logical shard record",
-        wire.version,
-        LOGICAL_SHARD_RECORD_CODEC_VERSION,
-    )?;
+    require_version("logical shard record", wire.version, 3)?;
+    if serde_json::to_vec(&wire).map_err(codec_error)?.as_slice() != bytes {
+        return Err(ControlError::Codec(
+            "logical shard record v3 input is not canonical".to_owned(),
+        ));
+    }
     logical_shard_record_from_wire(
         wire.logical_shard_id,
         wire.owner,
@@ -544,13 +691,15 @@ fn decode_hex_digit(byte: u8) -> Option<u8> {
     }
 }
 
-fn require_version(type_name: &str, actual: u8, expected: u8) -> Result<(), ControlError> {
+fn require_version(type_name: &'static str, actual: u8, expected: u8) -> Result<(), ControlError> {
     if actual == expected {
         Ok(())
     } else {
-        Err(ControlError::Codec(format!(
-            "unsupported {type_name} codec version {actual}"
-        )))
+        Err(ControlError::UnsupportedRecordVersion {
+            record: type_name,
+            version: actual,
+            supported: expected,
+        })
     }
 }
 
@@ -775,6 +924,261 @@ mod tests {
         }
     }
 
+    /// The logical shard record reader that shipped in NoKV 0.10.0, vendored
+    /// byte for byte from `crates/nokv-control/src/codec.rs` at tag `v0.10.0`.
+    ///
+    /// Every client released before the recovery-state split decodes the
+    /// routing record with these exact structs (`deny_unknown_fields`, one
+    /// exact version) and then applies the same durable-LSN consistency rule
+    /// as `validate_logical_shard_record` did at that tag. This module is the
+    /// executable form of the compatibility contract: whatever this crate
+    /// stores at the logical shard record key must decode here.
+    mod frozen_v0_10_0_reader {
+        use serde::{Deserialize, Serialize};
+
+        #[derive(Serialize, Deserialize, Debug, PartialEq, Eq)]
+        #[serde(deny_unknown_fields)]
+        pub(super) struct RootPlacementWire {
+            pub version: u8,
+            pub root_id: String,
+            pub logical_shard_id: String,
+            pub placement_generation: u64,
+            pub lifecycle: u8,
+        }
+
+        #[derive(Serialize, Deserialize, Debug, PartialEq, Eq)]
+        #[serde(deny_unknown_fields)]
+        pub(super) struct LogicalShardRecordWire {
+            pub version: u8,
+            pub logical_shard_id: String,
+            pub owner: Option<String>,
+            pub owner_epoch: Option<u64>,
+            pub lease_id: u64,
+            pub state: u8,
+            pub endpoint: Option<String>,
+            pub checkpoint: Option<CheckpointRefWire>,
+            pub log: Option<LogRefWire>,
+            pub durable_lsn: u64,
+        }
+
+        #[derive(Serialize, Deserialize, Debug, PartialEq, Eq)]
+        #[serde(deny_unknown_fields)]
+        pub(super) struct CheckpointRefWire {
+            pub object_key: String,
+            pub lsn: u64,
+            pub image_bytes: u64,
+            pub image_digest: String,
+            pub digest: String,
+        }
+
+        #[derive(Serialize, Deserialize, Debug, PartialEq, Eq)]
+        #[serde(deny_unknown_fields)]
+        pub(super) struct LogSegmentRefWire {
+            pub segment_key: String,
+            pub first_lsn: u64,
+            pub last_lsn: u64,
+            pub digest: String,
+        }
+
+        #[derive(Serialize, Deserialize, Debug, PartialEq, Eq)]
+        #[serde(deny_unknown_fields)]
+        pub(super) struct LogRefWire {
+            pub segments: Vec<LogSegmentRefWire>,
+            pub durable_lsn: u64,
+            pub digest: String,
+        }
+
+        /// Decode exactly like the 0.10.0 client route resolver did.
+        pub(super) fn decode_logical_shard_record(
+            bytes: &[u8],
+        ) -> Result<LogicalShardRecordWire, String> {
+            let wire: LogicalShardRecordWire =
+                serde_json::from_slice(bytes).map_err(|error| error.to_string())?;
+            if wire.version != 1 {
+                return Err(format!(
+                    "unsupported logical shard record codec version {}",
+                    wire.version
+                ));
+            }
+            if serde_json::to_vec(&wire).map_err(|error| error.to_string())? != bytes {
+                return Err("logical shard record input is not canonical".to_owned());
+            }
+            let reference_lsn = match (wire.checkpoint.as_ref(), wire.log.as_ref()) {
+                (Some(checkpoint), Some(log)) => checkpoint.lsn.max(log.durable_lsn),
+                (Some(checkpoint), None) => checkpoint.lsn,
+                (None, Some(log)) => log.durable_lsn,
+                (None, None) => 0,
+            };
+            if wire.durable_lsn != reference_lsn {
+                return Err(format!(
+                    "durable LSN {} does not match recovery reference tail {reference_lsn}",
+                    wire.durable_lsn
+                ));
+            }
+            Ok(wire)
+        }
+
+        pub(super) fn decode_root_placement(bytes: &[u8]) -> Result<RootPlacementWire, String> {
+            let wire: RootPlacementWire =
+                serde_json::from_slice(bytes).map_err(|error| error.to_string())?;
+            if wire.version != 1 {
+                return Err(format!(
+                    "unsupported root placement codec version {}",
+                    wire.version
+                ));
+            }
+            Ok(wire)
+        }
+    }
+
+    fn released_record() -> LogicalShardRecord {
+        let mut record = serving_record();
+        record.owner = None;
+        record.owner_epoch = Some(OwnerEpoch::new(7).unwrap());
+        record.lease_id = 0;
+        record.state = LogicalShardState::Unassigned;
+        record.endpoint = None;
+        record
+    }
+
+    /// Records covering every routing shape the store persists, with and
+    /// without owner-side recovery state.
+    fn routing_contract_records() -> Vec<LogicalShardRecord> {
+        let mut serving_without_recovery = serving_record();
+        serving_without_recovery.checkpoint = None;
+        serving_without_recovery.log = None;
+        serving_without_recovery.durable_lsn = 0;
+        vec![
+            LogicalShardRecord::unassigned(shard_id(2)),
+            serving_without_recovery,
+            serving_record(),
+            recovering_record_with_upload(),
+            released_record(),
+        ]
+    }
+
+    #[test]
+    fn routing_record_stays_decodable_by_the_frozen_v0_10_0_reader() {
+        assert_eq!(LOGICAL_SHARD_ROUTING_CODEC_VERSION, 1);
+        for record in routing_contract_records() {
+            let bytes = encode_logical_shard_routing_record(&record).unwrap();
+            let frozen = frozen_v0_10_0_reader::decode_logical_shard_record(&bytes)
+                .unwrap_or_else(|error| panic!("a 0.10.0 client must decode {record:?}: {error}"));
+            assert_eq!(frozen.version, 1);
+            assert_eq!(
+                frozen.logical_shard_id,
+                encode_fixed_id(record.logical_shard_id.as_bytes())
+            );
+            assert_eq!(
+                frozen.owner,
+                record.owner.as_ref().map(|owner| owner.as_str().to_owned())
+            );
+            assert_eq!(frozen.owner_epoch, record.owner_epoch.map(OwnerEpoch::get));
+            assert_eq!(frozen.lease_id, record.lease_id);
+            assert_eq!(frozen.state, u8::from(record.state));
+            assert_eq!(frozen.endpoint, record.endpoint);
+            // A frozen reader sees no shared recovery frontier; the frontier
+            // lives in the recovery state that only owners read.
+            assert_eq!(frozen.checkpoint, None);
+            assert_eq!(frozen.log, None);
+            assert_eq!(frozen.durable_lsn, 0);
+        }
+        let placement = encode_root_placement(&placement()).unwrap();
+        assert_eq!(
+            frozen_v0_10_0_reader::decode_root_placement(&placement)
+                .unwrap()
+                .version,
+            1
+        );
+    }
+
+    #[test]
+    fn recovery_state_never_leaks_into_the_routing_value() {
+        for record in routing_contract_records() {
+            let bytes = encode_logical_shard_routing_record(&record).unwrap();
+            let text = String::from_utf8(bytes).unwrap();
+            assert!(!text.contains("pending_recovery_upload"), "{text}");
+            assert!(!text.contains("receipt"), "{text}");
+            assert!(!text.contains("plan"), "{text}");
+            match encode_logical_shard_recovery_state(&record).unwrap() {
+                None => assert!(!record.has_recovery_state()),
+                Some(recovery) => {
+                    assert!(record.has_recovery_state());
+                    let state = decode_logical_shard_recovery_state(&recovery).unwrap();
+                    assert_eq!(state, record.recovery_state());
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn records_written_by_a_0_10_0_owner_stay_readable_and_canonical() {
+        // Exact bytes a 0.10.0 owner wrote for a serving shard without a
+        // shared recovery frontier (field order is the 0.10.0 struct order).
+        let written_by_0_10_0 = br#"{"version":1,"logical_shard_id":"02020202020202020202020202020202","owner":"node-a","owner_epoch":7,"lease_id":42,"state":3,"endpoint":"10.0.0.1:7000","checkpoint":null,"log":null,"durable_lsn":0}"#;
+        let decoded = decode_logical_shard_record_value(written_by_0_10_0).unwrap();
+        assert_eq!(decoded.wire, LogicalShardRecordWireKind::Routing);
+        assert!(!decoded.record.has_recovery_state());
+        assert_eq!(
+            decoded.record.owner_epoch,
+            Some(OwnerEpoch::new(7).unwrap())
+        );
+        assert_eq!(decoded.record.state, LogicalShardState::Serving);
+        // Re-encoding through this crate reproduces the same bytes, so a
+        // record that predates the split is canonical without a rewrite.
+        assert_eq!(
+            encode_logical_shard_routing_record(&decoded.record).unwrap(),
+            written_by_0_10_0
+        );
+    }
+
+    #[test]
+    fn legacy_combined_values_are_read_and_resplit() {
+        // Exact bytes a 0.11.0 owner wrote (combined version 3) for the two
+        // fixture records above.
+        let serving_v3 = br#"{"version":3,"logical_shard_id":"02020202020202020202020202020202","owner":"node-a","owner_epoch":7,"lease_id":42,"state":3,"endpoint":"10.0.0.1:7000","checkpoint":{"object_key":"checkpoints/7","lsn":128,"image_bytes":4096,"image_digest":"sha256:image","digest":"state-128","receipt":[1,2,3]},"log":{"segments":[{"segment_key":"logs/129-144","first_lsn":129,"last_lsn":144,"digest":"state-144","receipt":[4,5,6]}],"durable_lsn":144,"digest":"state-144"},"durable_lsn":144,"pending_recovery_upload":null}"#;
+        let recovering_v3 = br#"{"version":3,"logical_shard_id":"02020202020202020202020202020202","owner":"node-a","owner_epoch":7,"lease_id":42,"state":2,"endpoint":"10.0.0.1:7000","checkpoint":null,"log":null,"durable_lsn":0,"pending_recovery_upload":{"object_namespace_id":"03030303030303030303030303030303","first_lsn":1,"last_lsn":2,"previous_chain_digest":"0000000000000000000000000000000000000000000000000000000000000000","last_chain_digest":"1111111111111111111111111111111111111111111111111111111111111111","segment_digest":"2222222222222222222222222222222222222222222222222222222222222222","manifest_key":"nokv/recovery/log-segments/v1/manifest","receipt":[4,5,6],"plan":[1,2,3]}}"#;
+        for (bytes, expected) in [
+            (serving_v3.as_slice(), serving_record()),
+            (recovering_v3.as_slice(), recovering_record_with_upload()),
+        ] {
+            let decoded = decode_logical_shard_record_value(bytes).unwrap();
+            assert_eq!(
+                decoded.wire,
+                LogicalShardRecordWireKind::LegacyCombined { version: 3 }
+            );
+            assert_eq!(decoded.record, expected);
+            // The very same value is unreadable by a 0.10.0 client; that is
+            // the incompatibility the split removes on the next owner write.
+            assert!(frozen_v0_10_0_reader::decode_logical_shard_record(bytes).is_err());
+            assert_eq!(round_trip_split_record(&decoded.record), expected);
+        }
+    }
+
+    #[test]
+    fn recovery_state_codec_is_strict() {
+        let empty = br#"{"version":1,"logical_shard_id":"02020202020202020202020202020202","checkpoint":null,"log":null,"durable_lsn":0,"pending_recovery_upload":null}"#;
+        assert!(matches!(
+            decode_logical_shard_recovery_state(empty),
+            Err(ControlError::Codec(_))
+        ));
+        let recovery = encode_logical_shard_recovery_state(&serving_record())
+            .unwrap()
+            .unwrap();
+        let mut foreign = decode_logical_shard_recovery_state(&recovery).unwrap();
+        foreign.logical_shard_id = shard_id(9);
+        assert!(matches!(
+            LogicalShardRecord::unassigned(shard_id(2)).with_recovery_state(foreign),
+            Err(ControlError::Codec(_))
+        ));
+        let mut trailing = recovery.clone();
+        trailing.extend_from_slice(b" ");
+        assert!(matches!(
+            decode_logical_shard_recovery_state(&trailing),
+            Err(ControlError::Codec(_))
+        ));
+    }
+
     #[test]
     fn strict_codecs_round_trip_final_records() {
         let placement = placement();
@@ -796,16 +1200,28 @@ mod tests {
             binding
         );
 
-        let record = serving_record();
-        assert_eq!(
-            decode_logical_shard_record(&encode_logical_shard_record(&record).unwrap()).unwrap(),
-            record
-        );
-        let record = recovering_record_with_upload();
-        assert_eq!(
-            decode_logical_shard_record(&encode_logical_shard_record(&record).unwrap()).unwrap(),
-            record
-        );
+        for record in [serving_record(), recovering_record_with_upload()] {
+            assert_eq!(round_trip_split_record(&record), record);
+        }
+    }
+
+    /// Persist a record the way the etcd backend does (routing value plus the
+    /// optional recovery value) and read it back through both decoders.
+    fn round_trip_split_record(record: &LogicalShardRecord) -> LogicalShardRecord {
+        let routing = encode_logical_shard_routing_record(record).unwrap();
+        let decoded = decode_logical_shard_record_value(&routing).unwrap();
+        assert_eq!(decoded.wire, LogicalShardRecordWireKind::Routing);
+        assert_eq!(decoded.record, record.routing_projection());
+        match encode_logical_shard_recovery_state(record).unwrap() {
+            None => {
+                assert!(!record.has_recovery_state());
+                decoded.record
+            }
+            Some(recovery) => decoded
+                .record
+                .with_recovery_state(decode_logical_shard_recovery_state(&recovery).unwrap())
+                .unwrap(),
+        }
     }
 
     #[test]
@@ -823,8 +1239,14 @@ mod tests {
             br#"{"version":1,"root_id":"01010101010101010101010101010101","agent_id":"04040404040404040404040404040404"}"#
         );
         assert_eq!(
-            encode_logical_shard_record(&LogicalShardRecord::unassigned(shard_id(2))).unwrap(),
-            br#"{"version":3,"logical_shard_id":"02020202020202020202020202020202","owner":null,"owner_epoch":null,"lease_id":0,"state":1,"endpoint":null,"checkpoint":null,"log":null,"durable_lsn":0,"pending_recovery_upload":null}"#
+            encode_logical_shard_routing_record(&LogicalShardRecord::unassigned(shard_id(2)))
+                .unwrap(),
+            br#"{"version":1,"logical_shard_id":"02020202020202020202020202020202","owner":null,"owner_epoch":null,"lease_id":0,"state":1,"endpoint":null,"checkpoint":null,"log":null,"durable_lsn":0}"#
+        );
+        assert_eq!(
+            encode_logical_shard_recovery_state(&LogicalShardRecord::unassigned(shard_id(2)))
+                .unwrap(),
+            None
         );
         assert_eq!(
             decode_logical_shard_record(
@@ -857,17 +1279,48 @@ mod tests {
     }
 
     #[test]
-    fn codec_rejects_unknown_versions() {
+    fn codec_rejects_unknown_versions_with_a_typed_upgrade_error() {
         let bytes = br#"{"version":99,"root_id":"01010101010101010101010101010101","logical_shard_id":"02020202020202020202020202020202","placement_generation":1,"lifecycle":1}"#;
         assert!(matches!(
             decode_root_placement(bytes),
-            Err(ControlError::Codec(_))
+            Err(ControlError::UnsupportedRecordVersion {
+                record: "root placement",
+                version: 99,
+                supported: 1,
+            })
         ));
 
         let bytes = br#"{"version":99,"root_id":"01010101010101010101010101010101","agent_id":"04040404040404040404040404040404"}"#;
         assert!(matches!(
             decode_root_agent_binding(bytes),
-            Err(ControlError::Codec(_))
+            Err(ControlError::UnsupportedRecordVersion {
+                record: "root Agent binding",
+                ..
+            })
+        ));
+
+        // A newer routing or recovery record must name the version gap before
+        // any field parsing, so an old reader reports "upgrade me" instead of
+        // an unknown-field parse error.
+        let bytes = br#"{"version":4,"logical_shard_id":"02020202020202020202020202020202","future_field":true}"#;
+        let error = decode_logical_shard_record(bytes).unwrap_err();
+        assert!(matches!(
+            error,
+            ControlError::UnsupportedRecordVersion {
+                record: "logical shard record",
+                version: 4,
+                supported: 3,
+            }
+        ));
+        assert!(error.to_string().contains("must be upgraded"));
+        let bytes = br#"{"version":2,"logical_shard_id":"02020202020202020202020202020202","future_field":true}"#;
+        assert!(matches!(
+            decode_logical_shard_recovery_state(bytes),
+            Err(ControlError::UnsupportedRecordVersion {
+                record: "logical shard recovery state",
+                version: 2,
+                supported: 1,
+            })
         ));
     }
 

--- a/crates/nokv-control/src/errors.rs
+++ b/crates/nokv-control/src/errors.rs
@@ -72,6 +72,13 @@ pub enum ControlError {
     },
     InvalidRecord(String),
     InvalidOptions(String),
+    /// A durable control record declares a codec version this reader does not
+    /// implement. The record itself is intact; the reader is too old.
+    UnsupportedRecordVersion {
+        record: &'static str,
+        version: u8,
+        supported: u8,
+    },
     Codec(String),
     Backend(String),
 }
@@ -196,6 +203,16 @@ impl fmt::Display for ControlError {
             Self::InvalidOptions(reason) => {
                 write!(formatter, "invalid control store options: {reason}")
             }
+            Self::UnsupportedRecordVersion {
+                record,
+                version,
+                supported,
+            } => write!(
+                formatter,
+                "control store {record} uses codec version {version}; this reader supports \
+                 versions up to {supported}, so this client or owner must be upgraded before it \
+                 can use this control plane"
+            ),
             Self::Codec(reason) => write!(formatter, "control store codec error: {reason}"),
             Self::Backend(reason) => write!(formatter, "control store backend error: {reason}"),
         }

--- a/crates/nokv-control/src/etcd.rs
+++ b/crates/nokv-control/src/etcd.rs
@@ -1,20 +1,24 @@
+use std::collections::BTreeMap;
 use std::future::Future;
 
-use etcd_client::{Client, Compare, CompareOp, GetOptions, PutOptions, Txn, TxnOp};
+use etcd_client::{
+    Client, Compare, CompareOp, GetOptions, GetResponse, PutOptions, Txn, TxnOp, TxnOpResponse,
+};
 use tokio::runtime::{Builder, Runtime};
 
 use crate::codec::{
-    decode_logical_shard_record, decode_owner_session, decode_root_agent_binding,
-    decode_root_object_namespace_binding, decode_root_placement, encode_logical_shard_record,
-    encode_owner_session, encode_root_agent_binding, encode_root_object_namespace_binding,
-    encode_root_placement,
+    decode_logical_shard_record_value, decode_logical_shard_recovery_state, decode_owner_session,
+    decode_root_agent_binding, decode_root_object_namespace_binding, decode_root_placement,
+    encode_logical_shard_recovery_state, encode_logical_shard_routing_record, encode_owner_session,
+    encode_root_agent_binding, encode_root_object_namespace_binding, encode_root_placement,
+    DecodedLogicalShardRecord, LogicalShardRecordWireKind,
 };
 use crate::store::{
     prepare_mark_serving, prepare_owner_acquisition, prepare_owner_release,
     prepare_recovery_reacquisition, prepare_recovery_suspension, prepare_recovery_upload_abort,
     prepare_recovery_upload_finalization, prepare_recovery_upload_intent,
-    validate_new_root_placement, validate_record_lease, validate_root_placement_update,
-    ControlStore,
+    validate_logical_shard_record, validate_new_root_placement, validate_record_lease,
+    validate_root_placement_update, ControlStore,
 };
 use crate::{
     ControlError, EtcdControlStoreOptions, LogicalShardId, LogicalShardLease, LogicalShardRecord,
@@ -280,10 +284,9 @@ impl ControlStore for EtcdControlStore {
         self.block_on(async move {
             let desired = LogicalShardRecord::unassigned(logical_shard_id);
             let key = options.logical_shard_record_key(&logical_shard_id);
-            let encoded = encode_logical_shard_record(&desired)?;
             let txn = Txn::new()
-                .when(vec![Compare::version(key.clone(), CompareOp::Equal, 0)])
-                .and_then(vec![TxnOp::put(key, encoded, None)]);
+                .when(vec![Compare::version(key, CompareOp::Equal, 0)])
+                .and_then(logical_shard_record_ops(&options, &desired)?);
             if client.txn(txn).await.map_err(etcd_backend)?.succeeded() {
                 return Ok(desired);
             }
@@ -538,11 +541,7 @@ impl ControlStore for EtcdControlStore {
                     Compare::value(session_key.clone(), CompareOp::Equal, session.encoded),
                     Compare::lease(session_key, CompareOp::Equal, lease_id_i64(lease.lease_id)?),
                 ])
-                .and_then(vec![TxnOp::put(
-                    record_key,
-                    encode_logical_shard_record(&next)?,
-                    None,
-                )]);
+                .and_then(logical_shard_record_ops(&options, &next)?);
             match client.txn(txn).await {
                 Ok(response) if response.succeeded() => Ok(next),
                 Ok(_) | Err(_) => {
@@ -681,10 +680,11 @@ impl ControlStore for EtcdControlStore {
                         lease_id_i64(lease.lease_id)?,
                     ),
                 ])
-                .and_then(vec![
-                    TxnOp::put(record_key, encode_logical_shard_record(&next)?, None),
-                    TxnOp::delete(session_key, None),
-                ]);
+                .and_then({
+                    let mut ops = logical_shard_record_ops(&options, &next)?;
+                    ops.push(TxnOp::delete(session_key, None));
+                    ops
+                });
             match client.txn(txn).await {
                 Ok(response) if response.succeeded() => {
                     revoke_lease_best_effort(&mut client, lease.lease_id).await;
@@ -817,21 +817,37 @@ async fn fetch_logical_shard(
     options: &EtcdControlStoreOptions,
     logical_shard_id: &LogicalShardId,
 ) -> Result<Option<StoredLogicalShard>, ControlError> {
-    let key = options.logical_shard_record_key(logical_shard_id);
-    let response = client.get(key.clone(), None).await.map_err(etcd_backend)?;
-    let Some(kv) = response.kvs().first() else {
+    let record_key = options.logical_shard_record_key(logical_shard_id);
+    let recovery_key = options.logical_shard_recovery_key(logical_shard_id);
+    // One transaction reads both keys at the same etcd revision so the
+    // routing record and its recovery state can never be observed torn.
+    let response = client
+        .txn(Txn::new().and_then(vec![
+            TxnOp::get(record_key.clone(), None),
+            TxnOp::get(recovery_key.clone(), None),
+        ]))
+        .await
+        .map_err(etcd_backend)?;
+    let (record_response, recovery_response) = split_two_get_responses(response.op_responses())?;
+    let Some(kv) = record_response.kvs().first() else {
         return Ok(None);
     };
-    let record = decode_logical_shard_record(kv.value())?;
-    if record.logical_shard_id != *logical_shard_id || kv.key() != key.as_slice() {
+    if kv.key() != record_key.as_slice() {
         return Err(ControlError::Codec(
             "logical shard key and value identities differ".to_owned(),
         ));
     }
-    let canonical = encode_logical_shard_record(&record)?;
-    if canonical != kv.value() {
+    let record = assemble_logical_shard(
+        options,
+        decode_logical_shard_record_value(kv.value())?,
+        recovery_response
+            .kvs()
+            .first()
+            .map(|kv| (kv.key(), kv.value())),
+    )?;
+    if record.logical_shard_id != *logical_shard_id {
         return Err(ControlError::Codec(
-            "logical shard value is not canonical".to_owned(),
+            "logical shard key and value identities differ".to_owned(),
         ));
     }
     if kv.mod_revision() <= 0 {
@@ -850,26 +866,40 @@ async fn fetch_logical_shards(
     options: &EtcdControlStoreOptions,
 ) -> Result<Vec<StoredLogicalShard>, ControlError> {
     let response = client
-        .get(
-            options.logical_shard_records_prefix(),
-            Some(GetOptions::new().with_prefix()),
-        )
+        .txn(Txn::new().and_then(vec![
+            TxnOp::get(
+                options.logical_shard_records_prefix(),
+                Some(GetOptions::new().with_prefix()),
+            ),
+            TxnOp::get(
+                options.logical_shard_recovery_prefix(),
+                Some(GetOptions::new().with_prefix()),
+            ),
+        ]))
         .await
         .map_err(etcd_backend)?;
-    let mut records = Vec::with_capacity(response.kvs().len());
-    for kv in response.kvs() {
-        let record = decode_logical_shard_record(kv.value())?;
-        if kv.key() != options.logical_shard_record_key(&record.logical_shard_id) {
+    let (record_response, recovery_response) = split_two_get_responses(response.op_responses())?;
+    let mut recovery_by_key = BTreeMap::new();
+    for kv in recovery_response.kvs() {
+        recovery_by_key.insert(kv.key().to_vec(), kv.value());
+    }
+    let mut records = Vec::with_capacity(record_response.kvs().len());
+    for kv in record_response.kvs() {
+        let decoded = decode_logical_shard_record_value(kv.value())?;
+        let logical_shard_id = decoded.record.logical_shard_id;
+        if kv.key() != options.logical_shard_record_key(&logical_shard_id) {
             return Err(ControlError::Codec(
                 "logical shard key and value identities differ".to_owned(),
             ));
         }
-        let canonical = encode_logical_shard_record(&record)?;
-        if canonical != kv.value() {
-            return Err(ControlError::Codec(
-                "logical shard value is not canonical".to_owned(),
-            ));
-        }
+        let recovery_key = options.logical_shard_recovery_key(&logical_shard_id);
+        let record = assemble_logical_shard(
+            options,
+            decoded,
+            recovery_by_key
+                .get(&recovery_key)
+                .map(|value| (recovery_key.as_slice(), *value)),
+        )?;
         if kv.mod_revision() <= 0 {
             return Err(ControlError::Codec(
                 "logical shard has an invalid etcd modification revision".to_owned(),
@@ -882,6 +912,79 @@ async fn fetch_logical_shards(
     }
     records.sort_by_key(|stored| stored.record.logical_shard_id);
     Ok(records)
+}
+
+fn split_two_get_responses(
+    responses: Vec<TxnOpResponse>,
+) -> Result<(GetResponse, GetResponse), ControlError> {
+    let mut responses = responses.into_iter();
+    match (responses.next(), responses.next(), responses.next()) {
+        (Some(TxnOpResponse::Get(first)), Some(TxnOpResponse::Get(second)), None) => {
+            Ok((first, second))
+        }
+        _ => Err(ControlError::Backend(
+            "etcd read transaction returned an unexpected response shape".to_owned(),
+        )),
+    }
+}
+
+/// Rebuild one complete logical shard record from its routing value and the
+/// optional recovery value stored next to it.
+///
+/// A legacy combined value (versions 2 and 3, written by owners before the
+/// split) is already complete and wins over any recovery key beside it; that
+/// key is a leftover of a mixed-version owner sequence and is rewritten or
+/// removed by the next owner mutation. A version-1 routing value takes its
+/// recovery frontier from the recovery key, which must name the same shard.
+fn assemble_logical_shard(
+    options: &EtcdControlStoreOptions,
+    decoded: DecodedLogicalShardRecord,
+    recovery: Option<(&[u8], &[u8])>,
+) -> Result<LogicalShardRecord, ControlError> {
+    let record = match decoded.wire {
+        LogicalShardRecordWireKind::LegacyCombined { .. } => decoded.record,
+        LogicalShardRecordWireKind::Routing => match recovery {
+            None => decoded.record,
+            Some((key, value)) => {
+                let recovery = decode_logical_shard_recovery_state(value)?;
+                if key != options.logical_shard_recovery_key(&recovery.logical_shard_id) {
+                    return Err(ControlError::Codec(
+                        "logical shard recovery key and value identities differ".to_owned(),
+                    ));
+                }
+                let record = decoded.record.with_recovery_state(recovery)?;
+                validate_logical_shard_record(&record)?;
+                record
+            }
+        },
+    };
+    Ok(record)
+}
+
+/// The transaction operations that persist one logical shard record: the
+/// version-1 routing value at the record key, plus the recovery state at its
+/// own key when the record carries any, or that key's removal when it does
+/// not. Every owner-fenced mutation applies both in one transaction, guarded
+/// by the routing key's modification revision, so the two values are never
+/// observed torn.
+fn logical_shard_record_ops(
+    options: &EtcdControlStoreOptions,
+    record: &LogicalShardRecord,
+) -> Result<Vec<TxnOp>, ControlError> {
+    let routing = encode_logical_shard_routing_record(record)?;
+    let recovery_key = options.logical_shard_recovery_key(&record.logical_shard_id);
+    let recovery_op = match encode_logical_shard_recovery_state(record)? {
+        Some(recovery) => TxnOp::put(recovery_key, recovery, None),
+        None => TxnOp::delete(recovery_key, None),
+    };
+    Ok(vec![
+        TxnOp::put(
+            options.logical_shard_record_key(&record.logical_shard_id),
+            routing,
+            None,
+        ),
+        recovery_op,
+    ])
 }
 
 async fn find_write_placement(
@@ -957,8 +1060,8 @@ async fn install_owner(
     lease: &LogicalShardLease,
     expected_owner_epoch: Option<OwnerEpoch>,
 ) -> Result<LogicalShardLease, ControlError> {
-    let record_encoded = match encode_logical_shard_record(next) {
-        Ok(encoded) => encoded,
+    let record_ops = match logical_shard_record_ops(options, next) {
+        Ok(ops) => ops,
         Err(error) => {
             revoke_lease_best_effort(client, lease.lease_id).await;
             return Err(error);
@@ -990,14 +1093,15 @@ async fn install_owner(
                 placement.encoded.clone(),
             ),
         ])
-        .and_then(vec![
-            TxnOp::put(record_key, record_encoded, None),
-            TxnOp::put(
+        .and_then({
+            let mut ops = record_ops;
+            ops.push(TxnOp::put(
                 session_key,
                 session_encoded,
                 Some(PutOptions::new().with_lease(attached_lease_id)),
-            ),
-        ]);
+            ));
+            ops
+        });
 
     match client.txn(txn).await {
         Ok(response) if response.succeeded() => Ok(lease.clone()),
@@ -1109,11 +1213,7 @@ async fn put_owner_record_cas(
             Compare::value(session_key.clone(), CompareOp::Equal, session.encoded),
             Compare::lease(session_key, CompareOp::Equal, lease_id_i64(lease.lease_id)?),
         ])
-        .and_then(vec![TxnOp::put(
-            record_key,
-            encode_logical_shard_record(&next)?,
-            None,
-        )]);
+        .and_then(logical_shard_record_ops(options, &next)?);
     match client.txn(txn).await {
         Ok(response) if response.succeeded() => Ok(next),
         Ok(_) | Err(_) => {
@@ -1329,13 +1429,13 @@ mod tests {
         let mut interposed = current.record.clone();
         interposed.endpoint = Some("node-a:7001".to_owned());
         let record_key = options.logical_shard_record_key(&logical_shard_id);
-        let original = encode_logical_shard_record(&current.record).unwrap();
+        let original = encode_logical_shard_routing_record(&current.record).unwrap();
         store
             .block_on(async {
                 client
                     .put(
                         record_key.clone(),
-                        encode_logical_shard_record(&interposed)?,
+                        encode_logical_shard_routing_record(&interposed)?,
                         None,
                     )
                     .await
@@ -1363,7 +1463,11 @@ mod tests {
         store
             .block_on(async {
                 client
-                    .put(record_key, encode_logical_shard_record(&next)?, None)
+                    .put(
+                        record_key,
+                        encode_logical_shard_routing_record(&next)?,
+                        None,
+                    )
                     .await
                     .map_err(etcd_backend)?;
                 Ok(())
@@ -1401,6 +1505,268 @@ mod tests {
             )),
             Err(ControlError::StaleLease(_))
         ));
+
+        store
+            .block_on(async {
+                client
+                    .delete(prefix, Some(DeleteOptions::new().with_prefix()))
+                    .await
+                    .map_err(etcd_backend)?;
+                Ok(())
+            })
+            .unwrap();
+    }
+
+    /// A version-1 client reader for the routing key, mirroring what every
+    /// released NoKV client (<= 0.10.0) does when it resolves a route.
+    #[derive(serde::Deserialize)]
+    #[serde(deny_unknown_fields)]
+    struct FrozenRoutingReader {
+        version: u8,
+        logical_shard_id: String,
+        owner: Option<String>,
+        owner_epoch: Option<u64>,
+        lease_id: u64,
+        state: u8,
+        endpoint: Option<String>,
+        checkpoint: Option<serde_json::Value>,
+        log: Option<serde_json::Value>,
+        durable_lsn: u64,
+    }
+
+    fn frozen_read(bytes: &[u8]) -> FrozenRoutingReader {
+        let reader: FrozenRoutingReader =
+            serde_json::from_slice(bytes).expect("a 0.10.0 client must decode the routing value");
+        assert_eq!(reader.version, 1);
+        reader
+    }
+
+    #[test]
+    #[ignore = "requires NOKV_TEST_ETCD_ENDPOINT"]
+    fn split_record_keeps_routing_readable_by_frozen_clients_and_migrates_legacy_values() {
+        use crate::{CheckpointRef, LogRef, LogSegmentRef, ObjectNamespaceId};
+
+        let endpoint = std::env::var("NOKV_TEST_ETCD_ENDPOINT")
+            .expect("NOKV_TEST_ETCD_ENDPOINT must name an isolated test etcd endpoint");
+        let nonce = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        let prefix = format!("/nokv/test/split-record-{}-{nonce}", std::process::id());
+        let options = EtcdControlStoreOptions::new([endpoint]).with_key_prefix(prefix.clone());
+        let store = EtcdControlStore::connect(options.clone()).unwrap();
+        let logical_shard_id = shard(5);
+        store.create_logical_shard(logical_shard_id).unwrap();
+        store
+            .create_root_placement(RootPlacement {
+                root_id: root(6),
+                logical_shard_id,
+                placement_generation: PlacementGeneration::new(1).unwrap(),
+                lifecycle: RootPlacementLifecycle::Provisioning,
+            })
+            .unwrap();
+        let lease = store
+            .acquire_owner(
+                &logical_shard_id,
+                NodeId::new("node-a").unwrap(),
+                "node-a:7000".to_owned(),
+            )
+            .unwrap();
+        let record_key = options.logical_shard_record_key(&logical_shard_id);
+        let recovery_key = options.logical_shard_recovery_key(&logical_shard_id);
+        let mut client = store.client.clone();
+        let raw = |client: &mut Client, key: Vec<u8>| -> Option<Vec<u8>> {
+            store
+                .block_on(async {
+                    let response = client.get(key, None).await.map_err(etcd_backend)?;
+                    Ok(response.kvs().first().map(|kv| kv.value().to_vec()))
+                })
+                .unwrap()
+        };
+
+        // Publish a shared recovery frontier with receipts: the routing value
+        // must stay a version-1 record a frozen client decodes, while the
+        // frontier lands in the recovery key.
+        let serving = store
+            .mark_serving(
+                &lease,
+                RecoveryPublication {
+                    checkpoint: Some(CheckpointRef {
+                        object_key: "checkpoints/1".to_owned(),
+                        lsn: 128,
+                        image_bytes: 4096,
+                        image_digest: "sha256:image".to_owned(),
+                        digest: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+                            .to_owned(),
+                        receipt: vec![1, 2, 3],
+                    }),
+                    log: Some(LogRef {
+                        segments: vec![LogSegmentRef {
+                            segment_key: "logs/129-144".to_owned(),
+                            first_lsn: 129,
+                            last_lsn: 144,
+                            digest:
+                                "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+                                    .to_owned(),
+                            receipt: vec![4, 5, 6],
+                        }],
+                        durable_lsn: 144,
+                        digest: "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+                            .to_owned(),
+                    }),
+                    durable_lsn: 144,
+                },
+            )
+            .unwrap();
+        assert!(serving.has_recovery_state());
+        let routing = raw(&mut client, record_key.clone()).unwrap();
+        let frozen = frozen_read(&routing);
+        assert_eq!(frozen.owner.as_deref(), Some("node-a"));
+        assert_eq!(frozen.owner_epoch, Some(1));
+        assert_eq!(frozen.endpoint.as_deref(), Some("node-a:7000"));
+        assert_eq!(frozen.state, u8::from(crate::LogicalShardState::Serving));
+        assert!(frozen.checkpoint.is_none() && frozen.log.is_none());
+        assert_eq!(frozen.durable_lsn, 0);
+        assert_eq!(frozen.lease_id, lease.lease_id);
+        assert_eq!(
+            frozen.logical_shard_id,
+            crate::codec::encode_fixed_id(logical_shard_id.as_bytes())
+        );
+        let recovery = raw(&mut client, recovery_key.clone()).expect("recovery key");
+        assert_eq!(
+            decode_logical_shard_recovery_state(&recovery).unwrap(),
+            serving.recovery_state()
+        );
+        assert_eq!(
+            store.get_logical_shard(&logical_shard_id).unwrap(),
+            Some(serving.clone())
+        );
+        assert_eq!(store.list_logical_shards().unwrap(), vec![serving.clone()]);
+
+        // A legacy combined value written by an owner that predates the split
+        // (0.11.0 wrote version 3 at the routing key) is read completely and
+        // wins over a stale recovery key; the next owner mutation re-splits it.
+        let mut legacy = serving.clone();
+        legacy.durable_lsn = 144;
+        // Field order is the version-3 struct order 0.11.0 serialized.
+        let legacy_v3 = format!(
+            concat!(
+                r#"{{"version":3,"logical_shard_id":"{}","owner":"node-a","owner_epoch":1,"#,
+                r#""lease_id":{},"state":{},"endpoint":"node-a:7000","#,
+                r#""checkpoint":{{"object_key":"checkpoints/1","lsn":128,"image_bytes":4096,"#,
+                r#""image_digest":"sha256:image","digest":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","receipt":[1,2,3]}},"#,
+                r#""log":{{"segments":[{{"segment_key":"logs/129-144","first_lsn":129,"last_lsn":144,"#,
+                r#""digest":"bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb","receipt":[4,5,6]}}],"durable_lsn":144,"digest":"bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"}},"#,
+                r#""durable_lsn":144,"pending_recovery_upload":null}}"#
+            ),
+            crate::codec::encode_fixed_id(logical_shard_id.as_bytes()),
+            lease.lease_id,
+            u8::from(crate::LogicalShardState::Serving),
+        )
+        .into_bytes();
+        let stale_recovery = encode_logical_shard_recovery_state(&{
+            let mut stale = serving.clone();
+            stale.log = None;
+            stale.durable_lsn = 128;
+            stale
+        })
+        .unwrap()
+        .unwrap();
+        store
+            .block_on(async {
+                client
+                    .put(record_key.clone(), legacy_v3.clone(), None)
+                    .await
+                    .map_err(etcd_backend)?;
+                client
+                    .put(recovery_key.clone(), stale_recovery, None)
+                    .await
+                    .map_err(etcd_backend)?;
+                Ok(())
+            })
+            .unwrap();
+        assert_eq!(
+            crate::decode_logical_shard_record(&legacy_v3).unwrap(),
+            legacy
+        );
+        assert_eq!(
+            store.get_logical_shard(&logical_shard_id).unwrap(),
+            Some(legacy.clone())
+        );
+
+        let intent = RecoveryUploadIntent {
+            object_namespace_id: ObjectNamespaceId::from_bytes([3; 16]),
+            first_lsn: 145,
+            last_lsn: 146,
+            previous_chain_digest:
+                "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb".to_owned(),
+            last_chain_digest: "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+                .to_owned(),
+            segment_digest: "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd"
+                .to_owned(),
+            manifest_key: "nokv/recovery/log-segments/v1/manifest".to_owned(),
+            receipt: vec![7, 8, 9],
+            plan: vec![1],
+        };
+        let prepared = store.prepare_recovery_upload(&lease, intent).unwrap();
+        assert!(prepared.pending_recovery_upload.is_some());
+        let routing = raw(&mut client, record_key.clone()).unwrap();
+        assert!(frozen_read(&routing).checkpoint.is_none());
+        assert_eq!(
+            decode_logical_shard_record_value(&routing).unwrap().wire,
+            LogicalShardRecordWireKind::Routing
+        );
+        let recovery = raw(&mut client, recovery_key.clone()).unwrap();
+        assert_eq!(
+            decode_logical_shard_recovery_state(&recovery).unwrap(),
+            prepared.recovery_state()
+        );
+        assert_eq!(
+            store.get_logical_shard(&logical_shard_id).unwrap(),
+            Some(prepared.clone())
+        );
+
+        // Finalizing the upload publishes the exact segment and clears the
+        // intent in one owner-fenced mutation; releasing the owner then keeps
+        // the published frontier in the recovery key while the routing value
+        // stays version 1.
+        let intent = prepared.pending_recovery_upload.clone().unwrap();
+        let mut segments = prepared.log.clone().unwrap().segments;
+        segments.push(LogSegmentRef {
+            segment_key: intent.manifest_key.clone(),
+            first_lsn: intent.first_lsn,
+            last_lsn: intent.last_lsn,
+            digest: intent.last_chain_digest.clone(),
+            receipt: intent.receipt.clone(),
+        });
+        let finalized = store
+            .finalize_recovery_upload(
+                &lease,
+                &intent,
+                RecoveryPublication {
+                    checkpoint: None,
+                    log: Some(LogRef {
+                        segments,
+                        durable_lsn: intent.last_lsn,
+                        digest: intent.last_chain_digest.clone(),
+                    }),
+                    durable_lsn: intent.last_lsn,
+                },
+            )
+            .unwrap();
+        assert!(finalized.pending_recovery_upload.is_none());
+        assert_eq!(finalized.durable_lsn, 146);
+        let released = store.release_owner(&lease).unwrap();
+        assert!(released.owner.is_none());
+        let routing = raw(&mut client, record_key.clone()).unwrap();
+        let frozen = frozen_read(&routing);
+        assert!(frozen.owner.is_none());
+        assert_eq!(frozen.owner_epoch, Some(1));
+        assert!(raw(&mut client, recovery_key.clone()).is_some());
+        assert_eq!(
+            store.get_logical_shard(&logical_shard_id).unwrap(),
+            Some(released)
+        );
 
         store
             .block_on(async {

--- a/crates/nokv-control/src/lib.rs
+++ b/crates/nokv-control/src/lib.rs
@@ -14,9 +14,13 @@ mod store;
 mod types;
 
 pub use codec::{
-    decode_logical_shard_record, decode_root_agent_binding, decode_root_object_namespace_binding,
-    decode_root_placement, encode_logical_shard_record, encode_root_agent_binding,
-    encode_root_object_namespace_binding, encode_root_placement,
+    decode_logical_shard_record, decode_logical_shard_record_value,
+    decode_logical_shard_recovery_state, decode_root_agent_binding,
+    decode_root_object_namespace_binding, decode_root_placement,
+    encode_logical_shard_recovery_state, encode_logical_shard_routing_record,
+    encode_root_agent_binding, encode_root_object_namespace_binding, encode_root_placement,
+    DecodedLogicalShardRecord, LogicalShardRecordWireKind, LOGICAL_SHARD_RECOVERY_CODEC_VERSION,
+    LOGICAL_SHARD_ROUTING_CODEC_VERSION,
 };
 pub use errors::ControlError;
 #[cfg(feature = "etcd")]
@@ -28,7 +32,8 @@ pub use store::{
 };
 pub use types::{
     AgentId, CheckpointRef, LogRef, LogSegmentRef, LogicalShardId, LogicalShardLease,
-    LogicalShardRecord, LogicalShardState, NodeId, NodeIdError, ObjectNamespaceId, OwnerEpoch,
-    PlacementGeneration, RecoveryPublication, RecoveryUploadIntent, RootAgentBinding, RootId,
-    RootObjectNamespaceBinding, RootPlacement, RootPlacementLifecycle, UnknownLogicalShardState,
+    LogicalShardRecord, LogicalShardRecoveryState, LogicalShardState, NodeId, NodeIdError,
+    ObjectNamespaceId, OwnerEpoch, PlacementGeneration, RecoveryPublication, RecoveryUploadIntent,
+    RootAgentBinding, RootId, RootObjectNamespaceBinding, RootPlacement, RootPlacementLifecycle,
+    UnknownLogicalShardState,
 };

--- a/crates/nokv-control/src/options.rs
+++ b/crates/nokv-control/src/options.rs
@@ -130,6 +130,26 @@ impl EtcdControlStoreOptions {
         format!("{}/logical-shards/", self.normalized_key_prefix()).into_bytes()
     }
 
+    /// Owner-only recovery state stored next to the client-facing routing record.
+    ///
+    /// The prefix is deliberately disjoint from `logical-shards/` so a routing
+    /// listing never sees recovery values and readers that predate the split
+    /// never touch this key.
+    #[cfg(any(feature = "etcd", test))]
+    pub(crate) fn logical_shard_recovery_key(&self, logical_shard_id: &LogicalShardId) -> Vec<u8> {
+        format!(
+            "{}/logical-shard-recovery/{}",
+            self.normalized_key_prefix(),
+            encode_fixed_id(logical_shard_id.as_bytes())
+        )
+        .into_bytes()
+    }
+
+    #[cfg(feature = "etcd")]
+    pub(crate) fn logical_shard_recovery_prefix(&self) -> Vec<u8> {
+        format!("{}/logical-shard-recovery/", self.normalized_key_prefix()).into_bytes()
+    }
+
     /// Stable session key shared by every owner generation of one logical shard.
     #[cfg(any(feature = "etcd", test))]
     pub(crate) fn logical_shard_session_key(&self, logical_shard_id: &LogicalShardId) -> Vec<u8> {
@@ -198,6 +218,10 @@ mod tests {
         assert_eq!(
             String::from_utf8(options.logical_shard_record_key(&shard_id(0x02))).unwrap(),
             "/nokv/test/logical-shards/02020202020202020202020202020202"
+        );
+        assert_eq!(
+            String::from_utf8(options.logical_shard_recovery_key(&shard_id(0x02))).unwrap(),
+            "/nokv/test/logical-shard-recovery/02020202020202020202020202020202"
         );
         assert_eq!(
             String::from_utf8(options.logical_shard_session_key(&shard_id(0x02))).unwrap(),

--- a/crates/nokv-control/src/store.rs
+++ b/crates/nokv-control/src/store.rs
@@ -1574,7 +1574,8 @@ mod tests {
     use std::sync::{Arc, Barrier};
 
     use super::*;
-    use crate::{encode_logical_shard_record, AgentId, LogSegmentRef, PlacementGeneration};
+    use crate::codec::validate_logical_shard_record_encoded_size;
+    use crate::{AgentId, LogSegmentRef, PlacementGeneration};
 
     fn root_id(value: u8) -> RootId {
         RootId::from_bytes([value; 16])
@@ -2501,7 +2502,7 @@ mod tests {
                 digest: format!("{lsn:064x}"),
             });
             record.durable_lsn = lsn;
-            if encode_logical_shard_record(&record).is_err() {
+            if validate_logical_shard_record_encoded_size(&record).is_err() {
                 segments.pop();
                 let tail = segments.last().expect("one segment fits the record budget");
                 record.log = Some(LogRef {
@@ -2514,7 +2515,7 @@ mod tests {
             }
             assert!(segments.len() < MAX_RECOVERY_LOG_SEGMENTS);
         }
-        assert!(encode_logical_shard_record(&record).is_ok());
+        assert!(validate_logical_shard_record_encoded_size(&record).is_ok());
 
         let next_lsn = record.durable_lsn + 1;
         let intent = RecoveryUploadIntent {
@@ -2534,7 +2535,9 @@ mod tests {
 
         let error = prepare_recovery_upload_intent(&record, &lease, intent)
             .expect_err("prepare must reject a final record outside the persistence budget");
-        assert!(error.to_string().contains("encoded logical shard record"));
+        assert!(error
+            .to_string()
+            .contains("encoded logical shard recovery state"));
     }
 
     #[test]

--- a/crates/nokv-control/src/types.rs
+++ b/crates/nokv-control/src/types.rs
@@ -1,3 +1,4 @@
+use crate::ControlError;
 use std::fmt;
 
 pub use nokv_types::{
@@ -149,6 +150,23 @@ pub struct LogicalShardRecord {
     pub pending_recovery_upload: Option<RecoveryUploadIntent>,
 }
 
+/// Owner-side recovery frontier of one logical shard.
+///
+/// This is the part of [`LogicalShardRecord`] that only the shard owner reads
+/// and writes: the published checkpoint and log references with their object
+/// receipts, the durable LSN they prove, and the exact upload intent installed
+/// before an immutable recovery create. Backends persist it separately from the
+/// client-facing routing fields so that clients keep decoding the routing
+/// record with the frozen version-1 wire schema while owner state evolves.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct LogicalShardRecoveryState {
+    pub logical_shard_id: LogicalShardId,
+    pub checkpoint: Option<CheckpointRef>,
+    pub log: Option<LogRef>,
+    pub durable_lsn: u64,
+    pub pending_recovery_upload: Option<RecoveryUploadIntent>,
+}
+
 /// Exact owner fence presented to every owner-only mutation.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct LogicalShardLease {
@@ -257,6 +275,62 @@ impl LogicalShardRecord {
             durable_lsn: 0,
             pending_recovery_upload: None,
         }
+    }
+
+    /// True when the owner has published or staged any recovery state.
+    pub fn has_recovery_state(&self) -> bool {
+        self.checkpoint.is_some()
+            || self.log.is_some()
+            || self.durable_lsn != 0
+            || self.pending_recovery_upload.is_some()
+    }
+
+    /// The owner-side recovery frontier carried by this record.
+    pub fn recovery_state(&self) -> LogicalShardRecoveryState {
+        LogicalShardRecoveryState {
+            logical_shard_id: self.logical_shard_id,
+            checkpoint: self.checkpoint.clone(),
+            log: self.log.clone(),
+            durable_lsn: self.durable_lsn,
+            pending_recovery_upload: self.pending_recovery_upload.clone(),
+        }
+    }
+
+    /// The client-facing routing fields with every recovery field cleared.
+    ///
+    /// This is exactly what a version-1 routing reader observes; a shard whose
+    /// recovery frontier lives in its separate recovery state therefore looks
+    /// like a shard without a published shared frontier to such a reader.
+    pub fn routing_projection(&self) -> Self {
+        Self {
+            logical_shard_id: self.logical_shard_id,
+            owner: self.owner.clone(),
+            owner_epoch: self.owner_epoch,
+            lease_id: self.lease_id,
+            state: self.state,
+            endpoint: self.endpoint.clone(),
+            checkpoint: None,
+            log: None,
+            durable_lsn: 0,
+            pending_recovery_upload: None,
+        }
+    }
+
+    /// Reattach the separately persisted recovery frontier to routing fields.
+    pub fn with_recovery_state(
+        mut self,
+        recovery: LogicalShardRecoveryState,
+    ) -> Result<Self, ControlError> {
+        if recovery.logical_shard_id != self.logical_shard_id {
+            return Err(ControlError::Codec(
+                "logical shard recovery state names a different logical shard".to_owned(),
+            ));
+        }
+        self.checkpoint = recovery.checkpoint;
+        self.log = recovery.log;
+        self.durable_lsn = recovery.durable_lsn;
+        self.pending_recovery_upload = recovery.pending_recovery_upload;
+        Ok(self)
     }
 }
 

--- a/docs/development/metadata-store-interface.md
+++ b/docs/development/metadata-store-interface.md
@@ -508,6 +508,42 @@ durable `Recovering` epoch one if it did. Bootstrap never infers directory
 ownership from a path precheck or recursively deletes a prepared store; both
 would be unsafe under a concurrent path change.
 
+### Control Record Layout And Client Compatibility
+
+The control plane stores one logical shard under two etcd keys with two
+independent codec versions:
+
+- `logical-shards/<id>` holds the **routing record**: owner, owner epoch,
+  lease id, state, and endpoint. Its wire schema is frozen at version 1, the
+  same value every released NoKV client (0.10.0 and earlier) decodes with a
+  strict, exact-version reader. This key is the client compatibility contract:
+  a client that understands version 1 must keep decoding it, so no field is
+  ever added to it. Its recovery fields are always `null` and its
+  `durable_lsn` is always `0`; a client cannot consume recovery receipts and
+  therefore sees "no shared frontier", which is the only frontier a version-1
+  reader can validate.
+- `logical-shard-recovery/<id>` holds the **recovery state** only owners read:
+  the published checkpoint and log references with their object receipts, the
+  durable LSN they prove, and the pending recovery upload intent. It has its
+  own codec version and may evolve without touching the routing schema. The
+  key is absent whenever the record carries no recovery state; absence and
+  emptiness are the same durable fact.
+
+Every owner-fenced mutation writes both keys in one etcd transaction guarded
+by the routing key's modification revision, and every read fetches both keys
+in one transaction, so the pair is never observed torn. A legacy combined
+value (versions 2 and 3, written at the routing key by owners built between
+the recovery-outbox work and this split) is still decoded completely; it wins
+over any recovery key beside it and the next owner mutation re-splits it.
+Readers report a record version they do not implement as
+`ControlError::UnsupportedRecordVersion` before parsing any field, so an
+outdated client says "upgrade me" instead of failing on an unknown field.
+
+The frozen 0.10.0 reader is vendored into the `nokv-control` codec tests and
+must decode every routing value this crate writes; that test is the executable
+form of the contract above. Bumping the routing version is a deliberate,
+client-breaking release decision, never a side effect of adding owner state.
+
 The control record and the lease-backed session key have separate lifetimes.
 `Recovering` is a durable attempt token. A bootstrap rollback removes only its
 session (`suspend_recovery`) and retains the record; an ungraceful process loss


### PR DESCRIPTION
## Problem

`8025ebd103` (recovery outbox, #465, released as the 0.11.0 line) turned the single value at `logical-shards/<id>` into a combined version-3 record. Every released NoKV client (0.10.0 and earlier) decodes that key with a strict, exact-version reader, so each of them now fails at routing with an opaque codec error before the explicit RPC handshake rejection from `f86fff8703` can even run:

```
invalid root route: control-plane lookup failed: control store codec error:
unknown field `pending_recovery_upload`, expected one of `version`, `logical_shard_id`, ...
```

The 0.11.0 reader also re-encoded every fetched value with its own writer format and required byte equality, so it rejected control planes provisioned by 0.10.0 as `logical shard value is not canonical`. Both upgrade directions were broken; only builds from main between the two changes were unaffected. Reproduced live with the homebrew 0.10.0 CLI, a Python SDK built at `90883d1`, and a 0.10.0-provisioned prefix.

## Fix: a durable boundary, not a patch

- `logical-shards/<id>` is the **client-facing routing record** and stays at the frozen version-1 wire schema (owner, owner epoch, lease id, state, endpoint; recovery fields `null`, `durable_lsn` `0`, which is the only frontier a version-1 reader validates). Nothing is added to it again; bumping it is a deliberate, client-breaking release decision.
- `logical-shard-recovery/<id>` carries the **owner-only recovery state** (checkpoint/log references with receipts, durable LSN, pending upload intent) under its own codec version; absent when empty, so absence and emptiness are the same durable fact.
- Every owner-fenced mutation writes both keys in one etcd transaction guarded by the routing key's `mod_revision`; every read fetches both keys in one transaction. The pair is never observed torn.
- Legacy combined values (v2/v3) are still decoded completely, win over a stale recovery key beside them, and are re-split by the next owner mutation. The redundant re-encode-with-current-format check at fetch is replaced by the codec's per-version canonical checks.
- A record version a reader does not implement is `ControlError::UnsupportedRecordVersion` ("this client or owner must be upgraded"), raised before any field is parsed.
- `ControlStore` trait, `LogicalShardRecord`, and the server are unchanged; the split lives in codec + etcd store. New `LogicalShardRecoveryState` type and `has_recovery_state / recovery_state / routing_projection / with_recovery_state` helpers.
- `docs/development/metadata-store-interface.md` documents the layout and the contract.

## Verification

- `cargo test --workspace` green; `cargo test -p nokv-control --features etcd -- --include-ignored` against a local etcd: 45/45, including the new `split_record_keeps_routing_readable_by_frozen_clients_and_migrates_legacy_values` (mark_serving with a receipted frontier, raw routing value decoded by a frozen 0.10.0 reader struct, recovery key present, `get`/`list` merge, a raw v3 legacy value + stale recovery key read completely then re-split by `prepare_recovery_upload`, `finalize_recovery_upload`, `release_owner`).
- Codec contract tests: the vendored 0.10.0 reader (`deny_unknown_fields`, version 1, durable-LSN rule) decodes every routing shape (unassigned, serving with/without frontier, recovering with pending upload, released); exact 0.10.0-written bytes decode and re-encode byte-identical; exact 0.11.0-written v3 values decode, are provably unreadable by the frozen reader, and round-trip through the split; recovery codec is strict (empty, foreign id, trailing bytes); unknown versions are typed for placement, agent binding, routing, and recovery.
- `cargo fmt --check`, `cargo clippy --workspace --all-targets -D warnings` (also `-p nokv-control --features etcd`), `make workbench-test` scripts, `git diff --check`: clean.
- Live (etcd + moto S3 + `nokv serve` from this branch): homebrew `nokv` 0.10.0 as a client and the `90883d1` Python SDK both route and receive the typed `this NoKV client uses an unsupported workspace RPC schema; upgrade the NoKV client`; the rebuilt SDK passes the 16-case live suite (surface, CAS adapter, RFC §10 checks 1-9, read under sustained CAS writes) and reads a prefix provisioned by 0.10.0 (`logical_shard_preexisting: true` via the documented `--adopt-legacy-*` flags); the pre-fix main SDK fails on that same prefix with `not canonical`, the baseline SDK constructs fine.

## Compatibility statement

- Released clients (≤ 0.10.0): routing works again; the RPC schema policy (exact `nokv.workspace.rpc.v9`, typed rejection) is unchanged and now actually reached.
- Control planes written by 0.10.0 or by 0.11.0-line owners: read without rewrite; re-split on the next owner mutation.
- Builds from main between `8025ebd103` and this change were never released; they reject a version-1 routing value as "not canonical" and must be rebuilt. Mixed ownership of one shard between such a build and this change with `--recovery-publication shared` is not supported (the older owner would not see the recovery key); local-only owners are unaffected.
- A 0.10.0 owner adopting a shard whose recovery frontier was published with receipts remains fail-closed (`checkpoint lacks a recovery receipt`), as before.
