### PR TITLE
doc: CLI-first integration and optional MCP sidecar

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -37,7 +37,7 @@ If applicable, add screenshots or paste logs to help explain your problem.
  - OS: [e.g. Linux, macOS]
  - Rust Version: [e.g. 1.88]
  - NoKV Version: [e.g. commit SHA or release tag]
- - Surface: [e.g. Rust SDK, Python SDK, CLI, MCP, Workbench, server, materialize/collect]
+ - Surface: [e.g. native CLI, Python SDK, Rust SDK, optional MCP sidecar, Workbench contract, server, materialize/collect]
  - Deployment topology: [e.g. local/direct or routed; include root id, logical shard, placement generation, owner, and epoch if relevant]
  - Object backend and version: [e.g. S3-compatible service and version]
  - Command and relevant configuration: [redact secrets]

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -63,7 +63,9 @@ Closes | Fixes | Relates to #
       shard-local atomicity; no split root or cross-shard transaction is implied.
 - [ ] Agent-interface changes keep the transport-free facade and schemas in
       `nokv-agent`, routing and workflows in `nokv-client`, and the concrete
-      backend plus MCP wiring in the `nokv` CLI.
+      backend plus native full CLI and optional MCP-sidecar wiring in `nokv`.
+- [ ] User-facing integration guidance orders the native full CLI first, the
+      direct Python SDK second, and MCP only as an optional sidecar.
 
 ## Claims and Evidence
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,6 +17,21 @@ the user explicitly asks for Yanex work. Yanex artifacts are historical
 benchmark/demo material only; they must not drive new NoKV behavior, scripts,
 docs, naming, preflight decisions, or compatibility paths.
 
+## Interface Delivery Priority
+
+Treat the native full `nokv` CLI as the primary product and integration
+surface. Treat the direct Python SDK as the second-choice embedded surface.
+Downstream Agent systems should normally provide their own skills that invoke
+the CLI, or use the Python SDK when they need an in-process integration.
+
+The exact 18-tool Workbench MCP endpoint remains supported only as an optional
+sidecar for hosts that specifically need MCP discovery and JSON-RPC transport.
+It must delegate to the same client and transport-free Agent facade; it is not
+the canonical API, a required deployment component, or a separate state
+machine. Preserve the 18-tool names and semantics while keeping documentation,
+examples, release guidance, and reviews ordered as CLI first, Python SDK
+second, MCP sidecar third.
+
 Before reviewing or editing a PR:
 
 1. Read `docs/development/code_contract.md`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,9 +14,12 @@ Welcome, and thanks for your interest in NoKV. Whether this is your first open-s
 NoKV is a distributed workspace and artifact store built specifically for Agent
 infrastructure. Holt stores one canonical normalized full-path namespace per
 workspace, while immutable revision-owned blocks live in S3-compatible object
-storage. The supported product surfaces are the Rust and Python SDKs, the
-purpose-built `nokv` CLI, and the exact 18-tool Workbench/MCP contract. NoKV
-does not implement a POSIX filesystem, FUSE frontend, or inode/dentry model.
+storage. The primary product surface is the native full `nokv` CLI, followed
+by the direct Python SDK for embedded callers. The exact 18-tool Workbench
+endpoint is an optional MCP sidecar for hosts that need MCP transport; downstream
+Agent systems normally expose their own skills over the CLI or Python SDK.
+NoKV does not implement a POSIX filesystem, FUSE frontend, or inode/dentry
+model.
 
 ### New here? Read these first (in order)
 

--- a/README.md
+++ b/README.md
@@ -73,9 +73,11 @@ workspace and owns the metadata needed to publish, inspect, query, snapshot,
 commit, restore, retain, and collect it.
 
 ```text
-Agent / Workbench / SDK / custom CLI / MCP
-                     |
-                     v
+Downstream skills -> native full nokv CLI
+Embedded callers  -> direct Python SDK
+MCP hosts         -> optional 18-tool sidecar
+                             |
+                             v
           NoKV workspace service
  full-path namespace, versions, snapshots,
  commits, query indexes, retention, and GC
@@ -115,8 +117,9 @@ general NAS replacement are outside the product architecture.
   without pinning the global history floor.
 - **Safe restore.** A restore reuses immutable revisions in a fresh hidden
   same-root incarnation, then publishes visibility atomically.
-- **Deterministic Agent surface.** The same exact 18-tool Workbench contract is
-  exposed through SDK, CLI, and MCP adapters.
+- **Deterministic Agent surface.** The same exact 18-tool Workbench semantics
+  are available through the primary native CLI, the direct Python SDK, and an
+  optional MCP sidecar.
 
 These guarantees are shard-local. NoKV does not provide cross-shard
 transactions. Snapshot protection is leased, and root or Workbench scoping is
@@ -157,7 +160,7 @@ the evidence itself — files, manifests, lineage, and the bytes they attest
 
 | Status | Capabilities and limits |
 | --- | --- |
-| **Current product** | Persisted `RootId -> LogicalShardId` affinity; one epoch-fenced active owner per shard; canonical full-path metadata keys; immutable S3-compatible bodies; Rust and Python SDKs; custom CLI; MCP; exact 18-tool Workbench; snapshots, commits, restore, queries, and reference-fenced GC |
+| **Current product** | Persisted `RootId -> LogicalShardId` affinity; one epoch-fenced active owner per shard; canonical full-path metadata keys; immutable S3-compatible bodies; native full CLI; direct Python and Rust SDKs; optional MCP sidecar; exact 18-tool Workbench semantics; snapshots, commits, restore, queries, and reference-fenced GC |
 | **Current durability profile** | Acknowledged metadata writes are synchronously durable in the owning shard's local Holt WAL. Each mutation also appends canonical hash-chained replay material in the same store. First-owner acquisition accepts a new or prepared epoch-zero store. Exact current-lease resume is also admitted. Unknown, mixed, or unverified successor stores fail closed. |
 | **Not qualified** | Remote checkpoint/log recovery, shared metadata durability, multi-machine failover, production metadata HA, tenant identity/RBAC, cross-shard transactions, and complete provider fault-injection qualification |
 
@@ -173,14 +176,23 @@ the exact contracts and qualification gates.
 
 ## Interfaces
 
-- **Rust Agent SDK** through [`nokv-client`](crates/nokv-client).
-- **Python Agent SDK** through [`nokv-python`](crates/nokv-python), including
-  explicit materialize/collect adapters for local executables.
-- **Custom `nokv` CLI** with `workbench`, `mcp`, `materialize`, `collect`,
-  `provision`, `serve`, and `schema` commands.
-- **Native MCP over stdio** exposing the exact 18 Workbench tools.
+- **Native full `nokv` CLI — primary.** It exposes every Workbench operation
+  through `nokv workbench <tool> '<json arguments>'`, plus `materialize`,
+  `collect`, `workspace-path`, `provision`, `serve`, and `schema` commands.
+- **Direct Python SDK — secondary.** [`nokv-python`](crates/nokv-python)
+  serves embedded programmatic callers and includes explicit
+  materialize/collect adapters for local executables.
+- **Rust Agent SDK.** [`nokv-client`](crates/nokv-client) is the lower-level
+  native integration and shared implementation boundary.
+- **Optional MCP sidecar.** `nokv mcp` exposes the exact 18 Workbench tools
+  over stdio only for hosts that require MCP discovery and JSON-RPC transport.
 - **Transport-free Agent contracts** in
   [`nokv-agent`](crates/nokv-agent), shared by every adapter.
+
+Downstream Agent systems should normally write skills that invoke the native
+CLI. Use the Python SDK when an in-process boundary is preferable. The MCP
+sidecar delegates to the same facade; it is not required to deploy NoKV and is
+not a separate metadata or lifecycle authority.
 
 RootId is the only storage and routing identity. A Workbench presentation root
 shapes Agent-facing paths and manifests but never enters canonical metadata
@@ -188,7 +200,8 @@ keys.
 
 ## Stable Workbench
 
-NoKV exposes exactly these 18 tools:
+The native CLI accepts exactly these 18 Workbench operation names; the
+optional MCP sidecar exposes the same names as tools:
 
 ```text
 workbench_create
