### PR TITLE
ci: bound and retry the network fetches required checks depend on

### DIFF
--- a/.github/workflows/release-crates.yml
+++ b/.github/workflows/release-crates.yml
@@ -35,8 +35,22 @@ jobs:
 
       - name: Install protobuf compiler
         run: |
-          sudo apt-get update
-          sudo apt-get install -y protobuf-compiler
+          set -euo pipefail
+          # apt has hung on an unreachable mirror long enough to wedge a
+          # required check for half an hour, and the step it wedges is not
+          # the code under test, so the red lands nowhere useful. Bound each
+          # call and retry rather than letting a mirror decide the build.
+          for attempt in 1 2 3; do
+            if sudo timeout 300 apt-get update \
+              && sudo timeout 300 apt-get install -y protobuf-compiler; then
+              exit 0
+            fi
+            echo "apt attempt ${attempt} failed or timed out; retrying" >&2
+            sudo pkill -f apt-get || true
+            sleep $((attempt * 15))
+          done
+          echo "apt-get could not install protobuf-compiler after 3 attempts" >&2
+          exit 1
 
       - name: Resolve crate list
         id: crates

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -24,8 +24,22 @@ jobs:
 
       - name: Install protobuf compiler for typed qualification
         run: |
-          sudo apt-get update
-          sudo apt-get install -y protobuf-compiler
+          set -euo pipefail
+          # apt has hung on an unreachable mirror long enough to wedge a
+          # required check for half an hour, and the step it wedges is not
+          # the code under test, so the red lands nowhere useful. Bound each
+          # call and retry rather than letting a mirror decide the build.
+          for attempt in 1 2 3; do
+            if sudo timeout 300 apt-get update \
+              && sudo timeout 300 apt-get install -y protobuf-compiler; then
+              exit 0
+            fi
+            echo "apt attempt ${attempt} failed or timed out; retrying" >&2
+            sudo pkill -f apt-get || true
+            sleep $((attempt * 15))
+          done
+          echo "apt-get could not install protobuf-compiler after 3 attempts" >&2
+          exit 1
 
       - name: Cache typed qualification targets
         uses: Swatinem/rust-cache@v2
@@ -333,8 +347,22 @@ jobs:
 
       - name: Install protobuf compiler
         run: |
-          sudo apt-get update
-          sudo apt-get install -y protobuf-compiler
+          set -euo pipefail
+          # apt has hung on an unreachable mirror long enough to wedge a
+          # required check for half an hour, and the step it wedges is not
+          # the code under test, so the red lands nowhere useful. Bound each
+          # call and retry rather than letting a mirror decide the build.
+          for attempt in 1 2 3; do
+            if sudo timeout 300 apt-get update \
+              && sudo timeout 300 apt-get install -y protobuf-compiler; then
+              exit 0
+            fi
+            echo "apt attempt ${attempt} failed or timed out; retrying" >&2
+            sudo pkill -f apt-get || true
+            sleep $((attempt * 15))
+          done
+          echo "apt-get could not install protobuf-compiler after 3 attempts" >&2
+          exit 1
 
       - name: Cache cargo
         uses: Swatinem/rust-cache@v2
@@ -375,7 +403,12 @@ jobs:
           set -euo pipefail
           archive="$RUNNER_TEMP/etcd-$ETCD_VERSION-linux-amd64.tar.gz"
           install_dir="$RUNNER_TEMP/etcd-$ETCD_VERSION"
-          curl --fail --location --retry 3 \
+          # --retry alone does not cover a reset connection: curl treats it
+          # as fatal and exits without a single retry, which is how a 220 ms
+          # network blip has failed a required check. --retry-all-errors is
+          # what makes the retry budget apply to it.
+          curl --fail --location --retry 5 --retry-all-errors --retry-delay 5 \
+            --connect-timeout 30 --max-time 600 \
             --output "$archive" \
             "https://github.com/etcd-io/etcd/releases/download/$ETCD_VERSION/etcd-$ETCD_VERSION-linux-amd64.tar.gz"
           echo "$ETCD_LINUX_AMD64_SHA256  $archive" | sha256sum --check
@@ -552,8 +585,22 @@ jobs:
 
       - name: Install protobuf compiler
         run: |
-          sudo apt-get update
-          sudo apt-get install -y protobuf-compiler
+          set -euo pipefail
+          # apt has hung on an unreachable mirror long enough to wedge a
+          # required check for half an hour, and the step it wedges is not
+          # the code under test, so the red lands nowhere useful. Bound each
+          # call and retry rather than letting a mirror decide the build.
+          for attempt in 1 2 3; do
+            if sudo timeout 300 apt-get update \
+              && sudo timeout 300 apt-get install -y protobuf-compiler; then
+              exit 0
+            fi
+            echo "apt attempt ${attempt} failed or timed out; retrying" >&2
+            sudo pkill -f apt-get || true
+            sleep $((attempt * 15))
+          done
+          echo "apt-get could not install protobuf-compiler after 3 attempts" >&2
+          exit 1
 
       - name: Cache cargo
         uses: Swatinem/rust-cache@v2
