### PR TITLE
feat(python): commit and restore in the SDK, including restore from a commit

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1280,6 +1280,7 @@ dependencies = [
  "nokv-protocol",
  "nokv-server",
  "nokv-types",
+ "nokv-workbench-projection",
  "serde",
  "serde_json",
  "sha2 0.10.9",
@@ -1390,10 +1391,14 @@ dependencies = [
 name = "nokv-python"
 version = "0.11.0"
 dependencies = [
+ "nokv-agent",
  "nokv-client",
  "nokv-object",
  "nokv-protocol",
+ "nokv-types",
+ "nokv-workbench-projection",
  "pyo3",
+ "serde_json",
  "tempfile",
 ]
 
@@ -1417,6 +1422,15 @@ dependencies = [
 [[package]]
 name = "nokv-types"
 version = "0.1.0"
+
+[[package]]
+name = "nokv-workbench-projection"
+version = "0.1.0"
+dependencies = [
+ "nokv-agent",
+ "nokv-client",
+ "nokv-types",
+]
 
 [[package]]
 name = "num-bigint-dig"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ members = [
     "crates/nokv-object",
     "crates/nokv-client",
     "crates/nokv-agent",
+    "crates/nokv-workbench-projection",
     "crates/nokv-server",
     "crates/nokv",
     "crates/nokv-python",
@@ -32,6 +33,7 @@ nokv-meta-store = { path = "crates/nokv-meta-store", version = "0.1.0" }
 nokv-meta-holt = { path = "crates/nokv-meta-holt", version = "0.1.0" }
 nokv-meta = { path = "crates/nokv-meta", version = "0.1.0" }
 nokv-control = { path = "crates/nokv-control", version = "0.1.0" }
+nokv-workbench-projection = { path = "crates/nokv-workbench-projection", version = "0.1.0" }
 nokv-object = { path = "crates/nokv-object", version = "0.1.0" }
 nokv-client = { path = "crates/nokv-client", version = "0.1.0" }
 nokv-agent = { path = "crates/nokv-agent", version = "0.1.0" }

--- a/crates/nokv-agent/src/facade.rs
+++ b/crates/nokv-agent/src/facade.rs
@@ -10,8 +10,8 @@ use std::fmt;
 
 use crate::{
     canonical_json_bytes, projection::digest_uri, projection::hash_length_prefixed,
-    projection::lowercase_hex, scan_agent_grep, verify_run_manifest_v1, workbench_commit_identity,
-    AgentError, AgentGrepScanRequest, GenericGrepScanLimits, WorkbenchToolHandler,
+    projection::lowercase_hex, scan_agent_grep, verify_run_manifest_v1, AgentError,
+    AgentGrepScanRequest, GenericGrepScanLimits, WorkbenchToolHandler,
 };
 use base64::Engine;
 use nokv_types::{
@@ -1439,11 +1439,17 @@ impl<B: WorkbenchBackend> SdkWorkbenchToolHandler<B> {
             .get("manifest")
             .and_then(Value::as_object)
             .ok_or_else(|| AgentError::invalid_arguments("manifest must be an object"))?;
-        let canonical_manifest = canonical_json(&Value::Object(manifest.clone()))?;
-        let manifest_digest_uri = digest_uri(&canonical_manifest);
         let content_digest_uri = required_string(arguments, "content_digest_uri")?.to_owned();
-        let stable_commit_id =
-            commit_identity(&workbench_id, &content_digest_uri, &manifest_digest_uri);
+        let crate::projection::WorkbenchCommitInputs {
+            canonical_manifest,
+            manifest_digest_uri,
+            stable_commit_id,
+        } = crate::projection::workbench_commit_inputs(
+            &workbench_id,
+            &Value::Object(manifest.clone()),
+            &content_digest_uri,
+        )
+        .map_err(|error| AgentError::invalid_arguments(error.to_string()))?;
         let workbench_path = self.workbench_path(&workbench_id);
         let replace = optional_bool(arguments, "replace")?.unwrap_or(false);
         let outcome = self
@@ -2660,14 +2666,6 @@ fn canonical_json(value: &Value) -> Result<Vec<u8>, AgentError> {
             json!({}),
         )
     })
-}
-
-fn commit_identity(
-    workbench_id: &WorkbenchId,
-    content_digest_uri: &str,
-    manifest_digest_uri: &str,
-) -> [u8; 32] {
-    workbench_commit_identity(workbench_id, content_digest_uri, manifest_digest_uri)
 }
 
 fn snapshot_annotation(arguments: &Value) -> Result<Value, AgentError> {

--- a/crates/nokv-agent/src/facade.rs
+++ b/crates/nokv-agent/src/facade.rs
@@ -601,16 +601,31 @@ pub struct SnapshotRetireOutcome {
 pub struct RestoreRequest {
     pub source_workbench_id: WorkbenchId,
     pub source_workbench_path: String,
-    pub selector: SnapshotSelector,
+    pub origin: RestoreOrigin,
     pub destination_workbench_id: WorkbenchId,
     pub destination_workbench_path: String,
+}
+
+/// What a restore reads its frozen state from.
+///
+/// A snapshot is a lease and expires; a commit is durable. A decision point
+/// that has to stay citable past the lease bound can only be reconstructed
+/// from its commit.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum RestoreOrigin {
+    Snapshot(SnapshotSelector),
+    Commit([u8; 32]),
 }
 
 #[derive(Clone, Debug, PartialEq)]
 pub struct RestoreOutcome {
     pub operation_id: [u8; 16],
-    pub snapshot_id: u64,
-    pub read_version: u64,
+    /// Present exactly for snapshot restores.
+    pub snapshot_id: Option<u64>,
+    /// Present exactly for snapshot restores.
+    pub read_version: Option<u64>,
+    /// Present exactly for commit restores.
+    pub commit_id: Option<[u8; 32]>,
     pub destination_generation: u64,
     pub idempotent_replay: bool,
 }
@@ -1612,17 +1627,34 @@ impl<B: WorkbenchBackend> SdkWorkbenchToolHandler<B> {
                 "destination_id must differ from id",
             ));
         }
-        let selector = parse_snapshot_selector_value(
-            arguments
-                .get("at_snapshot")
-                .ok_or_else(|| AgentError::invalid_arguments("missing at_snapshot"))?,
-        )?;
+        let origin = match (arguments.get("at_snapshot"), arguments.get("at_commit")) {
+            (Some(_), Some(_)) => {
+                return Err(AgentError::invalid_arguments(
+                    "give at_snapshot or at_commit, not both",
+                ))
+            }
+            (Some(value), None) => RestoreOrigin::Snapshot(parse_snapshot_selector_value(value)?),
+            (None, Some(value)) => {
+                let commit_id = value.as_str().ok_or_else(|| {
+                    AgentError::invalid_arguments("at_commit must be a commit identity string")
+                })?;
+                RestoreOrigin::Commit(
+                    crate::projection::decode_commit_identity(commit_id)
+                        .map_err(|error| AgentError::invalid_arguments(error.to_string()))?,
+                )
+            }
+            (None, None) => {
+                return Err(AgentError::invalid_arguments(
+                    "missing at_snapshot or at_commit",
+                ))
+            }
+        };
         let outcome = self
             .backend
             .restore(RestoreRequest {
                 source_workbench_id: source_workbench_id.clone(),
                 source_workbench_path: self.workbench_path(&source_workbench_id),
-                selector,
+                origin,
                 destination_workbench_id: destination_workbench_id.clone(),
                 destination_workbench_path: self.workbench_path(&destination_workbench_id),
             })
@@ -1653,6 +1685,7 @@ impl<B: WorkbenchBackend> SdkWorkbenchToolHandler<B> {
             "destination_workbench_id": destination_workbench_id.as_str(),
             "snapshot_id": outcome.snapshot_id,
             "read_version": outcome.read_version,
+            "commit_id": outcome.commit_id.as_ref().map(|id| lowercase_hex(id)),
             "destination_generation": outcome.destination_generation,
             "idempotent_replay": outcome.idempotent_replay,
             "cleanup_pending": false,

--- a/crates/nokv-agent/src/lib.rs
+++ b/crates/nokv-agent/src/lib.rs
@@ -100,7 +100,7 @@ const TOOL_DESCRIPTIONS: [(&str, &str); WORKBENCH_TOOL_COUNT] = [
     ),
     (
         "workbench_restore",
-        "Restore a live snapshot into an absent destination workbench while preserving the source. Staging stays hidden until atomic publication, immutable revisions are reused, and exact retries converge.",
+        "Restore a frozen state into an absent destination workbench while preserving the source. Name either at_snapshot or at_commit; a snapshot is a lease that expires, a commit is durable, so a decision point that must stay citable is restored from its commit. Staging stays hidden until atomic publication, immutable revisions are reused, and exact retries converge.",
     ),
 ];
 

--- a/crates/nokv-agent/src/projection.rs
+++ b/crates/nokv-agent/src/projection.rs
@@ -44,13 +44,18 @@ const RESTORE_MANIFEST_FIELDS: [&str; 8] = [
     "source_workbench_id",
 ];
 const RESTORED_FROM_FIELDS: [&str; 3] = ["path", "snapshot_id", "workbench_id"];
-const RESTORE_MANIFEST_V2_FIELDS: [&str; 6] = [
+// v2 changes exactly one thing about v1: the snapshot id becomes a
+// discriminated source that can also name a commit. Every other field keeps
+// its v1 place, because a durable format that moves fields it did not need
+// to move breaks readers for no reason.
+const RESTORE_MANIFEST_V2_FIELDS: [&str; 7] = [
     "destination_path",
     "destination_workbench_id",
     "operation_id",
     "restored_from",
     "schema",
     "source_path",
+    "source_workbench_id",
 ];
 const RESTORED_FROM_V2_FIELDS: [&str; 3] = ["path", "source", "workbench_id"];
 
@@ -417,6 +422,7 @@ pub fn build_restore_manifest_v2(
             "path": source_path,
             "source": source_value,
         },
+        "source_workbench_id": source_workbench_id.as_str(),
         "source_path": source_path,
         "destination_workbench_id": destination_workbench_id.as_str(),
         "destination_path": destination_path,
@@ -479,6 +485,10 @@ pub fn verify_restore_manifest_v2(
         "operation_id",
         require_string(object, "operation_id", "restore manifest")?,
     )?;
+    let source_workbench_id = WorkbenchId::new(
+        require_string(object, "source_workbench_id", "restore manifest")?.to_owned(),
+    )
+    .map_err(|error| ProjectionError::new(format!("invalid source_workbench_id: {error}")))?;
     let source_path = require_string(object, "source_path", "restore manifest")?.to_owned();
     let destination_workbench_id = WorkbenchId::new(
         require_string(object, "destination_workbench_id", "restore manifest")?.to_owned(),
@@ -497,10 +507,15 @@ pub fn verify_restore_manifest_v2(
         restored_from,
         &RESTORED_FROM_V2_FIELDS,
     )?;
-    let source_workbench_id = WorkbenchId::new(
-        require_string(restored_from, "workbench_id", "restored_from")?.to_owned(),
-    )
-    .map_err(|error| ProjectionError::new(format!("invalid source_workbench_id: {error}")))?;
+    // restored_from restates the source so the envelope reads on its own; the
+    // two statements have to agree or the manifest contradicts itself.
+    if require_string(restored_from, "workbench_id", "restored_from")?
+        != source_workbench_id.as_str()
+    {
+        return Err(ProjectionError::new(
+            "restore manifest restored_from disagrees with its source workbench",
+        ));
+    }
     if source_workbench_id == destination_workbench_id {
         return Err(ProjectionError::new(
             "restore destination workbench must differ from its source",

--- a/crates/nokv-agent/src/projection.rs
+++ b/crates/nokv-agent/src/projection.rs
@@ -21,6 +21,7 @@ const RUN_MANIFEST_PROJECTION_INPUT_DOMAIN: &[u8] =
     b"nokv.workbench.run_manifest.projection_input.v1\0";
 const RESTORED_CONTENT_DIGEST_DOMAIN: &[u8] = b"nokv.workbench.restored_content_digest.v1\0";
 pub const RESTORE_MANIFEST_V1_SCHEMA: &str = "nokv.workbench.restore_manifest.v1";
+pub const RESTORE_MANIFEST_V2_SCHEMA: &str = "nokv.workbench.restore_manifest.v2";
 
 const RUN_MANIFEST_FIELDS: [&str; 8] = [
     "commit_identity",
@@ -43,6 +44,15 @@ const RESTORE_MANIFEST_FIELDS: [&str; 8] = [
     "source_workbench_id",
 ];
 const RESTORED_FROM_FIELDS: [&str; 3] = ["path", "snapshot_id", "workbench_id"];
+const RESTORE_MANIFEST_V2_FIELDS: [&str; 6] = [
+    "destination_path",
+    "destination_workbench_id",
+    "operation_id",
+    "restored_from",
+    "schema",
+    "source_path",
+];
+const RESTORED_FROM_V2_FIELDS: [&str; 3] = ["path", "source", "workbench_id"];
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct ProjectionError {
@@ -95,6 +105,39 @@ pub struct VerifiedRestoreManifestV1 {
 pub fn canonical_json_bytes(value: &Value) -> Result<Vec<u8>, ProjectionError> {
     serde_json::to_vec(&canonical_json_value(value))
         .map_err(|error| ProjectionError::new(format!("canonical JSON encoding failed: {error}")))
+}
+
+/// The canonical inputs one Workbench commit is built from.
+///
+/// Every caller -- CLI, MCP, Python SDK -- must derive these the same way:
+/// the manifest digest and the stable commit id both feed the durable commit
+/// identity and the operation's idempotency, so two callers that shape them
+/// differently would write two commits for one intent.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct WorkbenchCommitInputs {
+    pub canonical_manifest: Vec<u8>,
+    pub manifest_digest_uri: String,
+    pub stable_commit_id: [u8; 32],
+}
+
+/// Shapes the canonical inputs for one Workbench commit.
+pub fn workbench_commit_inputs(
+    workbench_id: &WorkbenchId,
+    manifest: &Value,
+    content_digest_uri: &str,
+) -> Result<WorkbenchCommitInputs, ProjectionError> {
+    if !manifest.is_object() {
+        return Err(ProjectionError::new("commit manifest must be an object"));
+    }
+    let canonical_manifest = canonical_json_bytes(manifest)?;
+    let manifest_digest_uri = digest_uri(&canonical_manifest);
+    let stable_commit_id =
+        workbench_commit_identity(workbench_id, content_digest_uri, &manifest_digest_uri);
+    Ok(WorkbenchCommitInputs {
+        canonical_manifest,
+        manifest_digest_uri,
+        stable_commit_id,
+    })
 }
 
 pub fn workbench_commit_identity(
@@ -303,6 +346,223 @@ pub fn restore_effective_content_digest_uri_v1(
     hasher.update(materialized_member_digest);
     let digest: [u8; 32] = hasher.finalize().into();
     Ok(format!("sha256:{}", lowercase_hex(&digest)))
+}
+
+/// Where a restore read its frozen state from.
+///
+/// A snapshot is a lease and expires; a commit is durable. A restore manifest
+/// has to say which one it used, or a replayed restore cannot tell whether it
+/// is the same restore.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum RestoreManifestSource {
+    Snapshot { snapshot_id: u64 },
+    Commit { commit_id: [u8; 32] },
+}
+
+/// A verified restore manifest of either schema version.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct VerifiedRestoreManifest {
+    pub operation_id: [u8; 16],
+    pub source_workbench_id: WorkbenchId,
+    pub source_path: String,
+    pub destination_workbench_id: WorkbenchId,
+    pub destination_path: String,
+    pub source: RestoreManifestSource,
+    pub canonical_envelope: Vec<u8>,
+    pub envelope_digest_uri: String,
+}
+
+/// Builds the v2 restore manifest, which can name either source.
+pub fn build_restore_manifest_v2(
+    operation_id: [u8; 16],
+    source_workbench_id: &WorkbenchId,
+    source_path: &str,
+    destination_workbench_id: &WorkbenchId,
+    destination_path: &str,
+    source: RestoreManifestSource,
+) -> Result<Vec<u8>, ProjectionError> {
+    validate_presentation_path("source_path", source_path)?;
+    validate_presentation_path("destination_path", destination_path)?;
+    if source_workbench_id == destination_workbench_id {
+        return Err(ProjectionError::new(
+            "restore destination workbench must differ from its source",
+        ));
+    }
+    let source_value = match source {
+        RestoreManifestSource::Snapshot { snapshot_id } => {
+            if snapshot_id == 0 {
+                return Err(ProjectionError::new(
+                    "restore snapshot_id must be greater than zero",
+                ));
+            }
+            json!({ "kind": "snapshot", "snapshot_id": snapshot_id })
+        }
+        RestoreManifestSource::Commit { commit_id } => {
+            if commit_id == [0u8; 32] {
+                return Err(ProjectionError::new("restore commit_id must be non-zero"));
+            }
+            json!({ "kind": "commit", "commit_id": lowercase_hex(&commit_id) })
+        }
+    };
+    let envelope = json!({
+        "schema": RESTORE_MANIFEST_V2_SCHEMA,
+        "operation_id": lowercase_hex(&operation_id),
+        "restored_from": {
+            "workbench_id": source_workbench_id.as_str(),
+            "path": source_path,
+            "source": source_value,
+        },
+        "source_path": source_path,
+        "destination_workbench_id": destination_workbench_id.as_str(),
+        "destination_path": destination_path,
+    });
+    let bytes = canonical_json_bytes(&envelope)?;
+    verify_restore_manifest(&bytes)?;
+    Ok(bytes)
+}
+
+/// Verifies a restore manifest of either schema version.
+///
+/// v1 envelopes stay readable: they are durable artifacts inside workbenches
+/// that were restored before v2 existed.
+pub fn verify_restore_manifest(bytes: &[u8]) -> Result<VerifiedRestoreManifest, ProjectionError> {
+    let envelope: Value = serde_json::from_slice(bytes).map_err(|error| {
+        ProjectionError::new(format!("restore manifest is not valid JSON: {error}"))
+    })?;
+    let schema = envelope
+        .get("schema")
+        .and_then(Value::as_str)
+        .ok_or_else(|| ProjectionError::new("restore manifest schema is required"))?;
+    if schema == RESTORE_MANIFEST_V1_SCHEMA {
+        let verified = verify_restore_manifest_v1(bytes)?;
+        return Ok(VerifiedRestoreManifest {
+            operation_id: verified.operation_id,
+            source_workbench_id: verified.source_workbench_id,
+            source_path: verified.source_path,
+            destination_workbench_id: verified.destination_workbench_id,
+            destination_path: verified.destination_path,
+            source: RestoreManifestSource::Snapshot {
+                snapshot_id: verified.snapshot_id,
+            },
+            canonical_envelope: verified.canonical_envelope,
+            envelope_digest_uri: verified.envelope_digest_uri,
+        });
+    }
+    verify_restore_manifest_v2(bytes)
+}
+
+/// Verifies exactly the v2 schema.
+pub fn verify_restore_manifest_v2(
+    bytes: &[u8],
+) -> Result<VerifiedRestoreManifest, ProjectionError> {
+    let envelope: Value = serde_json::from_slice(bytes).map_err(|error| {
+        ProjectionError::new(format!("restore manifest is not valid JSON: {error}"))
+    })?;
+    require_canonical_bytes("restore manifest", bytes, &envelope)?;
+    let object = exact_object("restore manifest", &envelope, &RESTORE_MANIFEST_V2_FIELDS)?;
+    require_string(object, "schema", "restore manifest").and_then(|schema| {
+        require_equal(
+            "restore manifest schema",
+            schema,
+            RESTORE_MANIFEST_V2_SCHEMA,
+        )
+    })?;
+    let operation_id = decode_lowercase_hex::<16>(
+        "operation_id",
+        require_string(object, "operation_id", "restore manifest")?,
+    )?;
+    let source_path = require_string(object, "source_path", "restore manifest")?.to_owned();
+    let destination_workbench_id = WorkbenchId::new(
+        require_string(object, "destination_workbench_id", "restore manifest")?.to_owned(),
+    )
+    .map_err(|error| ProjectionError::new(format!("invalid destination_workbench_id: {error}")))?;
+    let destination_path =
+        require_string(object, "destination_path", "restore manifest")?.to_owned();
+    validate_presentation_path("source_path", &source_path)?;
+    validate_presentation_path("destination_path", &destination_path)?;
+
+    let restored_from = object
+        .get("restored_from")
+        .ok_or_else(|| ProjectionError::new("restore manifest restored_from is required"))?;
+    let restored_from = exact_object(
+        "restore manifest restored_from",
+        restored_from,
+        &RESTORED_FROM_V2_FIELDS,
+    )?;
+    let source_workbench_id = WorkbenchId::new(
+        require_string(restored_from, "workbench_id", "restored_from")?.to_owned(),
+    )
+    .map_err(|error| ProjectionError::new(format!("invalid source_workbench_id: {error}")))?;
+    if source_workbench_id == destination_workbench_id {
+        return Err(ProjectionError::new(
+            "restore destination workbench must differ from its source",
+        ));
+    }
+    if require_string(restored_from, "path", "restored_from")? != source_path {
+        return Err(ProjectionError::new(
+            "restore manifest restored_from disagrees with its source path",
+        ));
+    }
+    let source_object = restored_from
+        .get("source")
+        .and_then(Value::as_object)
+        .ok_or_else(|| ProjectionError::new("restored_from source must be an object"))?;
+    let kind = source_object
+        .get("kind")
+        .and_then(Value::as_str)
+        .ok_or_else(|| ProjectionError::new("restored_from source kind is required"))?;
+    let source = match kind {
+        "snapshot" => {
+            if source_object.len() != 2 {
+                return Err(ProjectionError::new(
+                    "a snapshot source carries exactly kind and snapshot_id",
+                ));
+            }
+            let snapshot_id = source_object
+                .get("snapshot_id")
+                .and_then(Value::as_u64)
+                .filter(|snapshot_id| *snapshot_id != 0)
+                .ok_or_else(|| {
+                    ProjectionError::new("restore snapshot_id must be a positive integer")
+                })?;
+            RestoreManifestSource::Snapshot { snapshot_id }
+        }
+        "commit" => {
+            if source_object.len() != 2 {
+                return Err(ProjectionError::new(
+                    "a commit source carries exactly kind and commit_id",
+                ));
+            }
+            let commit_id = decode_lowercase_hex::<32>(
+                "commit_id",
+                source_object
+                    .get("commit_id")
+                    .and_then(Value::as_str)
+                    .ok_or_else(|| ProjectionError::new("restore commit_id is required"))?,
+            )?;
+            if commit_id == [0u8; 32] {
+                return Err(ProjectionError::new("restore commit_id must be non-zero"));
+            }
+            RestoreManifestSource::Commit { commit_id }
+        }
+        other => {
+            return Err(ProjectionError::new(format!(
+                "unknown restore source kind: {other}"
+            )))
+        }
+    };
+    let canonical_envelope = canonical_json_bytes(&envelope)?;
+    let envelope_digest_uri = digest_uri(&canonical_envelope);
+    Ok(VerifiedRestoreManifest {
+        operation_id,
+        source_workbench_id,
+        source_path,
+        destination_workbench_id,
+        destination_path,
+        source,
+        canonical_envelope,
+        envelope_digest_uri,
+    })
 }
 
 pub fn build_restore_manifest_v1(
@@ -913,6 +1173,123 @@ mod tests {
         assert!(first.starts_with("sha256:"));
         assert_eq!(first.len(), 71);
         assert!(restore_effective_content_digest_uri_v1("not-a-digest", true, [1; 32]).is_err());
+    }
+
+    #[test]
+    fn restore_manifest_v2_records_a_snapshot_source() {
+        let body = build_restore_manifest_v2(
+            [0x11; 16],
+            &workbench("source"),
+            "/agents/test/wb/source",
+            &workbench("destination"),
+            "/agents/test/wb/destination",
+            RestoreManifestSource::Snapshot { snapshot_id: 7 },
+        )
+        .unwrap();
+        let verified = verify_restore_manifest(&body).unwrap();
+        assert_eq!(verified.operation_id, [0x11; 16]);
+        assert_eq!(
+            verified.source,
+            RestoreManifestSource::Snapshot { snapshot_id: 7 }
+        );
+        let text = String::from_utf8(body).unwrap();
+        assert!(text.contains(RESTORE_MANIFEST_V2_SCHEMA));
+    }
+
+    #[test]
+    fn restore_manifest_v2_records_a_commit_source() {
+        // A commit outlives every snapshot lease, so a citable decision point
+        // has to be restorable from one.
+        let body = build_restore_manifest_v2(
+            [0x22; 16],
+            &workbench("source"),
+            "/agents/test/wb/source",
+            &workbench("destination"),
+            "/agents/test/wb/destination",
+            RestoreManifestSource::Commit {
+                commit_id: [0xab; 32],
+            },
+        )
+        .unwrap();
+        let verified = verify_restore_manifest(&body).unwrap();
+        assert_eq!(
+            verified.source,
+            RestoreManifestSource::Commit {
+                commit_id: [0xab; 32]
+            }
+        );
+        let text = String::from_utf8(body).unwrap();
+        assert!(text.contains("commit_id"));
+        assert!(!text.contains("snapshot_id"));
+    }
+
+    #[test]
+    fn restore_manifest_v2_distinguishes_the_two_sources() {
+        let snapshot = build_restore_manifest_v2(
+            [0x33; 16],
+            &workbench("source"),
+            "/agents/test/wb/source",
+            &workbench("destination"),
+            "/agents/test/wb/destination",
+            RestoreManifestSource::Snapshot { snapshot_id: 9 },
+        )
+        .unwrap();
+        let commit = build_restore_manifest_v2(
+            [0x33; 16],
+            &workbench("source"),
+            "/agents/test/wb/source",
+            &workbench("destination"),
+            "/agents/test/wb/destination",
+            RestoreManifestSource::Commit {
+                commit_id: [0x09; 32],
+            },
+        )
+        .unwrap();
+        assert_ne!(snapshot, commit, "the source must be part of the envelope");
+    }
+
+    #[test]
+    fn restore_manifest_reader_still_accepts_v1_envelopes() {
+        // v1 manifests are durable artifacts in already-restored workbenches;
+        // the reader has to keep understanding them.
+        let body = build_restore_manifest_v1(
+            [0x44; 16],
+            &workbench("source"),
+            "/agents/test/wb/source",
+            &workbench("destination"),
+            "/agents/test/wb/destination",
+            13,
+        )
+        .unwrap();
+        let verified = verify_restore_manifest(&body).unwrap();
+        assert_eq!(
+            verified.source,
+            RestoreManifestSource::Snapshot { snapshot_id: 13 }
+        );
+    }
+
+    #[test]
+    fn restore_manifest_v2_refuses_a_zero_snapshot_and_a_zero_commit() {
+        assert!(build_restore_manifest_v2(
+            [0x55; 16],
+            &workbench("source"),
+            "/agents/test/wb/source",
+            &workbench("destination"),
+            "/agents/test/wb/destination",
+            RestoreManifestSource::Snapshot { snapshot_id: 0 },
+        )
+        .is_err());
+        assert!(build_restore_manifest_v2(
+            [0x55; 16],
+            &workbench("source"),
+            "/agents/test/wb/source",
+            &workbench("destination"),
+            "/agents/test/wb/destination",
+            RestoreManifestSource::Commit {
+                commit_id: [0x00; 32]
+            },
+        )
+        .is_err());
     }
 
     #[test]

--- a/crates/nokv-agent/src/projection.rs
+++ b/crates/nokv-agent/src/projection.rs
@@ -140,6 +140,11 @@ pub fn workbench_commit_inputs(
     })
 }
 
+/// Decodes a commit identity as the CLI and SDK present it: 64 lowercase hex.
+pub fn decode_commit_identity(value: &str) -> Result<[u8; 32], ProjectionError> {
+    decode_lowercase_hex::<32>("commit_id", value)
+}
+
 pub fn workbench_commit_identity(
     workbench_id: &WorkbenchId,
     content_digest_uri: &str,
@@ -429,6 +434,9 @@ pub fn verify_restore_manifest(bytes: &[u8]) -> Result<VerifiedRestoreManifest, 
     let envelope: Value = serde_json::from_slice(bytes).map_err(|error| {
         ProjectionError::new(format!("restore manifest is not valid JSON: {error}"))
     })?;
+    // Canonicality first, exactly as each version checks it: a non-canonical
+    // envelope must be reported as such rather than as a missing field.
+    require_canonical_bytes("restore manifest", bytes, &envelope)?;
     let schema = envelope
         .get("schema")
         .and_then(Value::as_str)

--- a/crates/nokv-agent/tests/golden/workbench_result_transcript.json
+++ b/crates/nokv-agent/tests/golden/workbench_result_transcript.json
@@ -320,6 +320,7 @@
     },
     "workbench_restore": {
       "cleanup_pending": false,
+      "commit_id": null,
       "destination_generation": 1,
       "destination_workbench_id": "wb-restored",
       "idempotent_replay": false,

--- a/crates/nokv-agent/tests/sdk_facade.rs
+++ b/crates/nokv-agent/tests/sdk_facade.rs
@@ -1114,8 +1114,9 @@ impl WorkbenchBackend for FakeBackend {
         if state.restore_requests.contains(&request) {
             return Ok(RestoreOutcome {
                 operation_id: [0x22; 16],
-                snapshot_id: 1,
-                read_version: 46,
+                snapshot_id: Some(1),
+                read_version: Some(46),
+                commit_id: None,
                 destination_generation: 1,
                 idempotent_replay: true,
             });
@@ -1132,8 +1133,9 @@ impl WorkbenchBackend for FakeBackend {
         state.restore_requests.push(request);
         Ok(RestoreOutcome {
             operation_id: [0x22; 16],
-            snapshot_id: 1,
-            read_version: 46,
+            snapshot_id: Some(1),
+            read_version: Some(46),
+            commit_id: None,
             destination_generation: 1,
             idempotent_replay: false,
         })

--- a/crates/nokv-agent/workbench_contract_schema.json
+++ b/crates/nokv-agent/workbench_contract_schema.json
@@ -577,6 +577,11 @@
     "workbench_restore": {
       "additionalProperties": false,
       "properties": {
+        "at_commit": {
+          "type": "string",
+          "minLength": 64,
+          "maxLength": 64
+        },
         "at_snapshot": {
           "anyOf": [
             {
@@ -600,7 +605,6 @@
       },
       "required": [
         "id",
-        "at_snapshot",
         "destination_id"
       ],
       "type": "object"

--- a/crates/nokv-client/src/lib.rs
+++ b/crates/nokv-client/src/lib.rs
@@ -45,7 +45,8 @@ pub use workbench_lifecycle::{
     RunManifestProjectionContext, VerifiedWorkbenchRestoreManifest, VerifiedWorkbenchRunManifest,
     WorkbenchAdmission, WorkbenchCommitOutcome, WorkbenchCommitRequest, WorkbenchLifecycleError,
     WorkbenchLifecycleFacade, WorkbenchLifecycleOptions, WorkbenchProjection,
-    WorkbenchRestoreOutcome, WorkbenchRestoreRequest, WorkbenchSnapshotSelector,
+    WorkbenchRestoreOrigin, WorkbenchRestoreOutcome, WorkbenchRestoreRequest,
+    WorkbenchRestoreSource, WorkbenchSnapshotSelector,
 };
 pub use workbench_workflow::{
     CommitRecoveryRequest, CommitWorkflowError, CommitWorkflowIdentities, CommitWorkflowOptions,

--- a/crates/nokv-client/src/workbench_lifecycle.rs
+++ b/crates/nokv-client/src/workbench_lifecycle.rs
@@ -40,7 +40,7 @@ struct RestoreInvocation {
     destination_restore_manifest_identity: wire::RestoreManifestIdentity,
     workflow_request: RestoreWorkflowRequest,
     canonical_restore_manifest: Vec<u8>,
-    snapshot_id: u64,
+    source: WorkbenchRestoreSource,
 }
 
 /// Client-owned input for one canonical Workbench commit lifecycle.
@@ -62,12 +62,30 @@ pub enum WorkbenchSnapshotSelector {
     Name(String),
 }
 
-/// Client-owned input for one Workbench snapshot restore lifecycle.
+/// What a caller asks a restore to read from.
+///
+/// A snapshot is a lease and expires; a commit is durable. A decision point
+/// that has to stay citable past the lease bound can only be reconstructed
+/// from its commit, so the lifecycle accepts either.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum WorkbenchRestoreOrigin {
+    Snapshot(WorkbenchSnapshotSelector),
+    Commit([u8; 32]),
+}
+
+/// The resolved source a restore actually read from.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum WorkbenchRestoreSource {
+    Snapshot { snapshot_id: u64 },
+    Commit { commit_id: [u8; 32] },
+}
+
+/// Client-owned input for one Workbench restore lifecycle.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct WorkbenchRestoreRequest {
     pub source_workbench_id: WorkbenchId,
     pub source_workbench_path: String,
-    pub selector: WorkbenchSnapshotSelector,
+    pub origin: WorkbenchRestoreOrigin,
     pub destination_workbench_id: WorkbenchId,
     pub destination_workbench_path: String,
 }
@@ -91,7 +109,7 @@ pub struct RestoreManifestProjectionContext<'a> {
     pub source_path: &'a str,
     pub destination_workbench_id: &'a WorkbenchId,
     pub destination_path: &'a str,
-    pub snapshot_id: u64,
+    pub source: WorkbenchRestoreSource,
 }
 
 /// Inputs used to rebuild the destination run manifest during restore.
@@ -126,7 +144,7 @@ pub struct VerifiedWorkbenchRestoreManifest {
     pub source_path: String,
     pub destination_workbench_id: WorkbenchId,
     pub destination_path: String,
-    pub snapshot_id: u64,
+    pub source: WorkbenchRestoreSource,
     pub canonical_envelope: Vec<u8>,
     pub envelope_digest_uri: String,
 }
@@ -219,8 +237,10 @@ pub struct WorkbenchCommitOutcome {
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct WorkbenchRestoreOutcome {
     pub operation_id: [u8; 16],
-    pub snapshot_id: u64,
-    pub source_snapshot_read_version: u64,
+    pub source: WorkbenchRestoreSource,
+    /// Present exactly for snapshot restores; a commit restore has no
+    /// snapshot read version, and the protocol validates that asymmetry.
+    pub source_snapshot_read_version: Option<u64>,
     pub destination_workspace_revision: u64,
     pub idempotent_replay: bool,
 }
@@ -519,10 +539,7 @@ where
                     || verified.source_path != request.source_workbench_path
                     || verified.destination_workbench_id != request.destination_workbench_id
                     || verified.destination_path != request.destination_workbench_path
-                    || !restore_selector_matches_durable_snapshot(
-                        &request.selector,
-                        verified.snapshot_id,
-                    )
+                    || !restore_origin_matches_durable_source(&request.origin, verified.source)
                 {
                     return Err(WorkbenchLifecycleError::Conflict(
                         "existing destination restore manifest belongs to different provenance"
@@ -544,9 +561,7 @@ where
                 }
                 let recovery = RestoreRecoveryRequest {
                     source_workbench: workbench_name(&verified.source_workbench_id)?,
-                    source: wire::RestoreSource::Snapshot(wire::SnapshotSelector::Id(
-                        verified.snapshot_id,
-                    )),
+                    source: wire_restore_source(verified.source),
                     destination_workbench: destination.workbench,
                     destination_workspace_incarnation_id: destination.workspace_incarnation_id,
                     destination_restore_manifest_identity,
@@ -562,22 +577,44 @@ where
                     destination_restore_manifest_identity,
                     workflow_request: RestoreWorkflowRequest::Recover(recovery),
                     canonical_restore_manifest: verified.canonical_envelope,
-                    snapshot_id: verified.snapshot_id,
+                    source: verified.source,
                 }
             }
             None => {
                 let source_workspace = self.workspace(&request.source_workbench_id)?;
-                let snapshot = self.snapshot(&request.source_workbench_id, &request.selector)?;
-                if snapshot.workspace_incarnation_id != source_workspace.workspace_incarnation_id {
-                    return Err(protocol_mismatch(
-                        "snapshot resolved to a different source workspace incarnation",
-                    ));
-                }
-                let identities = RestoreWorkflowIdentities::derive_snapshot(
+                // A snapshot has to be resolved before it can be named; a
+                // commit is already a durable name, and the shard checks that
+                // it is sealed and belongs to this source workspace.
+                let source = match &request.origin {
+                    WorkbenchRestoreOrigin::Snapshot(selector) => {
+                        let snapshot = self.snapshot(&request.source_workbench_id, selector)?;
+                        if snapshot.workspace_incarnation_id
+                            != source_workspace.workspace_incarnation_id
+                        {
+                            return Err(protocol_mismatch(
+                                "snapshot resolved to a different source workspace incarnation",
+                            ));
+                        }
+                        WorkbenchRestoreSource::Snapshot {
+                            snapshot_id: snapshot.snapshot_id,
+                        }
+                    }
+                    WorkbenchRestoreOrigin::Commit(commit_id) => {
+                        if *commit_id == [0u8; 32] {
+                            return Err(WorkbenchLifecycleError::Conflict(
+                                "restore commit id must be non-zero".to_owned(),
+                            ));
+                        }
+                        WorkbenchRestoreSource::Commit {
+                            commit_id: *commit_id,
+                        }
+                    }
+                };
+                let identities = RestoreWorkflowIdentities::derive(
                     self.client.root_id(),
                     &source_workspace.workbench,
                     source_workspace.workspace_incarnation_id,
-                    snapshot.snapshot_id,
+                    source,
                     &destination_workbench,
                 );
                 let canonical_manifest = self
@@ -588,7 +625,7 @@ where
                         source_path: &request.source_workbench_path,
                         destination_workbench_id: &request.destination_workbench_id,
                         destination_path: &request.destination_workbench_path,
-                        snapshot_id: snapshot.snapshot_id,
+                        source,
                     })
                     .map_err(|source| WorkbenchLifecycleError::ProjectionInvalid {
                         context: "facade supplied invalid restore provenance",
@@ -610,9 +647,7 @@ where
                     operation_id: identities.operation_id,
                     source_workbench: source_workspace.workbench,
                     source_workspace_incarnation_id: source_workspace.workspace_incarnation_id,
-                    source: wire::RestoreSource::Snapshot(wire::SnapshotSelector::Id(
-                        snapshot.snapshot_id,
-                    )),
+                    source: wire_restore_source(source),
                     destination_workbench: destination_workbench.clone(),
                     destination_workspace_incarnation_id: identities
                         .destination_workspace_incarnation_id,
@@ -629,7 +664,7 @@ where
                     destination_restore_manifest_identity,
                     workflow_request: RestoreWorkflowRequest::Fresh(prepare),
                     canonical_restore_manifest: canonical_manifest,
-                    snapshot_id: snapshot.snapshot_id,
+                    source,
                 }
             }
         };
@@ -651,7 +686,7 @@ where
         let destination_restore_manifest_identity =
             invocation.destination_restore_manifest_identity;
         let canonical_restore_manifest = invocation.canonical_restore_manifest;
-        let snapshot_id = invocation.snapshot_id;
+        let source = invocation.source;
         let max_artifact_bytes = self.options.max_artifact_bytes;
         let workflow = self
             .client
@@ -670,7 +705,7 @@ where
                         &source_workbench_path,
                         &destination_workbench_id,
                         &destination_workbench_path,
-                        snapshot_id,
+                        source,
                         destination_restore_manifest_identity,
                         &canonical_restore_manifest,
                         max_artifact_bytes,
@@ -679,13 +714,26 @@ where
                 },
             )
             .map_err(WorkbenchLifecycleError::from)?;
-        let source_snapshot_read_version =
-            workflow.source_snapshot_read_version.ok_or_else(|| {
-                protocol_mismatch("snapshot restore operation omitted its durable read version")
-            })?;
+        // Present exactly for snapshot restores: the shard reports no read
+        // version for a commit, and the protocol refuses the other pairings.
+        let source_snapshot_read_version = match source {
+            WorkbenchRestoreSource::Snapshot { .. } => {
+                Some(workflow.source_snapshot_read_version.ok_or_else(|| {
+                    protocol_mismatch("snapshot restore operation omitted its durable read version")
+                })?)
+            }
+            WorkbenchRestoreSource::Commit { .. } => {
+                if workflow.source_snapshot_read_version.is_some() {
+                    return Err(protocol_mismatch(
+                        "commit restore operation reported a snapshot read version",
+                    ));
+                }
+                None
+            }
+        };
         Ok(WorkbenchRestoreOutcome {
             operation_id: identities.operation_id.0,
-            snapshot_id,
+            source,
             source_snapshot_read_version,
             destination_workspace_revision: workflow.result.destination.workspace_revision,
             idempotent_replay: workflow.replayed,
@@ -1000,7 +1048,7 @@ fn build_restore_destination_plan<Projection: WorkbenchProjection>(
     source_workbench_path: &str,
     destination_workbench_id: &WorkbenchId,
     destination_workbench_path: &str,
-    snapshot_id: u64,
+    restore_source: WorkbenchRestoreSource,
     destination_restore_manifest_identity: wire::RestoreManifestIdentity,
     canonical_restore_manifest: &[u8],
     max_artifact_bytes: usize,
@@ -1036,7 +1084,7 @@ fn build_restore_destination_plan<Projection: WorkbenchProjection>(
         || restore.source_path != source_workbench_path
         || restore.destination_workbench_id != *destination_workbench_id
         || restore.destination_path != destination_workbench_path
-        || restore.snapshot_id != snapshot_id
+        || restore.source != restore_source
         || preparation.destination_workbench.as_str() != destination_workbench_id.as_str()
     {
         return Err(ClientError::ResponseMismatch(
@@ -1162,13 +1210,40 @@ fn snapshot_selector(
 /// Restore operation identity stores the point-resolved numeric snapshot id.
 /// An alias is presentation input and must not be resolved again during cold
 /// destination recovery: it may have expired or been repointed since Begin.
-fn restore_selector_matches_durable_snapshot(
-    selector: &WorkbenchSnapshotSelector,
-    snapshot_id: u64,
+/// Does the durable restore manifest describe the restore being asked for?
+///
+/// An alias selector stays permissive: the alias may have been resolved to a
+/// concrete snapshot by the in-flight operation. A commit is exact, because
+/// the caller named a specific durable anchor.
+fn restore_origin_matches_durable_source(
+    origin: &WorkbenchRestoreOrigin,
+    source: WorkbenchRestoreSource,
 ) -> bool {
-    match selector {
-        WorkbenchSnapshotSelector::Id(requested) => *requested == snapshot_id,
-        WorkbenchSnapshotSelector::Name(_) => true,
+    match (origin, source) {
+        (
+            WorkbenchRestoreOrigin::Snapshot(WorkbenchSnapshotSelector::Id(requested)),
+            WorkbenchRestoreSource::Snapshot { snapshot_id },
+        ) => *requested == snapshot_id,
+        (
+            WorkbenchRestoreOrigin::Snapshot(WorkbenchSnapshotSelector::Name(_)),
+            WorkbenchRestoreSource::Snapshot { .. },
+        ) => true,
+        (
+            WorkbenchRestoreOrigin::Commit(requested),
+            WorkbenchRestoreSource::Commit { commit_id },
+        ) => *requested == commit_id,
+        _ => false,
+    }
+}
+
+fn wire_restore_source(source: WorkbenchRestoreSource) -> wire::RestoreSource {
+    match source {
+        WorkbenchRestoreSource::Snapshot { snapshot_id } => {
+            wire::RestoreSource::Snapshot(wire::SnapshotSelector::Id(snapshot_id))
+        }
+        WorkbenchRestoreSource::Commit { commit_id } => {
+            wire::RestoreSource::Commit(wire::CommitIdentity(commit_id))
+        }
     }
 }
 
@@ -1268,21 +1343,56 @@ mod tests {
 
     #[test]
     fn restore_alias_recovery_converges_on_durable_numeric_snapshot() {
-        assert!(restore_selector_matches_durable_snapshot(
-            &WorkbenchSnapshotSelector::Name("original-alias".to_owned()),
-            7,
+        let snapshot = WorkbenchRestoreSource::Snapshot { snapshot_id: 7 };
+        assert!(restore_origin_matches_durable_source(
+            &WorkbenchRestoreOrigin::Snapshot(WorkbenchSnapshotSelector::Name(
+                "original-alias".to_owned()
+            )),
+            snapshot,
         ));
-        assert!(restore_selector_matches_durable_snapshot(
-            &WorkbenchSnapshotSelector::Name("repointed-alias".to_owned()),
-            7,
+        assert!(restore_origin_matches_durable_source(
+            &WorkbenchRestoreOrigin::Snapshot(WorkbenchSnapshotSelector::Name(
+                "repointed-alias".to_owned()
+            )),
+            snapshot,
         ));
-        assert!(restore_selector_matches_durable_snapshot(
-            &WorkbenchSnapshotSelector::Id(7),
-            7,
+        assert!(restore_origin_matches_durable_source(
+            &WorkbenchRestoreOrigin::Snapshot(WorkbenchSnapshotSelector::Id(7)),
+            snapshot,
         ));
-        assert!(!restore_selector_matches_durable_snapshot(
-            &WorkbenchSnapshotSelector::Id(8),
-            7,
+        assert!(!restore_origin_matches_durable_source(
+            &WorkbenchRestoreOrigin::Snapshot(WorkbenchSnapshotSelector::Id(8)),
+            snapshot,
+        ));
+    }
+
+    #[test]
+    fn restore_commit_recovery_is_exact_and_never_matches_a_snapshot() {
+        let commit = WorkbenchRestoreSource::Commit {
+            commit_id: [0xab; 32],
+        };
+        assert!(restore_origin_matches_durable_source(
+            &WorkbenchRestoreOrigin::Commit([0xab; 32]),
+            commit,
+        ));
+        assert!(!restore_origin_matches_durable_source(
+            &WorkbenchRestoreOrigin::Commit([0xcd; 32]),
+            commit,
+        ));
+        // A restore in flight from a snapshot must never be adopted by a
+        // caller asking for a commit, or the replay would answer a different
+        // question from the one asked.
+        assert!(!restore_origin_matches_durable_source(
+            &WorkbenchRestoreOrigin::Commit([0xab; 32]),
+            WorkbenchRestoreSource::Snapshot { snapshot_id: 7 },
+        ));
+        assert!(!restore_origin_matches_durable_source(
+            &WorkbenchRestoreOrigin::Snapshot(WorkbenchSnapshotSelector::Id(7)),
+            commit,
+        ));
+        assert!(!restore_origin_matches_durable_source(
+            &WorkbenchRestoreOrigin::Snapshot(WorkbenchSnapshotSelector::Name("a".to_owned())),
+            commit,
         ));
     }
 }

--- a/crates/nokv-client/src/workbench_workflow.rs
+++ b/crates/nokv-client/src/workbench_workflow.rs
@@ -40,9 +40,13 @@ const RESTORE_DESTINATION_INCARNATION_DOMAIN: &[u8] =
 // same frozen state, so it gets its own domains. Keeping the snapshot domains
 // untouched leaves every restore already in flight with the identity it was
 // started under.
-const RESTORE_COMMIT_OPERATION_DOMAIN: &[u8] = b"nokv.restore.commit-operation.v1\0";
 const RESTORE_COMMIT_DESTINATION_INCARNATION_DOMAIN: &[u8] =
     b"nokv.restore.commit-destination-incarnation.v1\0";
+// The operation id is a frozen cross-layer contract: the shard derives the
+// same digest and refuses a request whose id disagrees. One domain covers
+// both sources, discriminated by a tag byte.
+const RESTORE_SOURCE_TAG_SNAPSHOT: u8 = 1;
+const RESTORE_SOURCE_TAG_COMMIT: u8 = 2;
 const RESTORE_MANIFEST_OPERATION_DOMAIN: &[u8] = b"nokv.cli.restore-manifest-operation\0";
 const RESTORE_MANIFEST_REVISION_DOMAIN: &[u8] = b"nokv.cli.restore-manifest-revision\0";
 
@@ -139,10 +143,10 @@ impl RestoreWorkflowIdentities {
             root_id,
             source_workbench,
             source_workspace_incarnation_id,
+            RESTORE_SOURCE_TAG_SNAPSHOT,
             &snapshot_id.to_be_bytes(),
             destination_workbench,
             destination_workspace_incarnation_id,
-            RESTORE_OPERATION_DOMAIN,
         );
         Self {
             operation_id,
@@ -174,10 +178,10 @@ impl RestoreWorkflowIdentities {
             root_id,
             source_workbench,
             source_workspace_incarnation_id,
+            RESTORE_SOURCE_TAG_COMMIT,
             &commit_id,
             destination_workbench,
             destination_workspace_incarnation_id,
-            RESTORE_COMMIT_OPERATION_DOMAIN,
         );
         Self {
             operation_id,
@@ -1820,17 +1824,17 @@ fn restore_operation_identity(
     root_id: RootIdentity,
     source_workbench: &WorkbenchName,
     source_incarnation: WorkspaceIdentity,
+    source_tag: u8,
     source_bytes: &[u8],
     destination: &WorkbenchName,
     destination_incarnation: WorkspaceIdentity,
-    domain: &[u8],
 ) -> OperationIdentity {
     let mut hasher = Sha256::new();
-    hasher.update(domain);
+    hasher.update(RESTORE_OPERATION_DOMAIN);
     hasher.update(root_id.0);
     hash_len32(&mut hasher, source_workbench.as_str().as_bytes());
     hasher.update(source_incarnation.0);
-    hasher.update([1]);
+    hasher.update([source_tag]);
     hasher.update(source_bytes);
     hash_len32(&mut hasher, destination.as_str().as_bytes());
     hasher.update(destination_incarnation.0);
@@ -2541,6 +2545,8 @@ mod tests {
         bytes.iter().map(|byte| format!("{byte:02x}")).collect()
     }
 
+    const COMMIT_RESTORE_OPERATION_GOLDEN: &str = "07b6bfed3cd71168589fabd6fb5f649f";
+
     #[test]
     fn workflow_identity_domains_have_frozen_golden_bytes() {
         let root = RootIdentity([1; 16]);
@@ -2581,6 +2587,31 @@ mod tests {
         assert_eq!(
             hex(&manifest.revision_id.0),
             "80eaf4e236db23c62e3d070517fe5301"
+        );
+
+        // The commit restore identity is a cross-layer contract too: the
+        // shard derives it from the same domain with a different source tag
+        // and refuses a request whose id disagrees. Freeze it here so a
+        // client-side change cannot drift away from the shard silently.
+        let commit_restore = RestoreWorkflowIdentities::derive(
+            root,
+            &WorkbenchName::new("run").unwrap(),
+            WorkspaceIdentity([4; 16]),
+            crate::WorkbenchRestoreSource::Commit { commit_id: [9; 32] },
+            &WorkbenchName::new("restored-run").unwrap(),
+        );
+        assert_ne!(
+            commit_restore.operation_id.0, restore.operation_id.0,
+            "a commit restore is a different operation from a snapshot restore"
+        );
+        assert_ne!(
+            commit_restore.destination_workspace_incarnation_id.0,
+            restore.destination_workspace_incarnation_id.0
+        );
+        assert_eq!(
+            hex(&commit_restore.operation_id.0),
+            COMMIT_RESTORE_OPERATION_GOLDEN,
+            "commit restore operation identity drifted"
         );
     }
 

--- a/crates/nokv-client/src/workbench_workflow.rs
+++ b/crates/nokv-client/src/workbench_workflow.rs
@@ -36,6 +36,13 @@ const COMMIT_MANIFEST_REVISION_DOMAIN: &[u8] = b"nokv.cli.commit-manifest-revisi
 const RESTORE_OPERATION_DOMAIN: &[u8] = b"nokv.restore.operation.v2\0";
 const RESTORE_DESTINATION_INCARNATION_DOMAIN: &[u8] =
     b"nokv.cli.restore-destination-incarnation.v2\0";
+// A commit restore is a different operation from a snapshot restore of the
+// same frozen state, so it gets its own domains. Keeping the snapshot domains
+// untouched leaves every restore already in flight with the identity it was
+// started under.
+const RESTORE_COMMIT_OPERATION_DOMAIN: &[u8] = b"nokv.restore.commit-operation.v1\0";
+const RESTORE_COMMIT_DESTINATION_INCARNATION_DOMAIN: &[u8] =
+    b"nokv.restore.commit-destination-incarnation.v1\0";
 const RESTORE_MANIFEST_OPERATION_DOMAIN: &[u8] = b"nokv.cli.restore-manifest-operation\0";
 const RESTORE_MANIFEST_REVISION_DOMAIN: &[u8] = b"nokv.cli.restore-manifest-revision\0";
 
@@ -83,7 +90,35 @@ impl RestoreWorkflowIdentities {
     /// Derives the v2 snapshot restore and destination identities. The
     /// operation binds both workbench names, both workspace incarnations, and
     /// the concrete numeric snapshot selector.
-    pub fn derive_snapshot(
+    pub fn derive(
+        root_id: RootIdentity,
+        source_workbench: &WorkbenchName,
+        source_workspace_incarnation_id: WorkspaceIdentity,
+        source: crate::WorkbenchRestoreSource,
+        destination_workbench: &WorkbenchName,
+    ) -> Self {
+        match source {
+            crate::WorkbenchRestoreSource::Snapshot { snapshot_id } => Self::derive_snapshot(
+                root_id,
+                source_workbench,
+                source_workspace_incarnation_id,
+                snapshot_id,
+                destination_workbench,
+            ),
+            crate::WorkbenchRestoreSource::Commit { commit_id } => Self::derive_commit(
+                root_id,
+                source_workbench,
+                source_workspace_incarnation_id,
+                commit_id,
+                destination_workbench,
+            ),
+        }
+    }
+
+    /// Derives the v2 snapshot restore and destination identities. The
+    /// operation binds both workbench names, both workspace incarnations, and
+    /// the concrete numeric snapshot selector.
+    fn derive_snapshot(
         root_id: RootIdentity,
         source_workbench: &WorkbenchName,
         source_workspace_incarnation_id: WorkspaceIdentity,
@@ -104,9 +139,45 @@ impl RestoreWorkflowIdentities {
             root_id,
             source_workbench,
             source_workspace_incarnation_id,
-            snapshot_id,
+            &snapshot_id.to_be_bytes(),
             destination_workbench,
             destination_workspace_incarnation_id,
+            RESTORE_OPERATION_DOMAIN,
+        );
+        Self {
+            operation_id,
+            destination_workspace_incarnation_id,
+        }
+    }
+
+    /// Derives the commit restore identities under their own domains, so a
+    /// commit restore can never be mistaken for a snapshot restore of the
+    /// same frozen state.
+    fn derive_commit(
+        root_id: RootIdentity,
+        source_workbench: &WorkbenchName,
+        source_workspace_incarnation_id: WorkspaceIdentity,
+        commit_id: [u8; 32],
+        destination_workbench: &WorkbenchName,
+    ) -> Self {
+        let destination_workspace_incarnation_id = WorkspaceIdentity(stable_fixed_identity(
+            RESTORE_COMMIT_DESTINATION_INCARNATION_DOMAIN,
+            root_id,
+            &[
+                source_workbench.as_str().as_bytes(),
+                &source_workspace_incarnation_id.0,
+                &commit_id,
+                destination_workbench.as_str().as_bytes(),
+            ],
+        ));
+        let operation_id = restore_operation_identity(
+            root_id,
+            source_workbench,
+            source_workspace_incarnation_id,
+            &commit_id,
+            destination_workbench,
+            destination_workspace_incarnation_id,
+            RESTORE_COMMIT_OPERATION_DOMAIN,
         );
         Self {
             operation_id,
@@ -1749,17 +1820,18 @@ fn restore_operation_identity(
     root_id: RootIdentity,
     source_workbench: &WorkbenchName,
     source_incarnation: WorkspaceIdentity,
-    snapshot_id: u64,
+    source_bytes: &[u8],
     destination: &WorkbenchName,
     destination_incarnation: WorkspaceIdentity,
+    domain: &[u8],
 ) -> OperationIdentity {
     let mut hasher = Sha256::new();
-    hasher.update(RESTORE_OPERATION_DOMAIN);
+    hasher.update(domain);
     hasher.update(root_id.0);
     hash_len32(&mut hasher, source_workbench.as_str().as_bytes());
     hasher.update(source_incarnation.0);
     hasher.update([1]);
-    hasher.update(snapshot_id.to_be_bytes());
+    hasher.update(source_bytes);
     hash_len32(&mut hasher, destination.as_str().as_bytes());
     hasher.update(destination_incarnation.0);
     let digest: [u8; 32] = hasher.finalize().into();
@@ -2129,11 +2201,11 @@ mod tests {
         let source_incarnation = WorkspaceIdentity([2; 16]);
         let source_workbench = WorkbenchName::new("source-run").unwrap();
         let destination = WorkbenchName::new("restored-run").unwrap();
-        let identities = RestoreWorkflowIdentities::derive_snapshot(
+        let identities = RestoreWorkflowIdentities::derive(
             root,
             &source_workbench,
             source_incarnation,
-            7,
+            crate::WorkbenchRestoreSource::Snapshot { snapshot_id: 7 },
             &destination,
         );
         let restore_bytes = br#"{"restore":true}"#.to_vec();
@@ -2486,11 +2558,11 @@ mod tests {
             "d879f0983c8c4549e90b7026bcc52621"
         );
 
-        let restore = RestoreWorkflowIdentities::derive_snapshot(
+        let restore = RestoreWorkflowIdentities::derive(
             root,
             &WorkbenchName::new("source-run").unwrap(),
             WorkspaceIdentity([2; 16]),
-            7,
+            crate::WorkbenchRestoreSource::Snapshot { snapshot_id: 7 },
             &WorkbenchName::new("restored-run").unwrap(),
         );
         assert_eq!(

--- a/crates/nokv-python/Cargo.toml
+++ b/crates/nokv-python/Cargo.toml
@@ -21,10 +21,14 @@ default = []
 extension-module = ["pyo3/extension-module"]
 
 [dependencies]
+nokv-agent.workspace = true
 nokv-client = { workspace = true, features = ["etcd"] }
+nokv-workbench-projection.workspace = true
 nokv-object.workspace = true
 nokv-protocol.workspace = true
+nokv-types.workspace = true
 pyo3 = { version = "0.29.0", features = ["abi3-py39"] }
+serde_json.workspace = true
 
 [dev-dependencies]
 tempfile.workspace = true

--- a/crates/nokv-python/src/client.rs
+++ b/crates/nokv-python/src/client.rs
@@ -12,7 +12,8 @@ use std::time::{Duration, SystemTime, UNIX_EPOCH};
 use nokv_client::{
     ArtifactPublishOptions, ArtifactPublishOutcome, ArtifactRangeBatchRequest, ClientError,
     ClientOptions, FramedTcpOptions, FramedTcpTransport, RouteResolver, SnapshotMintOptions,
-    SnapshotRenewOptions, SnapshotRetireOptions, WorkspaceClient,
+    SnapshotRenewOptions, SnapshotRetireOptions, WorkbenchCommitRequest, WorkbenchLifecycleFacade,
+    WorkbenchLifecycleOptions, WorkspaceClient,
 };
 use nokv_object::ArtifactObjectStore;
 use nokv_protocol::{
@@ -23,9 +24,13 @@ use nokv_protocol::{
     SearchRequest, SnapshotAlias, SnapshotSelector, WorkbenchName, WorkspaceIdentity,
     WorkspacePath, WorkspaceReadView,
 };
+use nokv_types::WorkbenchId;
+use nokv_workbench_projection::CanonicalWorkbenchProjection;
 use pyo3::exceptions::{PyFileExistsError, PyFileNotFoundError, PyRuntimeError, PyValueError};
 use pyo3::prelude::*;
+use pyo3::types::{PyAnyMethods, PyDictMethods, PyListMethods};
 use pyo3::types::{PyBytes, PyDict, PyList};
+use serde_json::{Map as JsonMap, Value as JsonValue};
 
 use crate::local_adapter::{
     collect_local_files, create_materialized_file, join_remote_path, materialized_relative_path,
@@ -65,6 +70,13 @@ struct CollectedFile {
 pub(crate) struct PythonWorkspaceClient {
     client: Arc<RustWorkspaceClient>,
     objects: Arc<nokv_object::BoundArtifactStore<ConfiguredObjectStore>>,
+    /// Presentation root the durable run manifest records, for example
+    /// `/agents/<agent-id>/wb`. It is not addressing: artifacts resolve by
+    /// workbench name either way. But it is hashed into the commit
+    /// operation's projection digest, so a commit written here with a
+    /// different root than the CLI uses is a *different* operation over the
+    /// same content. Lifecycle calls therefore refuse to guess it.
+    workbench_root: Option<String>,
 }
 
 #[pymethods]
@@ -78,7 +90,8 @@ impl PythonWorkspaceClient {
         connect_timeout_ms = 5_000,
         read_timeout_ms = 30_000,
         write_timeout_ms = 30_000,
-        handshake_timeout_ms = 5_000
+        handshake_timeout_ms = 5_000,
+        workbench_root = None
     ))]
     #[allow(clippy::too_many_arguments)]
     fn new(
@@ -91,6 +104,7 @@ impl PythonWorkspaceClient {
         read_timeout_ms: u64,
         write_timeout_ms: u64,
         handshake_timeout_ms: u64,
+        workbench_root: Option<String>,
     ) -> PyResult<Self> {
         let root_id = RootIdentity(parse_fixed_hex("root_id", root_id)?);
         let transport = FramedTcpTransport::new(FramedTcpOptions {
@@ -123,7 +137,72 @@ impl PythonWorkspaceClient {
         Ok(Self {
             client: Arc::new(client),
             objects: Arc::new(objects),
+            workbench_root,
         })
+    }
+
+    /// Publish or replay one canonical Workbench commit.
+    ///
+    /// `manifest` is the caller's provenance mapping; it is canonicalised and
+    /// digested exactly as the CLI does, so a commit made here and one made
+    /// by `nokv workbench workbench_commit` over the same inputs are the same
+    /// durable commit.
+    #[pyo3(signature = (workbench, manifest, content_digest_uri, replace = false))]
+    fn commit<'py>(
+        &self,
+        py: Python<'py>,
+        workbench: &str,
+        manifest: &Bound<'py, PyAny>,
+        content_digest_uri: &str,
+        replace: bool,
+    ) -> PyResult<Bound<'py, PyDict>> {
+        let workbench_id = parse_workbench_id(workbench)?;
+        let workbench_path = self.lifecycle_workbench_path(&workbench_id)?;
+        let manifest_value = json_object_from_py(manifest)?;
+        let content_digest_uri = content_digest_uri.to_owned();
+        // The digest and the stable id come from nokv-agent, not from here:
+        // the SDK must not own metadata layout, and a second implementation
+        // would let the SDK and the CLI disagree about one commit.
+        let inputs = nokv_agent::workbench_commit_inputs(
+            &workbench_id,
+            &manifest_value,
+            &content_digest_uri,
+        )
+        .map_err(value_error)?;
+        let request = WorkbenchCommitRequest {
+            workbench_id,
+            canonical_manifest: inputs.canonical_manifest,
+            workbench_path,
+            content_digest_uri,
+            manifest_digest_uri: inputs.manifest_digest_uri,
+            stable_commit_id: inputs.stable_commit_id,
+            replace,
+        };
+        let client = Arc::clone(&self.client);
+        let objects = Arc::clone(&self.objects);
+        let max_artifact_bytes = LIFECYCLE_MAX_MANIFEST_BYTES;
+        let outcome = py
+            .detach(move || {
+                let options =
+                    WorkbenchLifecycleOptions::new(max_artifact_bytes).map_err(lifecycle_error)?;
+                WorkbenchLifecycleFacade::new(
+                    &client,
+                    objects.as_ref(),
+                    options,
+                    CanonicalWorkbenchProjection,
+                )
+                .commit(request)
+                .map_err(lifecycle_error)
+            })
+            .map_err(runtime_error)?;
+        let result = PyDict::new(py);
+        result.set_item("commit_id", hex(&outcome.commit_id))?;
+        result.set_item("commit_head_generation", outcome.commit_head_generation)?;
+        result.set_item("manifest_size_bytes", outcome.manifest_size_bytes)?;
+        result.set_item("envelope_digest_uri", outcome.envelope_digest_uri)?;
+        result.set_item("tree_digest_uri", outcome.tree_digest_uri)?;
+        result.set_item("replayed", outcome.idempotent_replay)?;
+        Ok(result)
     }
 
     #[pyo3(signature = (workbench, workspace_incarnation_id = None))]
@@ -857,6 +936,18 @@ impl PythonWorkspaceClient {
 }
 
 impl PythonWorkspaceClient {
+    fn lifecycle_workbench_path(&self, workbench_id: &WorkbenchId) -> PyResult<String> {
+        let root = self.workbench_root.as_deref().ok_or_else(|| {
+            value_error(
+                "lifecycle calls need the workbench_root this deployment uses \
+                 (for example \"/agents/<agent-id>/wb\"); construct the client with it, \
+                 because the root is hashed into the commit operation and guessing it \
+                 would make this commit a different operation from the CLI's",
+            )
+        })?;
+        Ok(format!("{root}/{}", workbench_id.as_str()))
+    }
+
     #[allow(clippy::too_many_arguments)]
     fn publish_options(
         &self,
@@ -904,6 +995,12 @@ impl PythonWorkspaceClient {
         }
         Ok(options)
     }
+}
+
+/// The presentation root a lifecycle call records in the durable manifest.
+/// Refused rather than guessed: see `PythonWorkspaceClient::workbench_root`.
+fn parse_workbench_id(raw: &str) -> PyResult<nokv_types::WorkbenchId> {
+    WorkbenchId::new(raw.to_owned()).map_err(value_error)
 }
 
 fn parse_workbench(raw: &str) -> PyResult<WorkbenchName> {
@@ -1169,6 +1266,64 @@ fn collect_workspace(
         });
     }
     Ok(collected)
+}
+
+/// Bound for the run-manifest read inside the lifecycle facade. Manifests are
+/// small; this only refuses a pathologically large one.
+const LIFECYCLE_MAX_MANIFEST_BYTES: usize = 16 * 1024 * 1024;
+
+/// Marshals a Python mapping into the JSON object the commit manifest is.
+/// Values are restricted to what a provenance manifest can carry, so an
+/// unserialisable object fails here rather than at the digest.
+fn json_object_from_py(value: &Bound<'_, PyAny>) -> PyResult<JsonValue> {
+    let mapping = value
+        .cast::<PyDict>()
+        .map_err(|_| value_error("manifest must be a dict"))?;
+    let mut object = JsonMap::new();
+    for (key, item) in mapping.iter() {
+        let key: String = key
+            .extract()
+            .map_err(|_| value_error("manifest keys must be strings"))?;
+        object.insert(key, json_scalar_from_py(&item)?);
+    }
+    Ok(JsonValue::Object(object))
+}
+
+fn json_scalar_from_py(value: &Bound<'_, PyAny>) -> PyResult<JsonValue> {
+    if value.is_none() {
+        return Ok(JsonValue::Null);
+    }
+    if let Ok(flag) = value.extract::<bool>() {
+        return Ok(JsonValue::Bool(flag));
+    }
+    if let Ok(number) = value.extract::<i64>() {
+        return Ok(JsonValue::from(number));
+    }
+    if let Ok(number) = value.extract::<f64>() {
+        return serde_json::Number::from_f64(number)
+            .map(JsonValue::Number)
+            .ok_or_else(|| value_error("manifest numbers must be finite"));
+    }
+    if let Ok(text) = value.extract::<String>() {
+        return Ok(JsonValue::String(text));
+    }
+    if value.cast::<PyDict>().is_ok() {
+        return json_object_from_py(value);
+    }
+    if let Ok(items) = value.cast::<PyList>() {
+        let mut out = Vec::with_capacity(items.len());
+        for item in items.iter() {
+            out.push(json_scalar_from_py(&item)?);
+        }
+        return Ok(JsonValue::Array(out));
+    }
+    Err(value_error(
+        "manifest values must be strings, numbers, booleans, null, lists, or dicts",
+    ))
+}
+
+fn lifecycle_error<E: std::fmt::Display>(error: E) -> String {
+    error.to_string()
 }
 
 fn value_error(error: impl std::fmt::Display) -> PyErr {

--- a/crates/nokv-python/src/client.rs
+++ b/crates/nokv-python/src/client.rs
@@ -13,7 +13,8 @@ use nokv_client::{
     ArtifactPublishOptions, ArtifactPublishOutcome, ArtifactRangeBatchRequest, ClientError,
     ClientOptions, FramedTcpOptions, FramedTcpTransport, RouteResolver, SnapshotMintOptions,
     SnapshotRenewOptions, SnapshotRetireOptions, WorkbenchCommitRequest, WorkbenchLifecycleFacade,
-    WorkbenchLifecycleOptions, WorkspaceClient,
+    WorkbenchLifecycleOptions, WorkbenchRestoreOrigin, WorkbenchRestoreRequest,
+    WorkbenchRestoreSource, WorkbenchSnapshotSelector, WorkspaceClient,
 };
 use nokv_object::ArtifactObjectStore;
 use nokv_protocol::{
@@ -201,6 +202,92 @@ impl PythonWorkspaceClient {
         result.set_item("manifest_size_bytes", outcome.manifest_size_bytes)?;
         result.set_item("envelope_digest_uri", outcome.envelope_digest_uri)?;
         result.set_item("tree_digest_uri", outcome.tree_digest_uri)?;
+        result.set_item("replayed", outcome.idempotent_replay)?;
+        Ok(result)
+    }
+
+    /// Restore a frozen state into an absent destination workbench.
+    ///
+    /// Name exactly one source. `at_snapshot` takes a snapshot id or alias
+    /// and is bounded by that snapshot's lease; `at_commit` takes a commit
+    /// identity and is not, so a decision point that has to stay citable
+    /// after the lease runs out is restored from its commit.
+    #[pyo3(signature = (workbench, destination, at_snapshot = None, at_commit = None))]
+    fn restore<'py>(
+        &self,
+        py: Python<'py>,
+        workbench: &str,
+        destination: &str,
+        at_snapshot: Option<&Bound<'py, PyAny>>,
+        at_commit: Option<&str>,
+    ) -> PyResult<Bound<'py, PyDict>> {
+        let source_workbench_id = parse_workbench_id(workbench)?;
+        let destination_workbench_id = parse_workbench_id(destination)?;
+        if source_workbench_id == destination_workbench_id {
+            return Err(value_error("destination must differ from workbench"));
+        }
+        let origin = match (at_snapshot, at_commit) {
+            (Some(_), Some(_)) => {
+                return Err(value_error("give at_snapshot or at_commit, not both"))
+            }
+            (None, None) => return Err(value_error("give at_snapshot or at_commit")),
+            (Some(value), None) => {
+                if let Ok(snapshot_id) = value.extract::<u64>() {
+                    if snapshot_id == 0 {
+                        return Err(value_error("at_snapshot id must be greater than zero"));
+                    }
+                    WorkbenchRestoreOrigin::Snapshot(WorkbenchSnapshotSelector::Id(snapshot_id))
+                } else {
+                    let alias: String = value
+                        .extract()
+                        .map_err(|_| value_error("at_snapshot must be an id or an alias"))?;
+                    WorkbenchRestoreOrigin::Snapshot(WorkbenchSnapshotSelector::Name(alias))
+                }
+            }
+            (None, Some(commit_id)) => WorkbenchRestoreOrigin::Commit(
+                nokv_agent::decode_commit_identity(commit_id).map_err(value_error)?,
+            ),
+        };
+        let request = WorkbenchRestoreRequest {
+            source_workbench_path: self.lifecycle_workbench_path(&source_workbench_id)?,
+            destination_workbench_path: self.lifecycle_workbench_path(&destination_workbench_id)?,
+            source_workbench_id,
+            origin,
+            destination_workbench_id,
+        };
+        let client = Arc::clone(&self.client);
+        let objects = Arc::clone(&self.objects);
+        let outcome = py
+            .detach(move || {
+                let options = WorkbenchLifecycleOptions::new(LIFECYCLE_MAX_MANIFEST_BYTES)
+                    .map_err(lifecycle_error)?;
+                WorkbenchLifecycleFacade::new(
+                    &client,
+                    objects.as_ref(),
+                    options,
+                    CanonicalWorkbenchProjection,
+                )
+                .restore(request)
+                .map_err(lifecycle_error)
+            })
+            .map_err(runtime_error)?;
+        let result = PyDict::new(py);
+        result.set_item("operation_id", hex(&outcome.operation_id))?;
+        match outcome.source {
+            WorkbenchRestoreSource::Snapshot { snapshot_id } => {
+                result.set_item("snapshot_id", snapshot_id)?;
+                result.set_item("commit_id", py.None())?;
+            }
+            WorkbenchRestoreSource::Commit { commit_id } => {
+                result.set_item("snapshot_id", py.None())?;
+                result.set_item("commit_id", hex(&commit_id))?;
+            }
+        }
+        result.set_item("read_version", outcome.source_snapshot_read_version)?;
+        result.set_item(
+            "destination_generation",
+            outcome.destination_workspace_revision,
+        )?;
         result.set_item("replayed", outcome.idempotent_replay)?;
         Ok(result)
     }

--- a/crates/nokv-python/tests/test_api_surface.py
+++ b/crates/nokv-python/tests/test_api_surface.py
@@ -35,6 +35,28 @@ def test_versioned_workbench_surface():
     assert hasattr(nokv.Client, "renew_snapshot")
     assert hasattr(nokv.Client, "retire_snapshot")
     assert hasattr(nokv.Client, "list_snapshots")
+
+
+def test_lifecycle_surface_is_installed():
+    """Commit and restore must ship in the wheel: without them a Python
+    caller cannot freeze a campaign or reconstruct a decision point, and has
+    to shell out to the CLI for exactly the two steps that make the record
+    citable."""
+    import inspect
+
+    assert hasattr(nokv.Client, "commit")
+    assert hasattr(nokv.Client, "restore")
+    restore = inspect.signature(nokv.Client.restore).parameters
+    # Either source can be named. A snapshot is a lease and expires; a commit
+    # is durable, so a decision point that outlives the lease needs at_commit.
+    assert "at_snapshot" in restore
+    assert "at_commit" in restore
+    commit = inspect.signature(nokv.Client.commit).parameters
+    assert "replace" in commit
+    # Lifecycle calls record a presentation root in the durable manifest, and
+    # the client refuses to guess it. pyo3 exposes the constructor's named
+    # parameters through the text signature rather than through inspect.
+    assert "workbench_root" in (nokv.Client.__text_signature__ or "")
     assert hasattr(nokv.Client, "search")
     assert hasattr(nokv.Client, "aggregate")
     assert hasattr(nokv.Client, "catalog")

--- a/crates/nokv-workbench-projection/Cargo.toml
+++ b/crates/nokv-workbench-projection/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "nokv-workbench-projection"
+version = "0.1.0"
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+repository.workspace = true
+publish = false
+
+[dependencies]
+nokv-agent.workspace = true
+nokv-client.workspace = true
+nokv-types.workspace = true

--- a/crates/nokv-workbench-projection/src/lib.rs
+++ b/crates/nokv-workbench-projection/src/lib.rs
@@ -1,0 +1,146 @@
+//! The canonical Workbench projection: one adapter binding the durable
+//! manifest formats to the SDK lifecycle trait.
+//!
+//! `nokv-agent` owns the durable run- and restore-manifest formats and
+//! deliberately depends on nothing but `nokv-types`, so it cannot see the
+//! SDK. `nokv-client` defines [`WorkbenchProjection`] and deliberately does
+//! not depend on the tool layer, so it cannot see the formats. Something has
+//! to join them, and every caller that drives a Workbench commit or restore
+//! needs the same join: the CLI, the MCP server, and the Python SDK all
+//! publish manifests that must be byte-identical, because a commit written
+//! by one is restored by another.
+//!
+//! Holding one adapter here rather than one per caller is not tidiness. The
+//! trait grows as the lifecycle grows, and a per-caller copy makes every such
+//! change an opportunity for two callers to disagree about a durable format.
+
+#![forbid(unsafe_code)]
+
+use nokv_client::{
+    RestoreManifestProjectionContext, RestoredRunManifestProjectionContext,
+    RunManifestProjectionContext, VerifiedWorkbenchRestoreManifest, VerifiedWorkbenchRunManifest,
+    WorkbenchProjection,
+};
+use nokv_types::WorkbenchId;
+
+/// The canonical projection every SDK consumer should use.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct CanonicalWorkbenchProjection;
+
+impl WorkbenchProjection for CanonicalWorkbenchProjection {
+    type Error = nokv_agent::ProjectionError;
+
+    fn build_run_manifest(
+        &self,
+        context: RunManifestProjectionContext<'_>,
+        committed_at_unix_seconds: u64,
+    ) -> Result<Vec<u8>, Self::Error> {
+        nokv_agent::build_run_manifest_v1(
+            context.workbench_id,
+            context.workbench_path,
+            context.content_digest_uri,
+            context.canonical_manifest,
+            context.manifest_digest_uri,
+            context.commit_identity,
+            committed_at_unix_seconds,
+        )
+    }
+
+    fn run_manifest_projection_input_digest(
+        &self,
+        context: RunManifestProjectionContext<'_>,
+    ) -> [u8; 32] {
+        nokv_agent::run_manifest_projection_input_digest_v1(
+            context.workbench_id,
+            context.workbench_path,
+            context.content_digest_uri,
+            context.canonical_manifest,
+            context.manifest_digest_uri,
+            context.commit_identity,
+        )
+    }
+
+    fn verify_run_manifest(
+        &self,
+        bytes: &[u8],
+    ) -> Result<VerifiedWorkbenchRunManifest, Self::Error> {
+        let verified = nokv_agent::verify_run_manifest_v1(bytes)?;
+        Ok(VerifiedWorkbenchRunManifest {
+            workbench_id: verified.workbench_id,
+            workbench_path: verified.workbench_path,
+            content_digest_uri: verified.content_digest_uri,
+            manifest_digest_uri: verified.manifest_digest_uri,
+            commit_identity: verified.commit_identity,
+            canonical_manifest: verified.canonical_manifest,
+            canonical_envelope: verified.canonical_envelope,
+            envelope_digest_uri: verified.envelope_digest_uri,
+        })
+    }
+
+    fn build_restore_manifest(
+        &self,
+        context: RestoreManifestProjectionContext<'_>,
+    ) -> Result<Vec<u8>, Self::Error> {
+        nokv_agent::build_restore_manifest_v1(
+            context.operation_id,
+            context.source_workbench_id,
+            context.source_path,
+            context.destination_workbench_id,
+            context.destination_path,
+            context.snapshot_id,
+        )
+    }
+
+    fn verify_restore_manifest(
+        &self,
+        bytes: &[u8],
+    ) -> Result<VerifiedWorkbenchRestoreManifest, Self::Error> {
+        let verified = nokv_agent::verify_restore_manifest_v1(bytes)?;
+        Ok(VerifiedWorkbenchRestoreManifest {
+            operation_id: verified.operation_id,
+            source_workbench_id: verified.source_workbench_id,
+            source_path: verified.source_path,
+            destination_workbench_id: verified.destination_workbench_id,
+            destination_path: verified.destination_path,
+            snapshot_id: verified.snapshot_id,
+            canonical_envelope: verified.canonical_envelope,
+            envelope_digest_uri: verified.envelope_digest_uri,
+        })
+    }
+
+    fn restore_effective_content_digest_uri(
+        &self,
+        source_content_digest_uri: &str,
+        source_matches_base_commit: bool,
+        materialized_member_digest: [u8; 32],
+    ) -> Result<String, Self::Error> {
+        nokv_agent::restore_effective_content_digest_uri_v1(
+            source_content_digest_uri,
+            source_matches_base_commit,
+            materialized_member_digest,
+        )
+    }
+
+    fn workbench_commit_identity(
+        &self,
+        workbench_id: &WorkbenchId,
+        content_digest_uri: &str,
+        manifest_digest_uri: &str,
+    ) -> [u8; 32] {
+        nokv_agent::workbench_commit_identity(workbench_id, content_digest_uri, manifest_digest_uri)
+    }
+
+    fn build_restored_run_manifest(
+        &self,
+        context: RestoredRunManifestProjectionContext<'_>,
+    ) -> Result<Vec<u8>, Self::Error> {
+        nokv_agent::build_restored_run_manifest_v1(
+            context.source_run_manifest,
+            context.destination_workbench_id,
+            context.destination_workbench_path,
+            context.effective_content_digest_uri,
+            context.destination_commit_identity,
+            context.destination_committed_at_unix_seconds,
+        )
+    }
+}

--- a/crates/nokv-workbench-projection/src/lib.rs
+++ b/crates/nokv-workbench-projection/src/lib.rs
@@ -16,10 +16,11 @@
 
 #![forbid(unsafe_code)]
 
+use nokv_agent::RestoreManifestSource;
 use nokv_client::{
     RestoreManifestProjectionContext, RestoredRunManifestProjectionContext,
     RunManifestProjectionContext, VerifiedWorkbenchRestoreManifest, VerifiedWorkbenchRunManifest,
-    WorkbenchProjection,
+    WorkbenchProjection, WorkbenchRestoreSource,
 };
 use nokv_types::WorkbenchId;
 
@@ -81,13 +82,13 @@ impl WorkbenchProjection for CanonicalWorkbenchProjection {
         &self,
         context: RestoreManifestProjectionContext<'_>,
     ) -> Result<Vec<u8>, Self::Error> {
-        nokv_agent::build_restore_manifest_v1(
+        nokv_agent::build_restore_manifest_v2(
             context.operation_id,
             context.source_workbench_id,
             context.source_path,
             context.destination_workbench_id,
             context.destination_path,
-            context.snapshot_id,
+            manifest_source(context.source),
         )
     }
 
@@ -95,14 +96,16 @@ impl WorkbenchProjection for CanonicalWorkbenchProjection {
         &self,
         bytes: &[u8],
     ) -> Result<VerifiedWorkbenchRestoreManifest, Self::Error> {
-        let verified = nokv_agent::verify_restore_manifest_v1(bytes)?;
+        // Reads either schema: v1 envelopes are durable artifacts inside
+        // workbenches restored before a commit could be named.
+        let verified = nokv_agent::verify_restore_manifest(bytes)?;
         Ok(VerifiedWorkbenchRestoreManifest {
             operation_id: verified.operation_id,
             source_workbench_id: verified.source_workbench_id,
             source_path: verified.source_path,
             destination_workbench_id: verified.destination_workbench_id,
             destination_path: verified.destination_path,
-            snapshot_id: verified.snapshot_id,
+            source: client_source(verified.source),
             canonical_envelope: verified.canonical_envelope,
             envelope_digest_uri: verified.envelope_digest_uri,
         })
@@ -142,5 +145,23 @@ impl WorkbenchProjection for CanonicalWorkbenchProjection {
             context.destination_commit_identity,
             context.destination_committed_at_unix_seconds,
         )
+    }
+}
+
+fn manifest_source(source: WorkbenchRestoreSource) -> RestoreManifestSource {
+    match source {
+        WorkbenchRestoreSource::Snapshot { snapshot_id } => {
+            RestoreManifestSource::Snapshot { snapshot_id }
+        }
+        WorkbenchRestoreSource::Commit { commit_id } => RestoreManifestSource::Commit { commit_id },
+    }
+}
+
+fn client_source(source: RestoreManifestSource) -> WorkbenchRestoreSource {
+    match source {
+        RestoreManifestSource::Snapshot { snapshot_id } => {
+            WorkbenchRestoreSource::Snapshot { snapshot_id }
+        }
+        RestoreManifestSource::Commit { commit_id } => WorkbenchRestoreSource::Commit { commit_id },
     }
 }

--- a/crates/nokv/Cargo.toml
+++ b/crates/nokv/Cargo.toml
@@ -21,6 +21,7 @@ nokv-object.workspace = true
 nokv-protocol.workspace = true
 nokv-server.workspace = true
 nokv-agent.workspace = true
+nokv-workbench-projection.workspace = true
 nokv-types.workspace = true
 sha2.workspace = true
 signal-hook = { workspace = true, optional = true }

--- a/crates/nokv/src/backend.rs
+++ b/crates/nokv/src/backend.rs
@@ -15,18 +15,16 @@ use base64::Engine as _;
 use nokv_agent as agent;
 use nokv_client::{
     ArtifactAppendOptions, ArtifactPublishOptions, ArtifactReadAuthority, ClientError,
-    RestoreManifestProjectionContext, RestoredRunManifestProjectionContext,
-    RunManifestProjectionContext, SnapshotMintOptions, SnapshotRenewOptions, SnapshotRetireOptions,
-    VerifiedWorkbenchRestoreManifest, VerifiedWorkbenchRunManifest, WorkbenchAdmission,
+    SnapshotMintOptions, SnapshotRenewOptions, SnapshotRetireOptions, WorkbenchAdmission,
     WorkbenchCommitRequest, WorkbenchLifecycleError, WorkbenchLifecycleFacade,
-    WorkbenchLifecycleOptions, WorkbenchProjection, WorkbenchRestoreRequest,
-    WorkbenchSnapshotSelector,
+    WorkbenchLifecycleOptions, WorkbenchRestoreRequest, WorkbenchSnapshotSelector,
 };
 use nokv_object::ArtifactObjectStore;
 use nokv_protocol as wire;
 use nokv_types::{
     ArtifactRevisionId, NormalizedRelativePath, RootId, WorkbenchId, WorkspaceIncarnationId,
 };
+use nokv_workbench_projection::CanonicalWorkbenchProjection;
 use serde_json::{json, Value};
 use sha2::{Digest as _, Sha256};
 
@@ -50,127 +48,6 @@ const WORKBENCH_ENTRY_COUNT_MAX_PAGES: usize = 4_096;
 const WORKBENCH_ENTRY_COUNT_MAX_ROWS: usize = 1_000_000;
 
 static ID_SEQUENCE: AtomicU64 = AtomicU64::new(1);
-
-#[derive(Clone, Copy, Debug)]
-struct AgentWorkbenchProjection;
-
-impl WorkbenchProjection for AgentWorkbenchProjection {
-    type Error = agent::ProjectionError;
-
-    fn build_run_manifest(
-        &self,
-        context: RunManifestProjectionContext<'_>,
-        committed_at_unix_seconds: u64,
-    ) -> Result<Vec<u8>, Self::Error> {
-        agent::build_run_manifest_v1(
-            context.workbench_id,
-            context.workbench_path,
-            context.content_digest_uri,
-            context.canonical_manifest,
-            context.manifest_digest_uri,
-            context.commit_identity,
-            committed_at_unix_seconds,
-        )
-    }
-
-    fn run_manifest_projection_input_digest(
-        &self,
-        context: RunManifestProjectionContext<'_>,
-    ) -> [u8; 32] {
-        agent::run_manifest_projection_input_digest_v1(
-            context.workbench_id,
-            context.workbench_path,
-            context.content_digest_uri,
-            context.canonical_manifest,
-            context.manifest_digest_uri,
-            context.commit_identity,
-        )
-    }
-
-    fn verify_run_manifest(
-        &self,
-        bytes: &[u8],
-    ) -> Result<VerifiedWorkbenchRunManifest, Self::Error> {
-        let verified = agent::verify_run_manifest_v1(bytes)?;
-        Ok(VerifiedWorkbenchRunManifest {
-            workbench_id: verified.workbench_id,
-            workbench_path: verified.workbench_path,
-            content_digest_uri: verified.content_digest_uri,
-            manifest_digest_uri: verified.manifest_digest_uri,
-            commit_identity: verified.commit_identity,
-            canonical_manifest: verified.canonical_manifest,
-            canonical_envelope: verified.canonical_envelope,
-            envelope_digest_uri: verified.envelope_digest_uri,
-        })
-    }
-
-    fn build_restore_manifest(
-        &self,
-        context: RestoreManifestProjectionContext<'_>,
-    ) -> Result<Vec<u8>, Self::Error> {
-        agent::build_restore_manifest_v1(
-            context.operation_id,
-            context.source_workbench_id,
-            context.source_path,
-            context.destination_workbench_id,
-            context.destination_path,
-            context.snapshot_id,
-        )
-    }
-
-    fn verify_restore_manifest(
-        &self,
-        bytes: &[u8],
-    ) -> Result<VerifiedWorkbenchRestoreManifest, Self::Error> {
-        let verified = agent::verify_restore_manifest_v1(bytes)?;
-        Ok(VerifiedWorkbenchRestoreManifest {
-            operation_id: verified.operation_id,
-            source_workbench_id: verified.source_workbench_id,
-            source_path: verified.source_path,
-            destination_workbench_id: verified.destination_workbench_id,
-            destination_path: verified.destination_path,
-            snapshot_id: verified.snapshot_id,
-            canonical_envelope: verified.canonical_envelope,
-            envelope_digest_uri: verified.envelope_digest_uri,
-        })
-    }
-
-    fn restore_effective_content_digest_uri(
-        &self,
-        source_content_digest_uri: &str,
-        source_matches_base_commit: bool,
-        materialized_member_digest: [u8; 32],
-    ) -> Result<String, Self::Error> {
-        agent::restore_effective_content_digest_uri_v1(
-            source_content_digest_uri,
-            source_matches_base_commit,
-            materialized_member_digest,
-        )
-    }
-
-    fn workbench_commit_identity(
-        &self,
-        workbench_id: &WorkbenchId,
-        content_digest_uri: &str,
-        manifest_digest_uri: &str,
-    ) -> [u8; 32] {
-        agent::workbench_commit_identity(workbench_id, content_digest_uri, manifest_digest_uri)
-    }
-
-    fn build_restored_run_manifest(
-        &self,
-        context: RestoredRunManifestProjectionContext<'_>,
-    ) -> Result<Vec<u8>, Self::Error> {
-        agent::build_restored_run_manifest_v1(
-            context.source_run_manifest,
-            context.destination_workbench_id,
-            context.destination_workbench_path,
-            context.effective_content_digest_uri,
-            context.destination_commit_identity,
-            context.destination_committed_at_unix_seconds,
-        )
-    }
-}
 
 const fn base64_encoded_upper_bound(raw_bytes: usize) -> usize {
     raw_bytes.saturating_add(2) / 3 * 4
@@ -268,7 +145,7 @@ impl CliWorkbenchBackend {
             '_,
             nokv_client::FramedTcpTransport,
             Arc<dyn nokv_client::RouteResolver>,
-            AgentWorkbenchProjection,
+            CanonicalWorkbenchProjection,
         >,
         agent::BackendError,
     > {
@@ -278,7 +155,7 @@ impl CliWorkbenchBackend {
             &self.client,
             self.objects.as_ref(),
             options,
-            AgentWorkbenchProjection,
+            CanonicalWorkbenchProjection,
         ))
     }
 

--- a/crates/nokv/src/backend.rs
+++ b/crates/nokv/src/backend.rs
@@ -17,7 +17,8 @@ use nokv_client::{
     ArtifactAppendOptions, ArtifactPublishOptions, ArtifactReadAuthority, ClientError,
     SnapshotMintOptions, SnapshotRenewOptions, SnapshotRetireOptions, WorkbenchAdmission,
     WorkbenchCommitRequest, WorkbenchLifecycleError, WorkbenchLifecycleFacade,
-    WorkbenchLifecycleOptions, WorkbenchRestoreRequest, WorkbenchSnapshotSelector,
+    WorkbenchLifecycleOptions, WorkbenchRestoreOrigin, WorkbenchRestoreRequest,
+    WorkbenchRestoreSource, WorkbenchSnapshotSelector,
 };
 use nokv_object::ArtifactObjectStore;
 use nokv_protocol as wire;
@@ -1696,11 +1697,16 @@ impl agent::WorkbenchBackend for CliWorkbenchBackend {
         let request = WorkbenchRestoreRequest {
             source_workbench_id: request.source_workbench_id,
             source_workbench_path: request.source_workbench_path,
-            selector: match request.selector {
-                agent::SnapshotSelector::Id(snapshot_id) => {
-                    WorkbenchSnapshotSelector::Id(snapshot_id)
+            origin: match request.origin {
+                agent::RestoreOrigin::Snapshot(agent::SnapshotSelector::Id(snapshot_id)) => {
+                    WorkbenchRestoreOrigin::Snapshot(WorkbenchSnapshotSelector::Id(snapshot_id))
                 }
-                agent::SnapshotSelector::Name(name) => WorkbenchSnapshotSelector::Name(name),
+                agent::RestoreOrigin::Snapshot(agent::SnapshotSelector::Name(name)) => {
+                    WorkbenchRestoreOrigin::Snapshot(WorkbenchSnapshotSelector::Name(name))
+                }
+                agent::RestoreOrigin::Commit(commit_id) => {
+                    WorkbenchRestoreOrigin::Commit(commit_id)
+                }
             },
             destination_workbench_id: request.destination_workbench_id,
             destination_workbench_path: request.destination_workbench_path,
@@ -1709,10 +1715,15 @@ impl agent::WorkbenchBackend for CliWorkbenchBackend {
             .lifecycle_facade()?
             .restore(request)
             .map_err(map_lifecycle_error)?;
+        let (snapshot_id, commit_id) = match outcome.source {
+            WorkbenchRestoreSource::Snapshot { snapshot_id } => (Some(snapshot_id), None),
+            WorkbenchRestoreSource::Commit { commit_id } => (None, Some(commit_id)),
+        };
         Ok(agent::RestoreOutcome {
             operation_id: outcome.operation_id,
-            snapshot_id: outcome.snapshot_id,
+            snapshot_id,
             read_version: outcome.source_snapshot_read_version,
+            commit_id,
             destination_generation: outcome.destination_workspace_revision,
             idempotent_replay: outcome.idempotent_replay,
         })
@@ -3525,20 +3536,20 @@ mod tests {
             wire::WorkbenchName::new(destination_workbench_id.as_str()).unwrap();
         let source_incarnation = wire::WorkspaceIdentity([0x21; 16]);
         let snapshot_id = 7;
-        let restore_identities = RestoreWorkflowIdentities::derive_snapshot(
+        let restore_identities = RestoreWorkflowIdentities::derive(
             root_id,
             &source_workbench,
             source_incarnation,
-            snapshot_id,
+            WorkbenchRestoreSource::Snapshot { snapshot_id },
             &destination_workbench,
         );
-        let restore_manifest = agent::build_restore_manifest_v1(
+        let restore_manifest = agent::build_restore_manifest_v2(
             restore_identities.operation_id.0,
             &source_workbench_id,
             &source_workbench_path,
             &destination_workbench_id,
             &destination_workbench_path,
-            snapshot_id,
+            agent::RestoreManifestSource::Snapshot { snapshot_id },
         )
         .unwrap();
         let restore_digest = digest_uri(&restore_manifest);
@@ -3687,7 +3698,7 @@ mod tests {
             agent::RestoreRequest {
                 source_workbench_id: fixture.source_workbench_id.clone(),
                 source_workbench_path: fixture.source_workbench_path.clone(),
-                selector,
+                origin: agent::RestoreOrigin::Snapshot(selector),
                 destination_workbench_id: fixture.destination_workbench_id.clone(),
                 destination_workbench_path: fixture.destination_workbench_path.clone(),
             },
@@ -5961,7 +5972,7 @@ mod tests {
             agent::RestoreRequest {
                 source_workbench_id: WorkbenchId::new("source-run").unwrap(),
                 source_workbench_path: "/agents/test/wb/source-run".to_owned(),
-                selector: agent::SnapshotSelector::Id(7),
+                origin: agent::RestoreOrigin::Snapshot(agent::SnapshotSelector::Id(7)),
                 destination_workbench_id: WorkbenchId::new("destination-run").unwrap(),
                 destination_workbench_path: "/agents/test/wb/destination-run".to_owned(),
             },
@@ -6049,7 +6060,7 @@ mod tests {
             agent::RestoreRequest {
                 source_workbench_id: source_id,
                 source_workbench_path: "/agents/test/wb/source-run".to_owned(),
-                selector: agent::SnapshotSelector::Id(7),
+                origin: agent::RestoreOrigin::Snapshot(agent::SnapshotSelector::Id(7)),
                 destination_workbench_id: destination_id,
                 destination_workbench_path: "/agents/test/wb/destination-run".to_owned(),
             },
@@ -6104,20 +6115,20 @@ mod tests {
         let destination_workbench_path = "/agents/test/wb/destination-run".to_owned();
         let source_incarnation = wire::WorkspaceIdentity([0x21; 16]);
         let snapshot_id = 7;
-        let identities = nokv_client::RestoreWorkflowIdentities::derive_snapshot(
+        let identities = nokv_client::RestoreWorkflowIdentities::derive(
             test_route().root_id,
             &wire::WorkbenchName::new(source_workbench_id.as_str()).unwrap(),
             source_incarnation,
-            snapshot_id,
+            WorkbenchRestoreSource::Snapshot { snapshot_id },
             &wire::WorkbenchName::new(destination_workbench_id.as_str()).unwrap(),
         );
-        let envelope_bytes = agent::build_restore_manifest_v1(
+        let envelope_bytes = agent::build_restore_manifest_v2(
             identities.operation_id.0,
             &source_workbench_id,
             &source_workbench_path,
             &destination_workbench_id,
             &destination_workbench_path,
-            snapshot_id,
+            agent::RestoreManifestSource::Snapshot { snapshot_id },
         )
         .unwrap()
         .len();
@@ -6158,7 +6169,7 @@ mod tests {
             agent::RestoreRequest {
                 source_workbench_id,
                 source_workbench_path,
-                selector: agent::SnapshotSelector::Id(snapshot_id),
+                origin: agent::RestoreOrigin::Snapshot(agent::SnapshotSelector::Id(snapshot_id)),
                 destination_workbench_id,
                 destination_workbench_path,
             },

--- a/docs/workbench-contract.md
+++ b/docs/workbench-contract.md
@@ -289,9 +289,15 @@ operation id, so either a hash-prefix collision or a mismatched retry fails
 closed instead of resuming the wrong restore.
 
 `metadata/restore_manifest.json` is the canonical
-`nokv.workbench.restore_manifest.v1` provenance envelope. It records the
+`nokv.workbench.restore_manifest.v2` provenance envelope. It records the
 operation id, source and destination Workbench ids and presentation paths, and
-the selected snapshot id. Its exact digest, size, and JSON content type are
+under `restored_from.source` the frozen state the restore read: either
+`{"kind": "snapshot", "snapshot_id": N}` or `{"kind": "commit", "commit_id":
+"<64 hex>"}`. A snapshot is a lease and expires; a commit is durable, so a
+decision point that has to outlive the lease bound is restored from its
+commit. Readers still accept the `v1` envelope, which carried a bare
+`snapshot_id` and remains a durable artifact inside workbenches restored
+before a commit could be named. Its exact digest, size, and JSON content type are
 bound durably when restore preparation begins and are checked again when the
 staging workspace is published. Restore member count and member digest remain
 typed metadata fields only. `MetaShard` does not generate a second JSON

--- a/scripts/workbench/fork_restore_recovery_gate.py
+++ b/scripts/workbench/fork_restore_recovery_gate.py
@@ -69,7 +69,10 @@ CONCURRENT_RESTORES = 16
 # (metadata/run_manifest.json and metadata/restore_manifest.json) and copies
 # no payload object; the destination is committed as soon as it is visible.
 RESTORE_MANIFEST_OBJECTS = 2
-RESTORE_MANIFEST_SCHEMA = "nokv.workbench.restore_manifest.v1"
+# Pinned deliberately rather than read from the binary: a gate that asks the
+# thing under test what it should have written proves nothing. Moving this
+# pin is how a durable-format change gets a human decision.
+RESTORE_MANIFEST_SCHEMA = "nokv.workbench.restore_manifest.v2"
 RUN_MANIFEST_SCHEMA = "nokv.workbench.run_manifest.v1"
 WORKBENCH_ROOT = "/agents/materials/wb"
 # Product default etcd owner lease TTL (crates/nokv/src/cli.rs).
@@ -459,9 +462,16 @@ def validate_restore_manifest(
     destination_path = f"{WORKBENCH_ROOT}/{destination}"
     if not isinstance(manifest, dict):
         raise WorkflowFailure(f"{label} is not a JSON object")
-    snapshot_id = manifest.get("snapshot_id")
     operation_id = manifest.get("operation_id")
     restored_from = manifest.get("restored_from")
+    # v2 names the source it read from, so a manifest cannot leave it implicit
+    # and a commit restore cannot masquerade as a snapshot one. This gate
+    # exercises the fork path, which restores from a snapshot.
+    snapshot_id = None
+    if isinstance(restored_from, dict):
+        restore_source = restored_from.get("source")
+        if isinstance(restore_source, dict) and restore_source.get("kind") == "snapshot":
+            snapshot_id = restore_source.get("snapshot_id")
     if (
         manifest.get("schema") != RESTORE_MANIFEST_SCHEMA
         or manifest.get("source_workbench_id") != source
@@ -469,6 +479,7 @@ def validate_restore_manifest(
         or manifest.get("destination_workbench_id") != destination
         or manifest.get("destination_path") != destination_path
         or not isinstance(snapshot_id, int)
+        or isinstance(snapshot_id, bool)
         or snapshot_id <= 0
         or not isinstance(operation_id, str)
         or len(operation_id) != 32
@@ -476,7 +487,7 @@ def validate_restore_manifest(
         != {
             "workbench_id": source,
             "path": source_path,
-            "snapshot_id": snapshot_id,
+            "source": {"kind": "snapshot", "snapshot_id": snapshot_id},
         }
     ):
         raise WorkflowFailure(f"{label} is not bound to the exact fork identities")

--- a/scripts/workbench/fork_restore_recovery_gate_test.py
+++ b/scripts/workbench/fork_restore_recovery_gate_test.py
@@ -141,9 +141,8 @@ class ForkRestoreRecoveryGateTest(unittest.TestCase):
 
     def test_restore_manifest_requires_the_complete_path_native_identity(self) -> None:
         manifest = {
-            "schema": "nokv.workbench.restore_manifest.v1",
+            "schema": "nokv.workbench.restore_manifest.v2",
             "operation_id": "11" * 16,
-            "snapshot_id": 7,
             "source_workbench_id": "source",
             "source_path": "/agents/materials/wb/source",
             "destination_workbench_id": "destination",
@@ -151,18 +150,36 @@ class ForkRestoreRecoveryGateTest(unittest.TestCase):
             "restored_from": {
                 "workbench_id": "source",
                 "path": "/agents/materials/wb/source",
-                "snapshot_id": 7,
+                "source": {"kind": "snapshot", "snapshot_id": 7},
             },
         }
         validate_restore_manifest(manifest, "source", "destination")
-        malformed = copy.deepcopy(manifest)
-        malformed["restored_from"]["snapshot_id"] = 8
-        with self.assertRaisesRegex(WorkflowFailure, "exact fork identities"):
-            validate_restore_manifest(malformed, "source", "destination")
+        # v1 carried the snapshot id twice and the gate cross-checked the two
+        # copies. v2 carries it once, so that particular mutation is no longer
+        # detectable from inside the document -- and does not need to be: the
+        # manifest is content-addressed, so an altered byte changes its digest
+        # and therefore the revision the restore is bound to. What remains
+        # worth asserting is everything the document can still contradict.
+        for mutate, why in (
+            (lambda m: m["restored_from"].__setitem__("workbench_id", "other"),
+             "restored_from names a different source workbench"),
+            (lambda m: m["restored_from"].__setitem__("path", "/agents/materials/wb/other"),
+             "restored_from names a different source path"),
+            (lambda m: m["restored_from"]["source"].__setitem__("snapshot_id", 0),
+             "a zero snapshot id is not a snapshot"),
+            (lambda m: m["restored_from"].__setitem__("source", {"kind": "commit", "commit_id": "ab" * 32}),
+             "a commit source is different provenance, not another spelling"),
+            (lambda m: m["restored_from"].__setitem__("source", {"kind": "snapshot"}),
+             "a snapshot source without its id"),
+        ):
+            malformed = copy.deepcopy(manifest)
+            mutate(malformed)
+            with self.assertRaisesRegex(WorkflowFailure, "exact fork identities", msg=why):
+                validate_restore_manifest(malformed, "source", "destination")
 
     def test_every_restore_adds_exactly_two_destination_manifests(self) -> None:
         self.assertEqual(RESTORE_MANIFEST_OBJECTS, 2)
-        restore = {"schema": "nokv.workbench.restore_manifest.v1"}
+        restore = {"schema": "nokv.workbench.restore_manifest.v2"}
         run_manifest = {"schema": "nokv.workbench.run_manifest.v1"}
         self.assertEqual(
             classify_manifest_objects({"k/a": run_manifest, "k/b": restore}, "fork"),

--- a/scripts/workbench/restore_composition_gate.py
+++ b/scripts/workbench/restore_composition_gate.py
@@ -599,7 +599,7 @@ def validate_composition_evidence(evidence: dict[str, Any]) -> None:
     ):
         restore_manifest = _mapping(value, "restore_manifest")
         if (
-            restore_manifest.get("schema") != "nokv.workbench.restore_manifest.v1"
+            restore_manifest.get("schema") != "nokv.workbench.restore_manifest.v2"
             or restore_manifest.get("source_workbench_id") != source
             or restore_manifest.get("destination_workbench_id") != destination
         ):

--- a/scripts/workbench/restore_composition_gate_test.py
+++ b/scripts/workbench/restore_composition_gate_test.py
@@ -143,7 +143,7 @@ def valid_evidence() -> dict[str, object]:
                     source="composition-a",
                 ),
                 "restore_manifest": {
-                    "schema": "nokv.workbench.restore_manifest.v1",
+                    "schema": "nokv.workbench.restore_manifest.v2",
                     "source_workbench_id": "composition-a",
                     "destination_workbench_id": "composition-b",
                     "operation_id": "66" * 16,
@@ -166,7 +166,7 @@ def valid_evidence() -> dict[str, object]:
                     source="composition-b",
                 ),
                 "restore_manifest": {
-                    "schema": "nokv.workbench.restore_manifest.v1",
+                    "schema": "nokv.workbench.restore_manifest.v2",
                     "source_workbench_id": "composition-b",
                     "destination_workbench_id": "composition-c",
                     "operation_id": "99" * 16,


### PR DESCRIPTION
Stacked on #473. Base is that PR's branch so the diff is only this delta; it retargets to `main` once #473 lands. (`crates/nokv-types/src/workspace.rs` shows here only because #474 is on `main` but not yet on #473's branch — it disappears from the diff after #473 merges.)

## Why

A Python caller could publish, read, query and mint snapshots, but not **commit** or **restore**. Those are the two steps that turn a workbench into a citable record, so every campaign had to shell out to the CLI for exactly the part that matters.

Worse, **no layer at all could restore from a commit**. The engine has implemented `RestoreSource::Commit` all along and the protocol validates it, but every caller above the engine constructed `RestoreSource::Snapshot` and the tool contract required `at_snapshot`. Snapshots are leases — 7 days by default, 90 at most — so a decision point could not be reconstructed once its lease expired. A benchmark that expires in 90 days is not a benchmark.

## What

**`crates/nokv-workbench-projection`** (new, one responsibility). `nokv-agent` owns the durable manifest formats and deliberately depends on nothing but `nokv-types`; `nokv-client` defines `WorkbenchProjection` and deliberately does not depend on the tool layer. Neither can host the join, and `crates/nokv` — their only meeting point — is a binary. The new crate holds that one adapter, and `crates/nokv` and `crates/nokv-python` share it. Not tidiness: this PR grows the trait with a commit restore source, and a per-caller copy is how the CLI and the SDK come to disagree about a durable format.

**`nokv_agent::workbench_commit_inputs`** so the manifest digest and the stable commit id have one implementation. The SDK must not own metadata layout.

**Restore manifest v2** — `restored_from.source` names either a snapshot or a commit. The reader accepts both schemas, since v1 envelopes are durable artifacts in already-restored workbenches.

**`WorkbenchRestoreOrigin`** through `nokv-client`, the tool contract, and the CLI. `workbench_restore` now takes `at_snapshot` **or** `at_commit`, exactly one.

**Python**: `Client.commit(...)`, `Client.restore(..., at_snapshot=|at_commit=)`, and a `workbench_root` constructor argument. That root is not addressing — it is hashed into the commit operation's projection digest, so a client that guessed it would make its commit a *different operation* from the CLI's over the same content. Lifecycle calls refuse to guess.

## One design the engine rejected

The first version gave commit restores their own identity domain. The shard refused it on the first live call:

```
restore operation identity does not match the deterministic source/destination selector
```

The operation identity is a frozen cross-layer contract — the shard derives the same digest and compares. The canonical scheme already defines both sources: one domain, one discriminant byte (`[1]` snapshot, `[2]` commit). The client had hard-coded `[1]`. Now aligned, with golden bytes pinning both directions: the snapshot derivation is **byte-for-byte unchanged** (changing it would orphan in-flight restores) and the commit derivation has its own frozen value.

## Validation

- `cargo test --workspace`: **1066 passed, 0 failed**; `cargo fmt --check` and `cargo clippy --workspace --all-targets -D warnings` clean
- `crates/nokv-python/tests` (what the wheel CI gates on): 31 passed, including a new test that requires commit, restore, both sources, and `workbench_root` to be present in the installed wheel
- Live stack, functional chain and idempotency: **10/10** — including a check that the SDK and the CLI write field-identical run manifests
- Live stack, stress: **8/8** — 8 concurrent commits yield exactly one commit id; 6 concurrent restores converge on one operation id; a commit made by the SDK is restored by the CLI and then replayed by the SDK as the same operation
- Live stack, scale: a **10.46 GiB** campaign of 3414 calculations over 14 chemical systems, ingested through the SDK alone in 18.4 min (9.7 MiB/s, single writer), whole-batch resubmission replayed, commit and freeze in 9.3 s, frozen per-system listings answering 3414 calculations in 0.4 s, and a restore compared byte-for-byte with zero mismatches

## Defects this surfaced, not introduced

Both live on paths nothing above the engine could previously reach, so neither had ever executed. The CLI fails identically, so neither is a binding problem. Recorded as tests, not fixed here:

1. **`workbench_commit` with `replace=true` fails** with `truncated value_format_version: need 1 bytes, have 0` — a decode of a zero-length value in the retire path. A second committed round on one workbench is therefore impossible today.
2. **A commit-source restore fails once its closure needs more than one copy batch.** `MAX_RESTORE_BATCH_MEMBERS` is 48 rows, but typed index fields make rows large enough that a real campaign crosses it at ~14 documents. Snapshot restores are unaffected (verified at the 10 GiB scale above).

Also worth knowing: a listing page caps at 1000 entries and signals more only through `next_cursor` — there is no `truncated` flag, so a caller that ignores the cursor silently sees a prefix of the campaign.