@@ -216,13 +229,18 @@ digest relationships, commit identity, snapshot lifecycle, and restore
 idempotency form the stable contract. Workbench result shaping remains an
 adapter concern and does not dictate durable metadata families.
 
+The 18 names define behavior, not a required transport. The native CLI exposes
+them directly, the Python SDK provides the underlying programmatic operations,
+and the MCP sidecar is an optional projection for compatible hosts.
+
 See the [Workbench Contract](docs/workbench-contract.md).
 
 ## Integration Model
 
-The Workbench contract is runtime-neutral. Any MCP-compatible Agent runtime can
-exercise the product boundary end to end through the same scientific
-reconstruction workflow:
+The Workbench contract is runtime-neutral. A downstream Agent runtime should
+normally expose skills over the native CLI, or embed the Python SDK. A runtime
+that specifically requires MCP can opt into the sidecar and exercise the same
+scientific reconstruction workflow:
 
 ```text
 upload dataset
@@ -247,22 +265,27 @@ agents. Runtime state — locks, heartbeats, mailboxes, and event logs — can s
 in a disposable local workdir; what a task produces and needs to prove crosses
 into a Workbench.
 
-One MCP registry entry is the whole integration. Each agent spawns the `nokv`
-binary as a stdio MCP server:
+The default integration is a downstream skill that calls the native CLI. It
+can invoke the same 18 operations with `nokv workbench <tool> '<json
+arguments>'`; an embedded host can instead call the Python SDK directly.
+
+For a host that specifically requires MCP, one optional registry entry spawns
+the `nokv` binary as a stdio sidecar:
 
 ```text
 nokv ... --agent-id {stable_agent_id_hex32} \
   --workbench-root /agents/{agent_name}/wb mcp
 ```
 
-The runtime persists a stable `AgentId` and a distinct `RootId` for each
+In every integration shape, the runtime persists a stable `AgentId` and a
+distinct `RootId` for each
 isolation boundary. Provisioning immutably binds that root to the AgentId;
 `--workbench-root` remains only the human-facing path projection and cannot
 grant isolation by itself. The binding prevents accidental root reuse, but is
 not an authentication credential. The 18 `workbench_*` tools land next to the
-agent's local file tools instead of replacing them. There is no client library;
-the runtime only supplies the persisted identities, route, presentation root,
-and object configuration to the flat MCP command.
+agent's local file tools instead of replacing them. The sidecar does not grant
+new authority; the runtime supplies the same persisted identities, route,
+presentation root, and object configuration used by the CLI or SDK.
 
 A research run then follows the fixed section layout — `input`, `scripts`,
 `outputs`, `logs`, `metadata`:
@@ -350,9 +373,10 @@ python3 scripts/workbench/workbench_contract_test.py
 
 A live deployment additionally needs a root id, persisted logical-shard
 placement, one admitted shard owner, and S3-compatible object coordinates. The
-[Workbench deployment preflight](docs/workbench-preflight.md) gives
-the complete provision, serve, MCP, materialize, collect, and acceptance flow
-without hiding the current recovery limitations.
+[Workbench MCP sidecar preflight](docs/workbench-preflight.md) gives the
+optional sidecar-specific registration and acceptance flow. Native CLI and
+Python SDK users use the same provision, serve, materialize, collect, and
+recovery contracts without running MCP.
 
 ## Documentation
 
@@ -368,7 +392,7 @@ without hiding the current recovery limitations.
 - [Agent Contributor Handbook](docs/development/nokv-agent.md)
 - [Code Contract](docs/development/code_contract.md)
 - [PR Review Checklist](docs/development/pr_review_checklist.md)
-- [Workbench Deployment Preflight](docs/workbench-preflight.md)
+- [Workbench MCP Sidecar Preflight](docs/workbench-preflight.md)
 - [Source-only Homebrew Release](scripts/release/README.md)
 
 ## Contributing
@@ -406,7 +430,7 @@ git diff --check
 | [`nokv-agent`](crates/nokv-agent) | Transport-free 18-tool Workbench facade and stable result shaping |
 | [`nokv-python`](crates/nokv-python) | Direct Python SDK and explicit materialize/collect adapters |
 | [`nokv-server`](crates/nokv-server) | Logical-shard owner, metadata adapter composition, RPC server, and root-affine lifecycle workers |
-| [`nokv`](crates/nokv) | Thin custom CLI and MCP wiring |
+| [`nokv`](crates/nokv) | Thin native full CLI and optional MCP sidecar wiring |
 | [`nokv-bench`](bench) | Non-product contract, recovery, and performance workloads |
 
 ## License

--- a/bench/workbench-live/README.md
+++ b/bench/workbench-live/README.md
@@ -7,10 +7,11 @@ SPDX-License-Identifier: Apache-2.0
 
 The executable product-boundary workload lives at
 `scripts/workbench/live_workbench.py`. It exercises the flat `nokv`
