### PR TITLE
fix(release): give the wheel publish step a repository context

### DIFF
--- a/.github/workflows/release-python-sdk.yml
+++ b/.github/workflows/release-python-sdk.yml
@@ -166,6 +166,7 @@ jobs:
       contents: write
     env:
       EXPECTED_COMMIT: ${{ needs.validate.outputs.commit }}
+      GH_REPO: ${{ github.repository }}
       GH_TOKEN: ${{ github.token }}
       RELEASE_TAG: ${{ needs.validate.outputs.tag }}
       RELEASE_VERSION: ${{ needs.validate.outputs.version }}

--- a/scripts/release/test_python_sdk_release.py
+++ b/scripts/release/test_python_sdk_release.py
@@ -215,6 +215,9 @@ class WorkflowTest(unittest.TestCase):
         self.assertIn("python_sdk_release.py write-assets", workflow)
         self.assertIn("python_sdk_release.py verify-install", workflow)
         self.assertIn("--verify-tag", workflow)
+        # The publish step runs outside the checkout (cd "$RELEASE_DIR"), so gh
+        # must learn the repository from the environment, not from git context.
+        self.assertIn("GH_REPO: ${{ github.repository }}", workflow)
         self.assertIn("Release tag moved", workflow)
         self.assertIn("release asset already exists with different bytes", workflow)
         self.assertNotIn("archive/refs/tags", workflow)


### PR DESCRIPTION
First real dispatch of the Python SDK release pipeline (run 32629376154, tag v0.11.0): validate + all four platform wheels green, publish failed with `failed to run git: fatal: not a git repository` — the publish step `cd`s into `$RELEASE_DIR` (runner temp), where bare `gh release` calls cannot infer the repository; the `if gh release view` guard swallowed the first failure so `gh release create` failed the job.

Fix: `GH_REPO: ${{ github.repository }}` on the publish job env; pinned by a new assertion in `scripts/release/test_python_sdk_release.py` (red before the fix, 13/13 after). After merge, re-dispatching with the same immutable tag rebuilds and publishes; no tag movement involved.