### PR TITLE
fix(types): order relative paths the way the metadata store orders them

### DIFF
--- a/crates/nokv-types/src/workspace.rs
+++ b/crates/nokv-types/src/workspace.rs
@@ -798,8 +798,31 @@ durable_enum! {
 /// The stored string preserves its exact UTF-8 bytes. `/` is only a component
 /// separator; repeated, leading, and trailing separators are rejected instead
 /// of being normalized away.
-#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub struct NormalizedRelativePath(String);
+
+/// Ordered by component, which is how the metadata store orders these paths.
+///
+/// Keys encode each component with its bytes incremented by one and join
+/// components with a NUL delimiter, so the delimiter sorts below every
+/// component byte and a shorter component wins against a longer one that
+/// extends it. Comparing the joined text instead would disagree whenever a
+/// sibling name is a prefix of another followed by a byte below `/` (0x2f):
+/// `a-b/x` precedes `a/x` as text but follows it in the store. Code that
+/// validates a scan against a cursor -- commit closure construction, for one
+/// -- then rejects rows the scan legitimately produced, so the type carries
+/// the store's order rather than the text order.
+impl Ord for NormalizedRelativePath {
+    fn cmp(&self, other: &Self) -> core::cmp::Ordering {
+        self.components().cmp(other.components())
+    }
+}
+
+impl PartialOrd for NormalizedRelativePath {
+    fn partial_cmp(&self, other: &Self) -> Option<core::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum NormalizedRelativePathError {
@@ -1368,5 +1391,74 @@ mod tests {
                 max: NormalizedRelativePath::MAX_COMPONENTS,
             })
         );
+    }
+}
+
+#[cfg(test)]
+mod path_order_tests {
+    use super::NormalizedRelativePath;
+
+    fn path(value: &str) -> NormalizedRelativePath {
+        NormalizedRelativePath::new(value).expect("valid path")
+    }
+
+    /// Metadata keys encode each component with its bytes incremented by one
+    /// and join components with a NUL delimiter, so the delimiter sorts below
+    /// every component byte and stored order is component order. Path
+    /// comparison has to agree with that, or code that validates a scan
+    /// against a cursor rejects rows the scan legitimately produced.
+    fn storage_key(value: &str) -> Vec<u8> {
+        let mut key = Vec::new();
+        for (index, component) in path(value).components().enumerate() {
+            if index != 0 {
+                key.push(0u8);
+            }
+            key.extend(component.as_bytes().iter().map(|byte| byte + 1));
+        }
+        key
+    }
+
+    #[test]
+    fn ordering_matches_stored_key_ordering() {
+        // '-' (0x2d) sorts below '/' (0x2f) as raw text, so raw-text ordering
+        // puts the hyphenated sibling first while stored order does not.
+        for (left, right) in [
+            ("a", "a-b"),
+            ("a/x.json", "a-b/x.json"),
+            ("outputs/t/a/x.json", "outputs/t/a-b/x.json"),
+            ("src", "src-gen"),
+            ("docs/index.md", "docs-old/index.md"),
+            ("v1/x", "v1.1/x"),
+            ("tasks/Au/x", "tasks/Au-O/x"),
+        ] {
+            assert!(
+                path(left) < path(right),
+                "{left} must precede {right} the way the store orders them"
+            );
+            assert!(
+                storage_key(left) < storage_key(right),
+                "precondition: the stored keys order {left} before {right}"
+            );
+        }
+    }
+
+    #[test]
+    fn ordering_is_a_total_order_over_a_scan() {
+        let mut paths: Vec<_> = ["a-b/x", "a/x", "a/y", "ab/x", "a-b/y"]
+            .into_iter()
+            .map(path)
+            .collect();
+        paths.sort();
+        let sorted: Vec<_> = paths.iter().map(NormalizedRelativePath::as_str).collect();
+        assert_eq!(sorted, ["a/x", "a/y", "a-b/x", "a-b/y", "ab/x"]);
+        let keys: Vec<_> = sorted.iter().map(|value| storage_key(value)).collect();
+        assert!(keys.windows(2).all(|pair| pair[0] < pair[1]), "{sorted:?}");
+    }
+
+    #[test]
+    fn ordering_still_separates_plain_siblings() {
+        assert!(path("aa/x") < path("bb/x"));
+        assert!(path("outputs/a") < path("outputs/b"));
+        assert_eq!(path("outputs/a"), path("outputs/a"));
     }
 }


### PR DESCRIPTION
## The defect

A workbench holding two sibling directories where one name is a prefix of the other **can never be committed**. The artifacts publish, list and read normally; only `workbench_commit` refuses them:

```
commit members must be strictly increasing by path
```

Reproduces with any `<name>` + `<name>-<suffix>` pair: `src` + `src-gen`, `docs` + `docs-old`, `v1` + `v1.1`.

## Root cause

`NormalizedRelativePath` derived `Ord` from the joined text. The metadata store orders these paths **by component**: `push_ordered_path_components` encodes each component with its bytes incremented by one and joins components with a NUL delimiter, so the delimiter sorts below every component byte.

The two orders disagree whenever a sibling name is a prefix of another followed by a byte below `/` (0x2f):

| pair | text order | store order |
|---|---|---|
| `a/x` vs `a-b/x` | `a-b/x` first (`-`=0x2d < `/`=0x2f) | `a/x` first (delimiter 0x00 < `-`+1) |

`plan_commit_member` (`commit_closure.rs:96`) walks members in **store** order and validates each against a cursor using the **text** order, so it rejects rows its own scan just produced.

## The fix

`NormalizedRelativePath` now carries the store's order, so every comparison agrees with the scan by construction.

Fixing only the one comparison would have left the same mismatch latent elsewhere — `commit.rs:670` compares the run-manifest path against scanned paths the same way. One ordering, defined once, removes the class.

**Commits accepted before are unaffected**: the member digest already rolls forward in scan order, and the commits that previously succeeded are exactly those whose two orders coincided.

## Validation

- `cargo test --workspace`: **1060 passed, 0 failed**
- `cargo fmt --all -- --check`, `cargo clippy --workspace --all-targets -- -D warnings`: clean
- New unit tests in `nokv-types` assert the ordering against an independently computed storage key, including the total-order case over a mixed scan
- Live stack, before the fix: `a` + `a-b` refused, control `aa` + `bb` accepted. After: both accepted
- Live stack, a real 60-record campaign over 14 chemical systems containing both `Au` + `Au-O` and `C` + `C-H`: **committed and frozen in 1.3 s**, having failed outright on the previous build