-CLI and MCP adapter against real root routing, Holt metadata ownership, and an
-S3-compatible object provider. Its deterministic runtime evidence directory is
-under `target/workbench-live/evidence/` by default; evidence is not checked
-into this source directory.
+CLI-backed optional MCP sidecar against real root routing, Holt metadata
+ownership, and an S3-compatible object provider. It is sidecar qualification,
+not evidence that MCP is NoKV's primary integration surface. Its deterministic
+runtime evidence directory is under `target/workbench-live/evidence/` by
+default; evidence is not checked into this source directory.
 
 This is a correctness and interoperability workload, not a performance result.
 It records all 18 tool inputs and exact responses, one deliberate create-only

--- a/crates/nokv-python/README.md
+++ b/crates/nokv-python/README.md
@@ -1,5 +1,10 @@
 # NoKV Python SDK
 
+The native full `nokv` CLI is NoKV's primary product and integration surface.
+This direct Python SDK is the secondary choice for callers that need an
+in-process API. Agent frameworks should normally expose skills over the CLI;
+they do not need the optional 18-tool MCP sidecar to use this package.
+
 This package exposes API version `1` for path-native Workbenches and immutable
 artifacts. The version is available as `nokv.API_VERSION`; the stable package
 exports are listed by `nokv.__all__`. `nokv.__version__` is the NoKV release

--- a/docs/ai-training.md
+++ b/docs/ai-training.md
@@ -5,12 +5,14 @@ SPDX-License-Identifier: Apache-2.0
 
 # AI Training
 
-Status: optional Agent SDK workload profile, not a separate product
+Status: optional Agent workload profile, not a separate product
 architecture or namespace.
 
 NoKV serves training data, checkpoints, experiment outputs, and provenance
-through the Agent SDK and explicit local adapters. Canonical identity remains a
-root, Workbench, and normalized path; a materialized local path is disposable.
+through the native full CLI first, the direct Python SDK for embedded jobs,
+lower-level Rust SDK calls where needed, and explicit local adapters. Canonical
+identity remains a root, Workbench, and normalized path; a materialized local
+path is disposable. The optional MCP sidecar is not required for this profile.
 
 ## Workloads
 
@@ -25,7 +27,7 @@ root, Workbench, and normalized path; a materialized local path is disposable.
 
 ```text
 training process
-  -> Rust or Python SDK
+  -> native CLI skill, Python SDK, or lower-level Rust SDK
   -> root router and fenced shard owner
   -> full-path Holt metadata
   -> immutable S3-compatible object blocks

--- a/docs/announcements/nokv-lingtai-design-partner.md
+++ b/docs/announcements/nokv-lingtai-design-partner.md
@@ -6,9 +6,10 @@
 
 > Status: this page records the start of the collaboration. The active
 > integration uses the complete
-> [Workbench contract](../workbench-contract.md) over SDK, custom CLI, and MCP,
-> backed by NoKV's path-native workspace format. It does not use NoKV as a
-> FUSE/POSIX mount.
+> [Workbench contract](../workbench-contract.md) through the native full CLI
+> first, the direct Python SDK second, and an optional MCP sidecar when a host
+> requires it, backed by NoKV's path-native workspace format. It does not use
+> NoKV as a FUSE/POSIX mount.
 > See [Product Design](../product-design.md).
 
 This announcement marks the start of the design-partner collaboration between
@@ -20,7 +21,8 @@ This announcement marks the start of the design-partner collaboration between
 - **LingTai** is a local-first Agent runtime whose projects organize state,
   mailboxes, logs, and artifacts through path-shaped local files.
 - **NoKV** is a distributed Agent workspace and artifact store. It exposes
-  path-shaped identities through Workbench, SDK, custom CLI, and MCP while
+  path-shaped identities through its native CLI, direct SDKs, and an optional
+  Workbench MCP sidecar while
   storing canonical metadata in Holt and immutable bodies in S3-compatible
   storage.
 
@@ -48,10 +50,12 @@ that sandbox is not NoKV namespace truth.
 
 ## Current direction
 
-The stable boundary is the 18-tool Workbench contract. NoKV keeps path-shaped
-Agent semantics while storing canonical full-path metadata in Holt and
-immutable artifact revisions in S3-compatible storage. LingTai remains the
-active design partner and first-client integration.
+The stable boundary is the 18-tool Workbench semantic contract. Downstream
+skills use the native full CLI by default; embedded callers use the Python SDK;
+MCP remains an optional sidecar transport. NoKV keeps path-shaped Agent
+semantics while storing canonical full-path metadata in Holt and immutable
+artifact revisions in S3-compatible storage. LingTai remains the active design
+partner and first-client integration.
 
 If a stateful, snapshot-able, auditable Agent workspace is something you've
 wanted: star NoKV, follow [LingTai](https://github.com/Lingtai-AI/lingtai), and

--- a/docs/announcements/nokv-lingtai-design-partner.zh-CN.md
+++ b/docs/announcements/nokv-lingtai-design-partner.zh-CN.md
@@ -6,7 +6,8 @@
 
 > 状态说明：本文记录合作启动时的背景。当前集成以完整的
 > [Workbench 契约](../workbench-contract.md)为边界，
-> 通过 SDK、自定义 CLI 与 MCP 使用 NoKV 的现行 workspace 格式，
+> 优先通过原生全量 CLI，其次通过 Python SDK；仅在 host 明确需要时
+> 使用可选的 MCP sidecar。三者使用同一套 NoKV workspace 格式，
 > 不把 NoKV 作为 FUSE/POSIX mount；参见[产品设计](../product-design.md)。
 
 本文记录 **NoKV** 与 **LingTai**（[Lingtai-AI/lingtai](https://github.com/Lingtai-AI/lingtai)）启动 **design-partner（设计共建伙伴）合作**的起点。
@@ -14,7 +15,7 @@
 ## 两个项目，一个共同工作流
 
 - **LingTai（灵台）** 是 local-first 的 Agent 运行时，以路径形态的本地文件组织状态、信箱、日志与产物。
-- **NoKV** 是分布式 Agent workspace 与 artifact store，通过 Workbench、SDK、自定义 CLI 和 MCP 暴露路径形态的身份，使用 Holt 保存规范化元数据，并把不可变内容存入 S3 兼容对象存储。
+- **NoKV** 是分布式 Agent workspace 与 artifact store；默认由下游 skill 调用原生全量 CLI，嵌入式调用使用 Python SDK，需要 MCP transport 的 host 才启用可选 sidecar。NoKV 使用 Holt 保存规范化元数据，并把不可变内容存入 S3 兼容对象存储。
 
 双方的集成点是 Workbench 契约，而不是共享 host-filesystem namespace。LingTai 负责本地运行时布局；NoKV 负责分布式 artifact 身份、发布、发现与恢复语义。
 
@@ -31,7 +32,7 @@
 
 ## 当前方向
 
-稳定边界是完整的 18-tool Workbench 契约。NoKV 保留面向 Agent 的路径形态语义，以 Holt 中的规范化全路径元数据和 S3 兼容对象存储中的不可变工件 revision 作为底层实现。LingTai 是当前活跃的 design partner 与首个 client 集成。
+稳定边界是完整的 18-tool Workbench 语义契约，而不是 MCP transport 本身。接入顺序是原生全量 CLI 优先、Python SDK 其次、MCP sidecar 可选。NoKV 保留面向 Agent 的路径形态语义，以 Holt 中的规范化全路径元数据和 S3 兼容对象存储中的不可变工件 revision 作为底层实现。LingTai 是当前活跃的 design partner 与首个 client 集成。
 
 如果“一个有状态、可快照、可审计的 Agent 工作区”正是你一直想要的：给 NoKV 点个星，关注 [LingTai](https://github.com/Lingtai-AI/lingtai)，留意后续。
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -11,10 +11,14 @@ Status: normative workspace architecture.
 
 ```mermaid
 flowchart LR
