### PR TITLE
fix(ci): enforce review only above 5000 lines

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -42,9 +42,6 @@ Closes | Fixes | Relates to #
       current-head pusher approved the exact current head commit. The author,
       bots, non-core reviewers, duplicate reviewers, dismissed reviews, and
       stale approvals do not count.
-- [ ] If this changes a protected CI trust root listed in `.github/CODEOWNERS`,
-      one core maintainer other than the current-head pusher approved the exact
-      current head regardless of change size.
 - [ ] This change is still small enough for a focused review; approval count is
       not being used to justify mixed package or lifecycle boundaries.
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -42,6 +42,9 @@ Closes | Fixes | Relates to #
       current-head pusher approved the exact current head commit. The author,
       bots, non-core reviewers, duplicate reviewers, dismissed reviews, and
       stale approvals do not count.
+- [ ] If this changes a protected CI trust root listed in `.github/CODEOWNERS`,
+      one core maintainer other than the current-head pusher approved the exact
+      current head regardless of change size.
 - [ ] This change is still small enough for a focused review; approval count is
       not being used to justify mixed package or lifecycle boundaries.
 

--- a/.github/workflows/change-governance.yml
+++ b/.github/workflows/change-governance.yml
@@ -12,8 +12,6 @@ on:
       - synchronize
       - ready_for_review
       - converted_to_draft
-      - review_requested
-      - review_request_removed
   pull_request_review:
     types: [submitted, edited, dismissed]
 
@@ -31,7 +29,10 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  # Keep the job id and custom status context stable for branch-protection
+  # compatibility. The visible job name reflects both policy triggers.
   large-change-review:
+    name: governed-change-review
     if: github.event.pull_request != null && github.event.pull_request.base.ref == 'main'
     runs-on: ubuntu-latest
     timeout-minutes: 5
@@ -67,7 +68,7 @@ jobs:
               --jq .content | base64 --decode >"$destination"
           }
 
