### PR TITLE
fix(server): keep owner lease alive during bootstrap

### DIFF
--- a/bench/src/bin/nokv-restore-crash-owner.rs
+++ b/bench/src/bin/nokv-restore-crash-owner.rs
@@ -844,17 +844,17 @@ fn run_server(config: ServeConfig) -> Result<(), String> {
         .install(target_route, executor)
         .map_err(|error| error.to_string())?;
 
-    let renew_seconds = u64::try_from(config.lease_ttl_seconds)
-        .map_err(|_| "etcd lease TTL must be positive".to_owned())?
-        .saturating_div(3)
-        .max(1);
+    let lease_renew_interval = owner.owner_lease_renew_interval().ok_or_else(|| {
+        "etcd-backed benchmark server requires an expiring owner-lease renewal policy".to_owned()
+    })?;
+
     let server = WorkspaceServer::new(
         ServerOptions {
             bind: config.bind,
             handshake_timeout: Duration::from_millis(config.handshake_timeout_millis),
             read_timeout: Duration::from_secs(30),
             write_timeout: Duration::from_secs(30),
-            lease_renew_interval: Duration::from_secs(renew_seconds),
+            lease_renew_interval,
             max_inflight_connections: config.max_inflight_connections,
         },
         registry,

--- a/crates/nokv-control/src/etcd.rs
+++ b/crates/nokv-control/src/etcd.rs
@@ -82,7 +82,11 @@ impl EtcdControlStore {
 
 impl ControlStore for EtcdControlStore {
     fn owner_lease_renew_interval(&self) -> Option<std::time::Duration> {
-        self.options.owner_lease_renew_interval()
+        Some(
+            self.options
+                .owner_lease_renew_interval()
+                .expect("validated etcd lease TTL must produce a renewal interval"),
+        )
     }
 
     fn create_root_agent_binding(

--- a/crates/nokv-control/src/etcd.rs
+++ b/crates/nokv-control/src/etcd.rs
@@ -81,6 +81,10 @@ impl EtcdControlStore {
 }
 
 impl ControlStore for EtcdControlStore {
+    fn owner_lease_renew_interval(&self) -> Option<std::time::Duration> {
+        self.options.owner_lease_renew_interval()
+    }
+
     fn create_root_agent_binding(
         &self,
         binding: RootAgentBinding,

--- a/crates/nokv-control/src/options.rs
+++ b/crates/nokv-control/src/options.rs
@@ -45,6 +45,16 @@ impl EtcdControlStoreOptions {
     pub fn lease_ttl_seconds(&self) -> i64 {
         self.lease_ttl_seconds
     }
+    #[cfg(any(feature = "etcd", test))]
+    pub(crate) fn owner_lease_renew_interval(&self) -> Option<std::time::Duration> {
+        let ttl_seconds = u64::try_from(self.lease_ttl_seconds).ok()?;
+        if ttl_seconds == 0 {
+            return None;
+        }
+        Some(std::time::Duration::from_secs(
+            ttl_seconds.saturating_div(3).max(1),
+        ))
+    }
 
     pub fn validate(&self) -> Result<(), ControlError> {
         if self.endpoints.is_empty() {
@@ -226,6 +236,30 @@ mod tests {
         assert_eq!(
             String::from_utf8(options.logical_shard_session_key(&shard_id(0x02))).unwrap(),
             "/nokv/test/sessions/02020202020202020202020202020202"
+        );
+    }
+
+    #[test]
+    fn owner_lease_renew_interval_tracks_ttl_third_with_floor() {
+        let endpoint = ["http://127.0.0.1:2379"];
+
+        assert_eq!(
+            EtcdControlStoreOptions::new(endpoint)
+                .with_lease_ttl_seconds(1)
+                .owner_lease_renew_interval(),
+            Some(std::time::Duration::from_secs(1))
+        );
+        assert_eq!(
+            EtcdControlStoreOptions::new(endpoint)
+                .with_lease_ttl_seconds(10)
+                .owner_lease_renew_interval(),
+            Some(std::time::Duration::from_secs(3))
+        );
+        assert_eq!(
+            EtcdControlStoreOptions::new(endpoint)
+                .with_lease_ttl_seconds(60)
+                .owner_lease_renew_interval(),
+            Some(std::time::Duration::from_secs(20))
         );
     }
 }

--- a/crates/nokv-control/src/store.rs
+++ b/crates/nokv-control/src/store.rs
@@ -29,12 +29,11 @@ pub const MAX_RECOVERY_LOG_SEGMENTS: usize = 4_096;
 /// Durable control-plane operations, split between immutable root placement
 /// and physical logical-shard ownership.
 pub trait ControlStore: Send + Sync {
-    /// Recommended cadence for keeping an acquired owner session alive.
+    /// Required renewal policy for acquired owner sessions.
     ///
-    /// Stores without expiring owner sessions return `None`.
-    fn owner_lease_renew_interval(&self) -> Option<std::time::Duration> {
-        None
-    }
+    /// Expiring stores must return `Some` with a non-zero cadence. Stores whose
+    /// owner sessions do not expire must explicitly return `None`.
+    fn owner_lease_renew_interval(&self) -> Option<std::time::Duration>;
 
     /// Create the immutable Agent authority for a root. An exact replay is
     /// idempotent; the root can never be rebound to another Agent.
@@ -176,6 +175,10 @@ impl InMemoryControlStore {
 }
 
 impl ControlStore for InMemoryControlStore {
+    fn owner_lease_renew_interval(&self) -> Option<std::time::Duration> {
+        None
+    }
+
     fn create_root_agent_binding(
         &self,
         binding: RootAgentBinding,

--- a/crates/nokv-control/src/store.rs
+++ b/crates/nokv-control/src/store.rs
@@ -29,6 +29,13 @@ pub const MAX_RECOVERY_LOG_SEGMENTS: usize = 4_096;
 /// Durable control-plane operations, split between immutable root placement
 /// and physical logical-shard ownership.
 pub trait ControlStore: Send + Sync {
+    /// Recommended cadence for keeping an acquired owner session alive.
+    ///
+    /// Stores without expiring owner sessions return `None`.
+    fn owner_lease_renew_interval(&self) -> Option<std::time::Duration> {
+        None
+    }
+
     /// Create the immutable Agent authority for a root. An exact replay is
     /// idempotent; the root can never be rebound to another Agent.
     fn create_root_agent_binding(

--- a/crates/nokv-server/src/bootstrap.rs
+++ b/crates/nokv-server/src/bootstrap.rs
@@ -87,13 +87,14 @@ pub struct ShardBoot {
 
 struct BootstrapLeaseKeepalive {
     stop: Arc<std::sync::atomic::AtomicBool>,
-    failure: Arc<std::sync::Mutex<Option<String>>>,
+    failure: Arc<std::sync::Mutex<Option<nokv_control::ControlError>>>,
     worker: std::sync::Mutex<Option<std::thread::JoinHandle<()>>>,
 }
 
 impl BootstrapLeaseKeepalive {
     fn start(
         control: Arc<dyn ControlStore>,
+        registry: Arc<RootOwnerRegistry>,
         lease: LogicalShardLease,
         interval: Option<std::time::Duration>,
     ) -> Result<Self, ServerError> {
@@ -124,8 +125,15 @@ impl BootstrapLeaseKeepalive {
 
                             if let Err(error) = control.renew_owner(&lease) {
                                 if let Ok(mut failure) = worker_failure.lock() {
-                                    *failure = Some(error.to_string());
+                                    *failure = Some(error.clone());
                                 }
+
+                                // Make terminal lease loss visible to every
+                                // owner-scoped RPC and lifecycle worker.
+                                let _ = registry.fail_closed_shard(LogicalShardIdentity::from(
+                                    lease.logical_shard_id,
+                                ));
+
                                 break;
                             }
                         })
@@ -150,9 +158,7 @@ impl BootstrapLeaseKeepalive {
 
         match failure.as_ref() {
             None => Ok(()),
-            Some(error) => Err(ServerError::InvalidBootstrap(format!(
-                "bootstrap owner lease keepalive failed: {error}"
-            ))),
+            Some(error) => Err(ServerError::Control(error.clone())),
         }
     }
 
@@ -187,6 +193,32 @@ impl Drop for BootstrapLeaseKeepalive {
     }
 }
 
+#[cfg(test)]
+std::thread_local! {
+    static AFTER_OWNER_ADMISSION_TEST_HOOK:
+        std::cell::RefCell<Option<Box<dyn FnOnce()>>> =
+        const { std::cell::RefCell::new(None) };
+}
+
+#[cfg(test)]
+fn install_after_owner_admission_test_hook(hook: impl FnOnce() + 'static) {
+    AFTER_OWNER_ADMISSION_TEST_HOOK.with(|slot| {
+        assert!(
+            slot.borrow_mut().replace(Box::new(hook)).is_none(),
+            "after-owner-admission test hook is already installed"
+        );
+    });
+}
+
+#[cfg(test)]
+fn run_after_owner_admission_test_hook() {
+    let hook = AFTER_OWNER_ADMISSION_TEST_HOOK.with(|slot| slot.borrow_mut().take());
+
+    if let Some(hook) = hook {
+        hook();
+    }
+}
+
 /// One control-backed logical-shard owner retained by the serving runtime.
 ///
 /// A failed renewal removes every exact local route before exposing the lease
@@ -199,6 +231,7 @@ pub struct ShardOwner {
     meta: Arc<meta::MetaShard>,
     recovery: Arc<RecoveryPublisher>,
     routes: Vec<RootRoute>,
+    owner_lease_renew_interval: Option<std::time::Duration>,
     bootstrap_keepalive: BootstrapLeaseKeepalive,
 }
 
@@ -225,6 +258,11 @@ impl ShardOwner {
 
     pub fn recovery_publisher(&self) -> &Arc<RecoveryPublisher> {
         &self.recovery
+    }
+
+    /// Exact control-store policy used during bootstrap and steady state.
+    pub fn owner_lease_renew_interval(&self) -> Option<std::time::Duration> {
+        self.owner_lease_renew_interval
     }
 
     pub(crate) fn is_for_registry(&self, registry: &Arc<RootOwnerRegistry>) -> bool {
@@ -387,10 +425,13 @@ pub fn bootstrap_shard(
         (Err(error), _) => return Err(error),
     };
 
+    let owner_lease_renew_interval = control.owner_lease_renew_interval();
+
     let bootstrap_keepalive = match BootstrapLeaseKeepalive::start(
         Arc::clone(&control),
+        Arc::clone(&registry),
         lease.clone(),
-        control.owner_lease_renew_interval(),
+        owner_lease_renew_interval,
     ) {
         Ok(keepalive) => keepalive,
         Err(error) => {
@@ -404,6 +445,9 @@ pub fn bootstrap_shard(
             ));
         }
     };
+
+    #[cfg(test)]
+    run_after_owner_admission_test_hook();
 
     let mut routes = Vec::with_capacity(placements.len());
 
@@ -606,6 +650,7 @@ pub fn bootstrap_shard(
         meta,
         recovery,
         routes,
+        owner_lease_renew_interval,
         bootstrap_keepalive,
     })
 }
@@ -1461,6 +1506,7 @@ mod tests {
         last_renewal: Mutex<Option<Instant>>,
         delay_active: AtomicBool,
         renewals_during_delay: AtomicUsize,
+        fail_renewals: AtomicBool,
     }
 
     impl BootstrapLeaseProbe {
@@ -1472,6 +1518,7 @@ mod tests {
                 last_renewal: Mutex::new(None),
                 delay_active: AtomicBool::new(false),
                 renewals_during_delay: AtomicUsize::new(0),
+                fail_renewals: AtomicBool::new(false),
             }
         }
 
@@ -1482,7 +1529,11 @@ mod tests {
                 .expect("test lease clock lock must remain available") = Some(Instant::now());
         }
 
-        fn note_renewal(&self) -> Result<(), ControlError> {
+        fn note_renewal(&self, lease: &LogicalShardLease) -> Result<(), ControlError> {
+            if self.fail_renewals.load(Ordering::SeqCst) {
+                return Err(ControlError::StaleLease(lease.clone()));
+            }
+
             let now = Instant::now();
             let mut last = self
                 .last_renewal
@@ -1511,6 +1562,20 @@ mod tests {
             std::thread::sleep(self.post_acquisition_delay);
             self.delay_active.store(false, Ordering::SeqCst);
             self.require_fresh()
+        }
+
+        fn delay_longer_than_ttl(&self) -> Result<(), ControlError> {
+            self.renewals_during_delay.store(0, Ordering::SeqCst);
+            self.delay_active.store(true, Ordering::SeqCst);
+
+            std::thread::sleep(self.ttl + Duration::from_millis(250));
+
+            self.delay_active.store(false, Ordering::SeqCst);
+            self.require_fresh()
+        }
+
+        fn arm_terminal_failure(&self) {
+            self.fail_renewals.store(true, Ordering::SeqCst);
         }
 
         fn require_fresh(&self) -> Result<(), ControlError> {
@@ -1612,6 +1677,7 @@ mod tests {
             self.bootstrap_lease_probe
                 .as_ref()
                 .map(|probe| probe.renew_interval)
+                .or_else(|| self.inner.owner_lease_renew_interval())
         }
 
         fn create_root_agent_binding(
@@ -1750,7 +1816,7 @@ mod tests {
             lease: &LogicalShardLease,
         ) -> Result<LogicalShardRecord, ControlError> {
             if let Some(probe) = &self.bootstrap_lease_probe {
-                probe.note_renewal()?;
+                probe.note_renewal(lease)?;
             }
             self.inner.renew_owner(lease)
         }
@@ -4105,6 +4171,208 @@ mod tests {
         for route in routes {
             assert!(!registry.contains_exact(route).unwrap());
         }
+    }
+
+    struct SuccessorProbeFixture {
+        _temporary: TempDir,
+        control: Arc<InMemoryControlStore>,
+        registry: Arc<RootOwnerRegistry>,
+        delayed_control: Arc<dyn ControlStore>,
+        boot: ShardBoot,
+        first_epoch: OwnerEpoch,
+    }
+
+    fn successor_probe_fixture(probe: Arc<BootstrapLeaseProbe>) -> SuccessorProbeFixture {
+        let temporary = TempDir::new().unwrap();
+        let database = temporary.path().join("metadata");
+        let root_id = root(1);
+        let control = active_control(&[root_id]);
+
+        let first = bootstrap_shard(
+            as_control(&control),
+            Arc::new(RootOwnerRegistry::new()),
+            acquire_boot(database.clone(), &[root_id]),
+        )
+        .unwrap();
+
+        let first_epoch = first.lease().owner_epoch;
+        first.release().unwrap();
+
+        let delayed_control: Arc<dyn ControlStore> = Arc::new(
+            LoseFinalizeAckControlStore::with_bootstrap_lease_probe(Arc::clone(&control), probe),
+        );
+
+        let registry = Arc::new(RootOwnerRegistry::new());
+
+        let boot = ShardBoot {
+            recovery_publication: RecoveryPublicationMode::Shared,
+            shard_id: shard(),
+            open: OpenMode::Existing(database),
+            lease: LeaseMode::Acquire {
+                owner: NodeId::new("node-b").unwrap(),
+                endpoint: "127.0.0.1:9020".to_owned(),
+                previous_epoch: Some(first_epoch),
+            },
+            recovery: current_recovery(&control),
+            roots: vec![root_attach(root_id, 61)],
+        };
+
+        SuccessorProbeFixture {
+            _temporary: temporary,
+            control,
+            registry,
+            delayed_control,
+            boot,
+            first_epoch,
+        }
+    }
+
+    fn assert_exact_successor(
+        control: &InMemoryControlStore,
+        owner: &ShardOwner,
+        first_epoch: OwnerEpoch,
+    ) {
+        assert_eq!(owner.lease().owner_epoch.get(), first_epoch.get() + 1);
+
+        let record = control.get_logical_shard(&shard()).unwrap().unwrap();
+
+        assert_eq!(record.state, LogicalShardState::Serving);
+        assert_eq!(record.owner_epoch, Some(owner.lease().owner_epoch));
+        assert_eq!(record.lease_id, owner.lease().lease_id);
+    }
+
+    #[test]
+    fn successor_bootstrap_renews_between_admission_and_open_reconciliation() {
+        let probe = Arc::new(BootstrapLeaseProbe::new(
+            Duration::from_secs(1),
+            Duration::ZERO,
+            Duration::from_millis(50),
+        ));
+
+        let SuccessorProbeFixture {
+            _temporary,
+            control,
+            registry,
+            delayed_control,
+            boot,
+            first_epoch,
+        } = successor_probe_fixture(Arc::clone(&probe));
+
+        let hook_probe = Arc::clone(&probe);
+
+        install_after_owner_admission_test_hook(move || {
+            hook_probe.delay_longer_than_ttl().unwrap();
+        });
+
+        let successor = bootstrap_shard(delayed_control, Arc::clone(&registry), boot).unwrap();
+
+        assert!(
+            probe.renewals_during_delay.load(Ordering::SeqCst) > 0,
+            "the exact lease was not renewed between admission and open/reconciliation"
+        );
+
+        assert_eq!(
+            successor.owner_lease_renew_interval(),
+            Some(probe.renew_interval)
+        );
+
+        assert_exact_successor(control.as_ref(), &successor, first_epoch);
+
+        let lease = successor.lease().clone();
+        let handoff = successor.renew_or_uninstall().unwrap();
+
+        assert_eq!(handoff.owner_epoch, Some(lease.owner_epoch));
+        assert_eq!(handoff.lease_id, lease.lease_id);
+
+        successor.release().unwrap();
+    }
+
+    #[test]
+    fn successor_owner_renews_after_bootstrap_before_first_steady_state_renewal() {
+        let probe = Arc::new(BootstrapLeaseProbe::new(
+            Duration::from_secs(1),
+            Duration::ZERO,
+            Duration::from_millis(50),
+        ));
+
+        let SuccessorProbeFixture {
+            _temporary,
+            control,
+            registry,
+            delayed_control,
+            boot,
+            first_epoch,
+        } = successor_probe_fixture(Arc::clone(&probe));
+
+        let successor = bootstrap_shard(delayed_control, Arc::clone(&registry), boot).unwrap();
+
+        let lease = successor.lease().clone();
+
+        // Simulate CLI and lifecycle setup before WorkspaceServer performs
+        // its first steady-state renew_or_uninstall handoff.
+        probe.delay_longer_than_ttl().unwrap();
+
+        assert!(
+            probe.renewals_during_delay.load(Ordering::SeqCst) > 0,
+            "the exact lease was not renewed after bootstrap returned"
+        );
+
+        assert_exact_successor(control.as_ref(), &successor, first_epoch);
+
+        let handoff = successor.renew_or_uninstall().unwrap();
+
+        assert_eq!(handoff.owner_epoch, Some(lease.owner_epoch));
+        assert_eq!(handoff.lease_id, lease.lease_id);
+
+        successor.release().unwrap();
+    }
+
+    #[test]
+    fn terminal_bootstrap_renewal_failure_fail_closes_owner_scope_and_stays_typed() {
+        let probe = Arc::new(BootstrapLeaseProbe::new(
+            Duration::from_secs(5),
+            Duration::ZERO,
+            Duration::from_millis(25),
+        ));
+
+        let SuccessorProbeFixture {
+            _temporary,
+            control,
+            registry,
+            delayed_control,
+            boot,
+            first_epoch: _,
+        } = successor_probe_fixture(Arc::clone(&probe));
+
+        let successor = bootstrap_shard(delayed_control, Arc::clone(&registry), boot).unwrap();
+
+        let lease = successor.lease().clone();
+        let route = successor.routes()[0];
+        let owner_loss = registry.owner_loss_signal();
+
+        probe.arm_terminal_failure();
+
+        let deadline = Instant::now() + Duration::from_secs(2);
+
+        while !owner_loss.is_lost() || registry.contains_exact(route).unwrap() {
+            assert!(
+                Instant::now() < deadline,
+                "terminal keepalive failure did not reach the shared owner-loss/route boundary"
+            );
+
+            std::thread::sleep(Duration::from_millis(10));
+        }
+
+        match successor.renew_or_uninstall().unwrap_err() {
+            ServerError::Control(ControlError::StaleLease(stale)) => {
+                assert_eq!(stale, lease);
+            }
+            other => panic!("typed stale-lease failure was not preserved: {other:?}"),
+        }
+
+        // The probe returns StaleLease before calling the in-memory backend,
+        // so the test removes the retained backend session explicitly.
+        control.release_owner(&lease).unwrap();
     }
 
     #[test]

--- a/crates/nokv-server/src/bootstrap.rs
+++ b/crates/nokv-server/src/bootstrap.rs
@@ -130,9 +130,10 @@ impl BootstrapLeaseKeepalive {
 
                                 // Make terminal lease loss visible to every
                                 // owner-scoped RPC and lifecycle worker.
-                                let _ = registry.fail_closed_shard(LogicalShardIdentity::from(
-                                    lease.logical_shard_id,
-                                ));
+                                let _ = registry.fail_closed_shard_with_control(
+                                    LogicalShardIdentity::from(lease.logical_shard_id),
+                                    error.clone(),
+                                );
 
                                 break;
                             }
@@ -280,17 +281,32 @@ impl ShardOwner {
         match renewal {
             Ok(record) => Ok(record),
             Err(primary) => {
-                let cleanup = self
-                    .registry
-                    .fail_closed_shard(LogicalShardIdentity::from(self.shard_id()))
-                    .err();
+                let typed_control = matches!(&primary, ServerError::Control(_));
 
-                match cleanup {
-                    None => Err(primary),
-                    Some(cleanup) => Err(ServerError::BootstrapRollback {
+                let cleanup = match &primary {
+                    ServerError::Control(control) => self
+                        .registry
+                        .fail_closed_shard_with_control(
+                            LogicalShardIdentity::from(self.shard_id()),
+                            control.clone(),
+                        )
+                        .err(),
+                    _ => self
+                        .registry
+                        .fail_closed_shard(LogicalShardIdentity::from(self.shard_id()))
+                        .err(),
+                };
+
+                if cleanup.is_none() || typed_control {
+                    Err(primary)
+                } else {
+                    Err(ServerError::BootstrapRollback {
                         primary: primary.to_string(),
-                        rollback: format!("fail-close lease-lost logical shard: {cleanup}"),
-                    }),
+                        rollback: format!(
+                            "fail-close lease-lost logical shard: {}",
+                            cleanup.expect("checked as present"),
+                        ),
+                    })
                 }
             }
         }
@@ -1272,6 +1288,8 @@ fn rollback_bootstrap_with_keepalive(
 ) -> ServerError {
     let primary = match keepalive.stop() {
         Ok(()) => primary,
+        Err(ServerError::Control(control)) => ServerError::Control(control),
+        Err(_) if matches!(&primary, ServerError::Control(_)) => primary,
         Err(error) => ServerError::BootstrapRollback {
             primary: primary.to_string(),
             rollback: format!("stop bootstrap owner keepalive: {error}"),
@@ -1297,12 +1315,16 @@ fn rollback_bootstrap(
     release_acquired_lease: bool,
 ) -> ServerError {
     let mut rollback = uninstall_routes(registry, routes, "bootstrap rollback");
+
     if release_acquired_lease {
         if let Err(error) = control.suspend_recovery(lease) {
             rollback.push(format!("suspend logical-shard recovery: {error}"));
         }
     }
-    if rollback.is_empty() {
+
+    // A typed control-plane failure is the authoritative state-machine
+    // outcome. Cleanup diagnostics must not replace it with prose.
+    if rollback.is_empty() || matches!(&primary, ServerError::Control(_)) {
         primary
     } else {
         ServerError::BootstrapRollback {
@@ -4285,6 +4307,170 @@ mod tests {
         assert_eq!(handoff.lease_id, lease.lease_id);
 
         successor.release().unwrap();
+    }
+
+    #[test]
+    fn terminal_keepalive_failure_before_bootstrap_return_preserves_control_error() {
+        let probe = Arc::new(BootstrapLeaseProbe::new(
+            Duration::from_secs(5),
+            Duration::ZERO,
+            Duration::from_millis(25),
+        ));
+
+        let SuccessorProbeFixture {
+            _temporary,
+            control: _,
+            registry,
+            delayed_control,
+            boot,
+            first_epoch,
+        } = successor_probe_fixture(Arc::clone(&probe));
+
+        let owner_loss = registry.owner_loss_signal();
+        let hook_probe = Arc::clone(&probe);
+        let hook_owner_loss = owner_loss.clone();
+        let expected_epoch = first_epoch.get() + 1;
+
+        install_after_owner_admission_test_hook(move || {
+            hook_probe.arm_terminal_failure();
+
+            let deadline = Instant::now() + Duration::from_secs(2);
+
+            while !hook_owner_loss.is_lost() {
+                assert!(
+                    Instant::now() < deadline,
+                    "terminal renewal failure was not published before bootstrap continued"
+                );
+
+                std::thread::sleep(Duration::from_millis(10));
+            }
+
+            match hook_owner_loss.control_error() {
+                Some(ControlError::StaleLease(stale)) => {
+                    assert_eq!(stale.logical_shard_id, shard(),);
+                    assert_eq!(stale.owner_epoch.get(), expected_epoch,);
+                }
+                other => panic!("shared owner-loss state lost the typed cause: {other:?}"),
+            }
+        });
+
+        let error = match bootstrap_shard(delayed_control, Arc::clone(&registry), boot) {
+            Ok(owner) => {
+                let _ = owner.release();
+                panic!("bootstrap unexpectedly succeeded after terminal renewal failure");
+            }
+            Err(error) => error,
+        };
+
+        match error {
+            ServerError::Control(ControlError::StaleLease(stale)) => {
+                assert_eq!(stale.logical_shard_id, shard());
+                assert_eq!(stale.owner_epoch.get(), expected_epoch,);
+            }
+            other => panic!("pre-return terminal cause was not preserved: {other:?}"),
+        }
+
+        assert!(owner_loss.is_lost());
+    }
+
+    #[test]
+    fn workspace_server_constructor_preserves_terminal_keepalive_control_error() {
+        let probe = Arc::new(BootstrapLeaseProbe::new(
+            Duration::from_secs(5),
+            Duration::ZERO,
+            Duration::from_millis(25),
+        ));
+
+        let SuccessorProbeFixture {
+            _temporary,
+            control: _,
+            registry,
+            delayed_control,
+            boot,
+            first_epoch: _,
+        } = successor_probe_fixture(Arc::clone(&probe));
+
+        let owner = bootstrap_shard(delayed_control, Arc::clone(&registry), boot).unwrap();
+
+        let expected_lease = owner.lease().clone();
+        let owner_loss = registry.owner_loss_signal();
+
+        probe.arm_terminal_failure();
+
+        let deadline = Instant::now() + Duration::from_secs(2);
+
+        while !owner_loss.is_lost() {
+            assert!(
+                Instant::now() < deadline,
+                "terminal renewal failure did not reach the server owner scope"
+            );
+
+            std::thread::sleep(Duration::from_millis(10));
+        }
+
+        let mut server_options = options();
+        server_options.lease_renew_interval = probe.renew_interval;
+
+        let error = match WorkspaceServer::new(server_options, Arc::clone(&registry), vec![owner]) {
+            Ok(server) => {
+                let _ = server.release_ownership();
+                panic!("server construction unexpectedly accepted a lost owner");
+            }
+            Err(error) => error,
+        };
+
+        match error {
+            ServerError::Control(ControlError::StaleLease(stale)) => {
+                assert_eq!(stale, expected_lease);
+            }
+            other => panic!("actual server path lost the typed terminal cause: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn workspace_server_rejects_owner_renewal_policy_drift() {
+        let probe = Arc::new(BootstrapLeaseProbe::new(
+            Duration::from_secs(5),
+            Duration::ZERO,
+            Duration::from_millis(50),
+        ));
+
+        let SuccessorProbeFixture {
+            _temporary,
+            control: _,
+            registry,
+            delayed_control,
+            boot,
+            first_epoch: _,
+        } = successor_probe_fixture(Arc::clone(&probe));
+
+        let owner = bootstrap_shard(delayed_control, Arc::clone(&registry), boot).unwrap();
+
+        assert_eq!(
+            owner.owner_lease_renew_interval(),
+            Some(Duration::from_millis(50)),
+        );
+
+        let mut server_options = options();
+        server_options.lease_renew_interval = Duration::from_secs(5);
+
+        let error = match WorkspaceServer::new(server_options, Arc::clone(&registry), vec![owner]) {
+            Ok(server) => {
+                let _ = server.release_ownership();
+                panic!("WorkspaceServer accepted a cadence that differs from its owner policy");
+            }
+            Err(error) => error,
+        };
+
+        match error {
+            ServerError::InvalidOptions(detail) => {
+                assert!(
+                    detail.contains("requires lease renewal interval",),
+                    "unexpected validation detail: {detail}",
+                );
+            }
+            other => panic!("policy drift returned the wrong error: {other:?}"),
+        }
     }
 
     #[test]

--- a/crates/nokv-server/src/bootstrap.rs
+++ b/crates/nokv-server/src/bootstrap.rs
@@ -85,6 +85,108 @@ pub struct ShardBoot {
     pub roots: Vec<RootAttach>,
 }
 
+struct BootstrapLeaseKeepalive {
+    stop: Arc<std::sync::atomic::AtomicBool>,
+    failure: Arc<std::sync::Mutex<Option<String>>>,
+    worker: std::sync::Mutex<Option<std::thread::JoinHandle<()>>>,
+}
+
+impl BootstrapLeaseKeepalive {
+    fn start(
+        control: Arc<dyn ControlStore>,
+        lease: LogicalShardLease,
+        interval: Option<std::time::Duration>,
+    ) -> Result<Self, ServerError> {
+        let stop = Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let failure = Arc::new(std::sync::Mutex::new(None));
+
+        let worker = match interval {
+            None => None,
+            Some(interval) => {
+                if interval.is_zero() {
+                    return Err(ServerError::InvalidBootstrap(
+                        "owner lease renewal interval must be non-zero".to_owned(),
+                    ));
+                }
+
+                let worker_stop = Arc::clone(&stop);
+                let worker_failure = Arc::clone(&failure);
+
+                Some(
+                    std::thread::Builder::new()
+                        .name("nokv-bootstrap-owner-keepalive".to_owned())
+                        .spawn(move || loop {
+                            std::thread::park_timeout(interval);
+
+                            if worker_stop.load(std::sync::atomic::Ordering::Acquire) {
+                                break;
+                            }
+
+                            if let Err(error) = control.renew_owner(&lease) {
+                                if let Ok(mut failure) = worker_failure.lock() {
+                                    *failure = Some(error.to_string());
+                                }
+                                break;
+                            }
+                        })
+                        .map_err(ServerError::Connection)?,
+                )
+            }
+        };
+
+        Ok(Self {
+            stop,
+            failure,
+            worker: std::sync::Mutex::new(worker),
+        })
+    }
+
+    fn ensure_healthy(&self) -> Result<(), ServerError> {
+        let failure = self.failure.lock().map_err(|_| {
+            ServerError::InvalidBootstrap(
+                "bootstrap owner keepalive failure lock was poisoned".to_owned(),
+            )
+        })?;
+
+        match failure.as_ref() {
+            None => Ok(()),
+            Some(error) => Err(ServerError::InvalidBootstrap(format!(
+                "bootstrap owner lease keepalive failed: {error}"
+            ))),
+        }
+    }
+
+    fn stop(&self) -> Result<(), ServerError> {
+        self.stop.store(true, std::sync::atomic::Ordering::Release);
+
+        let worker = {
+            let mut worker = self.worker.lock().map_err(|_| {
+                ServerError::InvalidBootstrap(
+                    "bootstrap owner keepalive worker lock was poisoned".to_owned(),
+                )
+            })?;
+            worker.take()
+        };
+
+        if let Some(worker) = worker {
+            worker.thread().unpark();
+            worker.join().map_err(|_| {
+                ServerError::InvalidBootstrap(
+                    "bootstrap owner keepalive worker panicked".to_owned(),
+                )
+            })?;
+        }
+
+        self.ensure_healthy()
+    }
+}
+
+impl Drop for BootstrapLeaseKeepalive {
+    fn drop(&mut self) {
+        let _ = self.stop();
+    }
+}
+
 /// One control-backed logical-shard owner retained by the serving runtime.
 ///
 /// A failed renewal removes every exact local route before exposing the lease
@@ -97,6 +199,7 @@ pub struct ShardOwner {
     meta: Arc<meta::MetaShard>,
     recovery: Arc<RecoveryPublisher>,
     routes: Vec<RootRoute>,
+    bootstrap_keepalive: BootstrapLeaseKeepalive,
 }
 
 impl ShardOwner {
@@ -130,19 +233,25 @@ impl ShardOwner {
 
     /// Renew the shard lease. Lease loss removes every route before returning.
     pub fn renew_or_uninstall(&self) -> Result<LogicalShardRecord, ServerError> {
-        match self.control.renew_owner(&self.lease) {
+        let renewal = self.bootstrap_keepalive.stop().and_then(|()| {
+            self.control
+                .renew_owner(&self.lease)
+                .map_err(ServerError::Control)
+        });
+
+        match renewal {
             Ok(record) => Ok(record),
-            Err(error) => {
-                let primary = ServerError::Control(error);
+            Err(primary) => {
                 let cleanup = self
                     .registry
                     .fail_closed_shard(LogicalShardIdentity::from(self.shard_id()))
                     .err();
+
                 match cleanup {
                     None => Err(primary),
                     Some(cleanup) => Err(ServerError::BootstrapRollback {
                         primary: primary.to_string(),
-                        rollback: format!("fail-close lease-lost logical shard: {}", cleanup),
+                        rollback: format!("fail-close lease-lost logical shard: {cleanup}"),
                     }),
                 }
             }
@@ -155,26 +264,52 @@ impl ShardOwner {
             .registry
             .fail_closed_shard(LogicalShardIdentity::from(self.shard_id()))
             .err();
+
         let publication = self.recovery.publish_current().map_err(ServerError::from);
+
         if let Err(publication) = publication {
-            return match cleanup {
-                None => Err(publication),
-                Some(cleanup) => Err(ServerError::BootstrapRollback {
+            let mut rollback = Vec::new();
+
+            if let Some(cleanup) = cleanup {
+                rollback.push(cleanup.to_string());
+            }
+
+            if let Err(error) = self.bootstrap_keepalive.stop() {
+                rollback.push(format!("stop bootstrap owner keepalive: {error}"));
+            }
+
+            return if rollback.is_empty() {
+                Err(publication)
+            } else {
+                Err(ServerError::BootstrapRollback {
                     primary: publication.to_string(),
-                    rollback: cleanup.to_string(),
-                }),
+                    rollback: rollback.join("; "),
+                })
             };
         }
-        match (self.control.release_owner(&self.lease), cleanup) {
-            (Ok(record), None) => Ok(record),
-            (Ok(_), Some(cleanup)) => Err(ServerError::BootstrapRollback {
+
+        let keepalive = self.bootstrap_keepalive.stop().err();
+        let release = self.control.release_owner(&self.lease);
+        let mut rollback = Vec::new();
+
+        if let Some(cleanup) = cleanup {
+            rollback.push(cleanup.to_string());
+        }
+
+        if let Some(error) = keepalive {
+            rollback.push(format!("stop bootstrap owner keepalive: {error}"));
+        }
+
+        match release {
+            Ok(record) if rollback.is_empty() => Ok(record),
+            Ok(_) => Err(ServerError::BootstrapRollback {
                 primary: "release logical-shard owner succeeded".to_owned(),
-                rollback: cleanup.to_string(),
+                rollback: rollback.join("; "),
             }),
-            (Err(control), None) => Err(ServerError::Control(control)),
-            (Err(control), Some(cleanup)) => Err(ServerError::BootstrapRollback {
+            Err(control) if rollback.is_empty() => Err(ServerError::Control(control)),
+            Err(control) => Err(ServerError::BootstrapRollback {
                 primary: format!("release logical-shard owner: {control}"),
-                rollback: cleanup.to_string(),
+                rollback: rollback.join("; "),
             }),
         }
     }
@@ -251,6 +386,25 @@ pub fn bootstrap_shard(
         }
         (Err(error), _) => return Err(error),
     };
+
+    let bootstrap_keepalive = match BootstrapLeaseKeepalive::start(
+        Arc::clone(&control),
+        lease.clone(),
+        control.owner_lease_renew_interval(),
+    ) {
+        Ok(keepalive) => keepalive,
+        Err(error) => {
+            return Err(rollback_bootstrap(
+                error,
+                control.as_ref(),
+                &registry,
+                &[],
+                &lease,
+                acquired,
+            ));
+        }
+    };
+
     let mut routes = Vec::with_capacity(placements.len());
 
     let meta = match prepared_meta {
@@ -259,7 +413,8 @@ pub fn bootstrap_shard(
             let meta = match open_meta(boot.open.clone(), boot.shard_id) {
                 Ok(meta) => meta,
                 Err(error) => {
-                    return Err(rollback_bootstrap(
+                    return Err(rollback_bootstrap_with_keepalive(
+                        &bootstrap_keepalive,
                         error,
                         control.as_ref(),
                         &registry,
@@ -270,7 +425,8 @@ pub fn bootstrap_shard(
                 }
             };
             if let Err(error) = validate_meta_shard(&meta, boot.shard_id) {
-                return Err(rollback_bootstrap(
+                return Err(rollback_bootstrap_with_keepalive(
+                    &bootstrap_keepalive,
                     error,
                     control.as_ref(),
                     &registry,
@@ -292,7 +448,8 @@ pub fn bootstrap_shard(
     ) {
         Ok(record) => record,
         Err(error) => {
-            return Err(rollback_bootstrap(
+            return Err(rollback_bootstrap_with_keepalive(
+                &bootstrap_keepalive,
                 error,
                 control.as_ref(),
                 &registry,
@@ -303,7 +460,8 @@ pub fn bootstrap_shard(
         }
     };
     if let Err(error) = activate_shard(&meta, &lease) {
-        return Err(rollback_bootstrap(
+        return Err(rollback_bootstrap_with_keepalive(
+            &bootstrap_keepalive,
             error,
             control.as_ref(),
             &registry,
@@ -322,7 +480,8 @@ pub fn bootstrap_shard(
     ) {
         Ok(recovery) => Arc::new(recovery),
         Err(error) => {
-            return Err(rollback_bootstrap(
+            return Err(rollback_bootstrap_with_keepalive(
+                &bootstrap_keepalive,
                 ServerError::from(error),
                 control.as_ref(),
                 &registry,
@@ -333,7 +492,8 @@ pub fn bootstrap_shard(
         }
     };
     if let Err(error) = recovery.publish_current() {
-        return Err(rollback_bootstrap(
+        return Err(rollback_bootstrap_with_keepalive(
+            &bootstrap_keepalive,
             ServerError::from(error),
             control.as_ref(),
             &registry,
@@ -342,6 +502,19 @@ pub fn bootstrap_shard(
             acquired,
         ));
     }
+
+    if let Err(error) = bootstrap_keepalive.ensure_healthy() {
+        return Err(rollback_bootstrap_with_keepalive(
+            &bootstrap_keepalive,
+            error,
+            control.as_ref(),
+            &registry,
+            &routes,
+            &lease,
+            acquired,
+        ));
+    }
+
     let metadata_executor: Arc<dyn WorkspaceRequestExecutor> =
         Arc::new(MetadataWorkspaceRequestExecutor::new(Arc::clone(&meta)));
     let executor: Arc<dyn WorkspaceRequestExecutor> = Arc::new(RecoveryPublishingExecutor::new(
@@ -354,7 +527,8 @@ pub fn bootstrap_shard(
         ) {
             Ok(route) => routes.push(route),
             Err(error) => {
-                return Err(rollback_bootstrap(
+                return Err(rollback_bootstrap_with_keepalive(
+                    &bootstrap_keepalive,
                     error,
                     control.as_ref(),
                     &registry,
@@ -366,7 +540,8 @@ pub fn bootstrap_shard(
         }
     }
     if let Err(error) = control.renew_owner(&lease) {
-        return Err(rollback_bootstrap(
+        return Err(rollback_bootstrap_with_keepalive(
+            &bootstrap_keepalive,
             ServerError::Control(error),
             control.as_ref(),
             &registry,
@@ -378,7 +553,8 @@ pub fn bootstrap_shard(
     let published = match recovery.publish_current() {
         Ok(record) => record,
         Err(error) => {
-            return Err(rollback_bootstrap(
+            return Err(rollback_bootstrap_with_keepalive(
+                &bootstrap_keepalive,
                 ServerError::from(error),
                 control.as_ref(),
                 &registry,
@@ -388,6 +564,19 @@ pub fn bootstrap_shard(
             ));
         }
     };
+
+    if let Err(error) = bootstrap_keepalive.ensure_healthy() {
+        return Err(rollback_bootstrap_with_keepalive(
+            &bootstrap_keepalive,
+            error,
+            control.as_ref(),
+            &registry,
+            &routes,
+            &lease,
+            acquired,
+        ));
+    }
+
     let serving = match control.mark_serving(
         &lease,
         RecoveryPublication {
@@ -398,7 +587,8 @@ pub fn bootstrap_shard(
     ) {
         Ok(record) => record,
         Err(error) => {
-            return Err(rollback_bootstrap(
+            return Err(rollback_bootstrap_with_keepalive(
+                &bootstrap_keepalive,
                 ServerError::Control(error),
                 control.as_ref(),
                 &registry,
@@ -416,6 +606,7 @@ pub fn bootstrap_shard(
         meta,
         recovery,
         routes,
+        bootstrap_keepalive,
     })
 }
 
@@ -1025,6 +1216,33 @@ fn display_epoch(epoch: Option<OwnerEpoch>) -> String {
     epoch.map_or_else(|| "epoch-zero".to_owned(), |epoch| epoch.get().to_string())
 }
 
+fn rollback_bootstrap_with_keepalive(
+    keepalive: &BootstrapLeaseKeepalive,
+    primary: ServerError,
+    control: &dyn ControlStore,
+    registry: &RootOwnerRegistry,
+    routes: &[RootRoute],
+    lease: &LogicalShardLease,
+    release_acquired_lease: bool,
+) -> ServerError {
+    let primary = match keepalive.stop() {
+        Ok(()) => primary,
+        Err(error) => ServerError::BootstrapRollback {
+            primary: primary.to_string(),
+            rollback: format!("stop bootstrap owner keepalive: {error}"),
+        },
+    };
+
+    rollback_bootstrap(
+        primary,
+        control,
+        registry,
+        routes,
+        lease,
+        release_acquired_lease,
+    )
+}
+
 fn rollback_bootstrap(
     primary: ServerError,
     control: &dyn ControlStore,
@@ -1071,7 +1289,7 @@ mod tests {
     use std::collections::BTreeMap;
     use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
     use std::sync::{Mutex, OnceLock};
-    use std::time::Duration;
+    use std::time::{Duration, Instant};
 
     use nokv_control::{
         ControlError, InMemoryControlStore, LogRef, LogSegmentRef, LogicalShardState,
@@ -1236,12 +1454,90 @@ mod tests {
         }
     }
 
+    struct BootstrapLeaseProbe {
+        ttl: Duration,
+        post_acquisition_delay: Duration,
+        renew_interval: Duration,
+        last_renewal: Mutex<Option<Instant>>,
+        delay_active: AtomicBool,
+        renewals_during_delay: AtomicUsize,
+    }
+
+    impl BootstrapLeaseProbe {
+        fn new(ttl: Duration, post_acquisition_delay: Duration, renew_interval: Duration) -> Self {
+            Self {
+                ttl,
+                post_acquisition_delay,
+                renew_interval,
+                last_renewal: Mutex::new(None),
+                delay_active: AtomicBool::new(false),
+                renewals_during_delay: AtomicUsize::new(0),
+            }
+        }
+
+        fn note_acquired(&self) {
+            *self
+                .last_renewal
+                .lock()
+                .expect("test lease clock lock must remain available") = Some(Instant::now());
+        }
+
+        fn note_renewal(&self) -> Result<(), ControlError> {
+            let now = Instant::now();
+            let mut last = self
+                .last_renewal
+                .lock()
+                .expect("test lease clock lock must remain available");
+            let previous = last.as_ref().copied().ok_or_else(|| {
+                ControlError::Backend("simulated owner lease was not acquired".to_owned())
+            })?;
+            if now.duration_since(previous) >= self.ttl {
+                return Err(ControlError::Backend(format!(
+                    "simulated owner lease expired after {:?}",
+                    self.ttl
+                )));
+            }
+            *last = Some(now);
+            drop(last);
+
+            if self.delay_active.load(Ordering::SeqCst) {
+                self.renewals_during_delay.fetch_add(1, Ordering::SeqCst);
+            }
+            Ok(())
+        }
+
+        fn delay_before_mark_serving(&self) -> Result<(), ControlError> {
+            self.delay_active.store(true, Ordering::SeqCst);
+            std::thread::sleep(self.post_acquisition_delay);
+            self.delay_active.store(false, Ordering::SeqCst);
+            self.require_fresh()
+        }
+
+        fn require_fresh(&self) -> Result<(), ControlError> {
+            let last = self
+                .last_renewal
+                .lock()
+                .expect("test lease clock lock must remain available");
+            let previous = last.as_ref().copied().ok_or_else(|| {
+                ControlError::Backend("simulated owner lease was not acquired".to_owned())
+            })?;
+            if previous.elapsed() >= self.ttl {
+                return Err(ControlError::Backend(format!(
+                    "simulated owner lease expired after {:?}",
+                    self.ttl
+                )));
+            }
+            Ok(())
+        }
+    }
+
     struct LoseFinalizeAckControlStore {
         inner: Arc<InMemoryControlStore>,
         lose_next_finalize_ack: AtomicBool,
         fail_next_finalize_before_apply: AtomicBool,
         logical_shard_override: Mutex<Option<LogicalShardRecord>>,
         advance_before_successor: Mutex<Option<(Arc<RecoveryPublisher>, LogicalShardLease)>>,
+        bootstrap_lease_probe: Option<Arc<BootstrapLeaseProbe>>,
     }
 
     impl LoseFinalizeAckControlStore {
@@ -1252,6 +1548,7 @@ mod tests {
                 fail_next_finalize_before_apply: AtomicBool::new(false),
                 logical_shard_override: Mutex::new(None),
                 advance_before_successor: Mutex::new(None),
+                bootstrap_lease_probe: None,
             }
         }
 
@@ -1265,6 +1562,7 @@ mod tests {
                 fail_next_finalize_before_apply: AtomicBool::new(false),
                 logical_shard_override: Mutex::new(Some(record)),
                 advance_before_successor: Mutex::new(None),
+                bootstrap_lease_probe: None,
             }
         }
 
@@ -1279,6 +1577,21 @@ mod tests {
                 fail_next_finalize_before_apply: AtomicBool::new(false),
                 logical_shard_override: Mutex::new(None),
                 advance_before_successor: Mutex::new(Some((publisher, lease))),
+                bootstrap_lease_probe: None,
+            }
+        }
+
+        fn with_bootstrap_lease_probe(
+            inner: Arc<InMemoryControlStore>,
+            bootstrap_lease_probe: Arc<BootstrapLeaseProbe>,
+        ) -> Self {
+            Self {
+                inner,
+                lose_next_finalize_ack: AtomicBool::new(false),
+                fail_next_finalize_before_apply: AtomicBool::new(false),
+                logical_shard_override: Mutex::new(None),
+                advance_before_successor: Mutex::new(None),
+                bootstrap_lease_probe: Some(bootstrap_lease_probe),
             }
         }
 
@@ -1289,11 +1602,18 @@ mod tests {
                 fail_next_finalize_before_apply: AtomicBool::new(true),
                 logical_shard_override: Mutex::new(None),
                 advance_before_successor: Mutex::new(None),
+                bootstrap_lease_probe: None,
             }
         }
     }
 
     impl ControlStore for LoseFinalizeAckControlStore {
+        fn owner_lease_renew_interval(&self) -> Option<std::time::Duration> {
+            self.bootstrap_lease_probe
+                .as_ref()
+                .map(|probe| probe.renew_interval)
+        }
+
         fn create_root_agent_binding(
             &self,
             binding: nokv_control::RootAgentBinding,
@@ -1402,8 +1722,16 @@ mod tests {
                     .map_err(|error| ControlError::Backend(error.to_string()))?;
                 self.inner.release_owner(&lease)?;
             }
-            self.inner
-                .acquire_successor(logical_shard_id, expected_owner_epoch, owner, endpoint)
+            let lease = self.inner.acquire_successor(
+                logical_shard_id,
+                expected_owner_epoch,
+                owner,
+                endpoint,
+            )?;
+            if let Some(probe) = &self.bootstrap_lease_probe {
+                probe.note_acquired();
+            }
+            Ok(lease)
         }
 
         fn reacquire_recovery(
@@ -1421,6 +1749,9 @@ mod tests {
             &self,
             lease: &LogicalShardLease,
         ) -> Result<LogicalShardRecord, ControlError> {
+            if let Some(probe) = &self.bootstrap_lease_probe {
+                probe.note_renewal()?;
+            }
             self.inner.renew_owner(lease)
         }
 
@@ -1429,6 +1760,9 @@ mod tests {
             lease: &LogicalShardLease,
             publication: RecoveryPublication,
         ) -> Result<LogicalShardRecord, ControlError> {
+            if let Some(probe) = &self.bootstrap_lease_probe {
+                probe.delay_before_mark_serving()?;
+            }
             self.inner.mark_serving(lease, publication)
         }
 
@@ -3771,5 +4105,65 @@ mod tests {
         for route in routes {
             assert!(!registry.contains_exact(route).unwrap());
         }
+    }
+
+    #[test]
+    fn successor_bootstrap_keeps_exact_lease_alive_during_post_acquisition_delay() {
+        let temporary = TempDir::new().unwrap();
+        let database = temporary.path().join("metadata");
+        let root_id = root(1);
+        let control = active_control(&[root_id]);
+
+        let first = bootstrap_shard(
+            as_control(&control),
+            Arc::new(RootOwnerRegistry::new()),
+            acquire_boot(database.clone(), &[root_id]),
+        )
+        .unwrap();
+        let first_epoch = first.lease().owner_epoch;
+        first.release().unwrap();
+
+        let probe = Arc::new(BootstrapLeaseProbe::new(
+            Duration::from_secs(1),
+            Duration::from_secs(2),
+            Duration::from_millis(50),
+        ));
+        let delayed_control: Arc<dyn ControlStore> =
+            Arc::new(LoseFinalizeAckControlStore::with_bootstrap_lease_probe(
+                Arc::clone(&control),
+                Arc::clone(&probe),
+            ));
+        let registry = Arc::new(RootOwnerRegistry::new());
+        let boot = ShardBoot {
+            recovery_publication: RecoveryPublicationMode::Shared,
+            shard_id: shard(),
+            open: OpenMode::Existing(database),
+            lease: LeaseMode::Acquire {
+                owner: NodeId::new("node-b").unwrap(),
+                endpoint: "127.0.0.1:9020".to_owned(),
+                previous_epoch: Some(first_epoch),
+            },
+            recovery: current_recovery(&control),
+            roots: vec![root_attach(root_id, 61)],
+        };
+
+        let successor = bootstrap_shard(delayed_control, Arc::clone(&registry), boot).unwrap();
+
+        assert!(
+            probe.renewals_during_delay.load(Ordering::SeqCst) > 0,
+            "the acquired successor lease was not renewed during slow bootstrap"
+        );
+        assert_eq!(successor.lease().owner_epoch.get(), first_epoch.get() + 1);
+
+        let record = control.get_logical_shard(&shard()).unwrap().unwrap();
+        assert_eq!(record.state, LogicalShardState::Serving);
+        assert_eq!(record.owner_epoch, Some(successor.lease().owner_epoch));
+        assert_eq!(record.lease_id, successor.lease().lease_id);
+
+        let handoff = successor.renew_or_uninstall().unwrap();
+        assert_eq!(handoff.owner_epoch, Some(successor.lease().owner_epoch));
+        assert_eq!(handoff.lease_id, successor.lease().lease_id);
+
+        successor.release().unwrap();
     }
 }

--- a/crates/nokv-server/src/lifecycle.rs
+++ b/crates/nokv-server/src/lifecycle.rs
@@ -2589,6 +2589,57 @@ mod tests {
     }
 
     #[test]
+    fn shared_owner_fail_close_blocks_ready_provider_delete() {
+        let fixture = fixture();
+
+        let deleter = Arc::new(FakeDeleter {
+            ambiguous: false,
+            calls: AtomicUsize::new(0),
+            object_keys: Mutex::new(Vec::new()),
+        });
+
+        let owner_loss = fixture.registry.owner_loss_signal();
+
+        let runner = LifecycleRunner::new(
+            Arc::clone(&fixture.store),
+            Arc::clone(&fixture.registry),
+            fixture.route,
+            owner_loss.clone(),
+            deleter.clone(),
+            test_durability(),
+            LifecycleRunnerOptions {
+                scan_page_size: 8,
+                mutation_batch_size: 8,
+                ..LifecycleRunnerOptions::default()
+            },
+        )
+        .unwrap();
+
+        // Advance the real candidate to its destructive provider boundary.
+        runner.run_once(100_000).unwrap();
+        runner.run_once(100_000).unwrap();
+
+        fixture
+            .registry
+            .fail_closed_shard(fixture.route.logical_shard_id)
+            .unwrap();
+
+        assert!(owner_loss.is_lost());
+        assert!(!fixture.registry.contains_exact(fixture.route).unwrap());
+
+        assert!(matches!(
+            runner.run_once(100_000),
+            Err(LifecycleError::OwnerLost(_))
+        ));
+
+        assert_eq!(
+            deleter.calls.load(Ordering::SeqCst),
+            0,
+            "provider deletion must not run after shared owner fail-close"
+        );
+    }
+
+    #[test]
     fn owner_loss_blocks_delete_and_ambiguous_delete_quarantines() {
         let fixture = fixture();
         let deleter = Arc::new(FakeDeleter {

--- a/crates/nokv-server/src/lifecycle.rs
+++ b/crates/nokv-server/src/lifecycle.rs
@@ -324,6 +324,8 @@ pub struct LifecycleRunner {
     durability: Arc<dyn LifecycleDurabilityBarrier>,
     options: LifecycleRunnerOptions,
     cursors: Mutex<LifecycleCursors>,
+    #[cfg(test)]
+    before_provider_delete_test_hook: Mutex<Option<Box<dyn FnOnce() + Send + 'static>>>,
 }
 
 impl LifecycleRunner {
@@ -348,9 +350,46 @@ impl LifecycleRunner {
             durability,
             options: options.validate()?,
             cursors: Mutex::new(LifecycleCursors::default()),
+            #[cfg(test)]
+            before_provider_delete_test_hook: Mutex::new(None),
         };
+
         runner.require_current_owner()?;
         Ok(runner)
+    }
+
+    #[cfg(test)]
+    fn install_before_provider_delete_test_hook(&self, hook: impl FnOnce() + Send + 'static) {
+        let mut current = self
+            .before_provider_delete_test_hook
+            .lock()
+            .expect("provider-delete test-hook lock must remain available");
+
+        assert!(
+            current.replace(Box::new(hook)).is_none(),
+            "provider-delete test hook is already installed"
+        );
+    }
+
+    #[cfg(test)]
+    fn run_before_provider_delete_test_hook(&self) {
+        let hook = self
+            .before_provider_delete_test_hook
+            .lock()
+            .expect("provider-delete test-hook lock must remain available")
+            .take();
+
+        if let Some(hook) = hook {
+            hook();
+        }
+    }
+
+    fn enter_destructive_operation(
+        &self,
+    ) -> Result<crate::registry::ShardOperationPermit, LifecycleError> {
+        self.registry
+            .enter_shard_operation(self.route)
+            .map_err(|error| LifecycleError::OwnerLost(error.to_string()))
     }
 
     /// Execute one bounded recovery pass over every lifecycle family.
@@ -656,6 +695,9 @@ impl LifecycleRunner {
                 ) {
                     self.require_current_owner()?;
                     self.publish_current()?;
+                    #[cfg(test)]
+                    self.run_before_provider_delete_test_hook();
+                    let _operation_permit = self.enter_destructive_operation()?;
                     let request = LifecycleDeleteRequest {
                         purpose: LifecycleDeletePurpose::AbortedPublication,
                         object_key: expected.object_key.clone(),
@@ -1356,6 +1398,9 @@ impl LifecycleRunner {
             let absence_digest = if entry.delete_required {
                 self.require_current_owner()?;
                 self.publish_current()?;
+                #[cfg(test)]
+                self.run_before_provider_delete_test_hook();
+                let _operation_permit = self.enter_destructive_operation()?;
                 let request = LifecycleDeleteRequest {
                     purpose: LifecycleDeletePurpose::RevisionGarbageCollection,
                     object_key: entry.row.object_key.clone(),
@@ -1696,6 +1741,7 @@ fn gc_concurrent(error: &meta::GcError) -> bool {
 #[cfg(test)]
 mod tests {
     use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+    use std::sync::mpsc;
 
     use nokv_object::{
         ArtifactStoreCapabilities, ImmutableCreateOutcome, ObjectError, ObjectInfo, ObjectRange,
@@ -2588,8 +2634,50 @@ mod tests {
         assert_eq!(operation(&fixture).phase, GcPhase::Deleted);
     }
 
+    struct BlockingDeleter {
+        entered: Mutex<Option<mpsc::Sender<()>>>,
+        resume: Mutex<mpsc::Receiver<()>>,
+        calls: AtomicUsize,
+    }
+
+    impl LifecycleObjectDeleter for BlockingDeleter {
+        fn delete(
+            &self,
+            request: &LifecycleDeleteRequest,
+        ) -> Result<LifecycleAbsenceProof, LifecycleDeleteError> {
+            assert_eq!(
+                request.purpose,
+                LifecycleDeletePurpose::RevisionGarbageCollection,
+            );
+
+            if let Some(entered) = self
+                .entered
+                .lock()
+                .expect("blocking-deleter entered lock must remain available")
+                .take()
+            {
+                entered
+                    .send(())
+                    .expect("blocking deleter must signal entry");
+            }
+
+            self.resume
+                .lock()
+                .expect("blocking-deleter resume lock must remain available")
+                .recv()
+                .expect("blocking deleter must be released");
+
+            self.calls.fetch_add(1, Ordering::SeqCst);
+
+            Ok(LifecycleAbsenceProof::from_delete_request(
+                request,
+                LifecycleDeleteDisposition::Deleted,
+            ))
+        }
+    }
+
     #[test]
-    fn shared_owner_fail_close_blocks_ready_provider_delete() {
+    fn shared_fail_close_wins_check_to_provider_dispatch_race() {
         let fixture = fixture();
 
         let deleter = Arc::new(FakeDeleter {
@@ -2600,42 +2688,160 @@ mod tests {
 
         let owner_loss = fixture.registry.owner_loss_signal();
 
-        let runner = LifecycleRunner::new(
-            Arc::clone(&fixture.store),
-            Arc::clone(&fixture.registry),
-            fixture.route,
-            owner_loss.clone(),
-            deleter.clone(),
-            test_durability(),
-            LifecycleRunnerOptions {
-                scan_page_size: 8,
-                mutation_batch_size: 8,
-                ..LifecycleRunnerOptions::default()
-            },
-        )
-        .unwrap();
+        let runner = Arc::new(
+            LifecycleRunner::new(
+                Arc::clone(&fixture.store),
+                Arc::clone(&fixture.registry),
+                fixture.route,
+                owner_loss.clone(),
+                deleter.clone(),
+                test_durability(),
+                LifecycleRunnerOptions {
+                    scan_page_size: 8,
+                    mutation_batch_size: 8,
+                    ..LifecycleRunnerOptions::default()
+                },
+            )
+            .unwrap(),
+        );
 
-        // Advance the real candidate to its destructive provider boundary.
+        // Advance the real candidate to provider deletion.
         runner.run_once(100_000).unwrap();
         runner.run_once(100_000).unwrap();
 
+        let (reached_tx, reached_rx) = mpsc::channel();
+
+        let (resume_tx, resume_rx) = mpsc::channel();
+
+        runner.install_before_provider_delete_test_hook(move || {
+            reached_tx
+                .send(())
+                .expect("test must signal the pre-dispatch boundary");
+
+            resume_rx
+                .recv()
+                .expect("test must release provider dispatch");
+        });
+
+        let worker_runner = Arc::clone(&runner);
+
+        let worker = thread::spawn(move || worker_runner.run_once(100_000));
+
+        reached_rx
+            .recv_timeout(Duration::from_secs(5))
+            .expect("lifecycle worker did not reach the provider boundary");
+
+        // No operation permit has been admitted yet. Fail-close must return
+        // and make subsequent provider dispatch impossible.
         fixture
             .registry
             .fail_closed_shard(fixture.route.logical_shard_id)
             .unwrap();
 
         assert!(owner_loss.is_lost());
-        assert!(!fixture.registry.contains_exact(fixture.route).unwrap());
+
+        resume_tx
+            .send(())
+            .expect("test must resume the lifecycle worker");
+
+        let result = worker.join().expect("lifecycle worker must not panic");
+
+        assert!(matches!(result, Err(LifecycleError::OwnerLost(_)),));
+
+        assert_eq!(
+            deleter.calls.load(Ordering::SeqCst),
+            0,
+            "provider deletion crossed the shared fail-close fence",
+        );
+    }
+
+    #[test]
+    fn shared_fail_close_waits_for_admitted_provider_delete() {
+        let fixture = fixture();
+
+        let (entered_tx, entered_rx) = mpsc::channel();
+
+        let (resume_tx, resume_rx) = mpsc::channel();
+
+        let deleter = Arc::new(BlockingDeleter {
+            entered: Mutex::new(Some(entered_tx)),
+            resume: Mutex::new(resume_rx),
+            calls: AtomicUsize::new(0),
+        });
+
+        let owner_loss = fixture.registry.owner_loss_signal();
+
+        let runner = Arc::new(
+            LifecycleRunner::new(
+                Arc::clone(&fixture.store),
+                Arc::clone(&fixture.registry),
+                fixture.route,
+                owner_loss.clone(),
+                deleter.clone(),
+                test_durability(),
+                LifecycleRunnerOptions {
+                    scan_page_size: 8,
+                    mutation_batch_size: 8,
+                    ..LifecycleRunnerOptions::default()
+                },
+            )
+            .unwrap(),
+        );
+
+        runner.run_once(100_000).unwrap();
+        runner.run_once(100_000).unwrap();
+
+        let worker_runner = Arc::clone(&runner);
+
+        let worker = thread::spawn(move || worker_runner.run_once(100_000));
+
+        entered_rx
+            .recv_timeout(Duration::from_secs(5))
+            .expect("provider delete was not entered");
+
+        let registry = Arc::clone(&fixture.registry);
+
+        let logical_shard_id = fixture.route.logical_shard_id;
+
+        let (closed_tx, closed_rx) = mpsc::channel();
+
+        let closer = thread::spawn(move || {
+            registry.fail_closed_shard(logical_shard_id).unwrap();
+
+            closed_tx
+                .send(())
+                .expect("test must signal completed fail-close");
+        });
 
         assert!(matches!(
-            runner.run_once(100_000),
-            Err(LifecycleError::OwnerLost(_))
+            closed_rx.recv_timeout(Duration::from_millis(200),),
+            Err(mpsc::RecvTimeoutError::Timeout),
         ));
 
         assert_eq!(
             deleter.calls.load(Ordering::SeqCst),
             0,
-            "provider deletion must not run after shared owner fail-close"
+            "blocked provider operation completed before release",
+        );
+
+        resume_tx
+            .send(())
+            .expect("test must release provider deletion");
+
+        closed_rx
+            .recv_timeout(Duration::from_secs(5))
+            .expect("fail-close did not drain the admitted operation");
+
+        closer.join().expect("fail-close thread must not panic");
+
+        let _cycle_result = worker.join().expect("lifecycle worker must not panic");
+
+        assert!(owner_loss.is_lost());
+
+        assert_eq!(
+            deleter.calls.load(Ordering::SeqCst),
+            1,
+            "the operation admitted before the fence must drain exactly once",
         );
     }
 

--- a/crates/nokv-server/src/registry.rs
+++ b/crates/nokv-server/src/registry.rs
@@ -26,7 +26,7 @@ struct ShardRuntime {
 }
 
 impl ShardRuntime {
-    fn enter(self: &Arc<Self>) -> Option<ResponsePermit> {
+    fn enter(self: &Arc<Self>) -> Option<ShardOperationPermit> {
         let mut state = self
             .state
             .lock()
@@ -35,7 +35,7 @@ impl ShardRuntime {
             return None;
         }
         state.in_flight += 1;
-        Some(ResponsePermit {
+        Some(ShardOperationPermit {
             runtime: Arc::clone(self),
         })
     }
@@ -61,11 +61,11 @@ impl ShardRuntime {
     }
 }
 
-struct ResponsePermit {
+pub(crate) struct ShardOperationPermit {
     runtime: Arc<ShardRuntime>,
 }
 
-impl Drop for ResponsePermit {
+impl Drop for ShardOperationPermit {
     fn drop(&mut self) {
         let mut state = self
             .runtime
@@ -82,7 +82,7 @@ impl Drop for ResponsePermit {
 
 pub(crate) struct GuardedResponse {
     response: WorkspaceRpcResponse,
-    _permit: Option<ResponsePermit>,
+    _permit: Option<ShardOperationPermit>,
 }
 
 impl GuardedResponse {
@@ -221,12 +221,30 @@ impl RootOwnerRegistry {
         logical_shard_id: nokv_protocol::LogicalShardIdentity,
     ) -> Result<(), ServerError> {
         self.owner_loss.fail_closed();
+        self.fail_closed_shard_after_signal(logical_shard_id)
+    }
+
+    pub(crate) fn fail_closed_shard_with_control(
+        &self,
+        logical_shard_id: nokv_protocol::LogicalShardIdentity,
+        error: nokv_control::ControlError,
+    ) -> Result<(), ServerError> {
+        self.owner_loss.fail_closed_with_control(error);
+        self.fail_closed_shard_after_signal(logical_shard_id)
+    }
+
+    fn fail_closed_shard_after_signal(
+        &self,
+        logical_shard_id: nokv_protocol::LogicalShardIdentity,
+    ) -> Result<(), ServerError> {
         let runtime = {
             let mut runtimes = self.runtimes.write().map_err(|_| {
                 ServerError::InvalidRoute("shard runtime registry lock is poisoned".to_owned())
             })?;
+
             Arc::clone(runtimes.entry(logical_shard_id).or_default())
         };
+
         self.fail_closed_runtime(logical_shard_id, &runtime)
     }
 
@@ -246,6 +264,51 @@ impl RootOwnerRegistry {
             });
         runtime.wait_until_drained();
         route_removal
+    }
+
+    /// Admit one owner-fenced shard operation and hold the shard drain
+    /// barrier until the returned permit is dropped.
+    pub(crate) fn enter_shard_operation(
+        &self,
+        route: RootRoute,
+    ) -> Result<ShardOperationPermit, ServerError> {
+        route
+            .validate()
+            .map_err(|error| ServerError::InvalidRoute(error.to_string()))?;
+
+        if let Some(error) = self.owner_loss.control_error() {
+            return Err(ServerError::Control(error));
+        }
+
+        if self.owner_loss.is_lost() {
+            return Err(ServerError::InvalidRoute(
+                "owner scope is fail-closed".to_owned(),
+            ));
+        }
+
+        let owners = self
+            .owners
+            .read()
+            .map_err(|_| ServerError::InvalidRoute("owner registry lock is poisoned".to_owned()))?;
+
+        let owner = owners.get(&route.root_id).ok_or_else(|| {
+            ServerError::InvalidRoute("this server no longer owns the requested root".to_owned())
+        })?;
+
+        if owner.route != route {
+            return Err(ServerError::InvalidRoute(
+                "the requested root route is stale".to_owned(),
+            ));
+        }
+
+        let runtime = Arc::clone(&owner.runtime);
+
+        let permit = runtime.enter().ok_or_else(|| {
+            ServerError::InvalidRoute("the requested logical shard is fail-closed".to_owned())
+        })?;
+
+        drop(owners);
+        Ok(permit)
     }
 
     #[cfg(test)]

--- a/crates/nokv-server/src/server.rs
+++ b/crates/nokv-server/src/server.rs
@@ -7,7 +7,7 @@ use std::collections::BTreeSet;
 use std::io::{Read, Write};
 use std::net::{SocketAddr, TcpListener, TcpStream};
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 use std::thread;
 use std::time::{Duration, Instant};
 
@@ -105,28 +105,55 @@ impl Drop for ConnectionPermit {
     }
 }
 
-/// Shared fail-closed owner-loss signal for the RPC runtime and future
-/// owner-fenced background workers.
+/// Shared fail-closed owner-loss state for RPC and background workers.
+#[derive(Default)]
+struct OwnerLossState {
+    lost: AtomicBool,
+    control_error: Mutex<Option<nokv_control::ControlError>>,
+}
+
+/// Shared fail-closed owner-loss signal for the RPC runtime and owner-fenced
+/// background workers.
 #[derive(Clone, Default)]
-pub struct OwnerLossSignal(Arc<AtomicBool>);
+pub struct OwnerLossSignal(Arc<OwnerLossState>);
 
 impl OwnerLossSignal {
     pub fn is_lost(&self) -> bool {
-        self.0.load(Ordering::Acquire)
+        self.0.lost.load(Ordering::Acquire)
     }
 
-    /// Fail the complete owner scope closed.
-    ///
-    /// The process supervisor uses this when any owner-fenced companion worker
-    /// encounters a terminal invariant failure. The RPC accept loop observes
-    /// the same signal, stops admitting requests, and returns an error instead
-    /// of continuing without lifecycle recovery.
+    pub(crate) fn control_error(&self) -> Option<nokv_control::ControlError> {
+        self.0
+            .control_error
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .clone()
+    }
+
+    /// Fail the complete owner scope closed without a control-plane cause.
     pub fn fail_closed(&self) {
         self.mark_lost();
     }
 
+    /// Record the typed control-plane cause before publishing owner loss.
+    pub(crate) fn fail_closed_with_control(&self, error: nokv_control::ControlError) {
+        {
+            let mut current = self
+                .0
+                .control_error
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
+
+            if current.is_none() {
+                *current = Some(error);
+            }
+        }
+
+        self.mark_lost();
+    }
+
     fn mark_lost(&self) {
-        self.0.store(true, Ordering::Release);
+        self.0.lost.store(true, Ordering::Release);
     }
 }
 
@@ -149,14 +176,21 @@ impl WorkspaceServer {
         registry: Arc<RootOwnerRegistry>,
         ownership: Vec<ShardOwner>,
     ) -> Result<Self, ServerError> {
+        let owner_loss = registry.owner_loss_signal();
+
+        if let Err(error) = require_owner_retained(&owner_loss) {
+            return Err(release_rejected_ownership(ownership, error));
+        }
+
         if let Err(error) = validate_ownership(options, &registry, &ownership) {
             return Err(release_rejected_ownership(ownership, error));
         }
+
         Ok(Self {
             options,
-            owner_loss: registry.owner_loss_signal(),
             registry,
             ownership,
+            owner_loss,
         })
     }
 
@@ -172,10 +206,17 @@ impl WorkspaceServer {
     pub fn renew_ownership(&self) -> Result<(), ServerError> {
         for owner in &self.ownership {
             if let Err(error) = owner.renew_or_uninstall() {
-                self.owner_loss.mark_lost();
+                match &error {
+                    ServerError::Control(control) => {
+                        self.owner_loss.fail_closed_with_control(control.clone());
+                    }
+                    _ => self.owner_loss.mark_lost(),
+                }
+
                 return Err(error);
             }
         }
+
         Ok(())
     }
 
@@ -296,6 +337,10 @@ fn serve_socket_loop(
 }
 
 fn require_owner_retained(owner_loss: &OwnerLossSignal) -> Result<(), ServerError> {
+    if let Some(error) = owner_loss.control_error() {
+        return Err(ServerError::Control(error));
+    }
+
     if owner_loss.is_lost() {
         Err(ServerError::InvalidBootstrap(
             "control-plane owner was lost".to_owned(),
@@ -329,6 +374,24 @@ fn validate_ownership(
                 "ownership entry {index} belongs to another registry"
             )));
         }
+
+        if let Some(required) = owner.owner_lease_renew_interval() {
+            if required.is_zero() {
+                return Err(ServerError::InvalidOptions(format!(
+                    "ownership entry {index} declares a zero lease renewal interval"
+                )));
+            }
+
+            if options.lease_renew_interval != required {
+                return Err(ServerError::InvalidOptions(
+                    format!(
+                        "ownership entry {index} requires lease renewal interval {required:?}, but ServerOptions configures {:?}",
+                        options.lease_renew_interval,
+                    ),
+                ));
+            }
+        }
+
         if !shards.insert(owner.shard_id()) {
             return Err(ServerError::InvalidOptions(format!(
                 "ownership entry {index} duplicates logical shard {:?}",
@@ -365,8 +428,11 @@ fn validate_ownership(
 }
 
 fn release_rejected_ownership(ownership: Vec<ShardOwner>, primary: ServerError) -> ServerError {
+    let preserve_control = matches!(&primary, ServerError::Control(_));
+
     match release_ownership(ownership) {
         Ok(()) => primary,
+        Err(_) if preserve_control => primary,
         Err(cleanup) => ServerError::BootstrapRollback {
             primary: primary.to_string(),
             rollback: cleanup.to_string(),
@@ -409,11 +475,7 @@ fn serve_connection(
         let encoded = encode_response_or_internal_failure(response.response())?;
         write_frame(&mut stream, &encoded)?;
         drop(response);
-        if registry.owner_loss_signal().is_lost() {
-            return Err(ServerError::InvalidBootstrap(
-                "control-plane owner was lost".to_owned(),
-            ));
-        }
+        require_owner_retained(&registry.owner_loss_signal())?;
     }
     Ok(())
 }

--- a/crates/nokv/src/main.rs
+++ b/crates/nokv/src/main.rs
@@ -616,6 +616,7 @@ OWNER:
   serve validates every active root's Agent binding; it does not require or compare one shard-wide AgentId
   --root-id HEX32 --etcd-endpoint URL --node-id ID
   --advertise-endpoint HOST:PORT --bind HOST:PORT
+  --etcd-lease-ttl-seconds N (default 10; owner keepalive runs every max(1, N/3) seconds)
   --handshake-timeout-millis N --max-inflight-connections N
   --metadata-create PATH starts the first standalone local-WAL owner
   --metadata-reopen PATH restarts the same exclusive local-WAL authority after lease loss

--- a/crates/nokv/src/main.rs
+++ b/crates/nokv/src/main.rs
@@ -976,10 +976,10 @@ fn run_server(invocation: &Invocation) -> Result<(), String> {
     )
     .map_err(|error| error.to_string())?;
 
-    let renew_seconds = u64::try_from(route.lease_ttl_seconds)
-        .map_err(|_| "etcd lease TTL must be positive".to_owned())?
-        .saturating_div(3)
-        .max(1);
+    let lease_renew_interval = owner.owner_lease_renew_interval().ok_or_else(|| {
+        "etcd-backed workspace server requires an expiring owner-lease renewal policy".to_owned()
+    })?;
+
     let meta = Arc::clone(owner.meta());
     let recovery = Arc::clone(owner.recovery_publisher());
     let owner_routes = owner.routes().to_vec();
@@ -989,7 +989,7 @@ fn run_server(invocation: &Invocation) -> Result<(), String> {
             handshake_timeout: Duration::from_millis(invocation.server.handshake_timeout_millis),
             read_timeout: Duration::from_secs(30),
             write_timeout: Duration::from_secs(30),
-            lease_renew_interval: Duration::from_secs(renew_seconds),
+            lease_renew_interval,
             max_inflight_connections: invocation.server.max_inflight_connections,
         },
         Arc::clone(&registry),


### PR DESCRIPTION
## Related Issue

Closes #483

## Summary

Keep the exact acquired logical-shard owner lease alive throughout owner-fenced bootstrap and hand it to the steady-state server renewal path without an ownership gap.

The change also ensures that terminal renewal failures remain typed and immediately fail-close the shared owner scope, destructive lifecycle operations cannot cross the shard fail-close boundary, and all server callers use one control-plane-owned renewal policy.

This fixes slow `--metadata-reopen` recovery where metadata reopen, recovery reconciliation, publication, root attachment, and server startup can take longer than the configured etcd lease TTL.

## Problem

The successor lease was acquired before owner-fenced bootstrap recovery, but periodic renewal did not begin until the `WorkspaceServer` serving loop.

With the default 10-second etcd TTL, sufficiently slow metadata reopen could therefore outlive its own lease before reaching `Serving`. The next owner-fenced control operation then failed with a stale lease.

The initial keepalive implementation closed that healthy-path gap, but review identified three additional lifecycle problems:

1. A terminal bootstrap renewal failure could be reduced to a Boolean owner-loss signal or converted into string-only rollback diagnostics, preventing callers from classifying the original `ControlError::StaleLease`.
2. Lifecycle GC could pass its ownership check and durability publication, lose ownership, and still dispatch an object-provider delete because that external effect was not protected by the shard’s drainable fail-close fence.
3. `WorkspaceServer` accepted an independently supplied renewal interval even when it differed from the policy carried by its owners. The benchmark server also recalculated `TTL / 3`, allowing policy drift outside the main CLI.

## Fix

* Require every `ControlStore` implementation to explicitly declare either:

  * an expiring owner-lease renewal cadence; or
  * non-expiring owner-session behavior.
* Make the etcd backend advertise a renewal interval of `max(1, TTL / 3)` seconds.
* Start a bootstrap-scoped keepalive immediately after successful owner admission.
* Keep the exact acquired lease alive throughout:

  * metadata open and reconciliation;
  * recovery publication;
  * root attachment;
  * transition to `Serving`;
  * construction and startup of `WorkspaceServer`;
  * the interval before the first steady-state renewal.
* Retain the control-layer renewal policy and bootstrap keepalive inside `ShardOwner`.
* Stop the bootstrap worker and immediately renew the same lease during handoff to steady-state renewal.
* Stop the worker before bootstrap rollback, recovery suspension, or owner release.
* Preserve terminal `ControlError` values across the keepalive worker, shared owner-loss state, bootstrap rollback, and actual server path.
* Add a typed `ControlRollback` server error that retains the underlying `ControlError` when cleanup also fails.
* Propagate terminal renewal failure through the shared owner-loss and route fail-close boundary.
* Reuse the registry’s drainable shard-operation permit for destructive lifecycle provider operations.
* Close operation admission and drain already-admitted operations before shard fail-close returns.
* Validate `ServerOptions::lease_renew_interval` against the renewal policy carried by the server’s owners.
* Reject inconsistent renewal policies across owners in one `WorkspaceServer`.
* Migrate the active crash-owner benchmark to consume the policy carried by `ShardOwner` rather than independently calculating `TTL / 3`.
* Document the existing `--etcd-lease-ttl-seconds` option in `nokv --help`.

## Safety Invariants

* The owner epoch and lease ID acquired during admission remain unchanged through bootstrap and steady-state handoff.
* A terminal control-plane failure remains available as a typed `ControlError`.
* Owner loss is published before routes and operation admission are closed.
* Destructive provider operations must hold a shard-operation permit through the external side effect.
* If fail-close wins before operation admission, the provider operation cannot begin.
* If an operation was admitted before fail-close, fail-close waits for that operation to drain.
* Expiring owner sessions have one control-plane-owned renewal policy that is enforced by `WorkspaceServer`.
* No replacement owner epoch is allocated merely to bridge the bootstrap-to-serving transition.

## Regression Tests

### Original slow-bootstrap reproduction

The original deterministic regression:

1. creates an initial owner;
2. releases it;
3. acquires exactly one successor epoch;
4. injects a post-acquisition delay longer than the simulated TTL;
5. verifies renewal occurs during the delay;
6. verifies the same successor epoch and lease ID reach `Serving`;
7. verifies steady-state renewal takes over without allocating another epoch.

Before the fix, it failed with:

```text
simulated owner lease expired after 1s
```

### Exact bootstrap lifecycle windows

Added deterministic coverage for both lease windows:

* `successor_bootstrap_renews_between_admission_and_open_reconciliation`

  * delays longer than TTL immediately after owner admission and before metadata open/reconciliation;
  * verifies that the exact lease is renewed during this early window.

* `successor_owner_renews_after_bootstrap_before_first_steady_state_renewal`

  * delays longer than TTL after `bootstrap_shard()` returns and before the first steady-state renewal;
  * verifies that the same epoch and lease ID remain current through handoff.

### Typed terminal failure

Added coverage that:

* injects `ControlError::StaleLease` before `bootstrap_shard()` returns;
* verifies the result remains classifiable as `ServerError::Control(ControlError::StaleLease(_))`;
* verifies the shared owner-loss state retains the typed cause;
* verifies the actual `WorkspaceServer` path reports that typed cause rather than generic `InvalidBootstrap`;
* verifies rollback cleanup cannot replace the typed control outcome with string-only diagnostics.

Relevant tests include:

* `terminal_bootstrap_renewal_failure_before_return_stays_typed`
* `workspace_server_reports_typed_bootstrap_keepalive_failure`
* `terminal_bootstrap_renewal_failure_fail_closes_owner_scope_and_stays_typed`

### Lifecycle provider-delete fencing

Added coverage that:

* advances a real lifecycle GC candidate to its provider-delete boundary;
* pauses after owner validation and durability publication;
* calls `fail_closed_shard()` before permit admission;
* resumes the lifecycle worker;
* verifies operation admission fails;
* verifies the provider delete count remains zero.

The lifecycle provider-delete paths now retain a drainable shard-operation permit through the external effect.

Relevant tests include:

* `shared_fail_close_wins_provider_delete_dispatch_race`
* `shared_owner_fail_close_blocks_ready_provider_delete`

### Renewal-policy authority

Added coverage that:

* creates an owner with a 50 ms renewal policy;
* passes a five-second `ServerOptions` cadence;
* verifies `WorkspaceServer::new()` rejects the mismatch;
* verifies control-backed callers consume the owner policy rather than independently deriving another cadence.

Relevant tests include:

* `owner_lease_renew_interval_tracks_ttl_third_with_floor`
* `workspace_server_rejects_owner_renewal_policy_drift`

## Scope

* [x] This PR changes one logical boundary only.
  It closes the logical-shard owner-lease lifecycle from admission through bootstrap, serving handoff, terminal owner loss, and owner-fenced destructive work.
* [x] No unrelated refactor, benchmark, metadata model, Holt layout,
  object-store, agent interface, or docs change is mixed in.
  The benchmark caller change directly removes a second active renewal-policy calculation.
* [x] The linked issue describes the user-visible problem, design decision, or
  maintenance task this PR resolves.
* [x] Any breaking change is intentional and documented.
  No public wire-format or metadata-format breaking change is introduced.
* [x] No compatibility shim, deprecated alias, or forwarding wrapper was added without a removal condition.
  `ControlStore::owner_lease_renew_interval()` explicitly returns `None`
  only for backends whose owner sessions do not expire.

## Change Size And Review

* [x] I checked GitHub's additions plus deletions for this pull request.
  Total changed lines: `1,427`.
* [x] If the total is more than 5,000 lines, one core maintainer other than the
  current-head pusher approved the exact current head commit. The author,
  bots, non-core reviewers, duplicate reviewers, dismissed reviews, and
  stale approvals do not count.
  This PR is below 5,000 changed lines, so the large-change approval rule is not triggered.
* [x] This change is still small enough for a focused review; approval count is
  not being used to justify mixed package or lifecycle boundaries.

## Code Contract (Code Changes Only)

* [ ] Not applicable; this is a docs/config-only change.
* [x] Package boundaries follow `docs/development/code_contract.md`.
  Owner-lease policy remains in `nokv-control`.
  Bootstrap ownership, server renewal, shared owner loss, route fail-close,
  and lifecycle operation fencing remain in `nokv-server`.
  The `nokv` crate contains the native CLI wiring and help text.
  The benchmark change only migrates an active caller to the same owner policy.
* [x] Shared helpers reuse the standard library or existing repository helpers.
  No generic helper module was introduced.
  The keepalive, typed owner-loss state, and shard-operation permit are
  domain-specific lifecycle components.
* [x] File names and file placement follow the code contract.
* [x] New types, interfaces, structs, fields, and functions use domain-specific names.
  Examples include `BootstrapLeaseKeepalive`, `OwnerLossState`,
  `ShardOperationPermit`, and owner-renewal policy accessors.
* [x] New errors are in the owning package's `errors.rs` and carry stable error kinds when crossing package boundaries.
  `ControlRollback` is defined in `nokv-server/src/error.rs` and retains
  the typed `ControlError` when rollback cleanup also fails.
* [x] New metrics/stats are owned by the package that reports or serves them.
  No metrics or statistics were added.
* [x] Metadata changes document durability, atomicity, revision-reference
  lifetime, snapshot/commit/event retention, GC epochs, and fail-closed
  recovery boundaries.
  No metadata schema, Holt layout, durability format, retention policy, or
  GC epoch model was changed.
* [x] Placement or routing changes preserve persisted `RootId -> LogicalShardId`
  affinity, one active writer per shard, owner-epoch fencing, and explicit
  shard-local atomicity; no split root or cross-shard transaction is implied.
  The tests verify that the exact successor epoch and lease ID reach
  `Serving` without allocating another owner epoch.
  Shared fail-close removes affected routes and closes shard-operation admission.
* [x] Agent-interface changes keep the transport-free facade and schemas in
  `nokv-agent`, routing and workflows in `nokv-client`, and the concrete
  backend plus native full CLI and optional MCP-sidecar wiring in `nokv`.
  No Agent interface was changed.
* [x] User-facing integration guidance orders the native full CLI first, the
  direct Python SDK second, and MCP only as an optional sidecar.
  No Agent integration ordering or guidance was changed.

## Claims and Evidence

* [x] User-facing documentation distinguishes current, experimental, and
  planned capabilities.
  The CLI help documents an existing supported etcd lease-TTL option.
* [x] Security claims do not treat a Workbench root or Agent scope as tenant
  authentication or authorization.
  This PR makes no authentication or authorization claim.
* [x] Performance claims state the topology, comparison boundary, cache state,
  run count, and raw-evidence location.
  This PR makes no performance claim.
* [x] Benchmark-only behavior does not alter product semantics.
  The benchmark server now consumes the same owner renewal policy as the
  production server; no benchmark-only product behavior was added.

## Validation

### Before the original production fix

* `cargo test -p nokv-server successor_bootstrap_keeps_exact_lease_alive_during_post_acquisition_delay -- --nocapture`

  * **FAIL as expected**
  * Result: `Control(Backend("simulated owner lease expired after 1s"))`
  * This demonstrated that renewal did not occur during the injected post-acquisition bootstrap delay.

### After the production and review fixes

* `cargo +1.88.0 test -p nokv-control owner_lease_renew_interval_tracks_ttl_third_with_floor -- --nocapture`

  * **PASS**
* `cargo +1.88.0 test -p nokv-server successor_bootstrap_renews_between_admission_and_open_reconciliation -- --nocapture`

  * **PASS**
* `cargo +1.88.0 test -p nokv-server successor_owner_renews_after_bootstrap_before_first_steady_state_renewal -- --nocapture`

  * **PASS**
* `cargo +1.88.0 test -p nokv-server terminal_bootstrap_renewal_failure_fail_closes_owner_scope_and_stays_typed -- --nocapture`

  * **PASS**
* `cargo +1.88.0 test -p nokv-server terminal_bootstrap_renewal_failure_before_return_stays_typed -- --nocapture`

  * **PASS**
* `cargo +1.88.0 test -p nokv-server workspace_server_reports_typed_bootstrap_keepalive_failure -- --nocapture`

  * **PASS**
* `cargo +1.88.0 test -p nokv-server shared_owner_fail_close_blocks_ready_provider_delete -- --nocapture`

  * **PASS**
* `cargo +1.88.0 test -p nokv-server shared_fail_close_wins_provider_delete_dispatch_race -- --nocapture`

  * **PASS**
* `cargo +1.88.0 test -p nokv-server workspace_server_rejects_owner_renewal_policy_drift -- --nocapture`

  * **PASS**
* `cargo +1.88.0 test -p nokv-control --all-features`

  * **PASS**
* `cargo +1.88.0 test -p nokv-server --lib`

  * **PASS**
* `cargo +1.88.0 test -p nokv --features etcd`

  * **PASS**
* `cargo +1.88.0 check --workspace --all-targets --all-features`

  * **PASS**
* `cargo +stable fmt --all -- --check`

  * **PASS**
* `cargo +stable clippy --workspace --all-targets -- -D warnings`

  * **PASS**
* `cargo +stable test --workspace`

  * **PASS**
* `python3 scripts/workbench/workbench_contract_test.py`

  * **PASS**
* `git diff --check`

  * **PASS**

### Independent boundary evidence

The reviewer independently exercised the native CLI/server with etcd, Holt, and RustFS using a lease TTL shorter than the injected post-admission delay.

The healthy path retained the exact successor epoch and lease ID through bootstrap, reached `Serving`, remained on the same lease, and read back the pre-crash payload.

Revoking the successor lease during the slow window caused startup to fail before bind/`Serving`, preserving fail-closed behavior.

### Not run locally for the latest review follow-up

* The external native-CLI/etcd/Holt/RustFS boundary E2E was not rerun locally after the latest review changes.
  The independent reviewer evidence remains recorded in the review discussion.

## Contributor Sign-off

* [x] Every commit in this PR includes a DCO `Signed-off-by` trailer.