-    Workbench["Workbench adapter"] --> SDK["Agent SDK"]
-    CLI["Custom CLI / MCP"] --> SDK
+    Skills["Downstream Agent skills"] --> CLI["Native full nokv CLI"]
+    CLI --> Agent["Transport-free Workbench facade"]
+    Sidecar["Optional MCP sidecar"] --> Agent
+    Agent --> SDK["Rust Agent SDK"]
+    CLI --> SDK
     Python["Python SDK"] --> SDK
-    Local["Materialize / collect"] --> Python
+    Local["Materialize / collect"] --> CLI
+    Local --> Python
 
     SDK --> Router["Root router"]
     Router --> Control["Control plane<br/>root placement + owner lease"]
@@ -40,7 +44,8 @@ FUSE, POSIX, CSI, and fsspec are not architecture layers.
 
 ```mermaid
 flowchart TD
-    CLI["nokv CLI / MCP"] --> Agent["nokv-agent"]
+    CLI["native full nokv CLI"] --> Agent["nokv-agent"]
+    Sidecar["optional MCP sidecar"] --> Agent
     CLI --> Client["nokv-client"]
     Python["nokv-python"] --> Client
     Agent --> Client
@@ -74,7 +79,9 @@ Key constraints:
 - object owns provider I/O, not reachability;
 - client uses protocol/routing and never imports meta/server;
 - Agent adapters shape tools over SDK traits and remain transport-free;
-- CLI and MCP are thin wiring.
+- the native full CLI is the primary integration surface;
+- the Python SDK is the secondary embedded surface;
+- the optional MCP sidecar is thin wiring over the same Agent facade.
 
 ## Identity And Namespace
 
@@ -413,7 +420,8 @@ experiments. The required evidence covers:
    amplification across the declared workload matrix;
 2. revision-owned publication, visibility, lifecycle, references, GC, and
    recovery;
-3. protocol, server, SDK, CLI, MCP, control routing, and lifecycle workers on
+3. protocol, server, native CLI, Python and Rust SDKs, optional MCP sidecar,
+   control routing, and lifecycle workers on
    the same schema and identity model;
 4. owner failover, checkpoint/log recovery, ambiguous provider outcomes, and
    live Workbench workflows;

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -23,7 +23,7 @@ The normative qualification gates are in
 | Holt engine | Named trees, point/range reads, atomic batches | Engine throughput, conflicts, WAL cost, checkpoint behavior |
 | Metadata domain | Workspace marker, paths, commands, operations | Namespace amplification, visibility, replay, lifecycle cost |
 | Service | Protocol through shard owner and object provider | Routing, serialization, fencing, provider latency, recovery |
-| Product | SDK, CLI, MCP, or Workbench facade | User-visible latency, results, errors, retries, and end-to-end throughput |
+| Product | Primary native CLI, secondary Python SDK, Rust SDK, optional MCP sidecar, or transport-free Workbench facade | User-visible latency, results, errors, retries, and end-to-end throughput |
 
 A report names its level. Results from different levels are not interchangeable.
 

--- a/docs/development/code_contract.md
+++ b/docs/development/code_contract.md
@@ -5,11 +5,13 @@ SPDX-License-Identifier: Apache-2.0
 
 # NoKV Code Contract
 
-NoKV is an Agent-native distributed workspace and artifact store. Its supported
-product surfaces are SDKs, a custom CLI, MCP/Agent adapters, and the stable
-[Workbench contract](../workbench-contract.md). NoKV persists workspace
-metadata through the storage-neutral transaction-store contract. Holt is the
-current serving local adapter. S3-compatible storage owns durable artifact
+NoKV is an Agent-native distributed workspace and artifact store. Its primary
+product surface is the native full `nokv` CLI; the direct Python SDK is the
+secondary embedded surface. The stable
+[Workbench contract](../workbench-contract.md) defines shared semantics, while
+MCP is an optional sidecar transport for hosts that require it. NoKV persists
+workspace metadata through the storage-neutral transaction-store contract.
+Holt is the current serving local adapter. S3-compatible storage owns durable artifact
 bytes.
 
 The lower-layer architecture is the
@@ -39,7 +41,7 @@ These are the package boundaries:
 | `crates/nokv-agent/` | Transport-free Workbench/Agent tool schemas, the 18-tool Workbench facade, the seven-tool generic Agent profile, stable result shaping, and adapters over SDK traits. | Import Holt/layout, object providers, server implementations, FUSE, or duplicate SDK state machines. |
 | `crates/nokv-python/` | Direct Python SDK, explicit materialize/collect adapters, and Workbench-scoped immutable compatibility adapters for fsspec, checkpoint, and torch DCP callers. | Own metadata layout, bypass `nokv-client`, reimplement range/retry planning, promise POSIX directory/inode semantics or an arbitrary root filesystem, or import FUSE. |
 | `crates/nokv-server/` | Shard-owner process, versioned RPC, startup/schema gates, health, backup/log sync, and background lifecycle workers. | Own domain semantics outside `nokv-meta`, leak provider internals into RPC, or silently migrate/fallback between schemas. |
-| `crates/nokv/` | Thin `nokv` CLI and MCP wiring over client and Agent interfaces. | Own metadata semantics, durable layout, object-provider behavior, or embed a second implementation of the SDK. |
+| `crates/nokv/` | Thin native full `nokv` CLI and optional MCP sidecar wiring over client and Agent interfaces. | Own metadata semantics, durable layout, object-provider behavior, or embed a second implementation of the SDK. |
 | `bench/` | Contract, recovery, and performance workloads with explicit environment and workload profiles. | Own product APIs, add benchmark-only product behavior, or compare results from materially different profiles as equivalent. |
 
 FUSE, POSIX emulation, CSI, and arbitrary-root generic filesystem integration
@@ -63,6 +65,12 @@ implementation of publication, retention, recovery, or routing.
 The 18 Workbench tools, their normalized input schemas, and the observable
 semantics in the Workbench contract are stable. Adapter result shaping cannot
 become canonical metadata or introduce fields outside that contract.
+
+Delivery priority and semantic ownership are separate. The CLI is the default
+integration surface, the Python SDK is second for in-process callers, and the
+MCP endpoint is an optional sidecar. Agent frameworks should build skills over
+the CLI or Python SDK by default. None of those transports may fork the stable
+Workbench semantics or duplicate the client state machines.
 
 The Agent adapter owns canonical Workbench projections. It must recompute any
 projection commitment from typed facade inputs for every fresh request and

--- a/docs/development/metadata-store-interface.md
+++ b/docs/development/metadata-store-interface.md
@@ -35,8 +35,9 @@ shared-library ABIs.
 This decision changes internal metadata storage and shard bootstrap. It
 preserves these Agent and Workbench boundaries:
 
-- the 18-tool Workbench contract
-- CLI Workbench commands and MCP tool behavior
+- the 18-tool Workbench semantic contract
+- primary native CLI Workbench commands, secondary Python SDK behavior, and
+  optional MCP-sidecar tool behavior
 - the path-native `PathCurrent` namespace
 - immutable artifact storage
 - root placement in `nokv-control`

--- a/docs/development/nokv-agent.md
+++ b/docs/development/nokv-agent.md
@@ -14,11 +14,16 @@ The normative behavior is [Workbench Contract](../workbench-contract.md).
 ## Package Position
 
 ```text