-          post_status pending "Evaluating size and protected CI trust-root review policy."
+          post_status pending "Evaluating governed-change reviewer policy."
 
           set +e
           (
@@ -97,8 +98,8 @@ jobs:
           set -e
 
           if [[ "$policy_result" -eq 0 ]]; then
-            post_status success "Change-size and CI trust-root reviewer policy passed."
+            post_status success "Governed-change reviewer policy passed."
           else
-            post_status failure "Change policy failed or could not be evaluated."
+            post_status failure "Governed-change policy failed or could not be evaluated."
           fi
           exit "$policy_result"

--- a/.github/workflows/change-governance.yml
+++ b/.github/workflows/change-governance.yml
@@ -17,48 +17,32 @@ on:
 
 # The target workflow is loaded from the protected default branch. It never
 # checks out or executes pull-request code. The policy and its tests are fetched
-# from the exact base SHA, then a status is published on the PR head SHA.
+# from the exact base SHA, and the native job conclusion is the required check.
 permissions:
   actions: read
   contents: read
   pull-requests: read
-  statuses: write
 
 concurrency:
   group: change-governance-${{ github.event.pull_request.number }}-${{ github.event.pull_request.head.sha }}
   cancel-in-progress: true
 
 jobs:
-  # Keep the job id and custom status context stable for branch-protection
-  # compatibility. The visible job name reflects both policy triggers.
+  # Keep the native job name stable because branch protection requires it.
   large-change-review:
-    name: governed-change-review
+    name: large-change-review
     if: github.event.pull_request != null && github.event.pull_request.base.ref == 'main'
     runs-on: ubuntu-latest
     timeout-minutes: 5
     env:
       BASE_SHA: ${{ github.event.pull_request.base.sha }}
       GH_TOKEN: ${{ github.token }}
-      HEAD_SHA: ${{ github.event.pull_request.head.sha }}
       PR_NUMBER: ${{ github.event.pull_request.number }}
-      RUN_URL: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
-      STATUS_CONTEXT: change-governance/large-change-review
     steps:
       - name: Require current core maintainer approval for governed changes
         shell: bash
         run: |
           set -euo pipefail
-
-          post_status() {
-            local state="$1"
-            local description="$2"
-            gh api --method POST \
-              "repos/$GITHUB_REPOSITORY/statuses/$HEAD_SHA" \
-              -f state="$state" \
-              -f context="$STATUS_CONTEXT" \
-              -f description="$description" \
-              -f target_url="$RUN_URL" >/dev/null
-          }
 
           fetch_base_file() {
             local repository_path="$1"
@@ -68,38 +52,23 @@ jobs:
               --jq .content | base64 --decode >"$destination"
           }
 
-          post_status pending "Evaluating governed-change reviewer policy."
-
-          set +e
-          (
-            set -euo pipefail
-            policy_dir="$RUNNER_TEMP/nokv-change-governance"
-            mkdir -p "$policy_dir"
-            fetch_base_file \
-              scripts/ci/pr_change_governance.py \
-              "$policy_dir/pr_change_governance.py"
-            fetch_base_file \
-              scripts/ci/pr_change_governance_test.py \
-              "$policy_dir/pr_change_governance_test.py"
-            fetch_base_file \
-              .github/CODEOWNERS \
-              "$policy_dir/CODEOWNERS"
-            fetch_base_file \
-              .github/workflows/change-governance.yml \
-              "$policy_dir/change-governance.yml"
-            NOKV_CODEOWNERS_PATH="$policy_dir/CODEOWNERS" \
-              NOKV_CHANGE_GOVERNANCE_WORKFLOW_PATH="$policy_dir/change-governance.yml" \
-              python3 "$policy_dir/pr_change_governance_test.py"
-            python3 "$policy_dir/pr_change_governance.py" \
-              --repository "$GITHUB_REPOSITORY" \
-              --pull-request "$PR_NUMBER"
-          )
-          policy_result=$?
-          set -e
-
-          if [[ "$policy_result" -eq 0 ]]; then
-            post_status success "Governed-change reviewer policy passed."
-          else
-            post_status failure "Governed-change policy failed or could not be evaluated."
-          fi
-          exit "$policy_result"
+          policy_dir="$RUNNER_TEMP/nokv-change-governance"
+          mkdir -p "$policy_dir"
+          fetch_base_file \
+            scripts/ci/pr_change_governance.py \
+            "$policy_dir/pr_change_governance.py"
+          fetch_base_file \
+            scripts/ci/pr_change_governance_test.py \
+            "$policy_dir/pr_change_governance_test.py"
+          fetch_base_file \
+            .github/CODEOWNERS \
+            "$policy_dir/CODEOWNERS"
+          fetch_base_file \
+            .github/workflows/change-governance.yml \
+            "$policy_dir/change-governance.yml"
+          NOKV_CODEOWNERS_PATH="$policy_dir/CODEOWNERS" \
+            NOKV_CHANGE_GOVERNANCE_WORKFLOW_PATH="$policy_dir/change-governance.yml" \
+            python3 "$policy_dir/pr_change_governance_test.py"
+          python3 "$policy_dir/pr_change_governance.py" \
+            --repository "$GITHUB_REPOSITORY" \
+            --pull-request "$PR_NUMBER"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -115,12 +115,12 @@ and run `git diff --check`.
 - Keep PRs small enough for focused review.
 - An ordinary PR with 5,000 or fewer GitHub-reported changed lines (additions
   plus deletions) does not require a review.
-- A PR with more than 5,000 changed lines, or one that changes a protected CI
-  trust root listed in `.github/CODEOWNERS`, requires one core maintainer other
-  than the current-head pusher to approve the exact current head. Authors, bots,
-  non-core reviewers, duplicate reviewers, dismissed reviews, and approvals on
-  older commits do not count. The governance status fails closed if it cannot
-  verify these facts.
+- A PR with more than 5,000 changed lines requires one core maintainer other
+  than the current-head pusher to approve the exact current head. Authors,
+  bots, non-core reviewers, duplicate reviewers, dismissed reviews, and
+  approvals on older commits do not count. The governance check fails closed
+  if it cannot verify these facts. No path-based review trigger applies at or
+  below 5,000 changed lines.
 - Administrators remain subject to every required status check. All per-head PR
   validation jobs are required except Docker image, which runs in the
   background without delaying merge. Project-board automation is not CI.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -113,13 +113,14 @@ and run `git diff --check`.
 - Link related issue(s).
 - Include docs updates when behavior/config/CLI changes.
 - Keep PRs small enough for focused review.
-- A PR with 5,000 or fewer GitHub-reported changed lines (additions plus
-  deletions) does not require a review.
-- A PR with more than 5,000 changed lines requires one core maintainer other
-  than the current-head pusher to approve the exact current head. Authors,
-  bots, non-core reviewers, duplicate reviewers, dismissed reviews, and
-  approvals on older commits do not count. The governance status fails closed
-  if it cannot verify these facts.
+- An ordinary PR with 5,000 or fewer GitHub-reported changed lines (additions
+  plus deletions) does not require a review.
+- A PR with more than 5,000 changed lines, or one that changes a protected CI
+  trust root listed in `.github/CODEOWNERS`, requires one core maintainer other
+  than the current-head pusher to approve the exact current head. Authors, bots,
+  non-core reviewers, duplicate reviewers, dismissed reviews, and approvals on
+  older commits do not count. The governance status fails closed if it cannot
+  verify these facts.
 - Administrators remain subject to every required status check. All per-head PR
   validation jobs are required except Docker image, which runs in the
   background without delaying merge. Project-board automation is not CI.

--- a/docs/development/change-governance.md
+++ b/docs/development/change-governance.md
@@ -14,9 +14,11 @@ SDK, or Workbench rewrite.
 The `main` branch must enforce all of the following through GitHub branch
 protection:
 
-- pull requests with 5,000 or fewer changed lines do not require review;
-- a pull request with more than 5,000 changed lines requires one core
-  maintainer approval on its exact current head;
+- an ordinary pull request with 5,000 or fewer changed lines does not require
+  review;
+- a pull request with more than 5,000 changed lines, or one that changes a
+  protected CI trust root, requires one core maintainer approval on its exact
+  current head;
 - the current-head pusher cannot supply that approval;
 - unresolved review conversations block merge;
 - administrators are subject to the same restrictions;
@@ -28,11 +30,20 @@ dismissed reviews, requested changes, and approvals against an older head do
 not count. Generated files, fixtures, documentation, and deletions are not
 exempt.
 
+Protected CI trust roots are the paths owned by both core maintainers in
+[`.github/CODEOWNERS`](../../.github/CODEOWNERS): workflow and reusable-action
+definitions, governance and qualification scripts, CODEOWNERS itself, and the
+protected release test. Their review requirement is independent of change
+size because even a one-line edit can weaken the checks that authorize a
+merge or release.
+
 The `change-governance/large-change-review` status enforces the conditional
-review rule. It identifies the actor who introduced the current head from the
+review rule for both large changes and protected CI trust-root changes. Its
+legacy name remains stable because branch protection requires that exact
+context. It identifies the actor who introduced the current head from the
 earliest GitHub Actions `pull_request` run for that head. Missing, malformed,
 paginated-beyond-bound, or unavailable PR, review, workflow-run, or pusher data
-fails closed for changes above the threshold.
+fails closed for every governed change.
 
 ## Trust Boundary
 
@@ -67,11 +78,11 @@ them. This ordering avoids a fail-open migration window.
 
 ## Review Expectations
 
-For a change above the threshold, one non-pusher core maintainer approval is a
-minimum gate, not evidence that a broad rewrite is reviewable. Split a change
-when it crosses logical package or lifecycle boundaries, hides behavior changes
-among mechanical churn, or cannot be reproduced and reviewed within one focused
-diff. For storage changes, reviewers must apply the
+For a governed change, one non-pusher core maintainer approval is a minimum
+gate, not evidence that a broad rewrite is reviewable. Split a change when it
+crosses logical package or lifecycle boundaries, hides behavior changes among
+mechanical churn, or cannot be reproduced and reviewed within one focused diff.
+For storage changes, reviewers must apply the
 [PR Review Checklist](./pr_review_checklist.md) and retain exact recovery,
 failure, retry, retention, and downstream Workbench evidence.
 

--- a/docs/development/change-governance.md
+++ b/docs/development/change-governance.md
@@ -16,9 +16,8 @@ protection:
 
 - an ordinary pull request with 5,000 or fewer changed lines does not require
   review;
-- a pull request with more than 5,000 changed lines, or one that changes a
-  protected CI trust root, requires one core maintainer approval on its exact
-  current head;
+- a pull request with more than 5,000 changed lines requires one core
+  maintainer approval on its exact current head;
 - the current-head pusher cannot supply that approval;
 - unresolved review conversations block merge;
 - administrators are subject to the same restrictions;
@@ -30,28 +29,22 @@ dismissed reviews, requested changes, and approvals against an older head do
 not count. Generated files, fixtures, documentation, and deletions are not
 exempt.
 
-Protected CI trust roots are the paths owned by both core maintainers in
-[`.github/CODEOWNERS`](../../.github/CODEOWNERS): workflow and reusable-action
-definitions, governance and qualification scripts, CODEOWNERS itself, and the
-protected release test. Their review requirement is independent of change
-size because even a one-line edit can weaken the checks that authorize a
-merge or release.
-
-The `change-governance/large-change-review` status enforces the conditional
-review rule for both large changes and protected CI trust-root changes. Its
-legacy name remains stable because branch protection requires that exact
-context. It identifies the actor who introduced the current head from the
-earliest GitHub Actions `pull_request` run for that head. Missing, malformed,
-paginated-beyond-bound, or unavailable PR, review, workflow-run, or pusher data
-fails closed for every governed change.
+The native `Change Governance / large-change-review` job enforces this single
+size threshold. Changes at or below 5,000 lines do not require review from this
+gate, including changes to CI, qualification, release, workflow, or CODEOWNERS
+files. For a larger change, it identifies the actor who introduced the current
+head from the earliest GitHub Actions `pull_request` run for that head.
+Missing, malformed, paginated-beyond-bound, or unavailable PR, review,
+workflow-run, or pusher data fails closed for every large change.
 
 ## Trust Boundary
 
 [`change-governance.yml`](../../.github/workflows/change-governance.yml) uses
 `pull_request_target` and `pull_request_review` so GitHub loads the workflow
 from protected `main`. It never checks out or executes pull-request code. The
-runner fetches the policy and tests from the pull request's exact base SHA and
-publishes a dedicated commit status on the untrusted head SHA.
+runner fetches the policy and tests from the pull request's exact base SHA. The
+native GitHub Actions job conclusion is the required branch-protection check;
+the workflow does not publish a second custom commit status.
 
 This distinction is required: a normal `pull_request` workflow is part of the
 proposed diff and can otherwise weaken the check that evaluates itself.
@@ -62,7 +55,7 @@ The required status set is:
 - `object-namespace-recovery`;
 - `workbench-contract`;
 - `signoff`;
-- `change-governance/large-change-review`.
+- `large-change-review`.
 
 Every validation job that runs for each pull-request head is required. The
 Docker `image` check is the only CI exception: it continues in the background
@@ -70,11 +63,10 @@ and reports failures, but its runtime does not delay a merge. `sync-project` is
 project-board automation, does not run on `synchronize`, and is not a merge
 validation or required check.
 
-During initial rollout, the custom governance context is added to branch
-protection before the universal review rule is removed. Verified open PRs at
-or below the threshold receive a one-time status for their exact head. Unknown
-or later heads remain blocked until the protected workflow on `main` evaluates
-them. This ordering avoids a fail-open migration window.
+The native `large-change-review` check was added to branch protection before
+the legacy custom `change-governance/large-change-review` status was removed.
+That ordering avoided both a fail-open interval and a required context that no
+workflow could satisfy.
 
 ## Review Expectations
 

--- a/docs/development/pr_review_checklist.md
+++ b/docs/development/pr_review_checklist.md
@@ -11,11 +11,14 @@ boundaries, or Workbench behavior.
 
 ## Merge Governance
 
+- Does the change touch a protected CI trust root, requiring one core
+  maintainer other than the current-head pusher to approve the exact head
+  regardless of change size?
 - If additions plus deletions exceed 5,000 lines, does one core maintainer
   other than the current-head pusher approve the exact current head commit?
 - Did a new push make every older approval ineligible?
-- If additions plus deletions exceed 5,000 lines, does the protected
-  `change-governance/large-change-review` status pass?
+- Does the protected `change-governance/large-change-review` status pass for
+  every large or CI trust-root change?
 - Is the change actually reviewable as one logical boundary even if the formal
   approval count and status checks pass?
 - Are every required status and review conversation complete before merge?

--- a/docs/development/pr_review_checklist.md
+++ b/docs/development/pr_review_checklist.md
@@ -11,14 +11,10 @@ boundaries, or Workbench behavior.
 
 ## Merge Governance
 
-- Does the change touch a protected CI trust root, requiring one core
-  maintainer other than the current-head pusher to approve the exact head
-  regardless of change size?
 - If additions plus deletions exceed 5,000 lines, does one core maintainer
   other than the current-head pusher approve the exact current head commit?
 - Did a new push make every older approval ineligible?
-- Does the protected `change-governance/large-change-review` status pass for
-  every large or CI trust-root change?
+- Does the protected native `large-change-review` check pass for every change?
 - Is the change actually reviewable as one logical boundary even if the formal
   approval count and status checks pass?
 - Are every required status and review conversation complete before merge?

--- a/scripts/ci/pr_change_governance.py
+++ b/scripts/ci/pr_change_governance.py
@@ -19,19 +19,6 @@ from typing import Any
 LARGE_CHANGE_LINE_THRESHOLD = 5_000
 LARGE_CHANGE_REQUIRED_APPROVALS = 1
 CORE_MAINTAINER_LOGINS = frozenset({"feichai0017", "wchwawa"})
-GOVERNANCE_SENSITIVE_EXACT_PATHS = frozenset(
-    {
-        ".github/CODEOWNERS",
-        "scripts/release/test_homebrew_source_release.py",
-        "scripts/release/test_python_sdk_release.py",
-    }
-)
-GOVERNANCE_SENSITIVE_PREFIXES = (
-    ".github/actions/",
-    ".github/workflows/",
-    "scripts/ci/",
-    "scripts/workbench/",
-)
 MAX_API_PAGES = 100
 REPOSITORY_PATTERN = re.compile(r"^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$")
 
@@ -46,8 +33,6 @@ class GovernanceDecision:
     deletions: int
     changed_files: int
     changed_lines: int
-    changed_paths: tuple[str, ...]
-    governance_sensitive_paths: tuple[str, ...]
     threshold: int
     required_approvals: int
     current_approval_logins: tuple[str, ...]
@@ -57,10 +42,6 @@ class GovernanceDecision:
     @property
     def is_large_change(self) -> bool:
         return self.changed_lines > self.threshold
-
-    @property
-    def is_governance_sensitive(self) -> bool:
-        return bool(self.governance_sensitive_paths)
 
     @property
     def allowed(self) -> bool:
@@ -122,37 +103,6 @@ class GitHubApi:
         raise GovernanceInputError(
             f"GitHub API pagination exceeded {MAX_API_PAGES} pages for {path}"
         )
-
-    def get_changed_paths(
-        self, repository: str, pull_request_number: int, expected_count: int
-    ) -> tuple[str, ...]:
-        files = self.get_all(
-            f"repos/{repository}/pulls/{pull_request_number}/files"
-        )
-        if len(files) != expected_count:
-            raise GovernanceInputError(
-                "pull request changed-file list is incomplete: "
-                f"expected {expected_count}, received {len(files)}"
-            )
-        paths = tuple(
-            _required_string(item, "filename", "pull request file")
-            for item in files
-        )
-        previous_paths = tuple(
-            previous
-            for item in files
-            if isinstance((previous := item.get("previous_filename")), str)
-            and previous
-        )
-        all_paths = paths + previous_paths
-        if len(set(paths)) != len(paths):
-            raise GovernanceInputError("pull request changed-file list contains duplicates")
-        for path in all_paths:
-            if path.startswith("/") or path.endswith("/") or ".." in path.split("/"):
-                raise GovernanceInputError(
-                    f"pull request file path is not canonical: {path!r}"
-                )
-        return tuple(sorted(set(all_paths)))
 
     def get_current_head_introducers(
         self,
@@ -347,37 +297,19 @@ def current_core_maintainer_approvals(
     )
 
 
-def governance_sensitive_paths(changed_paths: tuple[str, ...]) -> tuple[str, ...]:
-    sensitive = []
-    for path in changed_paths:
-        if path in GOVERNANCE_SENSITIVE_EXACT_PATHS or path.startswith(
-            GOVERNANCE_SENSITIVE_PREFIXES
-        ):
-            sensitive.append(path)
-    return tuple(sorted(sensitive))
-
-
 def review_trigger_summary(decision: GovernanceDecision) -> str:
-    triggers = []
     if decision.is_large_change:
-        triggers.append(
+        return (
             f"large change ({decision.changed_lines:,} > "
             f"{decision.threshold:,} lines)"
         )
-    if decision.is_governance_sensitive:
-        path_count = len(decision.governance_sensitive_paths)
-        noun = "path" if path_count == 1 else "paths"
-        triggers.append(
-            f"protected CI trust-root change ({path_count:,} {noun})"
-        )
-    return " and ".join(triggers) or "none"
+    return "none"
 
 
 def evaluate_policy(
     pull_request: dict[str, Any],
     reviews: list[dict[str, Any]],
     head_introducer_logins: tuple[str, ...] = (),
-    changed_paths: tuple[str, ...] = (),
 ) -> GovernanceDecision:
     additions = _nonnegative_int(pull_request, "additions")
     deletions = _nonnegative_int(pull_request, "deletions")
@@ -387,10 +319,9 @@ def evaluate_policy(
         raise GovernanceInputError("pull request head identity is missing")
     head_sha = _required_string(head, "sha", "pull request head")
     changed_lines = additions + deletions
-    sensitive_paths = governance_sensitive_paths(changed_paths)
     required_approvals = (
         LARGE_CHANGE_REQUIRED_APPROVALS
-        if changed_lines > LARGE_CHANGE_LINE_THRESHOLD or sensitive_paths
+        if changed_lines > LARGE_CHANGE_LINE_THRESHOLD
         else 0
     )
     if required_approvals and not head_introducer_logins:
@@ -405,8 +336,6 @@ def evaluate_policy(
         deletions=deletions,
         changed_files=changed_files,
         changed_lines=changed_lines,
-        changed_paths=tuple(sorted(changed_paths)),
-        governance_sensitive_paths=sensitive_paths,
         threshold=LARGE_CHANGE_LINE_THRESHOLD,
         required_approvals=required_approvals,
         current_approval_logins=approvals,
@@ -437,8 +366,6 @@ def _write_step_summary(decision: GovernanceDecision) -> None:
         summary.write(
             f"- Independent-review trigger: **{review_trigger_summary(decision)}**\n"
         )
-        sensitive_text = ", ".join(decision.governance_sensitive_paths) or "none"
-        summary.write(f"- Governance-sensitive paths: **{sensitive_text}**\n")
         summary.write(f"- Current-head introducer: **{introducer_text}**\n")
         summary.write(
             "- Current-head core maintainer approvals: "
@@ -478,13 +405,7 @@ def main(argv: list[str] | None = None) -> int:
         additions = _nonnegative_int(pull_request, "additions")
         deletions = _nonnegative_int(pull_request, "deletions")
         changed_files = _nonnegative_int(pull_request, "changed_files")
-        changed_paths = api.get_changed_paths(
-            args.repository, args.pull_request, changed_files
-        )
-        requires_review = (
-            additions + deletions > LARGE_CHANGE_LINE_THRESHOLD
-            or bool(governance_sensitive_paths(changed_paths))
-        )
+        requires_review = additions + deletions > LARGE_CHANGE_LINE_THRESHOLD
         if requires_review:
             reviews = api.get_all(
                 f"repos/{args.repository}/pulls/{args.pull_request}/reviews"
@@ -519,7 +440,7 @@ def main(argv: list[str] | None = None) -> int:
             reviews = []
             head_introducer_logins = ()
         decision = evaluate_policy(
-            pull_request, reviews, head_introducer_logins, changed_paths
+            pull_request, reviews, head_introducer_logins
         )
     except GovernanceInputError as error:
         print(

--- a/scripts/ci/pr_change_governance.py
+++ b/scripts/ci/pr_change_governance.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Fail closed when a large pull request lacks core-maintainer approval."""
+"""Fail closed when a governed pull request lacks core-maintainer approval."""
 
 from __future__ import annotations
 
@@ -356,6 +356,22 @@ def governance_sensitive_paths(changed_paths: tuple[str, ...]) -> tuple[str, ...
     return tuple(sorted(sensitive))
 
 
+def review_trigger_summary(decision: GovernanceDecision) -> str:
+    triggers = []
+    if decision.is_large_change:
+        triggers.append(
+            f"large change ({decision.changed_lines:,} > "
+            f"{decision.threshold:,} lines)"
+        )
+    if decision.is_governance_sensitive:
+        path_count = len(decision.governance_sensitive_paths)
+        noun = "path" if path_count == 1 else "paths"
+        triggers.append(
+            f"protected CI trust-root change ({path_count:,} {noun})"
+        )
+    return " and ".join(triggers) or "none"
+
+
 def evaluate_policy(
     pull_request: dict[str, Any],
     reviews: list[dict[str, Any]],
@@ -417,6 +433,9 @@ def _write_step_summary(decision: GovernanceDecision) -> None:
             f"({decision.additions:,} additions + {decision.deletions:,} deletions)\n"
         )
         summary.write(f"- Changed files: **{decision.changed_files:,}**\n")
+        summary.write(
+            f"- Independent-review trigger: **{review_trigger_summary(decision)}**\n"
+        )
         sensitive_text = ", ".join(decision.governance_sensitive_paths) or "none"
         summary.write(f"- Governance-sensitive paths: **{sensitive_text}**\n")
         summary.write(f"- Current-head introducer: **{introducer_text}**\n")
@@ -509,11 +528,15 @@ def main(argv: list[str] | None = None) -> int:
         )
         return 2
 
-    print(json.dumps(asdict(decision), sort_keys=True))
+    decision_payload = asdict(decision)
+    decision_payload["review_trigger"] = review_trigger_summary(decision)
+    print(json.dumps(decision_payload, sort_keys=True))
     _write_step_summary(decision)
     if decision.allowed:
         print(
-            f"Change governance passed: {decision.changed_lines} changed lines, "
+            "Change governance passed: "
+            f"review trigger {review_trigger_summary(decision)}, "
+            f"{decision.changed_lines} changed lines, "
             f"{len(decision.current_approval_logins)} current core maintainer approvals."
         )
         return 0
@@ -521,9 +544,10 @@ def main(argv: list[str] | None = None) -> int:
     print(
         "::error title=Governed change lacks current core maintainer approval::"
         + _annotation(
-            f"PR #{args.pull_request} changes {decision.changed_lines} lines and "
-            f"touches {len(decision.governance_sensitive_paths)} protected CI trust-root "
-            f"paths, but has only "
+            f"PR #{args.pull_request} requires review because of "
+            f"{review_trigger_summary(decision)}. It changes "
+            f"{decision.changed_lines:,} lines; the large-change threshold is more than "
+            f"{decision.threshold:,}. It has only "
             f"{len(decision.current_approval_logins)} eligible approvals on head "
             f"{decision.head_sha}. The author, current-head introducer, bots, non-core "
             "reviewers, dismissed reviews, duplicate reviewers, and approvals on "

--- a/scripts/ci/pr_change_governance_test.py
+++ b/scripts/ci/pr_change_governance_test.py
@@ -16,6 +16,7 @@ from pr_change_governance import (  # noqa: E402
     GitHubApi,
     GovernanceInputError,
     evaluate_policy,
+    review_trigger_summary,
 )
 
 
@@ -119,6 +120,19 @@ class ChangeGovernancePolicyTest(unittest.TestCase):
         self.assertIn(".github/CODEOWNERS", workflow)
         self.assertIn("NOKV_CODEOWNERS_PATH", workflow)
 
+    def test_workflow_avoids_redundant_review_request_events(self) -> None:
+        workflow = WORKFLOW_PATH.read_text(encoding="utf-8")
+
+        self.assertIn("      - synchronize", workflow)
+        self.assertIn("  pull_request_review:", workflow)
+        self.assertIn("    types: [submitted, edited, dismissed]", workflow)
+        self.assertNotIn("      - review_requested", workflow)
+        self.assertNotIn("      - review_request_removed", workflow)
+        self.assertIn("    name: governed-change-review", workflow)
+        self.assertIn(
+            "STATUS_CONTEXT: change-governance/large-change-review", workflow
+        )
+
     def test_exact_threshold_does_not_trigger_large_change_rule(self) -> None:
         decision = evaluate_policy(pull_request(additions=3_000, deletions=2_000), [])
 
@@ -149,6 +163,44 @@ class ChangeGovernancePolicyTest(unittest.TestCase):
         self.assertEqual(decision.required_approvals, 1)
         self.assertEqual(decision.current_approval_logins, (CORE_TWO,))
         self.assertTrue(decision.allowed)
+
+    def test_review_trigger_summary_names_the_independent_policy_reasons(self) -> None:
+        ordinary = evaluate_policy(
+            pull_request(additions=10),
+            [],
+            changed_paths=("crates/nokv/src/main.rs",),
+        )
+        large = evaluate_policy(
+            pull_request(additions=5_001),
+            [],
+            head_introducer_logins=("contributor",),
+        )
+        sensitive = evaluate_policy(
+            pull_request(additions=10),
+            [],
+            head_introducer_logins=("contributor",),
+            changed_paths=(".github/workflows/rust.yml",),
+        )
+        both = evaluate_policy(
+            pull_request(additions=5_001),
+            [],
+            head_introducer_logins=("contributor",),
+            changed_paths=(".github/workflows/rust.yml",),
+        )
+
+        self.assertEqual(review_trigger_summary(ordinary), "none")
+        self.assertEqual(
+            review_trigger_summary(large), "large change (5,001 > 5,000 lines)"
+        )
+        self.assertEqual(
+            review_trigger_summary(sensitive),
+            "protected CI trust-root change (1 path)",
+        )
+        self.assertEqual(
+            review_trigger_summary(both),
+            "large change (5,001 > 5,000 lines) and "
+            "protected CI trust-root change (1 path)",
+        )
 
     def test_sensitive_workbench_gate_change_rejects_pusher_approval(self) -> None:
         decision = evaluate_policy(

--- a/scripts/ci/pr_change_governance_test.py
+++ b/scripts/ci/pr_change_governance_test.py
@@ -25,9 +25,6 @@ OLD_HEAD = "b" * 40
 CORE_ONE = "wchwawa"
 CORE_TWO = "feichai0017"
 REPO = Path(__file__).resolve().parents[2]
-CODEOWNERS_PATH = Path(
-    os.environ.get("NOKV_CODEOWNERS_PATH", REPO / ".github/CODEOWNERS")
-)
 WORKFLOW_PATH = Path(
     os.environ.get(
         "NOKV_CHANGE_GOVERNANCE_WORKFLOW_PATH",
@@ -96,30 +93,13 @@ class FakeGitHubApi(GitHubApi):
 
 
 class ChangeGovernancePolicyTest(unittest.TestCase):
-    def test_codeowners_protects_only_ci_trust_roots(self) -> None:
-        lines = {
-            line.strip()
-            for line in CODEOWNERS_PATH.read_text(encoding="utf-8").splitlines()
-            if line.strip() and not line.lstrip().startswith("#")
-        }
-        self.assertNotIn("* @wchwawa @feichai0017", lines)
-        self.assertEqual(
-            lines,
-            {
-                "/.github/CODEOWNERS @wchwawa @feichai0017",
-                "/.github/actions/ @wchwawa @feichai0017",
-                "/.github/workflows/ @wchwawa @feichai0017",
-                "/scripts/ci/ @wchwawa @feichai0017",
-                "/scripts/workbench/ @wchwawa @feichai0017",
-                "/scripts/release/test_homebrew_source_release.py @wchwawa @feichai0017",
-                "/scripts/release/test_python_sdk_release.py @wchwawa @feichai0017",
-            },
-        )
-
-    def test_base_owned_workflow_fetches_codeowners_before_policy_tests(self) -> None:
+    def test_base_owned_workflow_fetches_policy_and_tests(self) -> None:
         workflow = WORKFLOW_PATH.read_text(encoding="utf-8")
+        self.assertIn("scripts/ci/pr_change_governance.py", workflow)
+        self.assertIn("scripts/ci/pr_change_governance_test.py", workflow)
         self.assertIn(".github/CODEOWNERS", workflow)
         self.assertIn("NOKV_CODEOWNERS_PATH", workflow)
+        self.assertNotIn("actions/checkout", workflow)
 
     def test_workflow_avoids_redundant_review_request_events(self) -> None:
         workflow = WORKFLOW_PATH.read_text(encoding="utf-8")
@@ -129,10 +109,10 @@ class ChangeGovernancePolicyTest(unittest.TestCase):
         self.assertIn("    types: [submitted, edited, dismissed]", workflow)
         self.assertNotIn("      - review_requested", workflow)
         self.assertNotIn("      - review_request_removed", workflow)
-        self.assertIn("    name: governed-change-review", workflow)
-        self.assertIn(
-            "STATUS_CONTEXT: change-governance/large-change-review", workflow
-        )
+        self.assertIn("    name: large-change-review", workflow)
+        self.assertNotIn("statuses: write", workflow)
+        self.assertNotIn("STATUS_CONTEXT", workflow)
+        self.assertNotIn("post_status", workflow)
 
     def test_exact_threshold_does_not_trigger_large_change_rule(self) -> None:
         decision = evaluate_policy(pull_request(additions=3_000, deletions=2_000), [])
@@ -142,104 +122,35 @@ class ChangeGovernancePolicyTest(unittest.TestCase):
         self.assertEqual(decision.required_approvals, 0)
 
     def test_small_ordinary_change_keeps_fast_path_without_review(self) -> None:
-        decision = evaluate_policy(
-            pull_request(additions=10), [], changed_paths=("crates/nokv/src/main.rs",)
-        )
+        decision = evaluate_policy(pull_request(additions=10), [])
 
         self.assertFalse(decision.is_large_change)
-        self.assertFalse(decision.is_governance_sensitive)
         self.assertEqual(decision.required_approvals, 0)
         self.assertTrue(decision.allowed)
 
-    def test_small_governance_change_requires_non_pusher_core_review(self) -> None:
+    def test_small_ci_trust_root_change_does_not_require_review(self) -> None:
         decision = evaluate_policy(
             pull_request(additions=10),
-            [review(CORE_TWO)],
-            head_introducer_logins=("contributor",),
-            changed_paths=(".github/workflows/rust.yml",),
+            [],
         )
 
         self.assertFalse(decision.is_large_change)
-        self.assertTrue(decision.is_governance_sensitive)
-        self.assertEqual(decision.required_approvals, 1)
-        self.assertEqual(decision.current_approval_logins, (CORE_TWO,))
+        self.assertEqual(decision.required_approvals, 0)
+        self.assertEqual(decision.current_approval_logins, ())
         self.assertTrue(decision.allowed)
 
-    def test_review_trigger_summary_names_the_independent_policy_reasons(self) -> None:
-        ordinary = evaluate_policy(
-            pull_request(additions=10),
-            [],
-            changed_paths=("crates/nokv/src/main.rs",),
-        )
+    def test_review_trigger_summary_names_only_the_size_threshold(self) -> None:
+        ordinary = evaluate_policy(pull_request(additions=10), [])
         large = evaluate_policy(
             pull_request(additions=5_001),
             [],
             head_introducer_logins=("contributor",),
-        )
-        sensitive = evaluate_policy(
-            pull_request(additions=10),
-            [],
-            head_introducer_logins=("contributor",),
-            changed_paths=(".github/workflows/rust.yml",),
-        )
-        both = evaluate_policy(
-            pull_request(additions=5_001),
-            [],
-            head_introducer_logins=("contributor",),
-            changed_paths=(".github/workflows/rust.yml",),
         )
 
         self.assertEqual(review_trigger_summary(ordinary), "none")
         self.assertEqual(
             review_trigger_summary(large), "large change (5,001 > 5,000 lines)"
         )
-        self.assertEqual(
-            review_trigger_summary(sensitive),
-            "protected CI trust-root change (1 path)",
-        )
-        self.assertEqual(
-            review_trigger_summary(both),
-            "large change (5,001 > 5,000 lines) and "
-            "protected CI trust-root change (1 path)",
-        )
-
-    def test_sensitive_workbench_gate_change_rejects_pusher_approval(self) -> None:
-        decision = evaluate_policy(
-            pull_request(additions=10),
-            [review(CORE_ONE)],
-            head_introducer_logins=(CORE_ONE,),
-            changed_paths=("scripts/workbench/live_workbench.py",),
-        )
-
-        self.assertTrue(decision.is_governance_sensitive)
-        self.assertFalse(decision.allowed)
-        self.assertEqual(decision.current_approval_logins, ())
-
-    def test_all_trust_root_paths_are_sensitive_but_docs_are_not(self) -> None:
-        sensitive = (
-            ".github/CODEOWNERS",
-            ".github/actions/verify/action.yml",
-            ".github/workflows/rust.yml",
-            "scripts/ci/pr_change_governance.py",
-            "scripts/workbench/pre423_contract_ledger.json",
-            "scripts/release/test_homebrew_source_release.py",
-            "scripts/release/test_python_sdk_release.py",
-        )
-        for path in sensitive:
-            with self.subTest(path=path):
-                decision = evaluate_policy(
-                    pull_request(additions=1),
-                    [review(CORE_TWO)],
-                    head_introducer_logins=("contributor",),
-                    changed_paths=(path,),
-                )
-                self.assertTrue(decision.is_governance_sensitive)
-        decision = evaluate_policy(
-            pull_request(additions=1),
-            [],
-            changed_paths=("docs/development/code_contract.md",),
-        )
-        self.assertFalse(decision.is_governance_sensitive)
 
     def test_one_line_over_threshold_requires_one_core_approval(self) -> None:
         decision = evaluate_policy(
@@ -480,36 +391,6 @@ class ChangeGovernancePolicyTest(unittest.TestCase):
             api.get_current_head_introducers(
                 "NoKV-Lab/NoKV", HEAD, 17, 101, "feature", "2026-08-15T00:00:00Z"
             )
-
-    def test_changed_paths_are_complete_canonical_and_sorted(self) -> None:
-        api = FakeGitHubApi(
-            [
-                {
-                    "filename": "docs/live_workbench.py",
-                    "previous_filename": "scripts/workbench/live_workbench.py",
-                },
-                {"filename": ".github/workflows/rust.yml"},
-            ]
-        )
-
-        self.assertEqual(
-            api.get_changed_paths("NoKV-Lab/NoKV", 17, 2),
-            (
-                ".github/workflows/rust.yml",
-                "docs/live_workbench.py",
-                "scripts/workbench/live_workbench.py",
-            ),
-        )
-
-    def test_incomplete_or_noncanonical_changed_paths_fail_closed(self) -> None:
-        incomplete = FakeGitHubApi([{"filename": ".github/workflows/rust.yml"}])
-        with self.assertRaisesRegex(GovernanceInputError, "incomplete"):
-            incomplete.get_changed_paths("NoKV-Lab/NoKV", 17, 2)
-
-        noncanonical = FakeGitHubApi([{"filename": "../rust.yml"}])
-        with self.assertRaisesRegex(GovernanceInputError, "canonical"):
-            noncanonical.get_changed_paths("NoKV-Lab/NoKV", 17, 1)
-
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Related Issue

Relates to #473.

## Summary

- require one eligible CODEOWNER approval only when additions plus deletions exceed 5,000 lines;
- remove the protected CI trust-root path trigger, so every change at or below 5,000 lines takes the zero-review fast path;
- retain exact-head approval, stale-review, bot, author, and current-head-pusher validation for large changes;
- use the single native `Change Governance / large-change-review` check and remove the duplicate custom commit status;
- stop rerunning governance when a reviewer is merely requested or removed.

## Problem

The previous policy had two independent review triggers: change size and protected CI paths. That made #473 require approval at 1,040 changed lines even though the configured size threshold was 5,000. The workflow also exposed the same result twice through a native Actions check and a manually published commit status.

## Result

The review rule now has one threshold and one visible authority. A pull request with 5,000 or fewer changed lines does not require governance approval, regardless of its paths. A larger pull request still requires one current core CODEOWNER approval on the exact head from someone other than the author or current-head introducer.

Branch protection was migrated to the native `large-change-review` check before the custom status publisher was removed, avoiding a fail-open or unsatisfiable required-check window.

## Validation

- `python3 scripts/ci/pr_change_governance_test.py` — 24 tests passed;
- `python3 -m py_compile scripts/ci/pr_change_governance.py scripts/ci/pr_change_governance_test.py` — passed;
- Ruby YAML parse of `.github/workflows/change-governance.yml` — passed;
- live read-only evaluation of PR #473 — passed with 1,040 lines and zero required approvals;
- live read-only evaluation of the current #475 head — passed with 363 lines and zero required approvals;
- `git diff --check` — passed.

`actionlint` was not available locally; GitHub Actions remains the authoritative workflow validation.
