### PR TITLE
fix(meta): read durable typed projections through the decoder that accepts them

### DIFF
--- a/crates/nokv-meta/src/workspace/commit.rs
+++ b/crates/nokv-meta/src/workspace/commit.rs
@@ -1569,7 +1569,8 @@ impl<'a> CommitService<'a> {
             return Err(CommitError::HeadConflict);
         }
         if let Some(current) = current_path.as_ref() {
-            let projection = TypedProjection::decode(&current.record.typed_index_projection)?;
+            let projection =
+                TypedProjection::decode_stored(&current.record.typed_index_projection)?;
             if !projection.fields().is_empty() {
                 return Err(CommitError::ClosureMismatch {
                     closure: "run manifest secondary index",
@@ -5178,6 +5179,38 @@ mod tests {
         let replayed = service.begin_build(exact_replace).unwrap();
         assert!(replayed.replayed);
         assert_eq!(replayed.operation, begun.operation);
+    }
+
+    #[test]
+    fn the_run_manifest_projection_commit_installs_is_readable_by_commit() {
+        // finalize_build *requires* the virtual run-manifest member to carry
+        // an empty typed projection, and installs those bytes verbatim into
+        // the durable PathCurrent row. The next commit on the same workbench
+        // reads that row back before publishing its own run manifest. Writer
+        // and reader therefore have to agree on what "no projection" looks
+        // like once it is durable.
+        let installed_by_commit: Vec<u8> = Vec::new();
+        assert!(
+            TypedProjection::decode(&installed_by_commit).is_err(),
+            "the canonical decoder cannot express the durable empty form, so a \
+             reader of stored bytes that uses it rejects what commit wrote"
+        );
+        let read_back = TypedProjection::decode_stored(&installed_by_commit)
+            .expect("the durable-record decoder accepts what commit installs");
+        assert!(read_back.fields().is_empty());
+        // And it must stay strict about everything else: decode_stored differs
+        // from decode only on the empty slice.
+        assert!(TypedProjection::decode_stored(&[0xff]).is_err());
+        let canonical = TypedProjection::empty().encode().unwrap();
+        assert!(
+            !canonical.is_empty(),
+            "an empty projection still encodes to bytes"
+        );
+        assert_eq!(
+            TypedProjection::decode_stored(&canonical).unwrap(),
+            TypedProjection::decode(&canonical).unwrap(),
+            "the two decoders agree on every canonical encoding"
+        );
     }
 
     #[test]

--- a/crates/nokv-meta/src/workspace/publication.rs
+++ b/crates/nokv-meta/src/workspace/publication.rs
@@ -2906,7 +2906,7 @@ impl PublicationService<'_> {
             || path.record.content_type != RESTORE_MANIFEST_CONTENT_TYPE
             || path.record.producer.is_some()
             || path.record.manifest_id.is_some()
-            || !TypedProjection::decode(&path.record.typed_index_projection)?
+            || !TypedProjection::decode_stored(&path.record.typed_index_projection)?
                 .fields()
                 .is_empty()
         {
@@ -3545,7 +3545,7 @@ impl PublicationService<'_> {
         )?;
         let current_projection = current_path
             .as_ref()
-            .map(|current| TypedProjection::decode(&current.record.typed_index_projection))
+            .map(|current| TypedProjection::decode_stored(&current.record.typed_index_projection))
             .transpose()?;
         let next_path_generation =
             validate_path_claim(&request.expected_operation.claim, current_path.as_ref())?;

--- a/crates/nokv-meta/src/workspace/remove.rs
+++ b/crates/nokv-meta/src/workspace/remove.rs
@@ -238,7 +238,7 @@ pub fn remove_path(
             actual: path.generation.get(),
         });
     }
-    let projection = TypedProjection::decode(&path.typed_index_projection)?;
+    let projection = TypedProjection::decode_stored(&path.typed_index_projection)?;
 
     let revision_key = artifact_revision_key(request.context.root_id, path.artifact_revision_id);
     let revision_payload = read_current(

--- a/crates/nokv-meta/src/workspace/rename.rs
+++ b/crates/nokv-meta/src/workspace/rename.rs
@@ -298,7 +298,7 @@ pub fn rename_path(
         source.artifact_revision_id,
     );
 
-    let projection = TypedProjection::decode(&source.typed_index_projection)?;
+    let projection = TypedProjection::decode_stored(&source.typed_index_projection)?;
     let mut predicates = Vec::new();
     let mut mutations = Vec::new();
     let mut history_projection = Vec::new();

--- a/crates/nokv-meta/src/workspace/restore.rs
+++ b/crates/nokv-meta/src/workspace/restore.rs
@@ -13361,4 +13361,303 @@ mod tests {
             .is_some());
         }
     }
+    /// A second commit on one workbench must publish.
+    ///
+    /// The first commit installs `metadata/run_manifest.json` from a virtual
+    /// commit member whose `typed_projection` is hard-coded empty
+    /// (`commit.rs` -> `typed_projection: Vec::new()`), and copies that field
+    /// straight into the durable `PathCurrent` row. Every *strict* reader of
+    /// that field then rejects it; the second commit is the first caller to
+    /// read it back, in `finalize_publish` of the round-two run manifest.
+    ///
+    /// Nothing here touches commit retirement, the LifecycleRunner, or the
+    /// command dedupe result: the failing bytes are a durable record field.
+    #[test]
+    fn a_second_commit_reads_back_the_run_manifest_projection_the_first_one_wrote() {
+        let mut counter = 0_u128;
+        let owner_epoch = owner(1);
+        let store = crate::workspace::test_support::memory(shard()).unwrap();
+        activate_root(&store, &mut counter, owner_epoch);
+
+        let wb = workbench("two-rounds");
+        let inc = incarnation(10);
+        create_visible_workspace(
+            &store,
+            write_context(&store, &mut counter, owner_epoch),
+            &wb,
+            inc,
+        )
+        .unwrap();
+
+        // Round one: one artifact, one commit. This is the whole pre-pilot.
+        publish_text_file(
+            &store,
+            &mut counter,
+            owner_epoch,
+            &wb,
+            inc,
+            "input/note.txt",
+            b"round one",
+            revision(0x11),
+            operation(0x21),
+        );
+        drive_commit_wire_calls(
+            &store,
+            &mut counter,
+            owner_epoch,
+            &wb,
+            inc,
+            CommitId::from_bytes([0x42; SHA256_BYTES]),
+            operation(0x31),
+            operation(0x32),
+            revision(0x12),
+            br#"{"schema":"nokv.workbench.run_manifest.v1","round":1}"#,
+        );
+
+        // The durable evidence, written by the FIRST commit: the run-manifest
+        // path row carries zero projection bytes. The tolerant decoder accepts
+        // that; the strict one produces exactly the error the CLI reports.
+        let manifest_path = NormalizedRelativePath::new(RUN_MANIFEST_PATH).unwrap();
+        let after_round_one = get_visible_path_at(
+            &store,
+            read_context(&store, owner_epoch),
+            &wb,
+            &manifest_path,
+        )
+        .unwrap()
+        .expect("the first commit installs the run manifest");
+        assert!(
+            after_round_one.typed_index_projection.is_empty(),
+            "commit installs the run manifest with a zero-byte typed projection"
+        );
+        assert!(TypedProjection::decode_stored(&after_round_one.typed_index_projection).is_ok());
+        assert_eq!(
+            TypedProjection::decode(&after_round_one.typed_index_projection)
+                .unwrap_err()
+                .to_string(),
+            "truncated value_format_version: need 1 bytes, have 0"
+        );
+
+        // Round two: one more artifact, then the same wire calls again.
+        publish_text_file(
+            &store,
+            &mut counter,
+            owner_epoch,
+            &wb,
+            inc,
+            "input/note2.txt",
+            b"round two",
+            revision(0x13),
+            operation(0x22),
+        );
+
+        let commits = CommitService::new(&store);
+        let head = read_record(
+            &store,
+            write_context(&store, &mut counter, owner_epoch),
+            MetadataFamily::WorkbenchCommitHead,
+            &workbench_commit_head_key(root(), inc),
+            WorkbenchCommitHeadRecord::decode,
+        )
+        .unwrap()
+        .expect("round one installed a commit head");
+        let round_two_manifest: &[u8] = br#"{"schema":"nokv.workbench.run_manifest.v1","round":2}"#;
+        let round_two_revision = revision(0x14);
+        let round_two_commit_operation = operation(0x33);
+        let run_manifest_condition = CommitManifestCondition::ReplaceOnly {
+            expected_generation: after_round_one.generation,
+        };
+        let begun = commits
+            .begin_build(BeginBuildCommitRequest {
+                context: write_context(&store, &mut counter, owner_epoch),
+                operation_id: round_two_commit_operation,
+                workbench_id: wb.clone(),
+                expected_source_workspace_incarnation_id: inc,
+                commit_id: CommitId::from_bytes([0x43; SHA256_BYTES]),
+                content_digest_uri: format!("sha256:{:064x}", 0x430),
+                manifest_digest_uri: body_digest_uri(round_two_manifest),
+                projection_input_digest: [0; SHA256_BYTES],
+                tree_manifest_revision_id: round_two_revision,
+                replace: true,
+                run_manifest_condition,
+                committed_at_unix_seconds: 1_700_000_100,
+                expected_head_generation: Some(head.record.head_generation),
+                producer: None,
+                lineage_projection: Vec::new(),
+                parent_commits: vec![head.record.commit_id],
+            })
+            .expect("round two begin_build succeeds: nothing has read the bad field yet");
+        assert_eq!(begun.operation.phase, BuildCommitPhase::Building);
+
+        // The round-two run-manifest publication. Every step but the last one
+        // succeeds; finalize_publish is the first reader of the round-one
+        // projection bytes.
+        let service = PublicationService::new(&store);
+        let (staged, manifest) = single_object_rows(round_two_revision, round_two_manifest);
+        let mut publish = wire_publish_operation(
+            operation(0x34),
+            round_two_revision,
+            &wb,
+            inc,
+            manifest_path.clone(),
+            PublishAuthority::CommitStaging {
+                commit_operation_id: round_two_commit_operation,
+            },
+            owner_epoch,
+            &staged,
+            &manifest,
+        );
+        publish.claim = PublishClaim::ReplaceOnly {
+            expected_generation: after_round_one.generation,
+        };
+        seal_publish_operation(&mut publish);
+        let manifest_digest_uri = sha256_digest_uri(publish.manifest_seal);
+        let mut operation_record = service
+            .begin_publish(BeginPublishRequest {
+                context: publication_context(&store, &mut counter, owner_epoch),
+                operation: publish,
+            })
+            .unwrap()
+            .operation;
+        for batch in staged.chunks(MAX_PUBLICATION_BATCH_ROWS) {
+            operation_record = service
+                .stage_objects_batch(StageObjectsBatchRequest {
+                    context: publication_context(&store, &mut counter, owner_epoch),
+                    expected_operation: operation_record,
+                    staged_objects: batch.to_vec(),
+                })
+                .unwrap()
+                .operation;
+        }
+        let uploads: Vec<StagedObjectUpdate> = staged
+            .iter()
+            .cloned()
+            .map(|expected| {
+                let mut next = expected.clone();
+                next.provider_state = StagedProviderState::Uploaded;
+                StagedObjectUpdate { expected, next }
+            })
+            .collect();
+        for batch in uploads.chunks(MAX_PUBLICATION_BATCH_ROWS) {
+            operation_record = service
+                .mark_objects_uploaded_batch(MarkObjectsUploadedBatchRequest {
+                    context: publication_context(&store, &mut counter, owner_epoch),
+                    expected_operation: operation_record,
+                    staged_object_updates: batch.to_vec(),
+                })
+                .unwrap()
+                .operation;
+        }
+        for batch in manifest.chunks(MAX_PUBLICATION_BATCH_ROWS) {
+            operation_record = service
+                .stage_manifest_batch(StageManifestBatchRequest {
+                    context: publication_context(&store, &mut counter, owner_epoch),
+                    expected_operation: operation_record,
+                    manifest_rows: batch.to_vec(),
+                    dependency_owner_revision_ids: Vec::new(),
+                })
+                .unwrap()
+                .operation;
+        }
+        let operation_record = service
+            .transition_publish(TransitionPublishRequest {
+                context: publication_context(&store, &mut counter, owner_epoch),
+                expected_operation: operation_record,
+                transition: PublishTransition::BeginFinalization,
+            })
+            .unwrap()
+            .operation;
+        service
+            .finalize_publish(FinalizePublishRequest {
+                context: publication_context(&store, &mut counter, owner_epoch),
+                artifact: PublishedArtifact {
+                    logical_size: round_two_manifest.len() as u64,
+                    body_digest_uri: body_digest_uri(round_two_manifest),
+                    manifest_digest_uri,
+                    content_type: "application/json".to_owned(),
+                    producer: None,
+                    manifest_id: None,
+                    typed_index_projection: TypedProjection::empty().encode().unwrap(),
+                },
+                expected_operation: operation_record,
+                dependency_owner_revision_ids: Vec::new(),
+            })
+            .expect("commit-staging publication returns before the visible-path projection read");
+
+        // Every remaining build step succeeds. finalize_build is the first and
+        // only reader of the round-one projection bytes.
+        loop {
+            let outcome = commits
+                .build_members(BuildCommitStepRequest {
+                    context: write_context(&store, &mut counter, owner_epoch),
+                    operation_id: round_two_commit_operation,
+                    limit: MAX_COMMIT_MEMBER_BATCH_ROWS,
+                })
+                .expect("build_members copies the bad field without decoding it");
+            if outcome.operation.members_complete {
+                break;
+            }
+        }
+        loop {
+            let outcome = commits
+                .seal_revisions(BuildCommitStepRequest {
+                    context: write_context(&store, &mut counter, owner_epoch),
+                    operation_id: round_two_commit_operation,
+                    limit: MAX_COMMIT_REVISION_BATCH_ROWS,
+                })
+                .unwrap();
+            if outcome.operation.revisions_complete {
+                break;
+            }
+        }
+        commits
+            .attach_parents(BuildCommitStepRequest {
+                context: write_context(&store, &mut counter, owner_epoch),
+                operation_id: round_two_commit_operation,
+                limit: MAX_COMMIT_PARENT_BATCH_ROWS,
+            })
+            .unwrap();
+        commits
+            .begin_sealing(
+                write_context(&store, &mut counter, owner_epoch),
+                round_two_commit_operation,
+            )
+            .unwrap();
+        let sealed = commits
+            .finalize_build(
+                write_context(&store, &mut counter, owner_epoch),
+                round_two_commit_operation,
+            )
+            .expect("the round-two commit reads back what the round-one commit installed");
+        let result = sealed
+            .operation
+            .result
+            .expect("a finalized build carries its result");
+        assert_eq!(
+            result.head_generation,
+            Generation::new(2).unwrap(),
+            "the second round advances the commit head"
+        );
+
+        // And the row it just installed is the same shape, so a third round
+        // reads the same field again rather than a one-off.
+        let after_round_two = get_visible_path_at(
+            &store,
+            read_context(&store, owner_epoch),
+            &wb,
+            &manifest_path,
+        )
+        .unwrap()
+        .expect("round two installs its own run manifest");
+        assert!(
+            after_round_two.typed_index_projection.is_empty(),
+            "every commit installs the run manifest with a zero-byte projection"
+        );
+        assert!(
+            TypedProjection::decode_stored(&after_round_two.typed_index_projection)
+                .unwrap()
+                .fields()
+                .is_empty()
+        );
+    }
 }