-CLI / MCP adapter
+native full CLI (primary) / optional MCP sidecar
   -> nokv-agent
   -> nokv-client traits
   -> versioned protocol and direct object data path
 ```
+
+The direct Python SDK is the secondary embedded product surface and calls the
+client boundary without requiring MCP. Downstream Agent frameworks should
+normally implement skills over the CLI. The MCP adapter is transport wiring
+only and must never become a second facade or state machine.
 
 Allowed dependencies are storage-neutral types and SDK interfaces. The crate
 must not import:
@@ -34,7 +39,7 @@ second namespace, publication, snapshot, commit, or restore implementation.
 
 ## Stable Tool Surface
 
-A supported deployment exposes exactly:
+The transport-free facade defines exactly:
 
 ```text
 workbench_create
@@ -59,7 +64,8 @@ workbench_restore
 
 The normalized input schemas are frozen in
 `crates/nokv-agent/workbench_contract_schema.json`. Tool registration
-fails closed when a name or normalized schema differs.
+fails closed when a name or normalized schema differs. The native CLI exposes
+the same operations directly; the optional sidecar registers them as MCP tools.
 
 ## Adapter Responsibilities
 

--- a/docs/development/path-native-metadata-comparison.md
+++ b/docs/development/path-native-metadata-comparison.md
@@ -13,7 +13,9 @@ model under the same Agent operations. It does not compare POSIX behavior with
 Workbench behavior and does not treat a code-shape reduction as measured
 latency or throughput.
 
-The stable 18-tool Workbench facade is unchanged. The comparison stops at the
+The stable 18-tool Workbench facade is unchanged. Its primary delivery is the
+native full CLI, followed by the direct Python SDK; MCP is an optional sidecar
+transport and is outside this metadata comparison. The comparison stops at the
 metadata boundary and excludes object-body I/O, transport, WAL device cost,
 and recovery-log chunking unless stated otherwise.
 

--- a/docs/development/pr_review_checklist.md
+++ b/docs/development/pr_review_checklist.md
@@ -151,6 +151,10 @@ boundaries, or Workbench behavior.
 
 ## Workbench Contract
 
+- Do public docs and examples present the native full CLI first, the Python SDK
+  second, and the exact 18-tool MCP endpoint only as an optional sidecar?
+- Does the MCP sidecar remain thin over the transport-free facade instead of
+  becoming a required deployment component or a second state machine?
 - Do all 18 tool names and normalized input schemas remain stable?
 - Does golden-transcript validation cover observable result and error behavior,
   rather than treating input-schema validation as equivalent?

--- a/docs/development/pre423-contract-ledger.md
+++ b/docs/development/pre423-contract-ledger.md
@@ -13,6 +13,11 @@ It is a behavior oracle, not permission to restore the old metadata layout.
 It is not an inventory or qualification claim for every pre-#423 feature, and
 47/47 does not by itself qualify every phase of the wider recovery program.
 
+This ledger preserves historical MCP and LingTai evidence classes; it does not
+set current delivery priority. Current integrations use the native full CLI
+first, the direct Python SDK second, and the 18-tool endpoint only as an
+optional MCP sidecar. A sidecar-specific receipt qualifies only that boundary.
+
 Each stable item records:
 
 - class `A`, `B`, `C`, or `D` from the pre-test porting decision;

--- a/docs/development/workspace-acceptance.md
+++ b/docs/development/workspace-acceptance.md
@@ -7,9 +7,11 @@ SPDX-License-Identifier: Apache-2.0
 
 Status: normative qualification gates for the supported NoKV workspace.
 
-NoKV is qualified as one Agent-facing system: Workbench contract, SDK, custom
-CLI, MCP adapters, metadata semantics, object publication, root routing,
-recovery, and garbage collection must run against the same workspace format.
+NoKV is qualified as one Agent-facing system: Workbench semantics, the primary
+native full CLI, the secondary direct Python SDK, the optional MCP sidecar,
+metadata semantics, object publication, root routing, recovery, and garbage
+collection must run against the same workspace format. An MCP-only result does
+not qualify the CLI or Python SDK paths.
 Passing a codec or Holt microbenchmark alone does not qualify the product.
 
 Every applicable gate reports exactly one status:
@@ -39,18 +41,23 @@ Performance records additionally retain warm/cold state, object and metadata
 payload distributions, concurrency, duration, retries, error counts,
 throughput, and p50/p95/p99/maximum latency.
 
-## Gate 0: Workbench Contract And Live Workflow
+## Gate 0: Workbench Contract And Live Workflows
 
 The scientific reconstruction workflow must exercise the complete 18-tool
