### PR TITLE
feat(workbench): caller-pinned expected_generation for put_file

### DIFF
--- a/crates/nokv-agent/src/facade.rs
+++ b/crates/nokv-agent/src/facade.rs
@@ -961,17 +961,41 @@ impl<B: WorkbenchBackend> SdkWorkbenchToolHandler<B> {
             .unwrap_or(default_content_type)
             .to_owned();
         let replace = optional_bool(arguments, "replace")?.unwrap_or(false);
-        let condition = if replace {
-            let current = self
-                .backend
-                .stat(&path, &ReadView::Live)?
-                .ok_or_else(|| not_found(&path))?;
-            let artifact = current.artifact.ok_or_else(|| not_artifact(&path))?;
-            PublishCondition::ReplaceOnly {
-                expected_generation: artifact.generation,
+        let expected_generation = optional_u64(arguments, "expected_generation")?;
+        let condition = match (replace, expected_generation) {
+            (false, None) => PublishCondition::CreateOnly,
+            (false, Some(_)) => {
+                return Err(AgentError::invalid_arguments(
+                    "expected_generation requires replace=true; a create-only \
+                     publication has no generation to pin",
+                ));
             }
-        } else {
-            PublishCondition::CreateOnly
+            (true, Some(0)) => {
+                return Err(AgentError::invalid_arguments(
+                    "expected_generation must be at least 1; use replace=false \
+                     for a create-only publication",
+                ));
+            }
+            (true, Some(expected_generation)) => {
+                // The caller pins the generation it observed, so a competing
+                // replacement between the caller's own read and this publish
+                // surfaces as a typed Conflict instead of a lost update. The
+                // self-stat form below only protects the window inside this
+                // call, never the caller's read-modify-write span.
+                PublishCondition::ReplaceOnly {
+                    expected_generation,
+                }
+            }
+            (true, None) => {
+                let current = self
+                    .backend
+                    .stat(&path, &ReadView::Live)?
+                    .ok_or_else(|| not_found(&path))?;
+                let artifact = current.artifact.ok_or_else(|| not_artifact(&path))?;
+                PublishCondition::ReplaceOnly {
+                    expected_generation: artifact.generation,
+                }
+            }
         };
         let outcome = self.backend.publish(PublishRequest {
             path: path.clone(),

--- a/crates/nokv-agent/src/lib.rs
+++ b/crates/nokv-agent/src/lib.rs
@@ -36,7 +36,7 @@ const TOOL_DESCRIPTIONS: [(&str, &str); WORKBENCH_TOOL_COUNT] = [
     ),
     (
         "workbench_put_file",
-        "Publish one artifact at a section-relative jailed path. replace=false is create-only; replace=true is replace-only. This tool is never an upsert.",
+        "Publish one artifact at a section-relative jailed path. replace=false is create-only; replace=true is replace-only, optionally pinned to the caller-observed expected_generation so a stale caller conflicts instead of overwriting. This tool is never an upsert.",
     ),
     (
         "workbench_append",

--- a/crates/nokv-agent/tests/sdk_facade.rs
+++ b/crates/nokv-agent/tests/sdk_facade.rs
@@ -4159,6 +4159,102 @@ fn path_jail_and_put_modes_fail_closed() {
 }
 
 #[test]
+fn put_file_expected_generation_is_a_caller_pinned_cas() {
+    let backend = FakeBackend::default();
+    let handler = test_handler(backend.clone());
+    run(&handler, "workbench_create", json!({"id": "wb-cas"})).unwrap();
+    run(
+        &handler,
+        "workbench_put_file",
+        json!({"id": "wb-cas", "section": "outputs", "path": "head.json", "text": "v1"}),
+    )
+    .unwrap();
+
+    // A competitor replaces the artifact after our caller observed generation 1.
+    let competitor = run(
+        &handler,
+        "workbench_put_file",
+        json!({
+            "id": "wb-cas", "section": "outputs", "path": "head.json",
+            "text": "v2-competitor", "replace": true, "expected_generation": 1
+        }),
+    )
+    .unwrap();
+    assert_eq!(competitor["generation"], 2);
+
+    // The stale caller pins the generation it observed and must conflict
+    // instead of overwriting the competitor's update.
+    let stale = run(
+        &handler,
+        "workbench_put_file",
+        json!({
+            "id": "wb-cas", "section": "outputs", "path": "head.json",
+            "text": "v3-stale", "replace": true, "expected_generation": 1
+        }),
+    )
+    .expect_err("stale expected_generation must conflict");
+    assert_eq!(stale.code, "Conflict");
+    assert_eq!(
+        backend.body("wb-cas", "outputs/head.json"),
+        b"v2-competitor"
+    );
+
+    // Refreshing the observation succeeds against the current generation.
+    let refreshed = run(
+        &handler,
+        "workbench_put_file",
+        json!({
+            "id": "wb-cas", "section": "outputs", "path": "head.json",
+            "text": "v3", "replace": true, "expected_generation": 2
+        }),
+    )
+    .unwrap();
+    assert_eq!(refreshed["generation"], 3);
+
+    // The pin is meaningless outside replace mode and for generation zero.
+    for arguments in [
+        json!({
+            "id": "wb-cas", "section": "outputs", "path": "head.json",
+            "text": "x", "expected_generation": 3
+        }),
+        json!({
+            "id": "wb-cas", "section": "outputs", "path": "head.json",
+            "text": "x", "replace": true, "expected_generation": 0
+        }),
+    ] {
+        let error = run(&handler, "workbench_put_file", arguments)
+            .expect_err("invalid expected_generation shapes must fail closed");
+        assert_eq!(error.code, "InvalidArguments");
+    }
+
+    // Legacy self-stat replace stays byte-for-byte unchanged.
+    let legacy = run(
+        &handler,
+        "workbench_put_file",
+        json!({
+            "id": "wb-cas", "section": "outputs", "path": "head.json",
+            "text": "v4", "replace": true
+        }),
+    )
+    .unwrap();
+    assert_eq!(legacy["generation"], 4);
+
+    // The schema rejects generation 0 first on validated routes; a direct
+    // handler call bypasses the schema, so the facade's own zero check is
+    // load-bearing there and gets pinned separately.
+    let direct_zero = handler
+        .execute(
+            "workbench_put_file",
+            &json!({
+                "id": "wb-cas", "section": "outputs", "path": "head.json",
+                "text": "x", "replace": true, "expected_generation": 0
+            }),
+        )
+        .expect_err("a zero pin must fail even without schema validation");
+    assert_eq!(direct_zero.code, "InvalidArguments");
+}
+
+#[test]
 fn append_is_one_backend_operation_and_edit_revalidates_generation_conflicts() {
     let backend = FakeBackend::default();
     let handler = test_handler_with_limits(backend.clone(), 1024, 2);

--- a/crates/nokv-agent/workbench_contract_schema.json
+++ b/crates/nokv-agent/workbench_contract_schema.json
@@ -477,6 +477,10 @@
         "content_type": {
           "type": "string"
         },
+        "expected_generation": {
+          "minimum": 1,
+          "type": "integer"
+        },
         "id": {
           "type": "string"
         },

--- a/crates/nokv/src/cli.rs
+++ b/crates/nokv/src/cli.rs
@@ -129,6 +129,7 @@ pub enum Command {
         source: PathBuf,
         path: String,
         replace: bool,
+        expected_generation: Option<u64>,
         content_type: Option<String>,
     },
     WorkspacePath(WorkspacePathCommand),
@@ -186,6 +187,7 @@ pub enum CliError {
     MixedRoutingOptions,
     MixedMetadataStoreOptions,
     LocalOnlyRecoverLog,
+    UnpinnedExpectedGeneration,
 }
 
 impl fmt::Display for CliError {
@@ -219,6 +221,9 @@ impl fmt::Display for CliError {
                 .write_str("--metadata-create, --metadata-reopen, and --metadata-recover-log are mutually exclusive"),
             Self::LocalOnlyRecoverLog => formatter.write_str(
                 "--metadata-recover-log installs a shared-log frontier and cannot be combined with --recovery-publication local-only",
+            ),
+            Self::UnpinnedExpectedGeneration => formatter.write_str(
+                "--expected-generation pins a replace-only publication and requires --replace",
             ),
         }
     }
@@ -734,10 +739,17 @@ fn parse_collect(arguments: &mut impl Iterator<Item = String>) -> Result<Command
         .next()
         .ok_or(CliError::MissingArgument("workspace path"))?;
     let mut replace = false;
+    let mut expected_generation = None;
     let mut content_type = None;
     while let Some(argument) = arguments.next() {
         match argument.as_str() {
             "--replace" => replace = true,
+            "--expected-generation" => {
+                expected_generation = Some(parse_number(
+                    "--expected-generation",
+                    next_value(arguments, &argument)?,
+                )?);
+            }
             "--content-type" => {
                 content_type = Some(next_value(arguments, &argument)?);
             }
@@ -745,12 +757,16 @@ fn parse_collect(arguments: &mut impl Iterator<Item = String>) -> Result<Command
             _ => return Err(CliError::UnexpectedArgument(argument)),
         }
     }
+    if expected_generation.is_some() && !replace {
+        return Err(CliError::UnpinnedExpectedGeneration);
+    }
     Ok(Command::Collect {
         workbench,
         section,
         source,
         path,
         replace,
+        expected_generation,
         content_type,
     })
 }
@@ -880,8 +896,58 @@ mod tests {
                 source: PathBuf::from("/tmp/result.bin"),
                 path: "result.bin".to_owned(),
                 replace: true,
+                expected_generation: None,
                 content_type: Some("application/octet-stream".to_owned()),
             }
+        );
+    }
+
+    #[test]
+    fn collect_expected_generation_pins_the_replace_cas() {
+        let parsed = parse(args(&[
+            "--agent-id",
+            "44444444444444444444444444444444",
+            "--workbench-root",
+            "/agents/test/wb",
+            "collect",
+            "run-1",
+            "outputs",
+            "/tmp/result.bin",
+            "result.bin",
+            "--replace",
+            "--expected-generation",
+            "7",
+        ]))
+        .unwrap();
+        assert_eq!(
+            parsed.command,
+            Command::Collect {
+                workbench: "run-1".to_owned(),
+                section: "outputs".to_owned(),
+                source: PathBuf::from("/tmp/result.bin"),
+                path: "result.bin".to_owned(),
+                replace: true,
+                expected_generation: Some(7),
+                content_type: None,
+            }
+        );
+
+        let unpinned = parse(args(&[
+            "--agent-id",
+            "44444444444444444444444444444444",
+            "--workbench-root",
+            "/agents/test/wb",
+            "collect",
+            "run-1",
+            "outputs",
+            "/tmp/result.bin",
+            "result.bin",
+            "--expected-generation",
+            "7",
+        ]));
+        assert!(
+            unpinned.is_err(),
+            "expected-generation without --replace must fail"
         );
     }
 

--- a/crates/nokv/src/main.rs
+++ b/crates/nokv/src/main.rs
@@ -121,6 +121,7 @@ fn run() -> Result<(), String> {
             source,
             path,
             replace,
+            expected_generation,
             content_type,
         } => {
             let handler = build_handler(&invocation)?;
@@ -132,6 +133,7 @@ fn run() -> Result<(), String> {
                 source,
                 path,
                 *replace,
+                *expected_generation,
                 content_type.as_deref(),
             )
         }
@@ -477,6 +479,7 @@ fn collect(
     source: &Path,
     path: &str,
     replace: bool,
+    expected_generation: Option<u64>,
     content_type: Option<&str>,
 ) -> Result<(), String> {
     let bytes = transfer::read_collect_source(source, max_bytes)?;
@@ -487,6 +490,9 @@ fn collect(
         "base64": STANDARD.encode(bytes),
         "replace": replace,
     });
+    if let Some(expected_generation) = expected_generation {
+        arguments["expected_generation"] = Value::from(expected_generation);
+    }
     if let Some(content_type) = content_type {
         arguments["content_type"] = Value::String(content_type.to_owned());
     }
@@ -574,7 +580,7 @@ USAGE:
   nokv [connection/object options] workbench <tool> '<json arguments>'
   nokv [connection/object options] mcp [--profile workbench|agent]
   nokv [connection/object options] materialize <workbench> <section> <path> <destination>
-  nokv [connection/object options] collect <workbench> <section> <source> <path> [--replace] [--content-type TYPE]
+  nokv [connection/object options] collect <workbench> <section> <source> <path> [--replace] [--expected-generation N] [--content-type TYPE]
   nokv [route/agent options] workspace-path rename <workbench> <section> <source> <destination> --expected-generation N --request-id HEX32
   nokv [route/agent options] workspace-path remove <workbench> <section> <path> --expected-generation N --request-id HEX32
   nokv --root-id HEX32 --agent-id HEX32 --etcd-endpoint URL provision <logical-shard-id-hex32> [adoption options]


### PR DESCRIPTION
## Gap

The SDK publish surface takes a caller-supplied \`expected_generation\` CAS, but the workbench \`put_file\` tool only offered \`replace=true\`, which stats the **current** generation and replaces against it. That protects the window inside one call and nothing else. Reproduced live against a real stack: caller reads generation 1, a competitor CAS-advances to 2, the stale caller runs \`replace=true\` - rc 0, generation 3, competitor's write destroyed. The frozen tool schema rejected the field outright, while \`workspace-path rename/remove\` already take \`--expected-generation\`: the platform had the concept everywhere except the one publish verb coordination cares about. (#486 adds CLI qualification tooling but does not close this; the two do not conflict.)

## Fix

\`workbench_put_file\` accepts optional \`expected_generation\` (integer >= 1):

- \`replace=true\` + pin -> \`PublishCondition::ReplaceOnly\` built from the **caller's** observation; a stale pin surfaces as the typed \`Conflict\` with \`details.current_generation\`.
- \`replace=true\` alone -> legacy self-stat semantics byte-for-byte.
- pin without \`replace\`, or a zero pin -> typed \`InvalidArguments\` (the never-upsert contract holds). The schema enforces \`minimum: 1\` on every routed surface; the facade re-checks for direct handler callers, pinned by a schema-bypassing test.
- \`collect\` gains \`--expected-generation\` (requires \`--replace\`, dedicated error sentence).

Designs considered: caller-supplied pin (chosen, matches the SDK and the workspace-path precedent); CLI-side read-retry loop (still races, rejected); forbidding CLI replace (breaks legitimate uses, rejected).

## Verification

Workspace clippy clean with -D warnings; 213 nokv/nokv-agent tests pass including the new conditional-CAS matrix (matching pin succeeds, stale pin conflicts with the competitor's bytes preserved, invalid shapes fail closed, schema-bypass zero pin re-checked). Live on a real stack: the exact lost-update sequence now conflicts, a refreshed pin applies at generation 3, and unpinned replace behaves unchanged.