### PR TITLE
feat(python): publish installable SDK wheels from the release pipeline

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -11,3 +11,4 @@
 /scripts/ci/ @wchwawa @feichai0017
 /scripts/workbench/ @wchwawa @feichai0017
 /scripts/release/test_homebrew_source_release.py @wchwawa @feichai0017
+/scripts/release/test_python_sdk_release.py @wchwawa @feichai0017

--- a/.github/workflows/python-sdk.yml
+++ b/.github/workflows/python-sdk.yml
@@ -1,0 +1,76 @@
+# Copyright 2024-2026 The NoKV Authors.
+# SPDX-License-Identifier: Apache-2.0
+
+name: Python SDK
+
+# The release workflow builds the same wheel per platform from a validated tag.
+# This job proves on every change that the manylinux wheel still builds from
+# the tree, installs into a clean interpreter, and passes the SDK tests
+# against the installed distribution rather than the source checkout.
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+permissions:
+  contents: read
+
+jobs:
+  wheel:
+    name: manylinux wheel builds and installs
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+        with:
+          persist-credentials: false
+
+      - name: Set up Python
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97
+        with:
+          python-version: "3.12"
+
+      - name: Check the release identities the wheel will carry
+        shell: bash
+        run: |
+          set -euo pipefail
+          python3 scripts/release/test_python_sdk_release.py
+          python3 scripts/release/python_sdk_release.py sdk-version --repository .
+
+      - name: Build manylinux_2_28 wheel
+        uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b
+        with:
+          command: build
+          working-directory: crates/nokv-python
+          args: --release --out ../../dist
+          manylinux: 2_28
+          before-script-linux: |
+            set -euo pipefail
+            dnf install -y protobuf-compiler
+            protoc --version
+
+      - name: Install the built wheel into a clean environment and test it
+        shell: bash
+        run: |
+          set -euo pipefail
+          ls -l dist
+          version="$(python3 scripts/release/python_sdk_release.py sdk-version --repository .)"
+          venv="$RUNNER_TEMP/nokv-sdk-venv"
+          python3 -m venv "$venv"
+          "$venv/bin/python" -m pip install --quiet --upgrade pip
+          "$venv/bin/python" -m pip install --quiet pytest fsspec
+          "$venv/bin/python" -m pip install --quiet --no-index --find-links dist "nokv==$version"
+          python3 scripts/release/python_sdk_release.py verify-install \
+            --python "$venv/bin/python" --version "$version"
+          cd "$RUNNER_TEMP"
+          "$venv/bin/python" -m pytest -q "$GITHUB_WORKSPACE/crates/nokv-python/tests"
+
+      - name: Upload wheel for inspection
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+        with:
+          name: nokv-python-sdk-${{ github.sha }}-linux-x86_64
+          path: dist/*.whl
+          if-no-files-found: error
+          retention-days: 7

--- a/.github/workflows/release-python-sdk.yml
+++ b/.github/workflows/release-python-sdk.yml
@@ -1,0 +1,256 @@
+# Copyright 2024-2026 The NoKV Authors.
+# SPDX-License-Identifier: Apache-2.0
+
+name: Release Python SDK
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Canonical stable tag, for example v0.11.0"
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    name: Validate immutable release identity
+    runs-on: ubuntu-latest
+    outputs:
+      commit: ${{ steps.resolve.outputs.commit }}
+      tag: ${{ steps.resolve.outputs.tag }}
+      version: ${{ steps.resolve.outputs.version }}
+    env:
+      RELEASE_TAG: ${{ inputs.tag }}
+    steps:
+      - name: Checkout trusted release tooling
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+        with:
+          fetch-depth: 1
+          persist-credentials: false
+          sparse-checkout: scripts/release
+
+      - name: Validate tag before resolving a ref
+        id: resolve
+        shell: bash
+        run: |
+          set -euo pipefail
+          version="$(python3 scripts/release/python_sdk_release.py validate-tag "$RELEASE_TAG")"
+          git fetch --no-tags https://github.com/NoKV-Lab/NoKV.git \
+            "refs/tags/$RELEASE_TAG:refs/tags/$RELEASE_TAG"
+          commit="$(git rev-parse "refs/tags/$RELEASE_TAG^{commit}")"
+          if [[ ! "$commit" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "::error title=Invalid release commit::Resolved commit is not canonical."
+            exit 1
+          fi
+          {
+            echo "tag=$RELEASE_TAG"
+            echo "version=$version"
+            echo "commit=$commit"
+          } >>"$GITHUB_OUTPUT"
+
+  wheels:
+    name: Build and smoke wheel (${{ matrix.name }})
+    needs: validate
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: linux-x86_64
+            runner: ubuntu-latest
+            manylinux: "2_28"
+          - name: linux-aarch64
+            runner: ubuntu-24.04-arm
+            manylinux: "2_28"
+          - name: macos-arm64
+            runner: macos-15
+            manylinux: ""
+          - name: macos-x86_64
+            runner: macos-15-intel
+            manylinux: ""
+    runs-on: ${{ matrix.runner }}
+    env:
+      EXPECTED_COMMIT: ${{ needs.validate.outputs.commit }}
+      RELEASE_TAG: ${{ needs.validate.outputs.tag }}
+      RELEASE_VERSION: ${{ needs.validate.outputs.version }}
+    steps:
+      - name: Checkout validated commit
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+        with:
+          fetch-depth: 1
+          persist-credentials: false
+          ref: ${{ needs.validate.outputs.commit }}
+
+      - name: Set up Python
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97
+        with:
+          python-version: "3.12"
+
+      - name: Validate the SDK version against the tag
+        shell: bash
+        run: |
+          set -euo pipefail
+          declared="$(python3 scripts/release/python_sdk_release.py validate-version \
+            --repository . --tag "$RELEASE_TAG")"
+          if [[ "$declared" != "$RELEASE_VERSION" ]]; then
+            echo "::error title=Version drift::SDK declares $declared, tag is $RELEASE_VERSION."
+            exit 1
+          fi
+          python3 scripts/release/test_python_sdk_release.py
+
+      - name: Install protobuf compiler (macOS)
+        if: runner.os == 'macOS'
+        shell: bash
+        run: |
+          set -euo pipefail
+          brew install protobuf
+          protoc --version
+
+      # Linux wheels are built inside the official manylinux_2_28 image so the
+      # native module only links glibc >= 2.28 symbols. The etcd client crate
+      # compiles its protobuf definitions at build time, so the image needs a
+      # protoc; the AlmaLinux 8 package is enough for these proto3 files.
+      - name: Build manylinux wheel
+        if: runner.os == 'Linux'
+        uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b
+        with:
+          command: build
+          working-directory: crates/nokv-python
+          args: --release --out ../../dist
+          manylinux: ${{ matrix.manylinux }}
+          before-script-linux: |
+            set -euo pipefail
+            dnf install -y protobuf-compiler
+            protoc --version
+
+      - name: Build macOS wheel
+        if: runner.os == 'macOS'
+        uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b
+        with:
+          command: build
+          working-directory: crates/nokv-python
+          args: --release --out ../../dist
+
+      - name: Install the built wheel into a clean environment and test it
+        shell: bash
+        run: |
+          set -euo pipefail
+          ls -l dist
+          venv="$RUNNER_TEMP/nokv-sdk-venv"
+          python3 -m venv "$venv"
+          "$venv/bin/python" -m pip install --quiet --upgrade pip
+          "$venv/bin/python" -m pip install --quiet pytest fsspec
+          "$venv/bin/python" -m pip install --quiet --no-index --find-links dist "nokv==$RELEASE_VERSION"
+          python3 scripts/release/python_sdk_release.py verify-install \
+            --python "$venv/bin/python" --version "$RELEASE_VERSION"
+          cd "$RUNNER_TEMP"
+          "$venv/bin/python" -m pytest -q "$GITHUB_WORKSPACE/crates/nokv-python/tests"
+
+      - name: Upload wheel
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+        with:
+          name: nokv-python-sdk-${{ needs.validate.outputs.commit }}-${{ matrix.name }}
+          path: dist/*.whl
+          if-no-files-found: error
+          retention-days: 7
+
+  publish:
+    name: Publish wheels after every platform gate
+    needs:
+      - validate
+      - wheels
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    env:
+      EXPECTED_COMMIT: ${{ needs.validate.outputs.commit }}
+      GH_TOKEN: ${{ github.token }}
+      RELEASE_TAG: ${{ needs.validate.outputs.tag }}
+      RELEASE_VERSION: ${{ needs.validate.outputs.version }}
+    steps:
+      - name: Checkout validated commit
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+        with:
+          fetch-depth: 1
+          persist-credentials: false
+          ref: ${{ needs.validate.outputs.commit }}
+
+      - name: Download every tested wheel
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
+        with:
+          pattern: nokv-python-sdk-${{ needs.validate.outputs.commit }}-*
+          merge-multiple: true
+          path: ${{ runner.temp }}/dist
+
+      - name: Write manifest and checksums for the exact wheel set
+        shell: bash
+        env:
+          DIST_DIR: ${{ runner.temp }}/dist
+          RELEASE_DIR: ${{ runner.temp }}/release
+        run: |
+          set -euo pipefail
+          python3 scripts/release/python_sdk_release.py write-assets \
+            --dist "$DIST_DIR" \
+            --version "$RELEASE_VERSION" \
+            --tag "$RELEASE_TAG" \
+            --commit "$EXPECTED_COMMIT" \
+            --output "$RELEASE_DIR"
+          python3 scripts/release/python_sdk_release.py verify-wheels \
+            --manifest "$RELEASE_DIR/nokv-$RELEASE_VERSION-python-sdk.json" \
+            --dist "$DIST_DIR"
+          cp "$DIST_DIR"/*.whl "$RELEASE_DIR/"
+          ls -l "$RELEASE_DIR"
+
+      - name: Revalidate tag binding before publication
+        shell: bash
+        run: |
+          set -euo pipefail
+          git fetch --no-tags --force https://github.com/NoKV-Lab/NoKV.git \
+            "refs/tags/$RELEASE_TAG:refs/nokv-release/$RELEASE_TAG"
+          actual="$(git rev-parse "refs/nokv-release/$RELEASE_TAG^{commit}")"
+          if [[ "$actual" != "$EXPECTED_COMMIT" ]]; then
+            echo "::error title=Release tag moved::Expected $EXPECTED_COMMIT, found $actual."
+            exit 1
+          fi
+
+      # Assets are immutable once published: an existing asset with the same
+      # name must be byte-identical to the freshly built one, otherwise the
+      # release stops here and a human decides.
+      - name: Publish immutable wheel assets
+        shell: bash
+        env:
+          RELEASE_DIR: ${{ runner.temp }}/release
+        run: |
+          set -euo pipefail
+          cd "$RELEASE_DIR"
+          assets=( nokv-"$RELEASE_VERSION"-cp39-abi3-*.whl \
+                   nokv-"$RELEASE_VERSION"-python-sdk.json \
+                   nokv-"$RELEASE_VERSION"-python-sdk-SHA256SUMS )
+          if gh release view "$RELEASE_TAG" >/dev/null 2>&1; then
+            existing="$RUNNER_TEMP/existing-python-sdk-release"
+            mkdir -p "$existing"
+            published="$(gh release view "$RELEASE_TAG" --json assets --jq '.assets[].name')"
+            to_upload=()
+            for asset in "${assets[@]}"; do
+              if grep -qxF "$asset" <<<"$published"; then
+                gh release download "$RELEASE_TAG" --dir "$existing" --pattern "$asset"
+                if ! cmp "$asset" "$existing/$asset"; then
+                  echo "::error title=Immutable asset conflict::release asset already exists with different bytes: $asset"
+                  exit 1
+                fi
+              else
+                to_upload+=("$asset")
+              fi
+            done
+            if (( ${#to_upload[@]} > 0 )); then
+              gh release upload "$RELEASE_TAG" "${to_upload[@]}"
+            fi
+          else
+            gh release create "$RELEASE_TAG" "${assets[@]}" \
+              --verify-tag \
+              --latest \
+              --title "NoKV $RELEASE_VERSION" \
+              --notes "Python SDK wheels for commit $EXPECTED_COMMIT."
+          fi

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -312,6 +312,9 @@ jobs:
       - name: Check Homebrew release safety
         run: python3 scripts/release/test_homebrew_source_release.py
 
+      - name: Check Python SDK release safety
+        run: python3 scripts/release/test_python_sdk_release.py
+
       - name: Check pull request governance policy
         run: python3 scripts/ci/pr_change_governance_test.py
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1388,7 +1388,7 @@ dependencies = [
 
 [[package]]
 name = "nokv-python"
-version = "0.1.0"
+version = "0.11.0"
 dependencies = [
  "nokv-client",
  "nokv-object",

--- a/Makefile
+++ b/Makefile
@@ -42,6 +42,8 @@ workbench-test:
 
 governance-test:
 	python3 scripts/ci/pr_change_governance_test.py
+	python3 scripts/release/test_homebrew_source_release.py
+	python3 scripts/release/test_python_sdk_release.py
 
 verify:
 	cargo fmt --manifest-path $(NOKV_MANIFEST) --all -- --check
@@ -57,6 +59,8 @@ verify:
 	python3 scripts/workbench/workbench_contract_test.py
 	python3 scripts/workbench/live_workbench_test.py
 	python3 scripts/ci/pr_change_governance_test.py
+	python3 scripts/release/test_homebrew_source_release.py
+	python3 scripts/release/test_python_sdk_release.py
 	git diff --check
 
 clean:

--- a/crates/nokv-python/Cargo.toml
+++ b/crates/nokv-python/Cargo.toml
@@ -1,6 +1,8 @@
 [package]
 name = "nokv-python"
-version = "0.1.0"
+# Wheel version. Keep equal to the crates/nokv package version; the release
+# gate (scripts/release/python_sdk_release.py) refuses a tag otherwise.
+version = "0.11.0"
 publish = false
 description = "Python SDK for NoKV Agent workspaces and immutable artifacts."
 edition.workspace = true

--- a/crates/nokv-python/README.md
+++ b/crates/nokv-python/README.md
@@ -2,7 +2,48 @@
 
 This package exposes API version `1` for path-native Workbenches and immutable
 artifacts. The version is available as `nokv.API_VERSION`; the stable package
-exports are listed by `nokv.__all__`.
+exports are listed by `nokv.__all__`. `nokv.__version__` is the NoKV release
+line the installed wheel was built from (for example `0.11.0`); it is not the
+API version and it changes with every release.
+
+## Install
+
+Every stable NoKV release publishes one abi3 wheel per supported platform as
+GitHub release assets, next to a manifest and a checksum file:
+
+| Asset | Platform |
+| --- | --- |
+| `nokv-<version>-cp39-abi3-manylinux_2_28_x86_64.whl` | Linux x86_64, glibc >= 2.28 |
+| `nokv-<version>-cp39-abi3-manylinux_2_28_aarch64.whl` | Linux aarch64, glibc >= 2.28 |
+| `nokv-<version>-cp39-abi3-macosx_*_arm64.whl` | macOS Apple Silicon |
+| `nokv-<version>-cp39-abi3-macosx_*_x86_64.whl` | macOS Intel |
+| `nokv-<version>-python-sdk.json` | manifest: tag, commit, per-wheel SHA-256 |
+| `nokv-<version>-python-sdk-SHA256SUMS` | `sha256sum -c` input for the wheels |
+
+The wheels target CPython 3.9 and newer through the stable ABI. Install the
+release you pinned by pointing `pip` at that release's assets, and verify the
+download against the published checksum:
+
+```shell
+version=0.11.0
+pip install "nokv==$version" \
+  --find-links "https://github.com/NoKV-Lab/NoKV/releases/expanded_assets/v$version"
+python -c 'import nokv; print(nokv.__version__, nokv.API_VERSION)'
+```
+
+To pin one exact file instead, download the wheel and its checksum file from
+`https://github.com/NoKV-Lab/NoKV/releases/download/v<version>/`, run
+`sha256sum -c nokv-<version>-python-sdk-SHA256SUMS --ignore-missing`, then
+`pip install ./nokv-<version>-cp39-abi3-<platform>.whl`.
+
+The wheel version, the `crates/nokv` package version, and the release tag are
+one identity; the release workflow refuses to publish otherwise. A wheel built
+from an unreleased commit reports that commit's declared version, so pin by
+release tag, not by version string alone, when qualifying a deployment.
+
+Building from source (`maturin build --release` in `crates/nokv-python`)
+requires a Rust toolchain and a `protoc` binary; that path is for development,
+not for installing the SDK.
 
 ## Version 1 surface
 

--- a/crates/nokv-python/pyproject.toml
+++ b/crates/nokv-python/pyproject.toml
@@ -4,8 +4,13 @@ build-backend = "maturin"
 
 [project]
 name = "nokv"
-version = "0.1.0"
+# The wheel version is the NoKV release line: it is read from
+# crates/nokv-python/Cargo.toml, which the release process keeps equal to the
+# crates/nokv package version and the canonical vMAJOR.MINOR.PATCH tag.
+dynamic = ["version"]
 description = "NoKV Python SDK for Agent workspaces and immutable artifacts."
+readme = "README.md"
+license = "Apache-2.0"
 requires-python = ">=3.9"
 dependencies = ["fsspec>=2024.0.0"]
 classifiers = [
@@ -21,3 +26,10 @@ torch = ["torch>=2.2"]
 module-name = "nokv._native"
 python-source = "python"
 features = ["extension-module"]
+# A checkout used with `maturin develop` leaves bytecode caches and a native
+# module next to the sources; the wheel must only ever carry the freshly built
+# native module and the tracked Python sources.
+exclude = [
+    { path = "python/**/__pycache__/**", format = ["sdist", "wheel"] },
+    { path = "python/nokv/_native.abi3.so", format = ["sdist", "wheel"] },
+]

--- a/crates/nokv-python/python/nokv/__init__.py
+++ b/crates/nokv-python/python/nokv/__init__.py
@@ -1,10 +1,20 @@
 """Versioned Python SDK for NoKV Workbenches and immutable artifacts."""
 
+from importlib.metadata import PackageNotFoundError, version as _distribution_version
+
 from . import checkpoint
 from ._native import Client, RoutingConfig, ObjectStoreConfig
 from .fsspec import WorkbenchFileSystem
 
 API_VERSION = 1
+
+try:
+    # The installed distribution version is the NoKV release line the wheel
+    # was built from (for example "0.11.0"); it is distinct from API_VERSION,
+    # which only changes when the Python surface changes incompatibly.
+    __version__ = _distribution_version("nokv")
+except PackageNotFoundError:  # pragma: no cover - source tree without metadata
+    __version__ = "0+unknown"
 
 __all__ = [
     "API_VERSION",

--- a/scripts/ci/pr_change_governance.py
+++ b/scripts/ci/pr_change_governance.py
@@ -23,6 +23,7 @@ GOVERNANCE_SENSITIVE_EXACT_PATHS = frozenset(
     {
         ".github/CODEOWNERS",
         "scripts/release/test_homebrew_source_release.py",
+        "scripts/release/test_python_sdk_release.py",
     }
 )
 GOVERNANCE_SENSITIVE_PREFIXES = (

--- a/scripts/ci/pr_change_governance_test.py
+++ b/scripts/ci/pr_change_governance_test.py
@@ -111,6 +111,7 @@ class ChangeGovernancePolicyTest(unittest.TestCase):
                 "/scripts/ci/ @wchwawa @feichai0017",
                 "/scripts/workbench/ @wchwawa @feichai0017",
                 "/scripts/release/test_homebrew_source_release.py @wchwawa @feichai0017",
+                "/scripts/release/test_python_sdk_release.py @wchwawa @feichai0017",
             },
         )
 
@@ -170,6 +171,7 @@ class ChangeGovernancePolicyTest(unittest.TestCase):
             "scripts/ci/pr_change_governance.py",
             "scripts/workbench/pre423_contract_ledger.json",
             "scripts/release/test_homebrew_source_release.py",
+            "scripts/release/test_python_sdk_release.py",
         )
         for path in sensitive:
             with self.subTest(path=path):

--- a/scripts/release/README.md
+++ b/scripts/release/README.md
@@ -74,11 +74,36 @@ The generated archive comes from `git archive` at the validated commit and is
 gzip-compressed with a fixed timestamp. GitHub-generated tag archives and
 `latest` URLs are rejected.
 
+## Python SDK wheels
+
+`.github/workflows/release-python-sdk.yml` publishes the Python SDK for the
+same canonical stable tag. It validates the tag exactly like the Homebrew
+workflow, then builds one abi3 wheel per supported platform on the platform
+itself (Linux x86_64 and aarch64 inside the official `manylinux_2_28` images,
+macOS Apple Silicon and Intel natively), installs every wheel into a clean
+interpreter, runs the SDK tests against the installed distribution, and only
+after all four platform gates pass uploads the wheels together with
+`nokv-<version>-python-sdk.json` (tag, commit, per-wheel SHA-256) and
+`nokv-<version>-python-sdk-SHA256SUMS` to the GitHub release. Release assets
+are immutable: an existing asset with the same name must be byte-identical or
+the run stops. It never publishes to PyPI.
+
+`scripts/release/python_sdk_release.py` owns the identities that must agree:
+the tag, the `crates/nokv` package version, and the `crates/nokv-python`
+package version, which the Python project reads through
+`dynamic = ["version"]`. Bump both crates in the release change; the wheel
+version test refuses a diverged pair. Every pull request builds the Linux
+wheel and installs it (`python-sdk.yml`), so the packaging cannot rot between
+releases. Consumer instructions live in `crates/nokv-python/README.md`.
+
 ## Operator flow
 
-1. Merge the release PR, including the `crates/nokv` version update.
+1. Merge the release PR, including the `crates/nokv` and `crates/nokv-python`
+   version updates.
 2. Create the matching stable tag on that exact commit.
-3. Dispatch `Release Homebrew Source Formula` with that tag.
+3. Dispatch `Release Homebrew Source Formula` and `Release Python SDK` with
+   that tag; either may create the GitHub release, and each only adds its own
+   immutable assets.
 4. The workflow builds one deterministic source release candidate.
 5. Apple Silicon and Intel macOS runners each install, test, and inspect the
    same candidate through Homebrew.
@@ -101,8 +126,10 @@ directly to the tap's default branch.
 
 ```shell
 python3 scripts/release/test_homebrew_source_release.py
+python3 scripts/release/test_python_sdk_release.py
 python3 scripts/workbench/workbench_contract_test.py
 actionlint .github/workflows/release-homebrew.yml
+actionlint .github/workflows/release-python-sdk.yml
 cargo fmt --all -- --check
 cargo clippy --locked --workspace --all-targets -- -D warnings
 cargo test --locked --workspace

--- a/scripts/release/python_sdk_release.py
+++ b/scripts/release/python_sdk_release.py
@@ -1,0 +1,341 @@
+#!/usr/bin/env python3
+# Copyright 2024-2026 The NoKV Authors.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Validate and describe the NoKV Python SDK wheels attached to a GitHub release.
+
+The wheels are built by `.github/workflows/release-python-sdk.yml` from one
+validated tag commit. This module owns the release identities that must agree
+before any wheel is published:
+
+- the canonical `vMAJOR.MINOR.PATCH` tag, the `crates/nokv` package version,
+  and the `crates/nokv-python` package version (the wheel version);
+- the exact wheel set: one abi3 wheel per supported platform, nothing else;
+- the manifest and checksum assets that let a consumer verify a downloaded
+  wheel without trusting the download path.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import re
+import subprocess
+import sys
+import tomllib
+from pathlib import Path
+from typing import Any, NoReturn
+
+
+MANIFEST_SCHEMA = "nokv.python_sdk.release.v1"
+DISTRIBUTION = "nokv"
+API_VERSION = 1
+PYTHON_TAG = "cp39"
+ABI_TAG = "abi3"
+STABLE_TAG = re.compile(
+    r"v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)",
+    re.ASCII,
+)
+HEX_40 = re.compile(r"[0-9a-f]{40}", re.ASCII)
+WHEEL_NAME = re.compile(
+    r"nokv-(?P<version>[0-9][0-9A-Za-z.]*)-cp39-abi3-(?P<platform>[A-Za-z0-9_.]+)\.whl",
+    re.ASCII,
+)
+# One wheel per supported platform. Linux wheels are built inside the official
+# manylinux_2_28 images (glibc >= 2.28); macOS wheels are built natively on
+# Apple Silicon and Intel runners. The exact macOS deployment target in the tag
+# is owned by maturin, so it is matched by architecture.
+EXPECTED_PLATFORMS: dict[str, re.Pattern[str]] = {
+    "linux-x86_64": re.compile(r"manylinux_2_28_x86_64", re.ASCII),
+    "linux-aarch64": re.compile(r"manylinux_2_28_aarch64", re.ASCII),
+    "macos-arm64": re.compile(r"macosx_[0-9]+_[0-9]+_arm64", re.ASCII),
+    "macos-x86_64": re.compile(r"macosx_[0-9]+_[0-9]+_x86_64", re.ASCII),
+}
+
+
+class ReleaseError(ValueError):
+    """The requested release is not safe or internally consistent."""
+
+
+def validate_stable_tag(tag: str) -> str:
+    """Return the plain version for one canonical vMAJOR.MINOR.PATCH tag."""
+    if not isinstance(tag, str) or STABLE_TAG.fullmatch(tag) is None:
+        raise ReleaseError(
+            f"invalid release tag {tag!r}; expected canonical vMAJOR.MINOR.PATCH"
+        )
+    return tag[1:]
+
+
+def _load_toml(path: Path) -> dict[str, Any]:
+    try:
+        with path.open("rb") as source:
+            value = tomllib.load(source)
+    except (OSError, tomllib.TOMLDecodeError) as error:
+        raise ReleaseError(f"cannot read TOML file {path}: {error}") from error
+    if not isinstance(value, dict):
+        raise ReleaseError(f"TOML root must be a table: {path}")
+    return value
+
+
+def _package_version(path: Path, name: str) -> str:
+    package = _load_toml(path).get("package", {})
+    version = package.get("version")
+    if not isinstance(version, str) or not version:
+        raise ReleaseError(f"{name} package version is missing in {path}")
+    return version
+
+
+def sdk_version(repository: Path) -> str:
+    """Return the wheel version declared by the repository, after checking it
+    agrees with the `crates/nokv` release line and that the Python project
+    reads it from Cargo (not from a second hand-maintained copy)."""
+
+    cli_version = _package_version(repository / "crates/nokv/Cargo.toml", "nokv")
+    python_version = _package_version(
+        repository / "crates/nokv-python/Cargo.toml", "nokv-python"
+    )
+    if python_version != cli_version:
+        raise ReleaseError(
+            f"crates/nokv-python version {python_version!r} does not match "
+            f"crates/nokv version {cli_version!r}; bump both in the release change"
+        )
+    project = _load_toml(repository / "crates/nokv-python/pyproject.toml").get(
+        "project", {}
+    )
+    if "version" in project or "version" not in project.get("dynamic", []):
+        raise ReleaseError(
+            "crates/nokv-python/pyproject.toml must declare `dynamic = [\"version\"]` "
+            "and no static version so the wheel version comes from Cargo.toml"
+        )
+    return python_version
+
+
+def validate_version(repository: Path, tag: str) -> str:
+    version = validate_stable_tag(tag)
+    declared = sdk_version(repository)
+    if declared != version:
+        raise ReleaseError(
+            f"Python SDK version {declared!r} does not match tag {tag}"
+        )
+    return version
+
+
+def _sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as source:
+        for chunk in iter(lambda: source.read(1 << 20), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def classify_wheels(dist: Path, version: str) -> dict[str, Path]:
+    """Map every expected platform to exactly one wheel in `dist`.
+
+    Fails closed on a missing platform, a duplicate platform, a foreign file,
+    a wheel of another version, or a non-abi3 wheel.
+    """
+
+    if not dist.is_dir():
+        raise ReleaseError(f"wheel directory does not exist: {dist}")
+    found: dict[str, Path] = {}
+    for entry in sorted(dist.iterdir()):
+        if entry.name.startswith("."):
+            continue
+        match = WHEEL_NAME.fullmatch(entry.name)
+        if match is None or not entry.is_file():
+            raise ReleaseError(f"unexpected file in wheel directory: {entry.name}")
+        if match.group("version") != version:
+            raise ReleaseError(
+                f"wheel {entry.name} is version {match.group('version')!r}, "
+                f"expected {version!r}"
+            )
+        platform = match.group("platform")
+        owners = [
+            name
+            for name, pattern in EXPECTED_PLATFORMS.items()
+            if pattern.fullmatch(platform)
+        ]
+        if len(owners) != 1:
+            raise ReleaseError(f"wheel platform tag {platform!r} is not a release target")
+        if owners[0] in found:
+            raise ReleaseError(f"duplicate wheel for {owners[0]}: {entry.name}")
+        found[owners[0]] = entry
+    missing = sorted(set(EXPECTED_PLATFORMS) - set(found))
+    if missing:
+        raise ReleaseError(f"missing wheels for: {', '.join(missing)}")
+    return found
+
+
+def build_manifest(
+    *, version: str, tag: str, commit: str, wheels: dict[str, Path]
+) -> dict[str, Any]:
+    if HEX_40.fullmatch(commit) is None:
+        raise ReleaseError(f"commit is not a canonical SHA-1: {commit!r}")
+    if validate_stable_tag(tag) != version:
+        raise ReleaseError(f"tag {tag} does not match version {version}")
+    return {
+        "schema": MANIFEST_SCHEMA,
+        "distribution": DISTRIBUTION,
+        "version": version,
+        "api_version": API_VERSION,
+        "tag": tag,
+        "commit": commit,
+        "python_tag": PYTHON_TAG,
+        "abi_tag": ABI_TAG,
+        "requires_python": ">=3.9",
+        "wheels": {
+            platform: {
+                "file": path.name,
+                "sha256": _sha256_file(path),
+                "bytes": path.stat().st_size,
+            }
+            for platform, path in sorted(wheels.items())
+        },
+    }
+
+
+def render_checksums(manifest: dict[str, Any]) -> str:
+    lines = [
+        f"{entry['sha256']}  {entry['file']}"
+        for _platform, entry in sorted(manifest["wheels"].items())
+    ]
+    return "\n".join(lines) + "\n"
+
+
+def write_release_assets(
+    *, dist: Path, version: str, tag: str, commit: str, output: Path
+) -> tuple[Path, Path]:
+    wheels = classify_wheels(dist, version)
+    manifest = build_manifest(version=version, tag=tag, commit=commit, wheels=wheels)
+    output.mkdir(parents=True, exist_ok=True)
+    manifest_path = output / f"nokv-{version}-python-sdk.json"
+    checksums_path = output / f"nokv-{version}-python-sdk-SHA256SUMS"
+    manifest_path.write_text(json.dumps(manifest, indent=2, sort_keys=True) + "\n")
+    checksums_path.write_text(render_checksums(manifest))
+    return manifest_path, checksums_path
+
+
+def verify_manifest_wheels(manifest_path: Path, dist: Path) -> None:
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    if manifest.get("schema") != MANIFEST_SCHEMA:
+        raise ReleaseError(f"unexpected manifest schema {manifest.get('schema')!r}")
+    wheels = classify_wheels(dist, str(manifest["version"]))
+    for platform, entry in manifest["wheels"].items():
+        path = wheels.get(platform)
+        if path is None or path.name != entry["file"]:
+            raise ReleaseError(f"manifest wheel for {platform} is not in {dist}")
+        actual = _sha256_file(path)
+        if actual != entry["sha256"]:
+            raise ReleaseError(
+                f"wheel {path.name} sha256 {actual} differs from manifest {entry['sha256']}"
+            )
+
+
+def verify_installed_sdk(python: Path, version: str) -> None:
+    """Import the installed distribution with the given interpreter and check
+    that it is the release version with the frozen API version."""
+
+    script = (
+        "import json, nokv, importlib.metadata as m;"
+        "print(json.dumps({'version': nokv.__version__, 'api': nokv.API_VERSION,"
+        " 'dist': m.version('nokv'), 'file': nokv.__file__}))"
+    )
+    completed = subprocess.run(
+        [str(python), "-c", script],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if completed.returncode != 0:
+        raise ReleaseError(
+            f"installed SDK import failed: {completed.stderr.strip()[-2000:]}"
+        )
+    report = json.loads(completed.stdout)
+    if report["version"] != version or report["dist"] != version:
+        raise ReleaseError(
+            f"installed SDK reports version {report['version']!r} "
+            f"(distribution {report['dist']!r}), expected {version!r}"
+        )
+    if report["api"] != API_VERSION:
+        raise ReleaseError(f"installed SDK API version {report['api']!r} != {API_VERSION}")
+    if "site-packages" not in report["file"] and "dist-packages" not in report["file"]:
+        raise ReleaseError(
+            f"installed SDK was imported from a source tree, not a wheel: {report['file']}"
+        )
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    subcommands = parser.add_subparsers(dest="command", required=True)
+
+    validate = subcommands.add_parser("validate-tag")
+    validate.add_argument("tag")
+
+    version = subcommands.add_parser("validate-version")
+    version.add_argument("--repository", type=Path, default=Path.cwd())
+    version.add_argument("--tag", required=True)
+    version.set_defaults(
+        handler=lambda args: print(validate_version(args.repository, args.tag))
+    )
+
+    declared = subcommands.add_parser("sdk-version")
+    declared.add_argument("--repository", type=Path, default=Path.cwd())
+    declared.set_defaults(handler=lambda args: print(sdk_version(args.repository)))
+
+    assets = subcommands.add_parser("write-assets")
+    assets.add_argument("--dist", type=Path, required=True)
+    assets.add_argument("--version", required=True)
+    assets.add_argument("--tag", required=True)
+    assets.add_argument("--commit", required=True)
+    assets.add_argument("--output", type=Path, required=True)
+    assets.set_defaults(
+        handler=lambda args: print(
+            "\n".join(
+                str(path)
+                for path in write_release_assets(
+                    dist=args.dist,
+                    version=args.version,
+                    tag=args.tag,
+                    commit=args.commit,
+                    output=args.output,
+                )
+            )
+        )
+    )
+
+    verify_wheels = subcommands.add_parser("verify-wheels")
+    verify_wheels.add_argument("--manifest", type=Path, required=True)
+    verify_wheels.add_argument("--dist", type=Path, required=True)
+    verify_wheels.set_defaults(
+        handler=lambda args: verify_manifest_wheels(args.manifest, args.dist)
+    )
+
+    install = subcommands.add_parser("verify-install")
+    install.add_argument("--python", type=Path, required=True)
+    install.add_argument("--version", required=True)
+    install.set_defaults(
+        handler=lambda args: verify_installed_sdk(args.python, args.version)
+    )
+    return parser
+
+
+def _die(message: str) -> NoReturn:
+    print(f"python-sdk-release: {message}", file=sys.stderr)
+    raise SystemExit(2)
+
+
+def main() -> None:
+    parser = _parser()
+    arguments = parser.parse_args()
+    try:
+        if arguments.command == "validate-tag":
+            print(validate_stable_tag(arguments.tag))
+            return
+        arguments.handler(arguments)
+    except ReleaseError as error:
+        _die(str(error))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/release/python_sdk_release.py
+++ b/scripts/release/python_sdk_release.py
@@ -241,12 +241,15 @@ def verify_installed_sdk(python: Path, version: str) -> None:
         "print(json.dumps({'version': nokv.__version__, 'api': nokv.API_VERSION,"
         " 'dist': m.version('nokv'), 'file': nokv.__file__}))"
     )
-    completed = subprocess.run(
-        [str(python), "-c", script],
-        capture_output=True,
-        text=True,
-        check=False,
-    )
+    try:
+        completed = subprocess.run(
+            [str(python), "-c", script],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+    except OSError as error:
+        raise ReleaseError(f"cannot run {python}: {error}") from error
     if completed.returncode != 0:
         raise ReleaseError(
             f"installed SDK import failed: {completed.stderr.strip()[-2000:]}"

--- a/scripts/release/test_python_sdk_release.py
+++ b/scripts/release/test_python_sdk_release.py
@@ -1,0 +1,245 @@
+#!/usr/bin/env python3
+# Copyright 2024-2026 The NoKV Authors.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for the Python SDK wheel release boundary."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+REPOSITORY_ROOT = SCRIPT_DIR.parents[1]
+sys.path.insert(0, str(SCRIPT_DIR))
+
+import python_sdk_release as release  # noqa: E402
+
+COMMIT = "0123456789abcdef0123456789abcdef01234567"
+
+
+def _write_repository(root: Path, *, cli: str, python: str, static_version: bool = False) -> None:
+    (root / "crates/nokv").mkdir(parents=True)
+    (root / "crates/nokv-python").mkdir(parents=True)
+    (root / "crates/nokv/Cargo.toml").write_text(
+        f'[package]\nname = "nokv"\nversion = "{cli}"\n'
+    )
+    (root / "crates/nokv-python/Cargo.toml").write_text(
+        f'[package]\nname = "nokv-python"\nversion = "{python}"\npublish = false\n'
+    )
+    project = (
+        '[project]\nname = "nokv"\nversion = "9.9.9"\n'
+        if static_version
+        else '[project]\nname = "nokv"\ndynamic = ["version"]\n'
+    )
+    (root / "crates/nokv-python/pyproject.toml").write_text(project)
+
+
+def _write_wheels(dist: Path, version: str, platforms: list[str]) -> None:
+    dist.mkdir(parents=True, exist_ok=True)
+    for platform in platforms:
+        (dist / f"nokv-{version}-cp39-abi3-{platform}.whl").write_bytes(
+            f"wheel-{platform}".encode()
+        )
+
+
+FULL_SET = [
+    "manylinux_2_28_x86_64",
+    "manylinux_2_28_aarch64",
+    "macosx_11_0_arm64",
+    "macosx_10_12_x86_64",
+]
+
+
+class StableTagTest(unittest.TestCase):
+    def test_accepts_only_canonical_stable_tags(self) -> None:
+        self.assertEqual(release.validate_stable_tag("v0.11.0"), "0.11.0")
+        for tag in ("0.11.0", "v0.11", "v01.2.3", "v1.0.0-rc.1", "latest", "v1.0.0\n"):
+            with self.subTest(tag=tag), self.assertRaises(release.ReleaseError):
+                release.validate_stable_tag(tag)
+
+
+class VersionAgreementTest(unittest.TestCase):
+    def test_python_version_must_follow_the_cli_release_line(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            _write_repository(root, cli="0.11.0", python="0.11.0")
+            self.assertEqual(release.validate_version(root, "v0.11.0"), "0.11.0")
+            with self.assertRaises(release.ReleaseError):
+                release.validate_version(root, "v0.11.1")
+
+    def test_diverged_python_version_is_rejected(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            _write_repository(root, cli="0.11.0", python="0.1.0")
+            with self.assertRaises(release.ReleaseError):
+                release.sdk_version(root)
+
+    def test_static_pyproject_version_is_rejected(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            _write_repository(root, cli="0.11.0", python="0.11.0", static_version=True)
+            with self.assertRaises(release.ReleaseError):
+                release.sdk_version(root)
+
+    def test_checked_in_repository_declares_one_release_line(self) -> None:
+        version = release.sdk_version(REPOSITORY_ROOT)
+        self.assertRegex(version, r"^\d+\.\d+\.\d+$")
+
+
+class WheelSetTest(unittest.TestCase):
+    def test_exact_platform_set_is_required(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            dist = Path(directory) / "dist"
+            _write_wheels(dist, "0.11.0", FULL_SET)
+            wheels = release.classify_wheels(dist, "0.11.0")
+            self.assertEqual(sorted(wheels), sorted(release.EXPECTED_PLATFORMS))
+
+            (dist / "nokv-0.11.0-cp39-abi3-macosx_10_12_x86_64.whl").unlink()
+            with self.assertRaisesRegex(release.ReleaseError, "missing wheels for: macos-x86_64"):
+                release.classify_wheels(dist, "0.11.0")
+
+    def test_foreign_duplicate_and_wrong_version_wheels_fail_closed(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            dist = Path(directory) / "dist"
+            _write_wheels(dist, "0.11.0", FULL_SET)
+            (dist / "notes.txt").write_text("stray")
+            with self.assertRaisesRegex(release.ReleaseError, "unexpected file"):
+                release.classify_wheels(dist, "0.11.0")
+            (dist / "notes.txt").unlink()
+
+            _write_wheels(dist, "0.11.0", ["macosx_12_0_arm64"])
+            with self.assertRaisesRegex(release.ReleaseError, "duplicate wheel"):
+                release.classify_wheels(dist, "0.11.0")
+            (dist / "nokv-0.11.0-cp39-abi3-macosx_12_0_arm64.whl").unlink()
+
+            _write_wheels(dist, "0.11.1", ["manylinux_2_28_x86_64"])
+            with self.assertRaisesRegex(release.ReleaseError, "is version '0.11.1'"):
+                release.classify_wheels(dist, "0.11.0")
+            (dist / "nokv-0.11.1-cp39-abi3-manylinux_2_28_x86_64.whl").unlink()
+
+            (dist / "nokv-0.11.0-cp312-cp312-manylinux_2_28_x86_64.whl").write_bytes(b"x")
+            with self.assertRaisesRegex(release.ReleaseError, "unexpected file"):
+                release.classify_wheels(dist, "0.11.0")
+            (dist / "nokv-0.11.0-cp312-cp312-manylinux_2_28_x86_64.whl").unlink()
+
+            (dist / "nokv-0.11.0-cp39-abi3-win_amd64.whl").write_bytes(b"x")
+            with self.assertRaisesRegex(release.ReleaseError, "not a release target"):
+                release.classify_wheels(dist, "0.11.0")
+
+    def test_manifest_and_checksums_bind_exact_wheel_bytes(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            dist = root / "dist"
+            _write_wheels(dist, "0.11.0", FULL_SET)
+            manifest_path, checksums_path = release.write_release_assets(
+                dist=dist, version="0.11.0", tag="v0.11.0", commit=COMMIT, output=root / "out"
+            )
+            manifest = json.loads(manifest_path.read_text())
+            self.assertEqual(manifest["schema"], release.MANIFEST_SCHEMA)
+            self.assertEqual(manifest["commit"], COMMIT)
+            self.assertEqual(manifest["api_version"], 1)
+            self.assertEqual(sorted(manifest["wheels"]), sorted(release.EXPECTED_PLATFORMS))
+            expected = hashlib.sha256(b"wheel-macosx_11_0_arm64").hexdigest()
+            self.assertEqual(manifest["wheels"]["macos-arm64"]["sha256"], expected)
+            self.assertIn(f"{expected}  nokv-0.11.0-cp39-abi3-macosx_11_0_arm64.whl", checksums_path.read_text())
+            release.verify_manifest_wheels(manifest_path, dist)
+
+            (dist / "nokv-0.11.0-cp39-abi3-macosx_11_0_arm64.whl").write_bytes(b"tampered")
+            with self.assertRaisesRegex(release.ReleaseError, "differs from manifest"):
+                release.verify_manifest_wheels(manifest_path, dist)
+
+    def test_manifest_rejects_non_canonical_commit_or_tag(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            dist = Path(directory) / "dist"
+            _write_wheels(dist, "0.11.0", FULL_SET)
+            wheels = release.classify_wheels(dist, "0.11.0")
+            with self.assertRaises(release.ReleaseError):
+                release.build_manifest(version="0.11.0", tag="v0.11.0", commit="abc", wheels=wheels)
+            with self.assertRaises(release.ReleaseError):
+                release.build_manifest(version="0.11.0", tag="v0.11.1", commit=COMMIT, wheels=wheels)
+
+
+class InstalledSdkTest(unittest.TestCase):
+    def test_source_tree_import_is_not_an_installed_wheel(self) -> None:
+        # The running interpreter has no installed `nokv` distribution in a
+        # clean checkout, or imports it from a source tree; both must fail.
+        with self.assertRaises(release.ReleaseError):
+            release.verify_installed_sdk(Path(sys.executable), "0.11.0")
+
+
+class WorkflowTest(unittest.TestCase):
+    def _run_blocks(self, workflow: str) -> str:
+        lines = workflow.splitlines()
+        run_blocks: list[str] = []
+        index = 0
+        while index < len(lines):
+            line = lines[index]
+            if line.lstrip().startswith("run: |"):
+                indent = len(line) - len(line.lstrip())
+                block: list[str] = []
+                index += 1
+                while index < len(lines):
+                    candidate = lines[index]
+                    if candidate.strip() and len(candidate) - len(candidate.lstrip()) <= indent:
+                        break
+                    block.append(candidate)
+                    index += 1
+                run_blocks.append("\n".join(block))
+                continue
+            index += 1
+        return "\n".join(run_blocks)
+
+    def test_release_workflow_keeps_untrusted_tag_away_from_shell_and_pins_actions(self) -> None:
+        workflow = (
+            REPOSITORY_ROOT / ".github/workflows/release-python-sdk.yml"
+        ).read_text(encoding="utf-8")
+        lines = workflow.splitlines()
+        self.assertNotIn("${{ inputs.tag }}", self._run_blocks(workflow))
+        self.assertIn("persist-credentials: false", workflow)
+        for runner in ("ubuntu-latest", "ubuntu-24.04-arm", "macos-15", "macos-15-intel"):
+            with self.subTest(runner=runner):
+                self.assertIn(runner, workflow)
+        self.assertIn('manylinux: "2_28"', workflow)
+        self.assertIn("before-script-linux", workflow)
+        self.assertIn("python_sdk_release.py validate-version", workflow)
+        self.assertIn("python_sdk_release.py write-assets", workflow)
+        self.assertIn("python_sdk_release.py verify-install", workflow)
+        self.assertIn("--verify-tag", workflow)
+        self.assertIn("Release tag moved", workflow)
+        self.assertIn("release asset already exists with different bytes", workflow)
+        self.assertNotIn("archive/refs/tags", workflow)
+        self.assertNotIn("--clobber", workflow)
+
+        action_refs = [
+            line.split("@", 1)[1].strip()
+            for line in lines
+            if line.strip().startswith("uses:")
+        ]
+        self.assertTrue(action_refs)
+        for action_ref in action_refs:
+            with self.subTest(action_ref=action_ref):
+                self.assertRegex(action_ref, r"^[0-9a-f]{40}$")
+
+    def test_pull_request_workflow_installs_the_built_wheel_before_testing(self) -> None:
+        workflow = (REPOSITORY_ROOT / ".github/workflows/python-sdk.yml").read_text(
+            encoding="utf-8"
+        )
+        self.assertIn("pull_request", workflow)
+        self.assertIn("manylinux: 2_28", workflow)
+        self.assertIn("python_sdk_release.py verify-install", workflow)
+        self.assertIn("crates/nokv-python/tests", workflow)
+        self.assertNotIn("maturin develop", workflow)
+        for line in workflow.splitlines():
+            if line.strip().startswith("uses:"):
+                with self.subTest(line=line.strip()):
+                    self.assertRegex(line.split("@", 1)[1].strip(), r"^[0-9a-f]{40}$")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/release/test_python_sdk_release.py
+++ b/scripts/release/test_python_sdk_release.py
@@ -166,11 +166,15 @@ class WheelSetTest(unittest.TestCase):
 
 
 class InstalledSdkTest(unittest.TestCase):
-    def test_source_tree_import_is_not_an_installed_wheel(self) -> None:
-        # The running interpreter has no installed `nokv` distribution in a
-        # clean checkout, or imports it from a source tree; both must fail.
+    def test_wrong_version_or_missing_distribution_fails_closed(self) -> None:
+        # Whether or not the running interpreter can import `nokv`, it cannot
+        # be an installed wheel of this impossible version.
         with self.assertRaises(release.ReleaseError):
-            release.verify_installed_sdk(Path(sys.executable), "0.11.0")
+            release.verify_installed_sdk(Path(sys.executable), "0.0.0")
+
+    def test_missing_interpreter_is_a_release_error(self) -> None:
+        with self.assertRaises(release.ReleaseError):
+            release.verify_installed_sdk(Path("/nonexistent/python-interpreter"), "0.11.0")
 
 
 class WorkflowTest(unittest.TestCase):


### PR DESCRIPTION
## Why

The Python SDK has never been installable: consumers (the LoopX shared-goal provider work, the PhyMat pre-pilot adapter) pinned a commit and ran `maturin develop` with a local Rust toolchain. Homebrew ships only the CLI. Releases already have a pipeline; this adds the SDK to it.

## What

- **`release-python-sdk.yml`** (workflow_dispatch, canonical `vMAJOR.MINOR.PATCH` tag): validates the tag exactly like the Homebrew workflow, then per platform builds one abi3 wheel on the platform itself: Linux x86_64 (`ubuntu-latest`) and aarch64 (`ubuntu-24.04-arm`) inside the official `manylinux_2_28` images (protoc installed in the image for the etcd client build script), macOS Apple Silicon (`macos-15`) and Intel (`macos-15-intel`) natively. Each job installs the wheel into a clean venv, verifies `nokv.__version__`/API version and that the import comes from the wheel, and runs `crates/nokv-python/tests` against the installed distribution. Only after all four gates pass does `publish` upload the wheels + `nokv-<v>-python-sdk.json` (tag, commit, per-wheel SHA-256) + `nokv-<v>-python-sdk-SHA256SUMS` to the GitHub release. Assets are immutable (byte-different duplicate = stop). No PyPI.
- **`python-sdk.yml`** (PR/push): builds the manylinux wheel, installs it, runs the SDK tests against the installed wheel. Packaging cannot rot silently.
- **`scripts/release/python_sdk_release.py`** + test: tag ↔ `crates/nokv` version ↔ `crates/nokv-python` version (read via `dynamic = ["version"]`), exact wheel set (one per platform, nothing else), manifest/checksums, installed-distribution check. The test is a trust root next to the Homebrew one (CODEOWNERS, governance policy, `rust.yml`, `Makefile`).
- SDK: `crates/nokv-python` version follows the release line (0.11.0), `nokv.__version__` from installed metadata (`__all__` unchanged), local caches excluded from the wheel, install instructions in `crates/nokv-python/README.md`, release README updated (operator flow now bumps both crates and dispatches both workflows).

## Verification

- Local (macOS arm64): `maturin build --release` → `nokv-0.11.0-cp39-abi3-macosx_11_0_arm64.whl`; fresh venv `pip install` → 30/30 SDK tests against the installed wheel; `python_sdk_release.py` commands exercised (validate-version, write-assets, verify-wheels, verify-install); `scripts/release/test_python_sdk_release.py` 12/12; governance and Homebrew release tests green; `cargo fmt/clippy/build/test -p nokv-python` green.
- LoopX scenario with the installed wheel against a local etcd + S3 + `nokv serve` stack: shadow-provider live suite 16/16 (adapter verbs, RFC §10 checks 1-9 with two clients, read under sustained CAS writes).
- PhyMat pre-pilot flow reproduced with the installed wheel + CLI (60 records → 120 create-only artifacts with pinned ids, whole-batch replay 60/60, drift rejected, cost ledger parity, commit → snapshot → post-freeze write → as-of 60 vs live 61 → restore 20 byte-identical, frozen SDK read hides the late record): 6/6.
- Linux wheels are validated by CI on this PR (`Python SDK` workflow); the release workflow itself runs on the next tag.

## Notes for the release operator

- Bump `crates/nokv-python` together with `crates/nokv`; the wheel version test refuses a diverged pair.
- `pip install "nokv==<v>" --find-links https://github.com/NoKV-Lab/NoKV/releases/expanded_assets/v<v>` or the direct wheel URL; see the SDK README.
- Touches `.github/workflows/` and adds a trust-root test, so this needs the other core maintainer's review per CODEOWNERS.