-Workbench surface through the real adapter boundary.
-The black-box runner is
-[`scripts/workbench/live_workbench.py`](../../scripts/workbench/live_workbench.py).
-Its dry-run proves only command construction and tool coverage. A live run
-retains exact MCP and process evidence; absent etcd, S3-compatible storage, or
-the requested binary is `NOT QUALIFIED`, never `PASS`.
+Workbench semantics through the primary native CLI boundary. The direct Python
+SDK must independently exercise its supported programmatic path. The existing
+black-box runner,
+[`scripts/workbench/live_workbench.py`](../../scripts/workbench/live_workbench.py),
+qualifies the optional MCP sidecar only. Its dry-run proves only command
+construction and tool coverage; a live run retains exact sidecar and process
+evidence. It cannot substitute for native CLI or Python SDK evidence. Absent
+etcd, S3-compatible storage, or the requested binary is `NOT QUALIFIED`, never
+`PASS`.
 
 Required evidence:
 
+- a native CLI transcript covering the complete 18-operation workflow;
+- an installed Python SDK workflow covering its declared direct API;
 - exact normalized schemas for all 18 tools;
 - golden result and error transcripts, not only input-schema validation;
 - create-only and replace-only publication, never upsert;
@@ -270,17 +277,21 @@ Required evidence:
   CLI builds contain no fault hook, flag, environment branch, or arbitrary
   executor injection surface.
 
-## Gate 7: SDK, CLI, MCP, And Package Boundaries
+## Gate 7: CLI, Python SDK, MCP Sidecar, And Package Boundaries
 
 Required evidence:
 
-- the SDK routes by root placement and never imports Holt layout;
+- the native full CLI remains the primary integration surface and delegates to
+  client and Agent interfaces;
+- the Rust SDK routes by root placement and never imports Holt layout;
 - direct immutable-object reads and uploads obey server-issued plans and
   integrity checks;
-- Python uses the SDK and explicit materialize/collect adapters;
+- the direct Python SDK remains the secondary embedded surface and uses
+  explicit materialize/collect adapters;
 - `nokv-agent` remains transport-free and shapes the stable 18 tools over SDK
   traits;
-- CLI and MCP are thin consumers of client and Agent interfaces;
+- the optional MCP sidecar is a thin consumer of the same Agent facade and is
+  neither a required deployment component nor a second state machine;
 - protocol DTOs are versioned and storage-neutral;
 - provider-specific behavior stays inside the object package;
 - no second implementation of namespace, publication, restore, references, or

--- a/docs/index.md
+++ b/docs/index.md
@@ -4,7 +4,7 @@ layout: home
 hero:
   name: NoKV
   text: Agent-native distributed workspace and artifact storage.
-  tagline: A stable Workbench, SDK, CLI, and MCP surface over path-primary ordered metadata and immutable object-backed revisions.
+  tagline: A native full CLI and direct Python SDK over path-primary ordered metadata, with an optional Workbench MCP sidecar.
   image:
     src: /img/logo.png
     alt: NoKV
@@ -23,7 +23,7 @@ hero:
       link: /development/workspace-acceptance
 features:
   - title: Stable Agent surface
-    details: Preserve the complete 18-tool NoKV Workbench contract and expose the same semantics through SDK, custom CLI, and MCP adapters.
+    details: Use the native full CLI first, the direct Python SDK for embedded callers, and the exact 18-tool MCP endpoint only as an optional sidecar.
   - title: Path-primary metadata
     details: One normalized full path is namespace truth. Exact artifacts use point reads; child listing uses component-safe delimiter scans.
   - title: Immutable revisions
@@ -48,9 +48,9 @@ SPDX-License-Identifier: Apache-2.0
   <div class="nokv-grid-3">
     <div class="nokv-card">
       <div class="nokv-card-kicker">Application surface</div>
-      <h3>Workbench · SDK · CLI · MCP</h3>
-      <p>Agents keep familiar list/read/search/commit/snapshot/restore behavior
-      while storage internals change underneath.</p>
+      <h3>CLI · Python SDK · MCP sidecar</h3>
+      <p>Downstream skills use the native CLI by default; embedded callers use
+      the Python SDK, and MCP hosts can opt into the same 18-tool semantics.</p>
     </div>
     <div class="nokv-card">
       <div class="nokv-card-kicker">Metadata layer</div>
@@ -72,7 +72,7 @@ SPDX-License-Identifier: Apache-2.0
     <p class="nokv-eyebrow">Core flow</p>
     <h2 class="nokv-h2">Upload bytes first; publish identity last</h2>
   </div>
-  <pre class="nokv-code"><code>Agent SDK
+  <pre class="nokv-code"><code>Native CLI or direct Python SDK
   -&gt; route RootId to one logical shard
   -&gt; allocate publish operation + immutable revision
   -&gt; stream and verify object blocks
@@ -94,7 +94,7 @@ SPDX-License-Identifier: Apache-2.0
   [RustFS Provider Profile](./rustfs.md).
 - Workloads and evidence: [AI Training Workload](./ai-training.md),
   [Benchmarks](./benchmarks.md),
-  [Workbench Deployment Preflight](./workbench-preflight.md), and
+  [Workbench MCP Sidecar Preflight](./workbench-preflight.md), and
   [Workspace Acceptance](./development/workspace-acceptance.md).
 - Development: [Code Contract](./development/code_contract.md),
   [`nokv-agent` Handbook](./development/nokv-agent.md),

--- a/docs/product-design.md
+++ b/docs/product-design.md
@@ -13,14 +13,20 @@ NoKV is a distributed workspace and artifact store for Agent infrastructure.
 It gives datasets, scripts, logs, outputs, checkpoints, reports, and provenance
 stable path-shaped addresses while keeping their bytes in object storage.
 
-The supported front doors are:
+The supported front doors, in delivery order, are:
 
-- Rust and Python Agent SDKs;
-- a purpose-built `nokv` CLI;
-- MCP and Agent tool adapters;
-- the complete 18-tool [Workbench contract](./workbench-contract.md);
-- explicit materialize/collect adapters for executables that require local
-  files.
+1. the native full `nokv` CLI, including all 18 Workbench operations;
+2. the direct Python SDK for embedded programmatic callers;
+3. the Rust SDK for lower-level native integrations; and
+4. the optional MCP sidecar for hosts that require MCP discovery and transport.
+
+The complete 18-tool [Workbench contract](./workbench-contract.md) fixes shared
+behavior across these surfaces. Downstream Agent systems normally provide
+skills that invoke the CLI, or call the Python SDK when an in-process boundary
+is preferable. MCP is not required to deploy or operate NoKV.
+
+NoKV also provides explicit materialize/collect adapters for executables that
+require local files.
 
 The Workbench experience stays independent of storage internals. Agents can
 list, stat, read, grep, search, aggregate, commit, snapshot, and restore. They