@@ -564,7 +611,12 @@ jobs:
           set -euo pipefail
           archive="$RUNNER_TEMP/etcd-$ETCD_VERSION-linux-amd64.tar.gz"
           install_dir="$RUNNER_TEMP/etcd-$ETCD_VERSION"
-          curl --fail --location --retry 3 \
+          # --retry alone does not cover a reset connection: curl treats it
+          # as fatal and exits without a single retry, which is how a 220 ms
+          # network blip has failed a required check. --retry-all-errors is
+          # what makes the retry budget apply to it.
+          curl --fail --location --retry 5 --retry-all-errors --retry-delay 5 \
+            --connect-timeout 30 --max-time 600 \
             --output "$archive" \
             "https://github.com/etcd-io/etcd/releases/download/$ETCD_VERSION/etcd-$ETCD_VERSION-linux-amd64.tar.gz"
           echo "$ETCD_LINUX_AMD64_SHA256  $archive" | sha256sum --check
@@ -614,8 +666,22 @@ jobs:
 
       - name: Install protobuf compiler
         run: |
-          sudo apt-get update
-          sudo apt-get install -y protobuf-compiler
+          set -euo pipefail
+          # apt has hung on an unreachable mirror long enough to wedge a
+          # required check for half an hour, and the step it wedges is not
+          # the code under test, so the red lands nowhere useful. Bound each
+          # call and retry rather than letting a mirror decide the build.
+          for attempt in 1 2 3; do
+            if sudo timeout 300 apt-get update \
+              && sudo timeout 300 apt-get install -y protobuf-compiler; then
+              exit 0
+            fi
+            echo "apt attempt ${attempt} failed or timed out; retrying" >&2
+            sudo pkill -f apt-get || true
+            sleep $((attempt * 15))
+          done
+          echo "apt-get could not install protobuf-compiler after 3 attempts" >&2
+          exit 1
 
       - name: Cache cargo
         uses: Swatinem/rust-cache@v2
@@ -626,7 +692,12 @@ jobs:
           set -euo pipefail
           archive="$RUNNER_TEMP/etcd-$ETCD_VERSION-linux-amd64.tar.gz"
           install_dir="$RUNNER_TEMP/etcd-$ETCD_VERSION"
-          curl --fail --location --retry 3 \
+          # --retry alone does not cover a reset connection: curl treats it
+          # as fatal and exits without a single retry, which is how a 220 ms
+          # network blip has failed a required check. --retry-all-errors is
+          # what makes the retry budget apply to it.
+          curl --fail --location --retry 5 --retry-all-errors --retry-delay 5 \
+            --connect-timeout 30 --max-time 600 \
             --output "$archive" \
             "https://github.com/etcd-io/etcd/releases/download/$ETCD_VERSION/etcd-$ETCD_VERSION-linux-amd64.tar.gz"
           echo "$ETCD_LINUX_AMD64_SHA256  $archive" | sha256sum --check


### PR DESCRIPTION
## The problem

Four required-check failures in two days landed on **setup steps**, not on the code under test:

| PR | Step | Outcome |
|---|---|---|
| #474 | `curl` fetching etcd | connection reset, exit 35 after **220 ms** |
| #473 | `apt-get` | wedged **25 min** |
| #473 | `apt-get` | wedged **30 min**, then killed |
| #473 | `apt-get` | same step, same runner image, **succeeded** |

The last two ran in the *same workflow run*. So this is a coin flip on the mirror, not a property of either job — and re-running is just another toss.

## Why the existing guards did not hold

**apt** had none: `apt-get update && apt-get install -y protobuf-compiler`, no timeout, no retry. An unreachable mirror holds a required check until the job limit kills it.

**curl** looked retried but was not, for this failure. `curl --fail --location --retry 3` covers timeouts and transient HTTP status; a **reset connection is fatal to curl** and skips the retry budget entirely. The #474 log shows it exiting 220 ms after starting — curl's first retry delay is a full second, so no retry was ever attempted.

## The change

- **apt** (4 sites in `rust.yml`, 1 in `release-crates.yml`): three attempts, each call capped at 300 s via `timeout`, killing a stuck `apt-get` between tries, with backoff.
- **curl** (3 sites in `rust.yml`): `--retry-all-errors` so the budget actually applies to resets, `--retry 5 --retry-delay 5`, plus `--connect-timeout 30 --max-time 600`.

No product code, no test, no workflow trigger changes.

## Why it is worth a PR of its own

The cost is not the lost minutes. It is that the red lands on a step nobody touched, and the first thing anyone does with a red required check is go read their own diff. That happened twice this week.

## Validation

- Both workflows parse as YAML.
- The retry loop was exercised against a stub that fails twice then succeeds (retries, returns 0) and one that never succeeds (gives up after 3, returns 1) — so it neither gives up early nor loops forever.
- `timeout` (coreutils 9.4) and `pkill` confirmed present on `ubuntu:24.04`, the runner base image, since the fix depends on them.
- `--retry-all-errors` confirmed supported by a current curl; it needs 7.71+, and Ubuntu 22.04 ships 7.81.

The real proof is the failure rate on subsequent runs, which this PR's own CI starts measuring.