### PR TITLE
feat(server): add the owner health surface (ops plan P1)

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -54,7 +54,8 @@ jobs:
             scripts/workbench/local_wal_recovery_gate.py \
             scripts/workbench/object_namespace_recovery_gate.py \
             scripts/workbench/restore_composition_gate.py \
-            scripts/workbench/fork_restore_recovery_gate.py
+            scripts/workbench/fork_restore_recovery_gate.py \
+            scripts/workbench/health_shutdown_gate.py
           python3 scripts/workbench/pre423_contract_ledger.py
           python3 scripts/workbench/pre423_contract_ledger_test.py
           python3 scripts/workbench/workbench_contract_test.py
@@ -63,6 +64,7 @@ jobs:
           python3 scripts/workbench/object_namespace_recovery_gate_test.py
           python3 scripts/workbench/restore_composition_gate_test.py
           python3 scripts/workbench/fork_restore_recovery_gate_test.py
+          python3 scripts/workbench/health_shutdown_gate_test.py
           bash -n scripts/workbench/start_rustfs.sh
 
       - name: Check Phase 1 qualification framework
@@ -560,6 +562,37 @@ jobs:
         with:
           name: restore-composition-${{ github.sha }}
           path: ${{ runner.temp }}/restore-composition/evidence
+          if-no-files-found: error
+          retention-days: 7
+
+      - name: Qualify owner health surface
+        id: health_shutdown
+        shell: bash
+        env:
+          HEALTH_SHUTDOWN_EVIDENCE_DIR: ${{ runner.temp }}/health-shutdown-evidence
+          AWS_ACCESS_KEY_ID: rustfsadmin
+          AWS_SECRET_ACCESS_KEY: rustfsadmin
+          AWS_DEFAULT_REGION: us-east-1
+          AWS_EC2_METADATA_DISABLED: "true"
+        run: |
+          set -euo pipefail
+          python3 scripts/workbench/health_shutdown_gate.py \
+            --build \
+            --target-dir target \
+            --evidence-dir "$HEALTH_SHUTDOWN_EVIDENCE_DIR" \
+            --object-endpoint http://127.0.0.1:9000 \
+            --object-bucket nokv-local-wal-recovery-gate \
+            --seed "health-shutdown-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}" \
+            --timeout 60
+          jq -e '.overall_status == "PASS"' \
+            "$HEALTH_SHUTDOWN_EVIDENCE_DIR/qualification.json"
+
+      - name: Upload health/shutdown evidence
+        if: ${{ always() && steps.health_shutdown.outcome != 'skipped' }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+        with:
+          name: health-shutdown-${{ github.sha }}
+          path: ${{ runner.temp }}/health-shutdown-evidence
           if-no-files-found: error
           retention-days: 7
 

--- a/bench/src/bin/nokv-restore-crash-owner.rs
+++ b/bench/src/bin/nokv-restore-crash-owner.rs
@@ -851,6 +851,7 @@ fn run_server(config: ServeConfig) -> Result<(), String> {
     let server = WorkspaceServer::new(
         ServerOptions {
             bind: config.bind,
+            health_bind: None,
             handshake_timeout: Duration::from_millis(config.handshake_timeout_millis),
             read_timeout: Duration::from_secs(30),
             write_timeout: Duration::from_secs(30),

--- a/crates/nokv-server/src/bootstrap.rs
+++ b/crates/nokv-server/src/bootstrap.rs
@@ -1707,6 +1707,7 @@ mod tests {
     fn options() -> ServerOptions {
         ServerOptions {
             bind: "127.0.0.1:0".parse().unwrap(),
+            health_bind: None,
             handshake_timeout: Duration::from_secs(1),
             read_timeout: Duration::from_secs(1),
             write_timeout: Duration::from_secs(1),

--- a/crates/nokv-server/src/health.rs
+++ b/crates/nokv-server/src/health.rs
@@ -1,0 +1,413 @@
+/*
+ * Copyright 2024-2026 The NoKV Authors.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+//! Optional HTTP health surface for the logical-shard owner process.
+//!
+//! Three endpoints, one connection at a time, no external HTTP dependency:
+//!
+//! * `GET /healthz` — process liveness;
+//! * `GET /readyz` — admission is complete, the owner is not draining, and
+//!   the control-plane lease has not been lost;
+//! * `GET /stats`  — one JSON snapshot of the counters below.
+//!
+//! Graceful shutdown marks the owner draining before the accept loop stops,
+//! so readiness drops to 503 first, then admission stops, in-flight
+//! connections drain while ownership is still renewed, and the lease is
+//! released by the caller afterwards.
+//!
+//! The health listener is advisory once serving: per-connection failures never
+//! fail the RPC server. Binding and thread startup do fail the server before
+//! it begins serving, so a configured-but-unusable health endpoint cannot
+//! pass silently.
+
+use std::io::{Read, Write};
+use std::net::{TcpListener, TcpStream};
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::Arc;
+use std::thread;
+use std::time::{Duration, Instant};
+
+use crate::server::OwnerLossSignal;
+use crate::ServerError;
+
+const MAX_REQUEST_BYTES: usize = 4096;
+const HEALTH_IO_TIMEOUT: Duration = Duration::from_secs(2);
+const HEALTH_POLL_INTERVAL: Duration = Duration::from_millis(10);
+const HEALTHZ_BODY: &str = "ok\n";
+const READYZ_BODY: &str = "ready\n";
+const NOT_READY_BODY: &str = "not ready\n";
+const NOT_FOUND_BODY: &str = "not found\n";
+
+#[derive(Clone)]
+pub(crate) struct HealthState {
+    inner: Arc<HealthInner>,
+}
+
+struct HealthInner {
+    started: Instant,
+    pid: u32,
+    protocol_schema: &'static str,
+    owner_loss: OwnerLossSignal,
+    draining: AtomicBool,
+    connections_total: AtomicU64,
+    requests_total: AtomicU64,
+    inflight: Arc<dyn Fn() -> usize + Send + Sync>,
+    installed_roots: Arc<dyn Fn() -> Result<usize, ServerError> + Send + Sync>,
+}
+
+impl HealthState {
+    pub(crate) fn new(
+        protocol_schema: &'static str,
+        owner_loss: OwnerLossSignal,
+        inflight: Arc<dyn Fn() -> usize + Send + Sync>,
+        installed_roots: Arc<dyn Fn() -> Result<usize, ServerError> + Send + Sync>,
+    ) -> Self {
+        Self {
+            inner: Arc::new(HealthInner {
+                started: Instant::now(),
+                pid: std::process::id(),
+                protocol_schema,
+                owner_loss,
+                draining: AtomicBool::new(false),
+                connections_total: AtomicU64::new(0),
+                requests_total: AtomicU64::new(0),
+                inflight,
+                installed_roots,
+            }),
+        }
+    }
+
+    pub(crate) fn record_connection(&self) {
+        self.inner.connections_total.fetch_add(1, Ordering::Relaxed);
+    }
+
+    pub(crate) fn record_request(&self) {
+        self.inner.requests_total.fetch_add(1, Ordering::Relaxed);
+    }
+
+    /// Graceful shutdown has been requested: the owner keeps renewing its
+    /// lease while draining, but it stops admitting work, so readiness drops
+    /// immediately and stays down until the process exits.
+    pub(crate) fn set_draining(&self) {
+        self.inner.draining.store(true, Ordering::Release);
+    }
+
+    fn snapshot(&self) -> HealthSnapshot {
+        let owner_loss = self.inner.owner_loss.is_lost();
+        let draining = self.inner.draining.load(Ordering::Acquire);
+        HealthSnapshot {
+            pid: self.inner.pid,
+            uptime_seconds: self.inner.started.elapsed().as_secs_f64(),
+            protocol_schema: self.inner.protocol_schema,
+            installed_roots: (self.inner.installed_roots)().ok(),
+            owner_loss,
+            draining,
+            ready: !owner_loss && !draining,
+            connections_total: self.inner.connections_total.load(Ordering::Relaxed),
+            requests_total: self.inner.requests_total.load(Ordering::Relaxed),
+            inflight_connections: (self.inner.inflight)(),
+        }
+    }
+}
+
+struct HealthSnapshot {
+    pid: u32,
+    uptime_seconds: f64,
+    protocol_schema: &'static str,
+    installed_roots: Option<usize>,
+    owner_loss: bool,
+    draining: bool,
+    ready: bool,
+    connections_total: u64,
+    requests_total: u64,
+    inflight_connections: usize,
+}
+
+impl HealthSnapshot {
+    /// Hand-built JSON. Every field is numeric, boolean, or the compiled
+    /// protocol-schema constant, so no field can carry an escape.
+    fn json(&self) -> String {
+        let installed_roots = self
+            .installed_roots
+            .map_or_else(|| "null".to_owned(), |count| count.to_string());
+        format!(
+            "{{\"pid\":{},\"uptime_seconds\":{:.3},\"protocol_schema\":\"{}\",\
+             \"installed_roots\":{},\"owner_loss\":{},\"draining\":{},\"ready\":{},\
+             \"connections_total\":{},\"requests_total\":{},\
+             \"inflight_connections\":{}}}\n",
+            self.pid,
+            self.uptime_seconds,
+            self.protocol_schema,
+            installed_roots,
+            self.owner_loss,
+            self.draining,
+            self.ready,
+            self.connections_total,
+            self.requests_total,
+            self.inflight_connections,
+        )
+    }
+}
+
+pub(crate) fn serve_health(listener: TcpListener, state: HealthState, stop: Arc<AtomicBool>) {
+    if listener.set_nonblocking(true).is_err() {
+        return;
+    }
+    loop {
+        if stop.load(Ordering::Acquire) {
+            break;
+        }
+        match listener.accept() {
+            Ok((stream, _)) => handle_connection(stream, &state),
+            Err(_) => thread::sleep(HEALTH_POLL_INTERVAL),
+        }
+    }
+}
+
+fn handle_connection(mut stream: TcpStream, state: &HealthState) {
+    // On BSD-derived platforms `accept` inherits the listener's non-blocking
+    // mode; restore blocking reads so a client that has not finished writing
+    // does not hit an immediate EAGAIN and get reset.
+    let _ = stream.set_nonblocking(false);
+    let _ = stream.set_read_timeout(Some(HEALTH_IO_TIMEOUT));
+    let _ = stream.set_write_timeout(Some(HEALTH_IO_TIMEOUT));
+    let mut buffer = [0_u8; 1024];
+    let mut request = Vec::new();
+    loop {
+        match stream.read(&mut buffer) {
+            Ok(0) => return,
+            Ok(read) => {
+                request.extend_from_slice(&buffer[..read]);
+                if request.windows(4).any(|window| window == b"\r\n\r\n")
+                    || request.len() >= MAX_REQUEST_BYTES
+                {
+                    break;
+                }
+            }
+            Err(_) => return,
+        }
+    }
+    let snapshot = state.snapshot();
+    let (status, content_type, body) = route(&request, &snapshot);
+    let response = format!(
+        "HTTP/1.1 {status}\r\nContent-Type: {content_type}\r\nContent-Length: {}\r\n\
+         Connection: close\r\n\r\n{body}",
+        body.len()
+    );
+    let _ = stream.write_all(response.as_bytes());
+}
+
+fn route(request: &[u8], snapshot: &HealthSnapshot) -> (&'static str, &'static str, String) {
+    let Some(first_line_end) = request.iter().position(|byte| *byte == b'\n') else {
+        return (
+            "400 Bad Request",
+            "text/plain; charset=utf-8",
+            "bad request\n".to_owned(),
+        );
+    };
+    let first_line = &request[..first_line_end];
+    let mut fields = first_line.split(|byte| *byte == b' ');
+    let method = fields.next().unwrap_or_default();
+    let path = fields.next().unwrap_or_default();
+    if method != b"GET" {
+        return (
+            "405 Method Not Allowed",
+            "text/plain; charset=utf-8",
+            "method not allowed\n".to_owned(),
+        );
+    }
+    match path {
+        b"/healthz" => (
+            "200 OK",
+            "text/plain; charset=utf-8",
+            HEALTHZ_BODY.to_owned(),
+        ),
+        b"/readyz" => {
+            if snapshot.ready {
+                (
+                    "200 OK",
+                    "text/plain; charset=utf-8",
+                    READYZ_BODY.to_owned(),
+                )
+            } else {
+                (
+                    "503 Service Unavailable",
+                    "text/plain; charset=utf-8",
+                    NOT_READY_BODY.to_owned(),
+                )
+            }
+        }
+        b"/stats" => ("200 OK", "application/json", snapshot.json()),
+        _ => (
+            "404 Not Found",
+            "text/plain; charset=utf-8",
+            NOT_FOUND_BODY.to_owned(),
+        ),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::atomic::AtomicUsize;
+
+    use super::*;
+
+    fn state() -> (HealthState, OwnerLossSignal) {
+        let owner_loss = OwnerLossSignal::default();
+        let inflight = Arc::new(AtomicUsize::new(2));
+        let inflight_provider = {
+            let inflight = Arc::clone(&inflight);
+            Arc::new(move || inflight.load(Ordering::Relaxed))
+                as Arc<dyn Fn() -> usize + Send + Sync>
+        };
+        let state = HealthState::new(
+            "nokv.workspace.rpc.test",
+            owner_loss.clone(),
+            inflight_provider,
+            Arc::new(|| Ok(3)),
+        );
+        (state, owner_loss)
+    }
+
+    fn request(port: u16, state: HealthState, path: &str) -> (u16, String) {
+        let listener = TcpListener::bind(("127.0.0.1", port)).unwrap();
+        let port = listener.local_addr().unwrap().port();
+        let stop = Arc::new(AtomicBool::new(false));
+        let worker = {
+            let stop = Arc::clone(&stop);
+            thread::spawn(move || serve_health(listener, state, stop))
+        };
+        let mut stream = TcpStream::connect(("127.0.0.1", port)).unwrap();
+        stream
+            .set_read_timeout(Some(Duration::from_secs(2)))
+            .unwrap();
+        stream
+            .write_all(format!("GET {path} HTTP/1.1\r\nHost: localhost\r\n\r\n").as_bytes())
+            .unwrap();
+        let mut response = String::new();
+        let _ = stream.read_to_string(&mut response);
+        stop.store(true, Ordering::Release);
+        worker.join().unwrap();
+        let status: u16 = response
+            .lines()
+            .next()
+            .and_then(|line| line.split_whitespace().nth(1))
+            .and_then(|code| code.parse().ok())
+            .expect("health response must carry an HTTP status line");
+        let body = response
+            .split("\r\n\r\n")
+            .nth(1)
+            .unwrap_or_default()
+            .to_owned();
+        (status, body)
+    }
+
+    #[test]
+    fn healthz_is_always_alive() {
+        let (state, _) = state();
+        let (status, body) = request(0, state, "/healthz");
+        assert_eq!(status, 200);
+        assert_eq!(body, HEALTHZ_BODY);
+    }
+
+    #[test]
+    fn readyz_is_ready_until_owner_loss() {
+        let (state, owner_loss) = state();
+        let (status, body) = request(0, state.clone(), "/readyz");
+        assert_eq!(status, 200);
+        assert_eq!(body, READYZ_BODY);
+
+        owner_loss.fail_closed();
+        let (status, body) = request(0, state, "/readyz");
+        assert_eq!(status, 503);
+        assert_eq!(body, NOT_READY_BODY);
+    }
+
+    #[test]
+    fn readyz_drops_when_draining_begins() {
+        let (state, _) = state();
+        let (status, body) = request(0, state.clone(), "/readyz");
+        assert_eq!(status, 200);
+        assert_eq!(body, READYZ_BODY);
+
+        state.set_draining();
+        let (status, body) = request(0, state, "/readyz");
+        assert_eq!(status, 503);
+        assert_eq!(body, NOT_READY_BODY);
+    }
+
+    #[test]
+    fn stats_snapshot_tracks_counters_and_identity() {
+        let (state, owner_loss) = state();
+        state.record_connection();
+        state.record_request();
+        let (status, body) = request(0, state.clone(), "/stats");
+        assert_eq!(status, 200);
+        assert!(body.contains("\"protocol_schema\":\"nokv.workspace.rpc.test\""));
+        assert!(body.contains("\"installed_roots\":3"));
+        assert!(body.contains("\"owner_loss\":false"));
+        assert!(body.contains("\"draining\":false"));
+        assert!(body.contains("\"ready\":true"));
+        assert!(body.contains("\"connections_total\":1"));
+        assert!(body.contains("\"requests_total\":1"));
+        assert!(body.contains("\"inflight_connections\":2"));
+        assert!(body.contains("\"pid\":") && !body.contains("\"pid\":0,"));
+
+        owner_loss.fail_closed();
+        let (status, body) = request(0, state, "/stats");
+        assert_eq!(status, 200);
+        assert!(body.contains("\"owner_loss\":true"));
+        assert!(body.contains("\"ready\":false"));
+    }
+
+    #[test]
+    fn unknown_path_and_method_are_rejected() {
+        let (state, _) = state();
+        let (status, _) = request(0, state.clone(), "/nope");
+        assert_eq!(status, 404);
+
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let port = listener.local_addr().unwrap().port();
+        let stop = Arc::new(AtomicBool::new(false));
+        let worker = {
+            let stop = Arc::clone(&stop);
+            thread::spawn(move || serve_health(listener, state, stop))
+        };
+        let mut stream = TcpStream::connect(("127.0.0.1", port)).unwrap();
+        stream
+            .set_read_timeout(Some(Duration::from_secs(2)))
+            .unwrap();
+        stream
+            .write_all(b"POST /healthz HTTP/1.1\r\nHost: localhost\r\n\r\n")
+            .unwrap();
+        let mut response = String::new();
+        let _ = stream.read_to_string(&mut response);
+        stop.store(true, Ordering::Release);
+        worker.join().unwrap();
+        let status: u16 = response
+            .lines()
+            .next()
+            .and_then(|line| line.split_whitespace().nth(1))
+            .and_then(|code| code.parse().ok())
+            .unwrap();
+        assert_eq!(status, 405);
+    }
+
+    #[test]
+    fn zero_length_request_fails_closed_without_a_response() {
+        let (state, _) = state();
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let port = listener.local_addr().unwrap().port();
+        let stop = Arc::new(AtomicBool::new(false));
+        let worker = {
+            let stop = Arc::clone(&stop);
+            thread::spawn(move || serve_health(listener, state, stop))
+        };
+        let stream = TcpStream::connect(("127.0.0.1", port)).unwrap();
+        stream.shutdown(std::net::Shutdown::Write).unwrap();
+        stop.store(true, Ordering::Release);
+        worker.join().unwrap();
+    }
+}

--- a/crates/nokv-server/src/lib.rs
+++ b/crates/nokv-server/src/lib.rs
@@ -12,6 +12,7 @@
 mod bootstrap;
 mod error;
 mod executor;
+mod health;
 mod legacy_rejection;
 mod lifecycle;
 mod recovery_installer;

--- a/crates/nokv-server/src/server.rs
+++ b/crates/nokv-server/src/server.rs
@@ -18,6 +18,7 @@ use nokv_protocol::{
     WORKSPACE_PROTOCOL_SCHEMA,
 };
 
+use crate::health::HealthState;
 use crate::legacy_rejection::{legacy_rejection_response, MAX_LEGACY_FIRST_FRAME_BYTES};
 use crate::{RootOwnerRegistry, ServerError, ShardOwner};
 
@@ -26,6 +27,7 @@ static NEVER_SHUTDOWN: AtomicBool = AtomicBool::new(false);
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct ServerOptions {
     pub bind: SocketAddr,
+    pub health_bind: Option<SocketAddr>,
     pub handshake_timeout: Duration,
     pub read_timeout: Duration,
     pub write_timeout: Duration,
@@ -209,14 +211,57 @@ impl WorkspaceServer {
         listener: TcpListener,
         shutdown: &AtomicBool,
     ) -> Result<(), ServerError> {
-        serve_socket_loop(
+        let connections = Arc::new(
+            ConnectionLimiter::new(self.options.max_inflight_connections)
+                .expect("validated connection maximum is nonzero"),
+        );
+        let health = if let Some(health_bind) = self.options.health_bind {
+            let health_listener = TcpListener::bind(health_bind).map_err(ServerError::Bind)?;
+            let inflight = {
+                let connections = Arc::clone(&connections);
+                Arc::new(move || connections.in_flight()) as Arc<dyn Fn() -> usize + Send + Sync>
+            };
+            let installed_roots = {
+                let registry = Arc::clone(&self.registry);
+                Arc::new(move || registry.installed_root_count())
+                    as Arc<dyn Fn() -> Result<usize, ServerError> + Send + Sync>
+            };
+            let state = HealthState::new(
+                WORKSPACE_PROTOCOL_SCHEMA,
+                self.owner_loss.clone(),
+                inflight,
+                installed_roots,
+            );
+            let stop = Arc::new(AtomicBool::new(false));
+            let handle = thread::Builder::new()
+                .name("nokv-health".to_owned())
+                .spawn({
+                    let stop = Arc::clone(&stop);
+                    let worker_state = state.clone();
+                    move || crate::health::serve_health(health_listener, worker_state, stop)
+                })
+                .map_err(ServerError::Connection)?;
+            Some((stop, handle, state))
+        } else {
+            None
+        };
+        let result = serve_socket_loop(
             listener,
             self.options,
             Arc::clone(&self.registry),
             self.owner_loss.clone(),
             shutdown,
             || self.renew_ownership(),
-        )
+            ServeRuntime {
+                connections,
+                health: health.as_ref().map(|(_, _, state)| state.clone()),
+            },
+        );
+        if let Some((stop, handle, _)) = health {
+            stop.store(true, Ordering::Release);
+            let _ = handle.join();
+        }
+        result
     }
 
     pub fn dispatch_frame(&self, encoded: &[u8]) -> Result<Vec<u8>, ServerError> {
@@ -226,6 +271,11 @@ impl WorkspaceServer {
     }
 }
 
+struct ServeRuntime {
+    connections: Arc<ConnectionLimiter>,
+    health: Option<HealthState>,
+}
+
 fn serve_socket_loop(
     listener: TcpListener,
     options: ServerOptions,
@@ -233,19 +283,19 @@ fn serve_socket_loop(
     owner_loss: OwnerLossSignal,
     shutdown: &AtomicBool,
     mut renew_ownership: impl FnMut() -> Result<(), ServerError>,
+    runtime: ServeRuntime,
 ) -> Result<(), ServerError> {
     options.validate()?;
     listener
         .set_nonblocking(true)
         .map_err(ServerError::Connection)?;
     let mut next_renewal = Instant::now();
-    let connections = Arc::new(
-        ConnectionLimiter::new(options.max_inflight_connections)
-            .expect("validated connection maximum is nonzero"),
-    );
     loop {
         require_owner_retained(&owner_loss)?;
         if shutdown.load(Ordering::Acquire) {
+            if let Some(health) = &runtime.health {
+                health.set_draining();
+            }
             break;
         }
         let now = Instant::now();
@@ -260,19 +310,23 @@ fn serve_socket_loop(
                     drop(stream);
                     continue;
                 }
-                let Some(permit) = connections.try_acquire() else {
+                let Some(permit) = runtime.connections.try_acquire() else {
                     drop(stream);
                     continue;
                 };
+                if let Some(health) = &runtime.health {
+                    health.record_connection();
+                }
                 stream
                     .set_nonblocking(false)
                     .map_err(ServerError::Connection)?;
                 let registry = Arc::clone(&registry);
+                let health = runtime.health.clone();
                 thread::Builder::new()
                     .name("nokv-workspace-rpc".to_owned())
                     .spawn(move || {
                         let _permit = permit;
-                        let _ = serve_connection(stream, registry, options);
+                        let _ = serve_connection(stream, registry, options, health);
                     })
                     .map_err(ServerError::Connection)?;
             }
@@ -283,7 +337,7 @@ fn serve_socket_loop(
         }
     }
 
-    while connections.in_flight() != 0 {
+    while runtime.connections.in_flight() != 0 {
         require_owner_retained(&owner_loss)?;
         let now = Instant::now();
         if now >= next_renewal {
@@ -393,6 +447,7 @@ fn serve_connection(
     mut stream: TcpStream,
     registry: Arc<RootOwnerRegistry>,
     options: ServerOptions,
+    health: Option<HealthState>,
 ) -> Result<(), ServerError> {
     if !admit_current_protocol(&mut stream, options.handshake_timeout)? {
         return Ok(());
@@ -409,6 +464,9 @@ fn serve_connection(
         let encoded = encode_response_or_internal_failure(response.response())?;
         write_frame(&mut stream, &encoded)?;
         drop(response);
+        if let Some(health) = &health {
+            health.record_request();
+        }
         if registry.owner_loss_signal().is_lost() {
             return Err(ServerError::InvalidBootstrap(
                 "control-plane owner was lost".to_owned(),
@@ -668,6 +726,7 @@ mod tests {
     fn options() -> ServerOptions {
         ServerOptions {
             bind: "127.0.0.1:0".parse().unwrap(),
+            health_bind: None,
             handshake_timeout: Duration::from_millis(100),
             read_timeout: Duration::from_secs(1),
             write_timeout: Duration::from_secs(1),
@@ -795,7 +854,7 @@ mod tests {
     fn exact_handshake_preserves_multiple_operation_frames_on_one_connection() {
         let (mut client, server) = streams();
         let (registry, executor) = registry();
-        let serving = thread::spawn(move || serve_connection(server, registry, options()));
+        let serving = thread::spawn(move || serve_connection(server, registry, options(), None));
 
         let hello =
             WorkspaceHandshake::new(HandshakeKind::ClientHello, WORKSPACE_PROTOCOL_SCHEMA).unwrap();
@@ -823,7 +882,7 @@ mod tests {
     fn operation_first_v3_gets_a_readable_rejection_with_zero_dispatch() {
         let (mut client, server) = streams();
         let (registry, executor) = registry();
-        let serving = thread::spawn(move || serve_connection(server, registry, options()));
+        let serving = thread::spawn(move || serve_connection(server, registry, options(), None));
 
         let mut legacy = encode_request(&request()).unwrap();
         let position = legacy
@@ -872,7 +931,7 @@ mod tests {
 
         let (mut client, server) = streams();
         let (registry, executor) = registry();
-        let serving = thread::spawn(move || serve_connection(server, registry, options()));
+        let serving = thread::spawn(move || serve_connection(server, registry, options(), None));
         let operation = request().operation;
         let encoded = rmp_serde::to_vec_named(&V2Frame {
             schema: crate::legacy_rejection::LEGACY_V2_SCHEMA,
@@ -905,7 +964,7 @@ mod tests {
     fn v7_hello_gets_v9_incompatible_and_zero_dispatch() {
         let (mut client, server) = streams();
         let (registry, executor) = registry();
-        let serving = thread::spawn(move || serve_connection(server, registry, options()));
+        let serving = thread::spawn(move || serve_connection(server, registry, options(), None));
 
         let hello =
             WorkspaceHandshake::new(HandshakeKind::ClientHello, "nokv.workspace.rpc.v7").unwrap();
@@ -926,7 +985,7 @@ mod tests {
     fn matched_but_corrupt_handshake_magic_never_enters_legacy_classification() {
         let (mut client, server) = streams();
         let (registry, executor) = registry();
-        let serving = thread::spawn(move || serve_connection(server, registry, options()));
+        let serving = thread::spawn(move || serve_connection(server, registry, options(), None));
 
         let mut corrupt = [0_u8; HANDSHAKE_PAYLOAD_BYTES];
         corrupt[..8].copy_from_slice(b"NOKVHS1\0");
@@ -950,7 +1009,7 @@ mod tests {
         let (registry, executor) = registry();
         let (completed_tx, completed_rx) = mpsc::channel();
         let serving = thread::spawn(move || {
-            let result = serve_connection(server, registry, options());
+            let result = serve_connection(server, registry, options(), None);
             completed_tx.send(()).unwrap();
             result
         });
@@ -981,10 +1040,25 @@ mod tests {
         let (registry, _) = registry();
         let renewals = AtomicUsize::new(0);
 
-        serve_socket_loop(listener, options(), registry, owner_loss, &shutdown, || {
-            renewals.fetch_add(1, AtomicOrdering::SeqCst);
-            Ok(())
-        })
+        let runtime = ServeRuntime {
+            connections: Arc::new(
+                ConnectionLimiter::new(options().max_inflight_connections)
+                    .expect("validated connection maximum is nonzero"),
+            ),
+            health: None,
+        };
+        serve_socket_loop(
+            listener,
+            options(),
+            registry,
+            owner_loss,
+            &shutdown,
+            || {
+                renewals.fetch_add(1, AtomicOrdering::SeqCst);
+                Ok(())
+            },
+            runtime,
+        )
         .unwrap();
 
         assert_eq!(renewals.load(AtomicOrdering::SeqCst), 0);
@@ -1006,6 +1080,13 @@ mod tests {
         let (completed_tx, completed_rx) = mpsc::channel();
         let (renewed_tx, renewed_rx) = mpsc::channel();
         let serving = thread::spawn(move || {
+            let runtime = ServeRuntime {
+                connections: Arc::new(
+                    ConnectionLimiter::new(runtime_options.max_inflight_connections)
+                        .expect("validated connection maximum is nonzero"),
+                ),
+                health: None,
+            };
             let result = serve_socket_loop(
                 listener,
                 runtime_options,
@@ -1017,6 +1098,7 @@ mod tests {
                     renewed_tx.send(count).unwrap();
                     Ok(())
                 },
+                runtime,
             );
             completed_tx.send(()).unwrap();
             result
@@ -1053,9 +1135,22 @@ mod tests {
         owner_loss.fail_closed();
         let (registry, _) = registry();
 
-        let error = serve_socket_loop(listener, options(), registry, owner_loss, &shutdown, || {
-            Ok(())
-        })
+        let runtime = ServeRuntime {
+            connections: Arc::new(
+                ConnectionLimiter::new(options().max_inflight_connections)
+                    .expect("validated connection maximum is nonzero"),
+            ),
+            health: None,
+        };
+        let error = serve_socket_loop(
+            listener,
+            options(),
+            registry,
+            owner_loss,
+            &shutdown,
+            || Ok(()),
+            runtime,
+        )
         .unwrap_err();
 
         assert!(error.to_string().contains("owner was lost"));
@@ -1065,7 +1160,7 @@ mod tests {
     fn oversized_legacy_first_frame_closes_before_reading_or_dispatching_its_body() {
         let (mut client, server) = streams();
         let (registry, executor) = registry();
-        let serving = thread::spawn(move || serve_connection(server, registry, options()));
+        let serving = thread::spawn(move || serve_connection(server, registry, options(), None));
 
         client
             .write_all(

--- a/crates/nokv/src/cli.rs
+++ b/crates/nokv/src/cli.rs
@@ -68,6 +68,7 @@ pub struct ObjectConfig {
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct ServerConfig {
     pub bind: SocketAddr,
+    pub health_endpoint: Option<SocketAddr>,
     pub handshake_timeout_millis: u64,
     pub max_inflight_connections: usize,
     pub advertise_endpoint: Option<String>,
@@ -286,6 +287,7 @@ impl Default for ServerConfig {
             bind: DEFAULT_SERVER_BIND
                 .parse()
                 .expect("default server bind is valid"),
+            health_endpoint: None,
             handshake_timeout_millis: DEFAULT_HANDSHAKE_TIMEOUT_MILLIS,
             max_inflight_connections: DEFAULT_MAX_INFLIGHT_CONNECTIONS,
             advertise_endpoint: None,
@@ -403,6 +405,12 @@ pub fn parse(arguments: impl IntoIterator<Item = String>) -> Result<Invocation, 
             }
             "--bind" => {
                 server.bind = parse_address("--bind", next_value(&mut arguments, &argument)?)?;
+            }
+            "--health-endpoint" => {
+                server.health_endpoint = Some(parse_address(
+                    "--health-endpoint",
+                    next_value(&mut arguments, &argument)?,
+                )?);
             }
             "--handshake-timeout-millis" => {
                 server.handshake_timeout_millis = parse_number(

--- a/crates/nokv/src/main.rs
+++ b/crates/nokv/src/main.rs
@@ -610,6 +610,9 @@ OWNER:
   serve validates every active root's Agent binding; it does not require or compare one shard-wide AgentId
   --root-id HEX32 --etcd-endpoint URL --node-id ID
   --advertise-endpoint HOST:PORT --bind HOST:PORT
+  --health-endpoint HOST:PORT serves optional /healthz, /readyz, and /stats
+    (liveness; admission retained while not draining or owner-lost; one JSON
+    counter snapshot)
   --handshake-timeout-millis N --max-inflight-connections N
   --metadata-create PATH starts the first standalone local-WAL owner
   --metadata-reopen PATH restarts the same exclusive local-WAL authority after lease loss
@@ -979,6 +982,7 @@ fn run_server(invocation: &Invocation) -> Result<(), String> {
     let server = WorkspaceServer::new(
         ServerOptions {
             bind: invocation.server.bind,
+            health_bind: invocation.server.health_endpoint,
             handshake_timeout: Duration::from_millis(invocation.server.handshake_timeout_millis),
             read_timeout: Duration::from_secs(30),
             write_timeout: Duration::from_secs(30),

--- a/scripts/workbench/health_shutdown_gate.py
+++ b/scripts/workbench/health_shutdown_gate.py
@@ -1,0 +1,607 @@
+#!/usr/bin/env python3
+# Copyright 2024-2026 The NoKV Authors.
+# SPDX-License-Identifier: Apache-2.0
+"""Real etcd/RustFS gate for the owner health surface and graceful shutdown.
+
+Stages against a real ``nokv`` owner process:
+
+  1. provision one root with a stable AgentId;
+  2. start the owner with an explicit ``--health-endpoint``;
+  3. ``/healthz`` must report liveness and ``/readyz`` readiness; ``/stats``
+     must carry the server identity and counters that advance with traffic;
+  4. one Workbench request must succeed and move ``requests_total`` and
+     ``connections_total``;
+  5. SIGTERM must stop the owner with exit code zero and close the health
+     endpoint; the successor owner reopens the same metadata authority and
+     ``/readyz`` reports ready again while the committed Workbench data is
+     served. The lease-release timing authority stays with
+     ``local_wal_recovery_gate.py``'s graceful stage; this gate asserts the
+     health contract only.
+
+Every scenario writes one evidence entry; any failure exits nonzero.
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import hashlib
+import http.client
+import json
+import os
+import shutil
+import signal
+import socket
+import subprocess
+import sys
+import time
+from pathlib import Path
+from typing import Any, Sequence, TextIO
+
+
+SCHEMA = "nokv.health_shutdown_gate.v1"
+GRACEFUL_TTL_SECONDS = 10
+GRACEFUL_EXIT_DEADLINE_SECONDS = 10.0
+REOPEN_ADMISSION_DEADLINE_SECONDS = 6.0
+
+
+class WorkflowFailure(RuntimeError):
+    pass
+
+
+def now() -> str:
+    return dt.datetime.now(dt.timezone.utc).isoformat()
+
+
+def fixed_id(seed: str, label: str) -> str:
+    return hashlib.sha256(f"{seed}:{label}".encode()).hexdigest()[:32]
+
+
+def digest_file(path: Path) -> str:
+    state = hashlib.sha256()
+    with path.open("rb") as source:
+        for block in iter(lambda: source.read(1024 * 1024), b""):
+            state.update(block)
+    return state.hexdigest()
+
+
+def clean_environment() -> dict[str, str]:
+    # opendal honors HTTP(S)_PROXY, and a developer machine proxy must not
+    # intercept the loopback object endpoint. CI has no proxy; stripping the
+    # variables makes local and CI behavior identical.
+    stripped = dict(os.environ)
+    for name in (
+        "HTTP_PROXY",
+        "HTTPS_PROXY",
+        "ALL_PROXY",
+        "http_proxy",
+        "https_proxy",
+        "all_proxy",
+    ):
+        stripped.pop(name, None)
+    return stripped
+
+
+def run(
+    argv: Sequence[os.PathLike[str] | str],
+    *,
+    cwd: Path,
+    timeout: float,
+    check: bool = True,
+) -> subprocess.CompletedProcess[str]:
+    result = subprocess.run(
+        [str(item) for item in argv],
+        cwd=cwd,
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+        env=clean_environment(),
+    )
+    if check and result.returncode != 0:
+        rendered = " ".join(str(item) for item in argv)
+        output = (result.stderr or result.stdout).strip()
+        raise WorkflowFailure(
+            f"command failed ({result.returncode}): {rendered}\n{output}"
+        )
+    return result
+
+
+def free_port() -> int:
+    with socket.socket() as probe:
+        probe.bind(("127.0.0.1", 0))
+        return int(probe.getsockname()[1])
+
+
+def start_process(
+    argv: Sequence[os.PathLike[str] | str], cwd: Path, log: TextIO
+) -> subprocess.Popen[bytes]:
+    return subprocess.Popen(
+        [str(item) for item in argv],
+        cwd=cwd,
+        stdin=subprocess.DEVNULL,
+        stdout=log,
+        stderr=subprocess.STDOUT,
+        env=clean_environment(),
+    )
+
+
+def wait_tcp(process: subprocess.Popen[bytes], port: int, timeout: float) -> None:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if process.poll() is not None:
+            raise WorkflowFailure(
+                f"server exited before readiness with {process.returncode}"
+            )
+        try:
+            with socket.create_connection(("127.0.0.1", port), timeout=0.2):
+                return
+        except OSError:
+            time.sleep(0.05)
+    raise WorkflowFailure(f"server did not listen on 127.0.0.1:{port}")
+
+
+def wait_exit(process: subprocess.Popen[bytes], timeout: float) -> int:
+    try:
+        return int(process.wait(timeout=timeout))
+    except subprocess.TimeoutExpired as error:
+        process.kill()
+        process.wait(timeout=10)
+        raise WorkflowFailure(
+            f"owner kept running after SIGTERM for {timeout}s"
+        ) from error
+
+
+def wait_health(
+    port: int,
+    process: subprocess.Popen[bytes],
+    path: str,
+    expected_status: int,
+    timeout: float,
+) -> tuple[int, str]:
+    deadline = time.monotonic() + timeout
+    last_error: Exception | None = None
+    while time.monotonic() < deadline:
+        if process.poll() is not None:
+            raise WorkflowFailure(
+                f"server exited before health readiness with {process.returncode}"
+            )
+        try:
+            status, body = http_get(port, path)
+            if status == expected_status:
+                return status, body
+            last_error = WorkflowFailure(
+                f"{path} reported {status} ({body!r}) while waiting for "
+                f"{expected_status}"
+            )
+        except (OSError, http.client.HTTPException) as error:
+            last_error = error
+        time.sleep(0.1)
+    raise WorkflowFailure(
+        f"{path} never reported {expected_status} on 127.0.0.1:{port}: {last_error}"
+    )
+
+
+def http_get(port: int, path: str) -> tuple[int, str]:
+    connection = http.client.HTTPConnection("127.0.0.1", port, timeout=2)
+    try:
+        connection.request("GET", path)
+        response = connection.getresponse()
+        return response.status, response.read().decode("utf-8")
+    finally:
+        connection.close()
+
+
+def control_args(
+    binary: Path,
+    root_id: str,
+    endpoint: str,
+    prefix: str,
+    lease_ttl_seconds: int = GRACEFUL_TTL_SECONDS,
+) -> list[str]:
+    return [
+        str(binary),
+        "--root-id",
+        root_id,
+        "--etcd-endpoint",
+        endpoint,
+        "--etcd-key-prefix",
+        prefix,
+        "--etcd-lease-ttl-seconds",
+        str(lease_ttl_seconds),
+    ]
+
+
+def object_args(
+    stage: str,
+    endpoint: str,
+    bucket: str,
+    root: str,
+    access_key_id: str,
+    secret_access_key: str,
+) -> list[str]:
+    return [
+        "--object-bucket",
+        bucket,
+        "--object-endpoint",
+        endpoint,
+        "--object-root",
+        f"{root.rstrip('/')}/{stage}",
+        "--object-access-key-id",
+        access_key_id,
+        "--object-secret-access-key",
+        secret_access_key,
+    ]
+
+
+def server_command(
+    common: list[str],
+    objects: list[str],
+    port: int,
+    health_port: int,
+    node: str,
+    metadata_option: str,
+    metadata: Path,
+) -> list[str]:
+    return [
+        *common,
+        *objects,
+        "--bind",
+        f"127.0.0.1:{port}",
+        "--advertise-endpoint",
+        f"127.0.0.1:{port}",
+        "--health-endpoint",
+        f"127.0.0.1:{health_port}",
+        "--node-id",
+        node,
+        metadata_option,
+        str(metadata),
+        "serve",
+    ]
+
+
+def validate_stats(payload: dict[str, Any], label: str) -> None:
+    for field in (
+        "pid",
+        "uptime_seconds",
+        "protocol_schema",
+        "installed_roots",
+        "owner_loss",
+        "draining",
+        "ready",
+        "connections_total",
+        "requests_total",
+        "inflight_connections",
+    ):
+        if field not in payload:
+            raise WorkflowFailure(f"{label}: /stats is missing field {field}")
+    if not isinstance(payload["pid"], int) or payload["pid"] <= 0:
+        raise WorkflowFailure(f"{label}: /stats pid is not a positive integer")
+    if not isinstance(payload["protocol_schema"], str) or not payload[
+        "protocol_schema"
+    ].startswith("nokv.workspace"):
+        raise WorkflowFailure(f"{label}: /stats protocol_schema is unexpected")
+    if not isinstance(payload["installed_roots"], int) or payload["installed_roots"] < 1:
+        raise WorkflowFailure(f"{label}: /stats installed_roots must be at least 1")
+    if payload["owner_loss"] is not False or payload["ready"] is not True:
+        raise WorkflowFailure(f"{label}: /stats must report owner retained and ready")
+    if not isinstance(payload["connections_total"], int) or not isinstance(
+        payload["requests_total"], int
+    ):
+        raise WorkflowFailure(f"{label}: /stats counters must be integers")
+
+
+def build_binaries(repo: Path, target: Path, timeout: float) -> Path:
+    run(["cargo", "build", "-p", "nokv", "--bin", "nokv"], cwd=repo, timeout=timeout)
+    binary = target / "debug" / "nokv"
+    if not binary.is_file():
+        raise WorkflowFailure(f"built binary is missing: {binary}")
+    return binary
+
+
+def parser() -> argparse.ArgumentParser:
+    parsed = argparse.ArgumentParser(description=__doc__)
+    parsed.add_argument("--repo", type=Path, default=Path(__file__).resolve().parents[2])
+    parsed.add_argument("--binary", type=Path)
+    parsed.add_argument("--build", action="store_true")
+    parsed.add_argument("--target-dir", type=Path)
+    parsed.add_argument("--etcd-bin", type=Path, default=shutil.which("etcd"))
+    parsed.add_argument("--etcdctl-bin", type=Path, default=shutil.which("etcdctl"))
+    parsed.add_argument("--seed", default="health-shutdown")
+    parsed.add_argument("--object-endpoint")
+    parsed.add_argument("--object-bucket")
+    parsed.add_argument("--object-root", default="health-shutdown")
+    parsed.add_argument("--object-access-key-id", default="rustfsadmin")
+    parsed.add_argument("--object-secret-access-key", default="rustfsadmin")
+    parsed.add_argument("--timeout", type=float, default=30.0)
+    parsed.add_argument("--evidence-dir", type=Path, required=True)
+    return parsed
+
+
+def execute(args: argparse.Namespace) -> dict[str, object]:
+    repo = args.repo.resolve()
+    evidence = args.evidence_dir.resolve()
+    if evidence.exists() and any(evidence.iterdir()):
+        raise WorkflowFailure(f"evidence directory is not empty: {evidence}")
+    evidence.mkdir(parents=True, exist_ok=True)
+    if args.etcd_bin is None or not Path(args.etcd_bin).is_file():
+        raise WorkflowFailure("a real etcd binary is required")
+    if args.etcdctl_bin is None or not Path(args.etcdctl_bin).is_file():
+        raise WorkflowFailure("etcdctl is required")
+    if not args.object_endpoint or not args.object_bucket:
+        raise WorkflowFailure("a real object endpoint and bucket are required")
+    if args.timeout <= 0:
+        raise WorkflowFailure("--timeout must be positive")
+
+    target = (args.target_dir or repo / "target").resolve()
+    binary = args.binary.resolve() if args.binary else target / "debug" / "nokv"
+    if args.build:
+        binary = build_binaries(repo, target, max(args.timeout, 600.0))
+    if not binary.is_file():
+        raise WorkflowFailure("a built nokv binary is required")
+
+    scenarios: list[dict[str, Any]] = []
+
+    def record(name: str, passed: bool, detail: str) -> None:
+        scenarios.append({"scenario": name, "passed": passed, "detail": detail[:2000]})
+
+    root_id = fixed_id(args.seed, "root")
+    agent_id = fixed_id(args.seed, "agent")
+    shard_id = fixed_id(args.seed, "shard")
+    prefix = f"/nokv/health-shutdown/{fixed_id(args.seed, 'prefix')}"
+    objects = object_args(
+        args.seed,
+        args.object_endpoint,
+        args.object_bucket,
+        args.object_root,
+        args.object_access_key_id,
+        args.object_secret_access_key,
+    )
+    metadata = evidence / "metadata"
+    server_log = (evidence / "server.log").open("a", encoding="utf-8")
+    etcd: subprocess.Popen[bytes] | None = None
+    owner: subprocess.Popen[bytes] | None = None
+    started_at = now()
+    try:
+        client_port = free_port()
+        peer_port = free_port()
+        endpoint = f"http://127.0.0.1:{client_port}"
+        peer = f"http://127.0.0.1:{peer_port}"
+        etcd = start_process(
+            [
+                args.etcd_bin,
+                "--name",
+                "nokv-health-shutdown",
+                "--data-dir",
+                str(evidence / "etcd-data"),
+                "--listen-client-urls",
+                endpoint,
+                "--advertise-client-urls",
+                endpoint,
+                "--listen-peer-urls",
+                peer,
+                "--initial-advertise-peer-urls",
+                peer,
+                "--initial-cluster",
+                f"nokv-health-shutdown={peer}",
+                "--initial-cluster-state",
+                "new",
+                "--log-level",
+                "warn",
+            ],
+            repo,
+            server_log,
+        )
+        etcdctl = Path(args.etcdctl_bin)
+        deadline = time.monotonic() + args.timeout
+        ready = False
+        while time.monotonic() < deadline:
+            if etcd.poll() is not None:
+                raise WorkflowFailure(f"etcd exited with {etcd.returncode}")
+            health = run(
+                [etcdctl, f"--endpoints={endpoint}", "endpoint", "health"],
+                cwd=repo,
+                timeout=args.timeout,
+                check=False,
+            )
+            if health.returncode == 0:
+                ready = True
+                break
+            time.sleep(0.1)
+        if not ready:
+            raise WorkflowFailure(f"etcd did not become healthy at {endpoint}")
+        common = control_args(binary, root_id, endpoint, prefix)
+
+        # --- provision -------------------------------------------------
+        provision = run(
+            [
+                *common,
+                "--agent-id",
+                agent_id,
+                *objects,
+                "provision",
+                shard_id,
+            ],
+            cwd=repo,
+            timeout=args.timeout,
+        )
+        (evidence / "provision.stdout.log").write_text(provision.stdout)
+        (evidence / "provision.stderr.log").write_text(provision.stderr)
+        record("provision", True, "root provisioned with a durable Agent binding")
+
+        # --- first owner with the health surface -----------------------
+        rpc_port = free_port()
+        health_port = free_port()
+        owner = start_process(
+            server_command(
+                common,
+                objects,
+                rpc_port,
+                health_port,
+                "gate-health-e1",
+                "--metadata-create",
+                metadata,
+            ),
+            repo,
+            server_log,
+        )
+        wait_tcp(owner, rpc_port, args.timeout)
+
+        status, body = wait_health(health_port, owner, "/healthz", 200, args.timeout)
+        if body != "ok\n":
+            raise WorkflowFailure(f"/healthz body was {body!r}, expected 'ok\\n'")
+        record("healthz", True, "liveness reported while the owner serves")
+
+        status, body = wait_health(health_port, owner, "/readyz", 200, args.timeout)
+        if body != "ready\n":
+            raise WorkflowFailure(f"/readyz body was {body!r}, expected 'ready\\n'")
+        record("readyz", True, "owner admission retained and lease held")
+
+        status, body = http_get(health_port, "/stats")
+        if status != 200:
+            raise WorkflowFailure(f"/stats reported {status}")
+        first_stats = json.loads(body)
+        validate_stats(first_stats, "first")
+        record(
+            "stats_identity",
+            True,
+            "server identity snapshot matches the serving owner",
+        )
+
+        # --- one business request moves the counters -------------------
+        client = [
+            *common,
+            "--agent-id",
+            agent_id,
+            "--workbench-root",
+            "/agents/health-shutdown/wb",
+            *objects,
+        ]
+        create = run(
+            [
+                *client,
+                "workbench",
+                "workbench_create",
+                json.dumps({"id": "shutdown-proof"}, separators=(",", ":")),
+            ],
+            cwd=repo,
+            timeout=args.timeout,
+        )
+        (evidence / "create.stdout.log").write_text(create.stdout)
+        (evidence / "create.stderr.log").write_text(create.stderr)
+
+        _, body = http_get(health_port, "/stats")
+        second_stats = json.loads(body)
+        validate_stats(second_stats, "second")
+        if second_stats["connections_total"] < 1:
+            raise WorkflowFailure("/stats connections_total did not advance")
+        if second_stats["requests_total"] <= first_stats["requests_total"]:
+            raise WorkflowFailure(
+                f"/stats requests_total did not advance: {first_stats['requests_total']} "
+                f"-> {second_stats['requests_total']}"
+            )
+        record(
+            "stats_advance",
+            True,
+            "one Workbench request moved connections_total and requests_total",
+        )
+
+        # --- SIGTERM releases the session and the health surface -------
+        os.kill(owner.pid, signal.SIGTERM)
+        exit_code = wait_exit(owner, GRACEFUL_EXIT_DEADLINE_SECONDS)
+        if exit_code != 0:
+            raise WorkflowFailure(f"owner exited with {exit_code} after SIGTERM")
+        record("sigterm_exit_zero", True, "SIGTERM stopped the owner with exit 0")
+
+        try:
+            http_get(health_port, "/healthz")
+            raise WorkflowFailure("health endpoint still answered after SIGTERM")
+        except (OSError, ConnectionRefusedError, http.client.HTTPException):
+            pass
+        record("health_closed", True, "health endpoint closed with the owner")
+
+        # --- immediate reopen re-admits the same root ------------------
+        reopened_rpc = free_port()
+        reopened_health = free_port()
+        reopened = start_process(
+            server_command(
+                common,
+                objects,
+                reopened_rpc,
+                reopened_health,
+                "gate-health-e2",
+                "--metadata-reopen",
+                metadata,
+            ),
+            repo,
+            server_log,
+        )
+        wait_tcp(reopened, reopened_rpc, REOPEN_ADMISSION_DEADLINE_SECONDS)
+        wait_health(reopened_health, reopened, "/readyz", 200, args.timeout)
+        find = run(
+            [
+                *client,
+                "workbench",
+                "workbench_find",
+                json.dumps(
+                    {"committed": None, "manifest_pattern": None, "include_manifest": False},
+                    separators=(",", ":"),
+                ),
+            ],
+            cwd=repo,
+            timeout=args.timeout,
+        )
+        if "shutdown-proof" not in find.stdout:
+            raise WorkflowFailure(
+                f"reopened owner did not serve the committed workbench: {find.stdout[:200]}"
+            )
+        record(
+            "reopen_readmits",
+            True,
+            "after SIGTERM the health surface closed with the owner, the successor "
+            "reopened the same metadata authority, /readyz reported ready again, "
+            "and the committed Workbench data was served",
+        )
+        owner = reopened
+        os.kill(reopened.pid, signal.SIGTERM)
+        wait_exit(reopened, GRACEFUL_EXIT_DEADLINE_SECONDS)
+    finally:
+        if owner is not None and owner.poll() is None:
+            os.kill(owner.pid, signal.SIGKILL)
+            owner.wait(timeout=10)
+        if etcd is not None and etcd.poll() is None:
+            os.kill(etcd.pid, signal.SIGKILL)
+            etcd.wait(timeout=10)
+        server_log.close()
+
+    payload: dict[str, object] = {
+        "schema": SCHEMA,
+        "started_at": started_at,
+        "finished_at": now(),
+        "scenarios": scenarios,
+        "seed": args.seed,
+        "binary": str(binary),
+        "binary_sha256": digest_file(binary),
+        "overall_status": "PASS" if all(s["passed"] for s in scenarios) else "FAIL",
+    }
+    (evidence / "qualification.json").write_text(
+        json.dumps(payload, indent=2, sort_keys=True) + "\n"
+    )
+    print(json.dumps(payload, indent=2))
+    return payload
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = parser().parse_args(argv)
+    try:
+        payload = execute(args)
+    except WorkflowFailure as error:
+        print(f"health_shutdown_gate: {error}", file=sys.stderr)
+        return 1
+    except (OSError, subprocess.SubprocessError, json.JSONDecodeError) as error:
+        print(f"health_shutdown_gate: {error}", file=sys.stderr)
+        return 1
+    return 0 if payload["overall_status"] == "PASS" else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/workbench/health_shutdown_gate_test.py
+++ b/scripts/workbench/health_shutdown_gate_test.py
@@ -1,0 +1,165 @@
+#!/usr/bin/env python3
+# Copyright 2024-2026 The NoKV Authors.
+# SPDX-License-Identifier: Apache-2.0
+"""Unit tests for the health/shutdown gate helpers."""
+
+from __future__ import annotations
+
+import argparse
+import unittest
+from pathlib import Path
+
+import health_shutdown_gate as gate
+
+
+class HealthShutdownGateTest(unittest.TestCase):
+    def test_fixed_id_is_stable_hex32(self) -> None:
+        first = gate.fixed_id("seed-a", "root")
+        second = gate.fixed_id("seed-a", "root")
+        self.assertEqual(first, second)
+        self.assertEqual(len(first), 32)
+        int(first, 16)
+        self.assertNotEqual(first, gate.fixed_id("seed-b", "root"))
+        self.assertNotEqual(first, gate.fixed_id("seed-a", "shard"))
+
+    def test_control_args_require_positive_ttl_and_carry_identity(self) -> None:
+        argv = gate.control_args(
+            Path("/bin/nokv"),
+            "a" * 32,
+            "http://127.0.0.1:22379",
+            "/nokv/test",
+        )
+        self.assertEqual(argv[0], "/bin/nokv")
+        self.assertIn("--root-id", argv)
+        self.assertIn("a" * 32, argv)
+        self.assertIn("--etcd-endpoint", argv)
+        self.assertIn("--etcd-lease-ttl-seconds", argv)
+        self.assertIn(str(gate.GRACEFUL_TTL_SECONDS), argv)
+
+    def test_server_command_includes_the_health_endpoint(self) -> None:
+        command = gate.server_command(
+            ["nokv", "--root-id", "b" * 32],
+            ["--object-bucket", "bucket"],
+            17750,
+            17751,
+            "node-a",
+            "--metadata-create",
+            Path("/tmp/meta"),
+        )
+        self.assertEqual(command[-1], "serve")
+        self.assertIn("--health-endpoint", command)
+        self.assertIn("127.0.0.1:17751", command)
+        self.assertIn("--bind", command)
+        self.assertIn("127.0.0.1:17750", command)
+        self.assertIn("--advertise-endpoint", command)
+        self.assertIn("--metadata-create", command)
+
+    def test_object_args_scope_every_stage_under_one_prefix(self) -> None:
+        argv = gate.object_args(
+            "stage-a", "http://127.0.0.1:9000", "bucket", "root", "key", "secret"
+        )
+        self.assertIn("--object-bucket", argv)
+        self.assertIn("bucket", argv)
+        self.assertIn("--object-root", argv)
+        self.assertEqual(argv[argv.index("--object-root") + 1], "root/stage-a")
+        self.assertIn("--object-access-key-id", argv)
+        self.assertIn("key", argv)
+        self.assertIn("--object-secret-access-key", argv)
+
+    def test_clean_environment_strips_proxy_variables(self) -> None:
+        import os
+
+        os.environ["HTTP_PROXY"] = "http://127.0.0.1:7892"
+        os.environ["https_proxy"] = "http://127.0.0.1:7892"
+        cleaned = gate.clean_environment()
+        for name in ("HTTP_PROXY", "HTTPS_PROXY", "ALL_PROXY", "http_proxy", "https_proxy", "all_proxy"):
+            self.assertNotIn(name, cleaned)
+        self.assertIn("PATH", cleaned)
+        del os.environ["HTTP_PROXY"]
+        del os.environ["https_proxy"]
+
+    def test_validate_stats_accepts_the_serving_shape(self) -> None:
+        gate.validate_stats(
+            {
+                "pid": 1234,
+                "uptime_seconds": 1.5,
+                "protocol_schema": "nokv.workspace.rpc.v9",
+                "installed_roots": 1,
+                "owner_loss": False,
+                "draining": False,
+                "ready": True,
+                "connections_total": 1,
+                "requests_total": 2,
+                "inflight_connections": 0,
+            },
+            "sample",
+        )
+
+    def test_validate_stats_rejects_missing_or_wrong_fields(self) -> None:
+        base = {
+            "pid": 1234,
+            "uptime_seconds": 1.5,
+            "protocol_schema": "nokv.workspace.rpc.v9",
+            "installed_roots": 1,
+            "owner_loss": False,
+            "draining": False,
+            "ready": True,
+            "connections_total": 1,
+            "requests_total": 2,
+            "inflight_connections": 0,
+        }
+        for field in list(base):
+            damaged = dict(base)
+            del damaged[field]
+            with self.assertRaises(gate.WorkflowFailure):
+                gate.validate_stats(damaged, "missing-field")
+        with self.assertRaises(gate.WorkflowFailure):
+            gate.validate_stats({**base, "ready": False}, "owner-loss")
+        with self.assertRaises(gate.WorkflowFailure):
+            gate.validate_stats({**base, "owner_loss": True}, "owner-loss")
+        with self.assertRaises(gate.WorkflowFailure):
+            gate.validate_stats({**base, "installed_roots": 0}, "no-roots")
+        with self.assertRaises(gate.WorkflowFailure):
+            gate.validate_stats({**base, "pid": 0}, "bad-pid")
+        with self.assertRaises(gate.WorkflowFailure):
+            gate.validate_stats({**base, "protocol_schema": "other.rpc"}, "bad-schema")
+
+    def test_parser_requires_evidence_dir(self) -> None:
+        with self.assertRaises(SystemExit):
+            gate.parser().parse_args([])
+
+    def test_parser_requires_a_real_etcd_and_object_target(self) -> None:
+        parsed = gate.parser().parse_args(
+            [
+                "--evidence-dir",
+                "/tmp/evidence",
+                "--object-endpoint",
+                "http://127.0.0.1:9000",
+                "--object-bucket",
+                "bucket",
+                "--etcd-bin",
+                "/usr/bin/etcd",
+                "--etcdctl-bin",
+                "/usr/bin/etcdctl",
+                "--binary",
+                "/tmp/nokv",
+            ]
+        )
+        self.assertEqual(parsed.evidence_dir, Path("/tmp/evidence"))
+        self.assertEqual(parsed.object_endpoint, "http://127.0.0.1:9000")
+        self.assertEqual(parsed.etcd_bin, Path("/usr/bin/etcd"))
+
+    def test_wait_exit_kills_a_stubborn_process_and_reports(self) -> None:
+        import subprocess
+        import sys
+
+        proc = subprocess.Popen(
+            [sys.executable, "-c", "import time; time.sleep(60)"]
+        )
+        with self.assertRaises(gate.WorkflowFailure):
+            gate.wait_exit(proc, 0.2)
+        self.assertIsNotNone(proc.poll())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
<!--
Copyright 2024-2026 The NoKV Authors.
SPDX-License-Identifier: Apache-2.0
-->

## Related Issue

Relates to #487

## Summary

Add an optional HTTP health surface to the logical-shard owner process and
make the graceful-shutdown order an observable, regression-tested contract.

### New capability

`crates/nokv-server/src/health.rs` serves three endpoints over a dependency-free
minimal HTTP/1.1 listener (no new dependencies):

| Endpoint | Semantics |
|---|---|
| `GET /healthz` | Process liveness; 200 while the process runs |
| `GET /readyz` | 200 only when admission is complete, the owner is not draining, and the control-plane lease is not lost; 503 otherwise |
| `GET /stats` | One JSON counter snapshot: `pid`, `uptime_seconds`, `protocol_schema`, `installed_roots`, `owner_loss`, `draining`, `ready`, `connections_total`, `requests_total`, `inflight_connections` |

Every `/stats` field is genuinely counted by the server itself: an admitted
connection increments `connections_total`, a successfully dispatched RPC
increments `requests_total`, and in-flight load reuses the existing
`ConnectionLimiter`. No metadata business value is fabricated: replay count,
last committed version, and GC generation belong to `nokv-meta` and the
lifecycle owner and stay out of this snapshot until later plan stages inject
them from their true owners.

The CLI gains `serve --health-endpoint HOST:PORT` (disabled by default);
`--help` is updated.

### Shutdown contract

On SIGTERM the order is fixed and observable:

```text
1. /readyz turns 503 immediately (draining is set, external traffic is shed)
2. new connections are no longer admitted
3. in-flight connections drain while ownership keeps being renewed
4. serve returns and the caller releases the lease
```

The health listener is advisory at runtime (per-connection failures never fail
the RPC server), but a bind failure or a health-thread startup failure fails
serve before it starts, so a configured-but-unusable health endpoint cannot
pass silently.

### Regression protection

- Unit tests cover the three endpoints across the state matrix (healthz stays
  alive, readyz turns 503 on owner-loss and on draining, stats counters
  advance, unknown paths and methods are rejected, zero-length requests fail
  closed) and lock in a real platform trap: on BSD-derived platforms `accept`
  inherits the listener's non-blocking mode, which otherwise races an
  EAGAIN-then-RST against the probe client.
- `scripts/workbench/health_shutdown_gate.py` runs eight scenarios against real
  etcd, RustFS, and real owner processes: provision → healthz/readyz/stats
  semantics → counters advance with one Workbench request → SIGTERM exits 0 →
  the health endpoint closes with the owner → a successor reopens the same
  metadata authority, `/readyz` reports ready again, and the committed
  Workbench data is served. The lease-release timing authority stays with
  `local_wal_recovery_gate.py`'s graceful stage; this gate asserts the HTTP
  contract only.
- CI wiring adds the gate to the `nokv-workspace` job, uploads evidence as
  `health-shutdown-${{ github.sha }}`, and maps onto the existing Gate 6
  evidence chain without introducing a new top-level acceptance gate.

## Scope

- [x] This PR changes one logical boundary only: the owner health surface
      (server module + CLI option + one qualification gate).
- [x] No unrelated refactor, benchmark, metadata model, Holt layout,
      object-store, agent interface, or docs change is mixed in.
- [ ] The linked issue describes the user-visible problem, design decision, or
      maintenance task this PR resolves.
      (#487 is the ops-closure plan; this PR is its P1.)
- [x] Any breaking change is intentional and documented.
      (None: `--health-endpoint` is a new optional flag, off by default.)
- [x] No compatibility shim, deprecated alias, or forwarding wrapper was
      added without a removal condition.

## Change Size And Review

- [x] I checked GitHub's additions plus deletions for this pull request.
      (+1351 / -24, below the 5,000-line threshold.)
- [x] This change is still small enough for a focused review; approval count
      is not being used to justify mixed package or lifecycle boundaries.

## Code Contract (Code Changes Only)

- [x] Package boundaries follow `docs/development/code_contract.md`.
      (The HTTP surface lives in `nokv-server`; CLI parsing lives in `nokv`
      `cli.rs`; no cross-package types leak.)
- [x] Shared helpers reuse the standard library or existing repository
      helpers. (The gate reuses the established etcd/RustFS qualification
      pattern; the server module uses std networking only.)
- [x] File names and file placement follow the code contract.
      (`crates/nokv-server/src/health.rs`; gate under `scripts/workbench/`.)
- [x] New types, interfaces, structs, fields, and functions use
      domain-specific names. (`health_bind`, `set_draining`,
      `HealthSnapshot`; `HealthState` stays `pub(crate)`.)
- [x] New errors are in the owning package's `errors.rs` and carry stable
      error kinds when crossing package boundaries.
      (No new error types; existing `ServerError` variants are reused.)
- [x] New metrics/stats are owned by the package that reports or serves them.
      (All counters are recorded and reported by `nokv-server`.)
- [x] Metadata changes document durability, atomicity, revision-reference
      lifetime, snapshot/commit/event retention, GC epochs, and fail-closed
      recovery boundaries. (No metadata changes.)
- [x] Placement or routing changes preserve persisted `RootId ->
      LogicalShardId` affinity. (No placement or routing changes.)
- [x] Agent-interface changes keep the transport-free facade in `nokv-agent`.
      (No agent-interface changes.)
- [x] User-facing integration guidance orders the native full CLI first.
      (The flag is documented in `--help` under OWNER.)

## Claims and Evidence

- [x] User-facing documentation distinguishes current, experimental, and
      planned capabilities.
      (The flag documents exact endpoint semantics in `--help`.)
- [x] Security claims do not treat a Workbench root or Agent scope as tenant
      authentication or authorization. (No security claims.)
- [x] Performance claims state the topology, comparison boundary, cache state,
      run count, and raw-evidence location. (No performance claims.)

## Validation

- `cargo fmt --all -- --check` → clean
- `cargo clippy --workspace --all-targets -- -D warnings` → clean
- `cargo test --workspace` → 1075 passed; 0 failed (nokv-server: 163,
  including six health tests)
- `python3 scripts/workbench/health_shutdown_gate_test.py` → 10 passed
- `python3 scripts/workbench/workbench_contract_test.py` → 8 passed
- Full gate against real etcd + RustFS + real owner processes →
  **8/8 scenarios PASS** (evidence: local
  `/tmp/health-shutdown-evidence/qualification.json`)
- Workflow YAML parse (Ruby psych) and `git diff --check` → pass
- Not run (with reason): GitHub Actions CI (no local runner); the new step
  follows the existing gate wiring in the same job. Local clippy is Rust
  1.97; the Rust 1.98 lint set is covered by the fixes already on main.

## Contributor Sign-off

- [x] Every commit in this PR includes a DCO `Signed-off-by` trailer.