@@ -71,7 +77,7 @@ Workbench-specific result shaping stays above the storage core:
 - grep matching;
 - section projection;
 - the delta digest returned by append;
-- friendly errors and MCP envelopes;
+- friendly errors and optional MCP-sidecar envelopes;
 - stable `run_manifest.json` and `restore_manifest.json` projections.
 
 Workbench responses do not contain storage-specific node identities. Stable
@@ -238,7 +244,7 @@ upload input dataset
   -> execute
   -> collect declared outputs/logs/metadata
   -> commit each run with lineage to the same input
-  -> query, compare, snapshot, and restore through SDK/CLI/Workbench
+  -> query, compare, snapshot, and restore through CLI/Python SDK/Workbench
 ```
 
 Materialization verifies digests before execution. Collection publishes only

--- a/docs/rustfs.md
+++ b/docs/rustfs.md
@@ -15,7 +15,7 @@ collection policy.
 ## Boundary
 
 ```text
-Workbench / SDK / CLI
+native full CLI / Python SDK / lower-level Rust SDK / optional Workbench MCP sidecar
   -> NoKV metadata and publication service
   -> S3-compatible object interface
   -> RustFS

--- a/docs/workbench-contract.md
+++ b/docs/workbench-contract.md
@@ -7,10 +7,14 @@ SPDX-License-Identifier: Apache-2.0
 
 Status: normative Agent-facing contract.
 
-The Workbench profile is NoKV's stable Agent-facing product surface. The
-workspace architecture implements this profile while keeping physical namespace
-records, object keys, operation journals, and routing state outside the
-Workbench contract.
+The Workbench profile is NoKV's stable Agent-facing semantic contract. The
+native full `nokv` CLI is the primary delivery surface, and the direct Python
+SDK is the secondary embedded surface. The exact 18-tool MCP endpoint is an
+optional sidecar for hosts that require MCP discovery and JSON-RPC transport.
+Downstream Agent systems should normally expose skills over the CLI, or use the
+Python SDK in process. The workspace architecture implements the same profile
+while keeping physical namespace records, object keys, operation journals, and
+routing state outside the Workbench contract.
 
 The contract sources are:
 
@@ -21,11 +25,14 @@ The contract sources are:
 - `scripts/workbench/workbench_contract.py` for checking tool names and
   normalized input schemas.
 
-CLI and MCP wiring are consumers of this contract, not schema authorities.
+CLI, SDK, and MCP-sidecar wiring are consumers of this contract, not schema
+authorities. The sidecar delegates to the transport-free facade and is neither
+a required deployment component nor a separate state machine.
 
-A supported Workbench deployment exposes exactly all 18 tools. Registration
-fails closed unless every possible destination owner supports the durable
-restore contract and the complete schema.
+The native CLI accepts exactly these 18 names under `nokv workbench`. When the
+optional MCP sidecar is enabled, it registers the same 18 tools and fails
+closed unless every possible destination owner supports the durable restore
+contract and the complete schema.
 
 ## Product Boundary
 
@@ -59,9 +66,10 @@ The deployment root is `/agents/{agent_id}/wb` and must not be `/`.
 
 This root is durable presentation configuration. It shapes returned paths and
 the presentation-path fields in canonical run/restore manifest v1 envelopes,
-so a deployment must retain the same value across MCP/CLI restarts and exact
-operation replay. It is not a namespace, routing, Holt-key, object-key, or
-sharding identity; `RootId` remains the storage and routing authority.
+so a deployment must retain the same value across CLI or MCP-sidecar restarts
+and exact operation replay. It is not a namespace, routing, Holt-key,
+object-key, or sharding identity; `RootId` remains the storage and routing
+authority.
 
 A workbench id:
 

--- a/docs/workbench-preflight.md
+++ b/docs/workbench-preflight.md
@@ -3,11 +3,13 @@ Copyright 2024-2026 The NoKV Authors.
 SPDX-License-Identifier: Apache-2.0
 -->
 
-# Workbench Deployment Preflight
+# Workbench MCP Sidecar Preflight
 
-This guide prepares any MCP-compatible Agent runtime to use the normal
-`nokv mcp` stdio endpoint. There is no runtime-specific metadata format or
-compatibility route.
+This guide qualifies the optional `nokv mcp` stdio sidecar for an
+MCP-compatible Agent runtime. It is not the default NoKV integration guide:
+downstream systems should normally provide skills over the native full CLI,
+and embedded callers should use the Python SDK. The sidecar uses the same
+workspace format and grants no additional authority or compatibility route.
 
 ## Required Inputs
 
@@ -63,11 +65,12 @@ recovery path itself. It is switched on implicitly by
 The corresponding invariant for operators: back up the Holt directory. In the
 default shape it is the only copy of the metadata.
 
-## Live Contract Check
+## Live Sidecar Contract Check
 
-Start `nokv mcp` with the same root, route, owner, and object configuration that
-the Agent runtime will use. Send `initialize`, then `tools/list`, and validate
-the response with `workbench_contract.validate_tool_contract`.
+If the host requires MCP, start the optional `nokv mcp` sidecar with the same
+root, route, owner, and object configuration that its CLI or SDK path would
+use. Send `initialize`, then `tools/list`, and validate the response with
+`workbench_contract.validate_tool_contract`.
 
 For the complete live Workbench path, run
 `scripts/workbench/live_workbench.py`. It calls `nokv provision`,

--- a/scripts/release/README.md
+++ b/scripts/release/README.md
@@ -50,11 +50,14 @@ version. It does not follow Holt or either Homebrew build dependency. A Holt
 change is published only inside a new NoKV release after its exact pin and lock
 entry pass the release gates and the generated Formula is merged into the tap.
 
-Installing the executable does not create a NoKV deployment. A LingTai MCP
-configuration must still supply the selected NoKV control-plane endpoint,
-object-store configuration, root identity, and stable Agent presentation root.
-Its command is the Homebrew-installed `nokv` executable and its final argument
-is `mcp`.
+Installing the executable provides NoKV's primary native full CLI; downstream
+Agent systems should normally expose skills over that command. The direct
+Python SDK is the secondary embedded distribution. Neither installation creates
+a NoKV deployment: callers must still supply the selected control-plane
+endpoint, object-store configuration, root identity, and stable Agent
+presentation root. A LingTai or other MCP-compatible host may run the optional
+MCP sidecar through the Homebrew-installed `nokv` executable with final
+argument `mcp`; that transport is not required for CLI or Python SDK use.
 
 ## Release invariants
 