--- a/crates/nokv-meta/src/workspace/restore.rs
+++ b/crates/nokv-meta/src/workspace/restore.rs
@@ -3334,7 +3334,8 @@ pub fn cleanup_restore_batch(
         let additional = match &current {
             None => 1,
             Some(path) => {
-                let projection = TypedProjection::decode(&path.record.typed_index_projection)?;
+                let projection =
+                    TypedProjection::decode_stored(&path.record.typed_index_projection)?;
                 let new_revision = revisions.insert(path.record.artifact_revision_id);
                 3 + projection.fields().len() + if new_revision { 2 } else { 0 }
             }
@@ -4803,7 +4804,7 @@ fn secondary_index_rows(
     path: &nokv_types::NormalizedRelativePath,
     entry: &PathEntry,
 ) -> Result<BTreeMap<Vec<u8>, Vec<u8>>, RestoreError> {
-    let projection = TypedProjection::decode(&entry.typed_index_projection)?;
+    let projection = TypedProjection::decode_stored(&entry.typed_index_projection)?;
     let payload = SecondaryIndexRecord {
         path_generation: entry.generation,
         compact_projection: projection.clone(),
@@ -5486,7 +5487,7 @@ fn plan_restore_commit_member_batch(
             family: "PathCurrent(destination)",
         })?;
         let entry = PathEntry::decode(&row.value)?;
-        TypedProjection::decode(&entry.typed_index_projection)?;
+        TypedProjection::decode_stored(&entry.typed_index_projection)?;
         let member = CommitMemberRecord {
             artifact_revision_id: entry.artifact_revision_id,
             path_generation: entry.generation,
@@ -6061,11 +6062,11 @@ fn validate_initialization(
 ) -> Result<(), RestoreError> {
     let manifest = &initialization.restore_manifest;
     manifest.encode()?;
-    TypedProjection::decode(&manifest.typed_index_projection)?;
+    TypedProjection::decode_stored(&manifest.typed_index_projection)?;
     if manifest.logical_size != operation.restore_manifest.logical_size
         || manifest.body_digest_uri != operation.restore_manifest.body_digest_uri
         || manifest.content_type != operation.restore_manifest.content_type
-        || !TypedProjection::decode(&manifest.typed_index_projection)?
+        || !TypedProjection::decode_stored(&manifest.typed_index_projection)?
             .fields()
             .is_empty()
     {


### PR DESCRIPTION
## The defect

A **second commit on any workbench** fails, on the CLI and through the SDK alike:

```
truncated value_format_version: need 1 bytes, have 0
```

It reproduces on one artifact with no data written between the rounds. So a campaign cannot build a lineage of committed rounds on one workbench — which is the shape a citable record needs.

## Root cause, which the codebase already documents

Commit synthesises the virtual run-manifest member with an **empty** typed projection, *requires* it to be empty (`finalize_build` rejects a non-empty one), and installs those zero bytes verbatim into the durable `PathCurrent` row for `metadata/run_manifest.json`.

The next commit is the first reader of that row, and it read it with the **canonical** decoder, which cannot express the stored empty form: `TypedProjection::decode` on an empty slice fails its first byte read.

The tolerant decoder exists precisely for this, and its doc comment names this exact producer:

> *"Commit seals its virtual run-manifest member with a zero-byte `typed_projection`, so stored projection bytes carry 'no projection' as an empty slice; **every reader of durable projection bytes must accept that form** alongside the canonical encoding."*

The contract was written down. One reader was never converted.

## This is a class, not an instance

Auditing every call site found **ten** readers of durable projection bytes still using the canonical decoder — including two adjacent functions performing the same check on the same kind of manifest, one already converted *with a comment explaining why*, the other not. All ten now use `decode_stored`.

That is behaviour-preserving by construction: `decode_stored` delegates to `decode` for every non-empty input and differs only on the empty slice, which is the one case the contract says it must accept.

**Three sites stay canonical on purpose.** `publication.rs` reads a projection off an inbound *request*, where a client must send canonical bytes. The two `restore.rs` sites sit behind a "materialised rows only" guard, and for a materialised row an empty projection genuinely is a defect that should fail loudly.

## Tests

A regression test drives the real path at the meta layer: two rounds on one workbench, asserting the second `finalize_build` succeeds and advances the commit head, and that the row it installs carries the same zero-byte projection so a third round reads the same field rather than a one-off. **Red on `main`, green with this change.**

A second, smaller test pins the codec contract itself: the bytes commit installs are rejected by the canonical decoder and accepted by the durable one, and the two agree on every canonical encoding.

*(An earlier revision of this description claimed the staged-run-manifest commit path had no meta-layer fixture. That was wrong — `drive_commit_wire_calls` and `publish_text_file` already exist in the restore test module. The path was drivable all along; no test had driven a **second** commit through it. The regression test above now does.)*

## Validation

- `cargo test --workspace`: **1070 passed, 0 failed** (with #479 merged); fmt and clippy clean.
- **Live stack, real corpus, one workbench**: 208 real TaskDocuments ingested in three rounds of 70/70/68, each round committed on the **same** workbench (rounds 2 and 3 with `replace=true`), and a fourth round committed through the CLI. Every round succeeded; before this change round 2 failed.

### Composed with #479

The two engine fixes are independent, and together they deliver the requirement that motivated both:

```
[round 1] 140 artifacts committed (replace=False) and frozen
[round 2] 280 artifacts committed (replace=True)  and frozen
[round 3] 416 artifacts committed (replace=True)  and frozen
[lease]   all snapshots retired: "snapshot is not active"
[restore round 1] from commit alone: 140 artifacts in 2.0s (live now 416); 12 sampled SHA-256, 0 mismatched
[restore round 2] from commit alone: 280 artifacts in 2.9s (live now 416); 12 sampled SHA-256, 0 mismatched
[restore round 3] from commit alone: 416 artifacts in 4.1s (live now 416); 12 sampled SHA-256, 0 mismatched
```

Round 1 returns **140** artifacts while the live workbench holds 416. Each commit is a genuine independent frozen point, reconstructible with every lease gone — not merely a pointer at the latest state.