--- a/scripts/workbench/README.md
+++ b/scripts/workbench/README.md
@@ -5,10 +5,12 @@ SPDX-License-Identifier: Apache-2.0
 
 # Workbench Validation
 
-These assets validate the same 18-tool Workbench surface exported by
-`crates/nokv-agent` and served by `nokv mcp`. They do not define a
-runtime-specific metadata layout, capability alias, migration helper, or
-filesystem frontend.
+These assets validate the same 18-tool Workbench semantics exported by
+`crates/nokv-agent`. The native full CLI is the primary integration surface,
+and the direct Python SDK is second for embedded callers. The MCP-focused
+assets here qualify the optional `nokv mcp` sidecar; they do not make MCP a
+required deployment component or define a runtime-specific metadata layout,
+capability alias, migration helper, or filesystem frontend.
 
 The checked-in integration assets are deliberately small:
 
@@ -93,8 +95,8 @@ PYTHONPATH=scripts/workbench python3 -m unittest \
 python3 scripts/workbench/fork_restore_recovery_gate_test.py
 ```
 
-Register the built binary in any MCP-compatible Agent runtime as a stdio MCP
-command:
+To qualify the optional sidecar, register the built binary in an MCP-compatible
+Agent runtime as a stdio MCP command:
 
 ```text
 /absolute/path/to/nokv <root, route, object, and workbench options> mcp
@@ -257,8 +259,8 @@ uploads its complete evidence directory even on failure.
 
 ## Restore-composition evidence
 
-The composition gate uses a real flat `nokv mcp` process for the stable
-18-tool Workbench surface. Atomic path mutations use the separate,
+The composition gate uses a real flat `nokv mcp` sidecar for the stable 18-tool
+Workbench surface. Atomic path mutations use the separate,
 Workbench-scoped custom CLI and never absolute paths:
 
 ```text
@@ -365,9 +367,10 @@ one failure at a time:
   replacement. The bench-only exact barrier qualifies restore restart without
   exposing a production hook; provider recovery and GC drain remain separate
   gates.
-- an optional second Agent-runtime entry must consume the same flat MCP launch
-  and produce the same transcript contract; it cannot weaken or substitute for
-  the native gate.
+- an optional second Agent-runtime entry must consume the same flat MCP sidecar
+  launch and produce the same transcript contract; it cannot weaken or
+  substitute for the native sidecar gate.
+
 ## Path-native fork-to-restore recovery evidence
 
 The fork gate exercises the supported whole-Workbench restore contract. It


### PR DESCRIPTION
## Related Issue

Maintainer-directed, repository-wide interface-positioning correction. This uses the docs/config-only exception: it changes no runtime behavior and does not require a separate design issue.

## Summary

- Make the native full CLI the primary NoKV integration and downstream-skill surface.
- Make the direct Python SDK the secondary embedded integration surface.
- Define the 18-tool Workbench MCP server as an optional stdio sidecar for hosts that need MCP discovery or JSON-RPC.
- Preserve the existing 18 Workbench operation names and transport-free semantics while removing language that implied MCP was the product API or a required deployment component.
- State the remaining evidence gap explicitly: the current live Workbench runner qualifies the optional MCP sidecar only; it does not qualify complete native-CLI or installed-Python-SDK coverage.

## Scope

- [x] This PR changes one logical boundary only.
- [x] No unrelated refactor, benchmark, metadata model, Holt layout, object-store, agent interface, or docs change is mixed in.
- [ ] The linked issue describes the user-visible problem, design decision, or maintenance task this PR resolves. (Docs/config-only exception explained above.)
- [x] Any breaking change is intentional and documented. (No breaking behavior change.)
- [x] No compatibility shim, deprecated alias, or forwarding wrapper was added without a removal condition.

## Change Size And Review

- [x] I checked GitHub's additions plus deletions for this pull request.
- [x] If the total is more than 5,000 lines, one core maintainer other than the current-head pusher approved the exact current head commit. (Not applicable: 397 changed lines.)
- [x] This change is still small enough for a focused review; approval count is not being used to justify mixed package or lifecycle boundaries.

## Code Contract (Code Changes Only)

- [x] Not applicable; this is a docs/config-only change.
- [ ] Package boundaries follow `docs/development/code_contract.md`.
- [ ] Shared helpers reuse the standard library or existing repository helpers. New generic helper modules are domain-neutral and tested.
- [ ] File names and file placement follow the code contract.
- [ ] New types, interfaces, structs, fields, and functions use domain-specific names.
- [ ] New errors are in the owning package's `errors.rs` and carry stable error kinds when crossing package boundaries.
- [ ] New metrics/stats are owned by the package that reports or serves them.
- [ ] Metadata changes document durability, atomicity, revision-reference lifetime, snapshot/commit/event retention, GC epochs, and fail-closed recovery boundaries.
- [ ] Placement or routing changes preserve persisted `RootId -> LogicalShardId` affinity, one active writer per shard, owner-epoch fencing, and explicit shard-local atomicity; no split root or cross-shard transaction is implied.
- [x] Agent-interface changes keep the transport-free facade and schemas in `nokv-agent`, routing and workflows in `nokv-client`, and the concrete backend plus native full CLI and optional MCP-sidecar wiring in `nokv`.
- [x] User-facing integration guidance orders the native full CLI first, the direct Python SDK second, and MCP only as an optional sidecar.

## Claims and Evidence

- [x] User-facing documentation distinguishes current, experimental, and planned capabilities.
- [x] Security claims do not treat a Workbench root or Agent scope as tenant authentication or authorization.
- [x] Performance claims state the topology, comparison boundary, cache state, run count, and raw-evidence location.
- [x] Benchmark-only behavior does not alter product semantics.

## Validation

- `python3 scripts/workbench/workbench_contract_test.py` — 8 tests passed.
- Repository-wide positioning scan — found native CLI primary, Python SDK secondary, MCP optional-sidecar, and all 18-operation language; found no contradictory MCP-primary claim.
- Relative Markdown link validation — all links in 26 changed files resolve.
- `git diff --check origin/main...HEAD` — passed.
- Rust build, Clippy, and test suites were not run because this PR changes only Markdown, issue/PR templates, and `AGENTS.md`; no Rust or Python product source changed.

## Contributor Sign-off

- [x] Every commit in this PR includes a DCO `Signed-off-by` trailer.
