### PR TITLE
fix(control): make expired recovery suspension idempotent

### DIFF
--- a/crates/nokv-control/src/etcd.rs
+++ b/crates/nokv-control/src/etcd.rs
@@ -625,8 +625,20 @@ impl ControlStore for EtcdControlStore {
             let current = fetch_logical_shard(&mut client, &options, &lease.logical_shard_id)
                 .await?
                 .ok_or(ControlError::LogicalShardNotFound(lease.logical_shard_id))?;
-            let session = validate_owner_session(&mut client, &options, &lease).await?;
             let retained = prepare_recovery_suspension(&current.record, &lease)?;
+
+            let Some(session) =
+                fetch_owner_session(&mut client, &options, &lease.logical_shard_id).await?
+            else {
+                revoke_lease_best_effort(&mut client, lease.lease_id).await;
+                return Ok(retained);
+            };
+
+            if session.lease != lease || session.attached_lease_id != lease_id_i64(lease.lease_id)?
+            {
+                return Err(ControlError::StaleLease(lease.clone()));
+            }
+
             let record_key = options.logical_shard_record_key(&lease.logical_shard_id);
             let session_key = options.logical_shard_session_key(&lease.logical_shard_id);
             let txn = Txn::new()
@@ -1335,7 +1347,7 @@ mod tests {
     use etcd_client::DeleteOptions;
 
     use super::*;
-    use crate::{AgentId, PlacementGeneration, RootPlacementLifecycle};
+    use crate::{AgentId, LogicalShardState, PlacementGeneration, RootPlacementLifecycle};
 
     fn root(fill: u8) -> RootId {
         RootId::from_bytes([fill; 16])
@@ -1775,6 +1787,133 @@ mod tests {
                     .await
                     .map_err(etcd_backend)?;
                 Ok(())
+            })
+            .unwrap();
+    }
+
+    #[test]
+    #[ignore = "requires NOKV_TEST_ETCD_ENDPOINT"]
+    fn etcd_expired_recovery_session_cleanup_rebinds_same_epoch() {
+        let endpoint = std::env::var("NOKV_TEST_ETCD_ENDPOINT")
+            .expect("NOKV_TEST_ETCD_ENDPOINT must name an isolated test etcd endpoint");
+
+        let nonce = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+
+        let prefix = format!(
+            "/nokv/test/expired-recovery-session-{}-{nonce}",
+            std::process::id()
+        );
+
+        let options = EtcdControlStoreOptions::new([endpoint]).with_key_prefix(prefix.clone());
+        let store = EtcdControlStore::connect(options.clone()).unwrap();
+        let logical_shard_id = shard(9);
+
+        store.create_logical_shard(logical_shard_id).unwrap();
+
+        store
+            .create_root_placement(RootPlacement {
+                root_id: root(9),
+                logical_shard_id,
+                placement_generation: PlacementGeneration::new(1).unwrap(),
+                lifecycle: RootPlacementLifecycle::Provisioning,
+            })
+            .unwrap();
+
+        let first = store
+            .acquire_owner(
+                &logical_shard_id,
+                NodeId::new("node-a").unwrap(),
+                "node-a:7000".to_owned(),
+            )
+            .unwrap();
+
+        // Revoke the real etcd lease. etcd removes the attached session key,
+        // while the durable Recovering record intentionally remains.
+        let mut client = store.client.clone();
+
+        store
+            .block_on(async {
+                client
+                    .lease_revoke(lease_id_i64(first.lease_id)?)
+                    .await
+                    .map_err(etcd_backend)?;
+
+                Ok::<(), ControlError>(())
+            })
+            .unwrap();
+
+        assert!(
+            store
+                .block_on(fetch_owner_session(
+                    &mut client,
+                    &options,
+                    &logical_shard_id,
+                ))
+                .unwrap()
+                .is_none(),
+            "revoking the etcd lease must remove its attached owner session"
+        );
+
+        assert!(matches!(
+            store.renew_owner(&first),
+            Err(ControlError::StaleLease(_))
+        ));
+
+        // Before the fix this returns StaleLease.
+        let retained = store.suspend_recovery(&first).unwrap();
+
+        assert_eq!(retained.state, LogicalShardState::Recovering);
+        assert_eq!(retained.owner_epoch, Some(first.owner_epoch));
+        assert_eq!(retained.lease_id, first.lease_id);
+        assert_eq!(store.suspend_recovery(&first).unwrap(), retained);
+
+        let rebound = store
+            .reacquire_recovery(
+                &logical_shard_id,
+                first.owner_epoch,
+                NodeId::new("node-b").unwrap(),
+                "node-b:7000".to_owned(),
+            )
+            .unwrap();
+
+        assert_eq!(rebound.owner_epoch, first.owner_epoch);
+        assert_ne!(rebound.lease_id, first.lease_id);
+
+        // Cleanup using the expired lease must not affect the live replacement.
+        assert!(matches!(
+            store.suspend_recovery(&first),
+            Err(ControlError::NotOwner { .. }) | Err(ControlError::StaleLease(_))
+        ));
+
+        assert_eq!(
+            store.renew_owner(&rebound).unwrap().lease_id,
+            rebound.lease_id
+        );
+
+        store
+            .mark_serving(
+                &rebound,
+                RecoveryPublication {
+                    checkpoint: None,
+                    log: None,
+                    durable_lsn: 0,
+                },
+            )
+            .unwrap();
+
+        store.release_owner(&rebound).unwrap();
+
+        store
+            .block_on(async {
+                client
+                    .delete(prefix, Some(DeleteOptions::new().with_prefix()))
+                    .await
+                    .map_err(etcd_backend)?;
+
+                Ok::<(), ControlError>(())
             })
             .unwrap();
     }

--- a/crates/nokv-control/src/etcd.rs
+++ b/crates/nokv-control/src/etcd.rs
@@ -48,6 +48,81 @@ struct StoredOwnerSession {
     attached_lease_id: i64,
 }
 
+#[cfg(test)]
+type SuspendRecoveryMissingSessionHook =
+    Box<dyn FnOnce() + Send + 'static>;
+
+#[cfg(test)]
+static SUSPEND_RECOVERY_MISSING_SESSION_HOOK:
+    std::sync::OnceLock<
+        std::sync::Mutex<
+            Option<(
+                LogicalShardId,
+                SuspendRecoveryMissingSessionHook,
+            )>,
+        >,
+    > = std::sync::OnceLock::new();
+
+#[cfg(test)]
+fn install_suspend_recovery_missing_session_hook(
+    logical_shard_id: LogicalShardId,
+    hook: impl FnOnce() + Send + 'static,
+) {
+    let slot =
+        SUSPEND_RECOVERY_MISSING_SESSION_HOOK
+            .get_or_init(|| std::sync::Mutex::new(None));
+
+    let mut guard = slot
+        .lock()
+        .expect(
+            "suspend-recovery test-hook mutex must remain available",
+        );
+
+    assert!(
+        guard.is_none(),
+        "suspend-recovery missing-session hook is already installed"
+    );
+
+    *guard = Some((
+        logical_shard_id,
+        Box::new(hook),
+    ));
+}
+
+#[cfg(test)]
+fn run_suspend_recovery_missing_session_hook(
+    logical_shard_id: &LogicalShardId,
+) {
+    let slot =
+        SUSPEND_RECOVERY_MISSING_SESSION_HOOK
+            .get_or_init(|| std::sync::Mutex::new(None));
+
+    let hook = {
+        let mut guard = slot
+            .lock()
+            .expect(
+                "suspend-recovery test-hook mutex must remain available",
+            );
+
+        let should_run = guard
+            .as_ref()
+            .map(|(expected, _)| {
+                expected == logical_shard_id
+            })
+            .unwrap_or(false);
+
+        if should_run {
+            guard.take().map(|(_, hook)| hook)
+        } else {
+            None
+        }
+    };
+
+    if let Some(hook) = hook {
+        hook();
+    }
+}
+
 impl EtcdControlStore {
     pub fn connect(options: EtcdControlStoreOptions) -> Result<Self, ControlError> {
         options.validate()?;
@@ -621,47 +696,124 @@ impl ControlStore for EtcdControlStore {
         let mut client = self.client.clone();
         let options = self.options.clone();
         let lease = lease.clone();
+
         self.block_on(async move {
-            let current = fetch_logical_shard(&mut client, &options, &lease.logical_shard_id)
+            let current =
+                fetch_logical_shard(
+                    &mut client,
+                    &options,
+                    &lease.logical_shard_id,
+                )
                 .await?
-                .ok_or(ControlError::LogicalShardNotFound(lease.logical_shard_id))?;
-            let retained = prepare_recovery_suspension(&current.record, &lease)?;
+                .ok_or(ControlError::LogicalShardNotFound(
+                    lease.logical_shard_id,
+                ))?;
 
-            let Some(session) =
-                fetch_owner_session(&mut client, &options, &lease.logical_shard_id).await?
-            else {
-                revoke_lease_best_effort(&mut client, lease.lease_id).await;
-                return Ok(retained);
-            };
+            let retained =
+                prepare_recovery_suspension(&current.record, &lease)?;
 
-            if session.lease != lease || session.attached_lease_id != lease_id_i64(lease.lease_id)?
-            {
-                return Err(ControlError::StaleLease(lease.clone()));
-            }
+            let session =
+                fetch_owner_session(
+                    &mut client,
+                    &options,
+                    &lease.logical_shard_id,
+                )
+                .await?;
 
-            let record_key = options.logical_shard_record_key(&lease.logical_shard_id);
-            let session_key = options.logical_shard_session_key(&lease.logical_shard_id);
-            let txn = Txn::new()
-                .when(vec![
-                    Compare::mod_revision(record_key, CompareOp::Equal, current.mod_revision),
-                    Compare::value(session_key.clone(), CompareOp::Equal, session.encoded),
-                    Compare::lease(
-                        session_key.clone(),
-                        CompareOp::Equal,
-                        lease_id_i64(lease.lease_id)?,
-                    ),
-                ])
-                .and_then(vec![TxnOp::delete(session_key, None)]);
-            let result = match client.txn(txn).await {
-                Ok(response) if response.succeeded() => Ok(retained),
-                Ok(_) | Err(_) => {
-                    classify_suspend_recovery_failure(&mut client, &options, &lease, &retained)
+            let result = match session {
+                None => {
+                    #[cfg(test)]
+                    run_suspend_recovery_missing_session_hook(
+                        &lease.logical_shard_id,
+                    );
+
+                    if exact_recovery_record_is_sessionless(
+                        &mut client,
+                        &options,
+                        &current,
+                    )
+                    .await?
+                    {
+                        Ok(retained.clone())
+                    } else {
+                        classify_suspend_recovery_failure(
+                            &mut client,
+                            &options,
+                            &lease,
+                            &current,
+                            &retained,
+                        )
                         .await
+                    }
+                }
+                Some(session) => {
+                    if session.lease != lease
+                        || session.attached_lease_id
+                            != lease_id_i64(lease.lease_id)?
+                    {
+                        return Err(ControlError::StaleLease(
+                            lease.clone(),
+                        ));
+                    }
+
+                    let record_key = options
+                        .logical_shard_record_key(
+                            &lease.logical_shard_id,
+                        );
+
+                    let session_key = options
+                        .logical_shard_session_key(
+                            &lease.logical_shard_id,
+                        );
+
+                    let txn = Txn::new()
+                        .when(vec![
+                            Compare::mod_revision(
+                                record_key,
+                                CompareOp::Equal,
+                                current.mod_revision,
+                            ),
+                            Compare::value(
+                                session_key.clone(),
+                                CompareOp::Equal,
+                                session.encoded,
+                            ),
+                            Compare::lease(
+                                session_key.clone(),
+                                CompareOp::Equal,
+                                lease_id_i64(lease.lease_id)?,
+                            ),
+                        ])
+                        .and_then(vec![
+                            TxnOp::delete(session_key, None),
+                        ]);
+
+                    match client.txn(txn).await {
+                        Ok(response) if response.succeeded() => {
+                            Ok(retained.clone())
+                        }
+                        Ok(_) | Err(_) => {
+                            classify_suspend_recovery_failure(
+                                &mut client,
+                                &options,
+                                &lease,
+                                &current,
+                                &retained,
+                            )
+                            .await
+                        }
+                    }
                 }
             };
+
             if result.is_ok() {
-                revoke_lease_best_effort(&mut client, lease.lease_id).await;
+                revoke_lease_best_effort(
+                    &mut client,
+                    lease.lease_id,
+                )
+                .await;
             }
+
             result
         })
     }
@@ -1254,26 +1406,82 @@ async fn classify_owner_record_mutation_failure(
     ))
 }
 
+async fn exact_recovery_record_is_sessionless(
+    client: &mut Client,
+    options: &EtcdControlStoreOptions,
+    expected: &StoredLogicalShard,
+) -> Result<bool, ControlError> {
+    let logical_shard_id = expected.record.logical_shard_id;
+
+    let record_key =
+        options.logical_shard_record_key(&logical_shard_id);
+
+    let session_key =
+        options.logical_shard_session_key(&logical_shard_id);
+
+    // This transaction is the linearization point for sessionless recovery
+    // suspension. The validated record revision and session absence must both
+    // still be true at the same etcd revision.
+    let txn = Txn::new()
+        .when(vec![
+            Compare::mod_revision(
+                record_key.clone(),
+                CompareOp::Equal,
+                expected.mod_revision,
+            ),
+            Compare::version(
+                session_key,
+                CompareOp::Equal,
+                0,
+            ),
+        ])
+        .and_then(vec![
+            TxnOp::get(record_key, None),
+        ]);
+
+    Ok(
+        client
+            .txn(txn)
+            .await
+            .map_err(etcd_backend)?
+            .succeeded(),
+    )
+}
+
 async fn classify_suspend_recovery_failure(
     client: &mut Client,
     options: &EtcdControlStoreOptions,
     lease: &LogicalShardLease,
+    expected: &StoredLogicalShard,
     retained: &LogicalShardRecord,
 ) -> Result<LogicalShardRecord, ControlError> {
-    let latest = fetch_logical_shard(client, options, &lease.logical_shard_id)
-        .await?
-        .ok_or(ControlError::LogicalShardNotFound(lease.logical_shard_id))?;
-    if latest.record == *retained
-        && fetch_owner_session(client, options, &lease.logical_shard_id)
-            .await?
-            .is_none()
+    if exact_recovery_record_is_sessionless(
+        client,
+        options,
+        expected,
+    )
+    .await?
     {
         return Ok(retained.clone());
     }
+
+    let latest =
+        fetch_logical_shard(
+            client,
+            options,
+            &lease.logical_shard_id,
+        )
+        .await?
+        .ok_or(ControlError::LogicalShardNotFound(
+            lease.logical_shard_id,
+        ))?;
+
     validate_record_lease(&latest.record, lease)?;
     validate_owner_session(client, options, lease).await?;
+
     Err(ControlError::Backend(
-        "recovery suspension CAS failed while the exact owner session remained current".to_owned(),
+        "recovery suspension CAS failed while the exact owner session remained current"
+            .to_owned(),
     ))
 }
 
@@ -1342,7 +1550,9 @@ fn etcd_backend(error: etcd_client::Error) -> ControlError {
 
 #[cfg(test)]
 mod tests {
-    use std::time::{SystemTime, UNIX_EPOCH};
+    use std::sync::mpsc;
+    use std::thread;
+    use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
     use etcd_client::DeleteOptions;
 
@@ -1917,4 +2127,390 @@ mod tests {
             })
             .unwrap();
     }
+
+    #[test]
+    #[ignore = "requires NOKV_TEST_ETCD_ENDPOINT"]
+    fn etcd_missing_session_fast_path_is_linearizable_against_rebind_and_mark_serving() {
+        let endpoint =
+            std::env::var("NOKV_TEST_ETCD_ENDPOINT")
+                .expect(
+                    "NOKV_TEST_ETCD_ENDPOINT must name an isolated test etcd endpoint",
+                );
+
+        let nonce = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+
+        let prefix = format!(
+            "/nokv/test/suspend-linearizability-{}-{nonce}",
+            std::process::id(),
+        );
+
+        let options =
+            EtcdControlStoreOptions::new([endpoint])
+                .with_key_prefix(prefix.clone());
+
+        let setup_store =
+            EtcdControlStore::connect(options.clone()).unwrap();
+
+        let logical_shard_id = shard(10);
+
+        setup_store
+            .create_logical_shard(logical_shard_id)
+            .unwrap();
+
+        setup_store
+            .create_root_placement(RootPlacement {
+                root_id: root(10),
+                logical_shard_id,
+                placement_generation:
+                    PlacementGeneration::new(1).unwrap(),
+                lifecycle:
+                    RootPlacementLifecycle::Provisioning,
+            })
+            .unwrap();
+
+        let first = setup_store
+            .acquire_owner(
+                &logical_shard_id,
+                NodeId::new("node-a").unwrap(),
+                "node-a:7000".to_owned(),
+            )
+            .unwrap();
+
+        let mut setup_client =
+            setup_store.client.clone();
+
+        setup_store
+            .block_on(async {
+                setup_client
+                    .lease_revoke(
+                        lease_id_i64(first.lease_id)?,
+                    )
+                    .await
+                    .map_err(etcd_backend)?;
+
+                Ok::<(), ControlError>(())
+            })
+            .unwrap();
+
+        assert!(
+            setup_store
+                .block_on(fetch_owner_session(
+                    &mut setup_client,
+                    &options,
+                    &logical_shard_id,
+                ))
+                .unwrap()
+                .is_none(),
+        );
+
+        let cleanup_store =
+            EtcdControlStore::connect(options.clone()).unwrap();
+
+        let contender_store =
+            EtcdControlStore::connect(options.clone()).unwrap();
+
+        let (reached_tx, reached_rx) =
+            mpsc::channel();
+
+        let (resume_tx, resume_rx) =
+            mpsc::channel();
+
+        install_suspend_recovery_missing_session_hook(
+            logical_shard_id,
+            move || {
+                reached_tx
+                    .send(())
+                    .expect(
+                        "test must signal the missing-session boundary",
+                    );
+
+                resume_rx
+                    .recv()
+                    .expect(
+                        "test must resume missing-session cleanup",
+                    );
+            },
+        );
+
+        let first_for_cleanup = first.clone();
+
+        let cleanup_thread = thread::spawn(move || {
+            cleanup_store
+                .suspend_recovery(&first_for_cleanup)
+        });
+
+        reached_rx
+            .recv_timeout(Duration::from_secs(5))
+            .expect(
+                "cleanup did not reach the missing-session boundary",
+            );
+
+        let rebound = contender_store
+            .reacquire_recovery(
+                &logical_shard_id,
+                first.owner_epoch,
+                first.owner.clone(),
+                "node-a:7001".to_owned(),
+            )
+            .unwrap();
+
+        assert_eq!(
+            rebound.owner_epoch,
+            first.owner_epoch,
+        );
+
+        assert_ne!(
+            rebound.lease_id,
+            first.lease_id,
+        );
+
+        contender_store
+            .mark_serving(
+                &rebound,
+                RecoveryPublication {
+                    checkpoint: None,
+                    log: None,
+                    durable_lsn: 0,
+                },
+            )
+            .unwrap();
+
+        resume_tx
+            .send(())
+            .expect(
+                "test must release the cleanup thread",
+            );
+
+        let cleanup_result = cleanup_thread
+            .join()
+            .expect(
+                "cleanup thread must not panic",
+            );
+
+        assert!(matches!(
+            cleanup_result,
+            Err(ControlError::StaleLease(_))
+                | Err(ControlError::NotOwner { .. })
+                | Err(
+                    ControlError::RecoveryStateConflict { .. }
+                )
+        ));
+
+        let latest = contender_store
+            .get_logical_shard(&logical_shard_id)
+            .unwrap()
+            .unwrap();
+
+        assert_eq!(
+            latest.state,
+            LogicalShardState::Serving,
+        );
+
+        assert_eq!(
+            latest.owner_epoch,
+            Some(rebound.owner_epoch),
+        );
+
+        assert_eq!(
+            latest.lease_id,
+            rebound.lease_id,
+        );
+
+        contender_store
+            .release_owner(&rebound)
+            .unwrap();
+
+        let mut cleanup_client =
+            contender_store.client.clone();
+
+        contender_store
+            .block_on(async {
+                cleanup_client
+                    .delete(
+                        prefix,
+                        Some(
+                            DeleteOptions::new()
+                                .with_prefix(),
+                        ),
+                    )
+                    .await
+                    .map_err(etcd_backend)?;
+
+                Ok::<(), ControlError>(())
+            })
+            .unwrap();
+    }
+
+    #[test]
+    #[ignore = "requires NOKV_TEST_ETCD_ENDPOINT"]
+    fn etcd_double_expiry_cleanup_requires_exact_rebound_lease() {
+        let endpoint =
+            std::env::var("NOKV_TEST_ETCD_ENDPOINT")
+                .expect(
+                    "NOKV_TEST_ETCD_ENDPOINT must name an isolated test etcd endpoint",
+                );
+
+        let nonce = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+
+        let prefix = format!(
+            "/nokv/test/double-expiry-{}-{nonce}",
+            std::process::id(),
+        );
+
+        let options =
+            EtcdControlStoreOptions::new([endpoint])
+                .with_key_prefix(prefix.clone());
+
+        let store =
+            EtcdControlStore::connect(options.clone()).unwrap();
+
+        let logical_shard_id = shard(11);
+
+        store
+            .create_logical_shard(logical_shard_id)
+            .unwrap();
+
+        store
+            .create_root_placement(RootPlacement {
+                root_id: root(11),
+                logical_shard_id,
+                placement_generation:
+                    PlacementGeneration::new(1).unwrap(),
+                lifecycle:
+                    RootPlacementLifecycle::Provisioning,
+            })
+            .unwrap();
+
+        let first = store
+            .acquire_owner(
+                &logical_shard_id,
+                NodeId::new("node-a").unwrap(),
+                "node-a:7000".to_owned(),
+            )
+            .unwrap();
+
+        let mut client = store.client.clone();
+
+        store
+            .block_on(async {
+                client
+                    .lease_revoke(
+                        lease_id_i64(first.lease_id)?,
+                    )
+                    .await
+                    .map_err(etcd_backend)?;
+
+                Ok::<(), ControlError>(())
+            })
+            .unwrap();
+
+        assert!(
+            store
+                .block_on(fetch_owner_session(
+                    &mut client,
+                    &options,
+                    &logical_shard_id,
+                ))
+                .unwrap()
+                .is_none(),
+        );
+
+        let rebound = store
+            .reacquire_recovery(
+                &logical_shard_id,
+                first.owner_epoch,
+                first.owner.clone(),
+                "node-a:7001".to_owned(),
+            )
+            .unwrap();
+
+        assert_eq!(
+            &rebound.owner,
+            &first.owner,
+        );
+
+        assert_eq!(
+            rebound.owner_epoch,
+            first.owner_epoch,
+        );
+
+        assert_ne!(
+            rebound.lease_id,
+            first.lease_id,
+        );
+
+        store
+            .block_on(async {
+                client
+                    .lease_revoke(
+                        lease_id_i64(rebound.lease_id)?,
+                    )
+                    .await
+                    .map_err(etcd_backend)?;
+
+                Ok::<(), ControlError>(())
+            })
+            .unwrap();
+
+        assert!(
+            store
+                .block_on(fetch_owner_session(
+                    &mut client,
+                    &options,
+                    &logical_shard_id,
+                ))
+                .unwrap()
+                .is_none(),
+        );
+
+        // Both sessions are absent. Cleanup for L1 must still be rejected
+        // because the durable Recovering record now identifies L2.
+        assert!(matches!(
+            store.suspend_recovery(&first),
+            Err(ControlError::StaleLease(_))
+                | Err(ControlError::NotOwner { .. })
+        ));
+
+        let retained =
+            store.suspend_recovery(&rebound).unwrap();
+
+        assert_eq!(
+            retained.state,
+            LogicalShardState::Recovering,
+        );
+
+        assert_eq!(
+            retained.owner_epoch,
+            Some(rebound.owner_epoch),
+        );
+
+        assert_eq!(
+            retained.lease_id,
+            rebound.lease_id,
+        );
+
+        store
+            .block_on(async {
+                client
+                    .delete(
+                        prefix,
+                        Some(
+                            DeleteOptions::new()
+                                .with_prefix(),
+                        ),
+                    )
+                    .await
+                    .map_err(etcd_backend)?;
+
+                Ok::<(), ControlError>(())
+            })
+            .unwrap();
+    }
+
 }

--- a/crates/nokv-control/src/etcd.rs
+++ b/crates/nokv-control/src/etcd.rs
@@ -49,66 +49,44 @@ struct StoredOwnerSession {
 }
 
 #[cfg(test)]
-type SuspendRecoveryMissingSessionHook =
-    Box<dyn FnOnce() + Send + 'static>;
+type SuspendRecoveryMissingSessionHook = Box<dyn FnOnce() + Send + 'static>;
 
 #[cfg(test)]
-static SUSPEND_RECOVERY_MISSING_SESSION_HOOK:
-    std::sync::OnceLock<
-        std::sync::Mutex<
-            Option<(
-                LogicalShardId,
-                SuspendRecoveryMissingSessionHook,
-            )>,
-        >,
-    > = std::sync::OnceLock::new();
+static SUSPEND_RECOVERY_MISSING_SESSION_HOOK: std::sync::OnceLock<
+    std::sync::Mutex<Option<(LogicalShardId, SuspendRecoveryMissingSessionHook)>>,
+> = std::sync::OnceLock::new();
 
 #[cfg(test)]
 fn install_suspend_recovery_missing_session_hook(
     logical_shard_id: LogicalShardId,
     hook: impl FnOnce() + Send + 'static,
 ) {
-    let slot =
-        SUSPEND_RECOVERY_MISSING_SESSION_HOOK
-            .get_or_init(|| std::sync::Mutex::new(None));
+    let slot = SUSPEND_RECOVERY_MISSING_SESSION_HOOK.get_or_init(|| std::sync::Mutex::new(None));
 
     let mut guard = slot
         .lock()
-        .expect(
-            "suspend-recovery test-hook mutex must remain available",
-        );
+        .expect("suspend-recovery test-hook mutex must remain available");
 
     assert!(
         guard.is_none(),
         "suspend-recovery missing-session hook is already installed"
     );
 
-    *guard = Some((
-        logical_shard_id,
-        Box::new(hook),
-    ));
+    *guard = Some((logical_shard_id, Box::new(hook)));
 }
 
 #[cfg(test)]
-fn run_suspend_recovery_missing_session_hook(
-    logical_shard_id: &LogicalShardId,
-) {
-    let slot =
-        SUSPEND_RECOVERY_MISSING_SESSION_HOOK
-            .get_or_init(|| std::sync::Mutex::new(None));
+fn run_suspend_recovery_missing_session_hook(logical_shard_id: &LogicalShardId) {
+    let slot = SUSPEND_RECOVERY_MISSING_SESSION_HOOK.get_or_init(|| std::sync::Mutex::new(None));
 
     let hook = {
         let mut guard = slot
             .lock()
-            .expect(
-                "suspend-recovery test-hook mutex must remain available",
-            );
+            .expect("suspend-recovery test-hook mutex must remain available");
 
         let should_run = guard
             .as_ref()
-            .map(|(expected, _)| {
-                expected == logical_shard_id
-            })
+            .map(|(expected, _)| expected == logical_shard_id)
             .unwrap_or(false);
 
         if should_run {
@@ -698,41 +676,21 @@ impl ControlStore for EtcdControlStore {
         let lease = lease.clone();
 
         self.block_on(async move {
-            let current =
-                fetch_logical_shard(
-                    &mut client,
-                    &options,
-                    &lease.logical_shard_id,
-                )
+            let current = fetch_logical_shard(&mut client, &options, &lease.logical_shard_id)
                 .await?
-                .ok_or(ControlError::LogicalShardNotFound(
-                    lease.logical_shard_id,
-                ))?;
+                .ok_or(ControlError::LogicalShardNotFound(lease.logical_shard_id))?;
 
-            let retained =
-                prepare_recovery_suspension(&current.record, &lease)?;
+            let retained = prepare_recovery_suspension(&current.record, &lease)?;
 
             let session =
-                fetch_owner_session(
-                    &mut client,
-                    &options,
-                    &lease.logical_shard_id,
-                )
-                .await?;
+                fetch_owner_session(&mut client, &options, &lease.logical_shard_id).await?;
 
             let result = match session {
                 None => {
                     #[cfg(test)]
-                    run_suspend_recovery_missing_session_hook(
-                        &lease.logical_shard_id,
-                    );
+                    run_suspend_recovery_missing_session_hook(&lease.logical_shard_id);
 
-                    if exact_recovery_record_is_sessionless(
-                        &mut client,
-                        &options,
-                        &current,
-                    )
-                    .await?
+                    if exact_recovery_record_is_sessionless(&mut client, &options, &current).await?
                     {
                         Ok(retained.clone())
                     } else {
@@ -748,23 +706,14 @@ impl ControlStore for EtcdControlStore {
                 }
                 Some(session) => {
                     if session.lease != lease
-                        || session.attached_lease_id
-                            != lease_id_i64(lease.lease_id)?
+                        || session.attached_lease_id != lease_id_i64(lease.lease_id)?
                     {
-                        return Err(ControlError::StaleLease(
-                            lease.clone(),
-                        ));
+                        return Err(ControlError::StaleLease(lease.clone()));
                     }
 
-                    let record_key = options
-                        .logical_shard_record_key(
-                            &lease.logical_shard_id,
-                        );
+                    let record_key = options.logical_shard_record_key(&lease.logical_shard_id);
 
-                    let session_key = options
-                        .logical_shard_session_key(
-                            &lease.logical_shard_id,
-                        );
+                    let session_key = options.logical_shard_session_key(&lease.logical_shard_id);
 
                     let txn = Txn::new()
                         .when(vec![
@@ -773,25 +722,17 @@ impl ControlStore for EtcdControlStore {
                                 CompareOp::Equal,
                                 current.mod_revision,
                             ),
-                            Compare::value(
-                                session_key.clone(),
-                                CompareOp::Equal,
-                                session.encoded,
-                            ),
+                            Compare::value(session_key.clone(), CompareOp::Equal, session.encoded),
                             Compare::lease(
                                 session_key.clone(),
                                 CompareOp::Equal,
                                 lease_id_i64(lease.lease_id)?,
                             ),
                         ])
-                        .and_then(vec![
-                            TxnOp::delete(session_key, None),
-                        ]);
+                        .and_then(vec![TxnOp::delete(session_key, None)]);
 
                     match client.txn(txn).await {
-                        Ok(response) if response.succeeded() => {
-                            Ok(retained.clone())
-                        }
+                        Ok(response) if response.succeeded() => Ok(retained.clone()),
                         Ok(_) | Err(_) => {
                             classify_suspend_recovery_failure(
                                 &mut client,
@@ -807,11 +748,7 @@ impl ControlStore for EtcdControlStore {
             };
 
             if result.is_ok() {
-                revoke_lease_best_effort(
-                    &mut client,
-                    lease.lease_id,
-                )
-                .await;
+                revoke_lease_best_effort(&mut client, lease.lease_id).await;
             }
 
             result
@@ -1413,39 +1350,21 @@ async fn exact_recovery_record_is_sessionless(
 ) -> Result<bool, ControlError> {
     let logical_shard_id = expected.record.logical_shard_id;
 
-    let record_key =
-        options.logical_shard_record_key(&logical_shard_id);
+    let record_key = options.logical_shard_record_key(&logical_shard_id);
 
-    let session_key =
-        options.logical_shard_session_key(&logical_shard_id);
+    let session_key = options.logical_shard_session_key(&logical_shard_id);
 
     // This transaction is the linearization point for sessionless recovery
     // suspension. The validated record revision and session absence must both
     // still be true at the same etcd revision.
     let txn = Txn::new()
         .when(vec![
-            Compare::mod_revision(
-                record_key.clone(),
-                CompareOp::Equal,
-                expected.mod_revision,
-            ),
-            Compare::version(
-                session_key,
-                CompareOp::Equal,
-                0,
-            ),
+            Compare::mod_revision(record_key.clone(), CompareOp::Equal, expected.mod_revision),
+            Compare::version(session_key, CompareOp::Equal, 0),
         ])
-        .and_then(vec![
-            TxnOp::get(record_key, None),
-        ]);
+        .and_then(vec![TxnOp::get(record_key, None)]);
 
-    Ok(
-        client
-            .txn(txn)
-            .await
-            .map_err(etcd_backend)?
-            .succeeded(),
-    )
+    Ok(client.txn(txn).await.map_err(etcd_backend)?.succeeded())
 }
 
 async fn classify_suspend_recovery_failure(
@@ -1455,33 +1374,19 @@ async fn classify_suspend_recovery_failure(
     expected: &StoredLogicalShard,
     retained: &LogicalShardRecord,
 ) -> Result<LogicalShardRecord, ControlError> {
-    if exact_recovery_record_is_sessionless(
-        client,
-        options,
-        expected,
-    )
-    .await?
-    {
+    if exact_recovery_record_is_sessionless(client, options, expected).await? {
         return Ok(retained.clone());
     }
 
-    let latest =
-        fetch_logical_shard(
-            client,
-            options,
-            &lease.logical_shard_id,
-        )
+    let latest = fetch_logical_shard(client, options, &lease.logical_shard_id)
         .await?
-        .ok_or(ControlError::LogicalShardNotFound(
-            lease.logical_shard_id,
-        ))?;
+        .ok_or(ControlError::LogicalShardNotFound(lease.logical_shard_id))?;
 
     validate_record_lease(&latest.record, lease)?;
     validate_owner_session(client, options, lease).await?;
 
     Err(ControlError::Backend(
-        "recovery suspension CAS failed while the exact owner session remained current"
-            .to_owned(),
+        "recovery suspension CAS failed while the exact owner session remained current".to_owned(),
     ))
 }
 
@@ -2131,11 +2036,8 @@ mod tests {
     #[test]
     #[ignore = "requires NOKV_TEST_ETCD_ENDPOINT"]
     fn etcd_missing_session_fast_path_is_linearizable_against_rebind_and_mark_serving() {
-        let endpoint =
-            std::env::var("NOKV_TEST_ETCD_ENDPOINT")
-                .expect(
-                    "NOKV_TEST_ETCD_ENDPOINT must name an isolated test etcd endpoint",
-                );
+        let endpoint = std::env::var("NOKV_TEST_ETCD_ENDPOINT")
+            .expect("NOKV_TEST_ETCD_ENDPOINT must name an isolated test etcd endpoint");
 
         let nonce = SystemTime::now()
             .duration_since(UNIX_EPOCH)
@@ -2147,27 +2049,20 @@ mod tests {
             std::process::id(),
         );
 
-        let options =
-            EtcdControlStoreOptions::new([endpoint])
-                .with_key_prefix(prefix.clone());
+        let options = EtcdControlStoreOptions::new([endpoint]).with_key_prefix(prefix.clone());
 
-        let setup_store =
-            EtcdControlStore::connect(options.clone()).unwrap();
+        let setup_store = EtcdControlStore::connect(options.clone()).unwrap();
 
         let logical_shard_id = shard(10);
 
-        setup_store
-            .create_logical_shard(logical_shard_id)
-            .unwrap();
+        setup_store.create_logical_shard(logical_shard_id).unwrap();
 
         setup_store
             .create_root_placement(RootPlacement {
                 root_id: root(10),
                 logical_shard_id,
-                placement_generation:
-                    PlacementGeneration::new(1).unwrap(),
-                lifecycle:
-                    RootPlacementLifecycle::Provisioning,
+                placement_generation: PlacementGeneration::new(1).unwrap(),
+                lifecycle: RootPlacementLifecycle::Provisioning,
             })
             .unwrap();
 
@@ -2179,15 +2074,12 @@ mod tests {
             )
             .unwrap();
 
-        let mut setup_client =
-            setup_store.client.clone();
+        let mut setup_client = setup_store.client.clone();
 
         setup_store
             .block_on(async {
                 setup_client
-                    .lease_revoke(
-                        lease_id_i64(first.lease_id)?,
-                    )
+                    .lease_revoke(lease_id_i64(first.lease_id)?)
                     .await
                     .map_err(etcd_backend)?;
 
@@ -2195,58 +2087,41 @@ mod tests {
             })
             .unwrap();
 
-        assert!(
-            setup_store
-                .block_on(fetch_owner_session(
-                    &mut setup_client,
-                    &options,
-                    &logical_shard_id,
-                ))
-                .unwrap()
-                .is_none(),
-        );
+        assert!(setup_store
+            .block_on(fetch_owner_session(
+                &mut setup_client,
+                &options,
+                &logical_shard_id,
+            ))
+            .unwrap()
+            .is_none(),);
 
-        let cleanup_store =
-            EtcdControlStore::connect(options.clone()).unwrap();
+        let cleanup_store = EtcdControlStore::connect(options.clone()).unwrap();
 
-        let contender_store =
-            EtcdControlStore::connect(options.clone()).unwrap();
+        let contender_store = EtcdControlStore::connect(options.clone()).unwrap();
 
-        let (reached_tx, reached_rx) =
-            mpsc::channel();
+        let (reached_tx, reached_rx) = mpsc::channel();
 
-        let (resume_tx, resume_rx) =
-            mpsc::channel();
+        let (resume_tx, resume_rx) = mpsc::channel();
 
-        install_suspend_recovery_missing_session_hook(
-            logical_shard_id,
-            move || {
-                reached_tx
-                    .send(())
-                    .expect(
-                        "test must signal the missing-session boundary",
-                    );
+        install_suspend_recovery_missing_session_hook(logical_shard_id, move || {
+            reached_tx
+                .send(())
+                .expect("test must signal the missing-session boundary");
 
-                resume_rx
-                    .recv()
-                    .expect(
-                        "test must resume missing-session cleanup",
-                    );
-            },
-        );
+            resume_rx
+                .recv()
+                .expect("test must resume missing-session cleanup");
+        });
 
         let first_for_cleanup = first.clone();
 
-        let cleanup_thread = thread::spawn(move || {
-            cleanup_store
-                .suspend_recovery(&first_for_cleanup)
-        });
+        let cleanup_thread =
+            thread::spawn(move || cleanup_store.suspend_recovery(&first_for_cleanup));
 
         reached_rx
             .recv_timeout(Duration::from_secs(5))
-            .expect(
-                "cleanup did not reach the missing-session boundary",
-            );
+            .expect("cleanup did not reach the missing-session boundary");
 
         let rebound = contender_store
             .reacquire_recovery(
@@ -2257,15 +2132,9 @@ mod tests {
             )
             .unwrap();
 
-        assert_eq!(
-            rebound.owner_epoch,
-            first.owner_epoch,
-        );
+        assert_eq!(rebound.owner_epoch, first.owner_epoch,);
 
-        assert_ne!(
-            rebound.lease_id,
-            first.lease_id,
-        );
+        assert_ne!(rebound.lease_id, first.lease_id,);
 
         contender_store
             .mark_serving(
@@ -2280,23 +2149,17 @@ mod tests {
 
         resume_tx
             .send(())
-            .expect(
-                "test must release the cleanup thread",
-            );
+            .expect("test must release the cleanup thread");
 
         let cleanup_result = cleanup_thread
             .join()
-            .expect(
-                "cleanup thread must not panic",
-            );
+            .expect("cleanup thread must not panic");
 
         assert!(matches!(
             cleanup_result,
             Err(ControlError::StaleLease(_))
                 | Err(ControlError::NotOwner { .. })
-                | Err(
-                    ControlError::RecoveryStateConflict { .. }
-                )
+                | Err(ControlError::RecoveryStateConflict { .. })
         ));
 
         let latest = contender_store
@@ -2304,38 +2167,20 @@ mod tests {
             .unwrap()
             .unwrap();
 
-        assert_eq!(
-            latest.state,
-            LogicalShardState::Serving,
-        );
+        assert_eq!(latest.state, LogicalShardState::Serving,);
 
-        assert_eq!(
-            latest.owner_epoch,
-            Some(rebound.owner_epoch),
-        );
+        assert_eq!(latest.owner_epoch, Some(rebound.owner_epoch),);
 
-        assert_eq!(
-            latest.lease_id,
-            rebound.lease_id,
-        );
+        assert_eq!(latest.lease_id, rebound.lease_id,);
 
-        contender_store
-            .release_owner(&rebound)
-            .unwrap();
+        contender_store.release_owner(&rebound).unwrap();
 
-        let mut cleanup_client =
-            contender_store.client.clone();
+        let mut cleanup_client = contender_store.client.clone();
 
         contender_store
             .block_on(async {
                 cleanup_client
-                    .delete(
-                        prefix,
-                        Some(
-                            DeleteOptions::new()
-                                .with_prefix(),
-                        ),
-                    )
+                    .delete(prefix, Some(DeleteOptions::new().with_prefix()))
                     .await
                     .map_err(etcd_backend)?;
 
@@ -2347,43 +2192,30 @@ mod tests {
     #[test]
     #[ignore = "requires NOKV_TEST_ETCD_ENDPOINT"]
     fn etcd_double_expiry_cleanup_requires_exact_rebound_lease() {
-        let endpoint =
-            std::env::var("NOKV_TEST_ETCD_ENDPOINT")
-                .expect(
-                    "NOKV_TEST_ETCD_ENDPOINT must name an isolated test etcd endpoint",
-                );
+        let endpoint = std::env::var("NOKV_TEST_ETCD_ENDPOINT")
+            .expect("NOKV_TEST_ETCD_ENDPOINT must name an isolated test etcd endpoint");
 
         let nonce = SystemTime::now()
             .duration_since(UNIX_EPOCH)
             .unwrap()
             .as_nanos();
 
-        let prefix = format!(
-            "/nokv/test/double-expiry-{}-{nonce}",
-            std::process::id(),
-        );
+        let prefix = format!("/nokv/test/double-expiry-{}-{nonce}", std::process::id(),);
 
-        let options =
-            EtcdControlStoreOptions::new([endpoint])
-                .with_key_prefix(prefix.clone());
+        let options = EtcdControlStoreOptions::new([endpoint]).with_key_prefix(prefix.clone());
 
-        let store =
-            EtcdControlStore::connect(options.clone()).unwrap();
+        let store = EtcdControlStore::connect(options.clone()).unwrap();
 
         let logical_shard_id = shard(11);
 
-        store
-            .create_logical_shard(logical_shard_id)
-            .unwrap();
+        store.create_logical_shard(logical_shard_id).unwrap();
 
         store
             .create_root_placement(RootPlacement {
                 root_id: root(11),
                 logical_shard_id,
-                placement_generation:
-                    PlacementGeneration::new(1).unwrap(),
-                lifecycle:
-                    RootPlacementLifecycle::Provisioning,
+                placement_generation: PlacementGeneration::new(1).unwrap(),
+                lifecycle: RootPlacementLifecycle::Provisioning,
             })
             .unwrap();
 
@@ -2400,9 +2232,7 @@ mod tests {
         store
             .block_on(async {
                 client
-                    .lease_revoke(
-                        lease_id_i64(first.lease_id)?,
-                    )
+                    .lease_revoke(lease_id_i64(first.lease_id)?)
                     .await
                     .map_err(etcd_backend)?;
 
@@ -2410,16 +2240,14 @@ mod tests {
             })
             .unwrap();
 
-        assert!(
-            store
-                .block_on(fetch_owner_session(
-                    &mut client,
-                    &options,
-                    &logical_shard_id,
-                ))
-                .unwrap()
-                .is_none(),
-        );
+        assert!(store
+            .block_on(fetch_owner_session(
+                &mut client,
+                &options,
+                &logical_shard_id,
+            ))
+            .unwrap()
+            .is_none(),);
 
         let rebound = store
             .reacquire_recovery(
@@ -2430,27 +2258,16 @@ mod tests {
             )
             .unwrap();
 
-        assert_eq!(
-            &rebound.owner,
-            &first.owner,
-        );
+        assert_eq!(&rebound.owner, &first.owner,);
 
-        assert_eq!(
-            rebound.owner_epoch,
-            first.owner_epoch,
-        );
+        assert_eq!(rebound.owner_epoch, first.owner_epoch,);
 
-        assert_ne!(
-            rebound.lease_id,
-            first.lease_id,
-        );
+        assert_ne!(rebound.lease_id, first.lease_id,);
 
         store
             .block_on(async {
                 client
-                    .lease_revoke(
-                        lease_id_i64(rebound.lease_id)?,
-                    )
+                    .lease_revoke(lease_id_i64(rebound.lease_id)?)
                     .await
                     .map_err(etcd_backend)?;
 
@@ -2458,53 +2275,34 @@ mod tests {
             })
             .unwrap();
 
-        assert!(
-            store
-                .block_on(fetch_owner_session(
-                    &mut client,
-                    &options,
-                    &logical_shard_id,
-                ))
-                .unwrap()
-                .is_none(),
-        );
+        assert!(store
+            .block_on(fetch_owner_session(
+                &mut client,
+                &options,
+                &logical_shard_id,
+            ))
+            .unwrap()
+            .is_none(),);
 
         // Both sessions are absent. Cleanup for L1 must still be rejected
         // because the durable Recovering record now identifies L2.
         assert!(matches!(
             store.suspend_recovery(&first),
-            Err(ControlError::StaleLease(_))
-                | Err(ControlError::NotOwner { .. })
+            Err(ControlError::StaleLease(_)) | Err(ControlError::NotOwner { .. })
         ));
 
-        let retained =
-            store.suspend_recovery(&rebound).unwrap();
+        let retained = store.suspend_recovery(&rebound).unwrap();
 
-        assert_eq!(
-            retained.state,
-            LogicalShardState::Recovering,
-        );
+        assert_eq!(retained.state, LogicalShardState::Recovering,);
 
-        assert_eq!(
-            retained.owner_epoch,
-            Some(rebound.owner_epoch),
-        );
+        assert_eq!(retained.owner_epoch, Some(rebound.owner_epoch),);
 
-        assert_eq!(
-            retained.lease_id,
-            rebound.lease_id,
-        );
+        assert_eq!(retained.lease_id, rebound.lease_id,);
 
         store
             .block_on(async {
                 client
-                    .delete(
-                        prefix,
-                        Some(
-                            DeleteOptions::new()
-                                .with_prefix(),
-                        ),
-                    )
+                    .delete(prefix, Some(DeleteOptions::new().with_prefix()))
                     .await
                     .map_err(etcd_backend)?;
 
@@ -2513,4 +2311,193 @@ mod tests {
             .unwrap();
     }
 
+    #[test]
+    #[ignore = "requires NOKV_TEST_ETCD_ENDPOINT"]
+    fn etcd_record_revision_fences_stale_cleanup_after_double_expiry_interleaving() {
+        let endpoint = std::env::var("NOKV_TEST_ETCD_ENDPOINT")
+            .expect("NOKV_TEST_ETCD_ENDPOINT must name an isolated test etcd endpoint");
+
+        let nonce = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+
+        let process_id = std::process::id();
+
+        let prefix = format!("/nokv/test/record-revision-double-expiry-{process_id}-{nonce}");
+
+        let options = EtcdControlStoreOptions::new([endpoint]).with_key_prefix(prefix.clone());
+
+        let setup_store = EtcdControlStore::connect(options.clone()).unwrap();
+
+        let logical_shard_id = shard(12);
+
+        setup_store.create_logical_shard(logical_shard_id).unwrap();
+
+        setup_store
+            .create_root_placement(RootPlacement {
+                root_id: root(12),
+                logical_shard_id,
+                placement_generation: PlacementGeneration::new(1).unwrap(),
+                lifecycle: RootPlacementLifecycle::Provisioning,
+            })
+            .unwrap();
+
+        let first = setup_store
+            .acquire_owner(
+                &logical_shard_id,
+                NodeId::new("node-a").unwrap(),
+                "node-a:7000".to_owned(),
+            )
+            .unwrap();
+
+        let mut setup_client = setup_store.client.clone();
+
+        setup_store
+            .block_on(async {
+                setup_client
+                    .lease_revoke(lease_id_i64(first.lease_id)?)
+                    .await
+                    .map_err(etcd_backend)?;
+
+                Ok::<(), ControlError>(())
+            })
+            .unwrap();
+
+        assert!(
+            setup_store
+                .block_on(fetch_owner_session(
+                    &mut setup_client,
+                    &options,
+                    &logical_shard_id,
+                ))
+                .unwrap()
+                .is_none(),
+            "L1 session must be absent before cleanup reads it",
+        );
+
+        let cleanup_store = EtcdControlStore::connect(options.clone()).unwrap();
+
+        let contender_store = EtcdControlStore::connect(options.clone()).unwrap();
+
+        let (reached_tx, reached_rx) = std::sync::mpsc::channel();
+
+        let (resume_tx, resume_rx) = std::sync::mpsc::channel();
+
+        install_suspend_recovery_missing_session_hook(logical_shard_id, move || {
+            reached_tx
+                .send(())
+                .expect("test must signal that cleanup observed the absent L1 session");
+
+            resume_rx
+                .recv_timeout(std::time::Duration::from_secs(10))
+                .expect("test must resume stale L1 cleanup");
+        });
+
+        let first_for_cleanup = first.clone();
+
+        let cleanup_thread =
+            std::thread::spawn(move || cleanup_store.suspend_recovery(&first_for_cleanup));
+
+        reached_rx
+            .recv_timeout(std::time::Duration::from_secs(5))
+            .expect("cleanup did not reach the missing-session boundary");
+
+        // Rebind the exact same owner and recovery epoch as L2.
+        let rebound = contender_store
+            .reacquire_recovery(
+                &logical_shard_id,
+                first.owner_epoch,
+                first.owner.clone(),
+                "node-a:7001".to_owned(),
+            )
+            .unwrap();
+
+        assert_eq!(rebound.owner_epoch, first.owner_epoch,);
+
+        assert_ne!(rebound.lease_id, first.lease_id,);
+
+        // Expire L2 as well. Both session keys are now absent, while the
+        // durable Recovering record identifies L2 rather than L1.
+        let mut contender_client = contender_store.client.clone();
+
+        contender_store
+            .block_on(async {
+                contender_client
+                    .lease_revoke(lease_id_i64(rebound.lease_id)?)
+                    .await
+                    .map_err(etcd_backend)?;
+
+                Ok::<(), ControlError>(())
+            })
+            .unwrap();
+
+        let rebound_session = contender_store
+            .block_on(fetch_owner_session(
+                &mut contender_client,
+                &options,
+                &logical_shard_id,
+            ))
+            .unwrap();
+
+        let latest = contender_store
+            .get_logical_shard(&logical_shard_id)
+            .unwrap()
+            .unwrap();
+
+        assert_eq!(latest.state, LogicalShardState::Recovering,);
+
+        assert_eq!(latest.owner_epoch, Some(rebound.owner_epoch),);
+
+        assert_eq!(latest.lease_id, rebound.lease_id,);
+
+        assert_ne!(latest.lease_id, first.lease_id,);
+
+        // Always release the paused cleanup thread before assertions that can
+        // terminate this test.
+        resume_tx
+            .send(())
+            .expect("test must release stale L1 cleanup");
+
+        assert!(
+            rebound_session.is_none(),
+            "L2 session must be absent before stale L1 cleanup resumes",
+        );
+
+        let cleanup_result = cleanup_thread
+            .join()
+            .expect("stale L1 cleanup thread must not panic");
+
+        match cleanup_result {
+            Err(ControlError::StaleLease(stale)) => {
+                assert_eq!(
+                    stale, first,
+                    "StaleLease must identify the rejected L1 lease",
+                );
+            }
+            other => {
+                panic!("cleanup(L1) must be exactly StaleLease after L2 expires; got {other:?}")
+            }
+        }
+
+        // Cleanup of the exact currently recorded L2 lease must still succeed.
+        let retained = contender_store.suspend_recovery(&rebound).unwrap();
+
+        assert_eq!(retained.state, LogicalShardState::Recovering,);
+
+        assert_eq!(retained.owner_epoch, Some(rebound.owner_epoch),);
+
+        assert_eq!(retained.lease_id, rebound.lease_id,);
+
+        contender_store
+            .block_on(async {
+                contender_client
+                    .delete(prefix, Some(DeleteOptions::new().with_prefix()))
+                    .await
+                    .map_err(etcd_backend)?;
+
+                Ok::<(), ControlError>(())
+            })
+            .unwrap();
+    }
 }

--- a/crates/nokv-control/src/store.rs
+++ b/crates/nokv-control/src/store.rs
@@ -2181,10 +2181,7 @@ mod tests {
             .owner_sessions
             .remove(&first.logical_shard_id);
 
-        assert_eq!(
-            expired_first,
-            Some(first.clone()),
-        );
+        assert_eq!(expired_first, Some(first.clone()),);
 
         let rebound = store
             .reacquire_recovery(
@@ -2195,20 +2192,11 @@ mod tests {
             )
             .unwrap();
 
-        assert_eq!(
-            &rebound.owner,
-            &first.owner,
-        );
+        assert_eq!(&rebound.owner, &first.owner,);
 
-        assert_eq!(
-            rebound.owner_epoch,
-            first.owner_epoch,
-        );
+        assert_eq!(rebound.owner_epoch, first.owner_epoch,);
 
-        assert_ne!(
-            rebound.lease_id,
-            first.lease_id,
-        );
+        assert_ne!(rebound.lease_id, first.lease_id,);
 
         let expired_rebound = store
             .state
@@ -2217,10 +2205,7 @@ mod tests {
             .owner_sessions
             .remove(&rebound.logical_shard_id);
 
-        assert_eq!(
-            expired_rebound,
-            Some(rebound.clone()),
-        );
+        assert_eq!(expired_rebound, Some(rebound.clone()),);
 
         // Both sessions are absent. Only the durable record's exact lease ID
         // can distinguish stale L1 cleanup from current L2 cleanup.
@@ -2229,23 +2214,13 @@ mod tests {
             Err(ControlError::StaleLease(_))
         ));
 
-        let retained =
-            store.suspend_recovery(&rebound).unwrap();
+        let retained = store.suspend_recovery(&rebound).unwrap();
 
-        assert_eq!(
-            retained.state,
-            LogicalShardState::Recovering,
-        );
+        assert_eq!(retained.state, LogicalShardState::Recovering,);
 
-        assert_eq!(
-            retained.owner_epoch,
-            Some(rebound.owner_epoch),
-        );
+        assert_eq!(retained.owner_epoch, Some(rebound.owner_epoch),);
 
-        assert_eq!(
-            retained.lease_id,
-            rebound.lease_id,
-        );
+        assert_eq!(retained.lease_id, rebound.lease_id,);
     }
 
     #[test]

--- a/crates/nokv-control/src/store.rs
+++ b/crates/nokv-control/src/store.rs
@@ -139,6 +139,10 @@ pub trait ControlStore: Send + Sync {
 
     /// End the live session for a boot that has not reached `Serving`, while
     /// retaining its durable recovery epoch for an exact retry.
+    ///
+    /// If the exact recorded recovery session has already expired, suspension
+    /// is an idempotent success. A different live or rebound session remains
+    /// fenced and must never be removed by this operation.
     fn suspend_recovery(
         &self,
         lease: &LogicalShardLease,
@@ -540,11 +544,16 @@ impl ControlStore for InMemoryControlStore {
             .get(&lease.logical_shard_id)
             .cloned()
             .ok_or(ControlError::LogicalShardNotFound(lease.logical_shard_id))?;
-        validate_record_lease(&current, lease)?;
-        validate_in_memory_session(&state, lease)?;
         let retained = prepare_recovery_suspension(&current, lease)?;
-        state.owner_sessions.remove(&lease.logical_shard_id);
-        Ok(retained)
+
+        match state.owner_sessions.get(&lease.logical_shard_id).cloned() {
+            None => Ok(retained),
+            Some(session) if session == *lease => {
+                state.owner_sessions.remove(&lease.logical_shard_id);
+                Ok(retained)
+            }
+            Some(_) => Err(ControlError::StaleLease(lease.clone())),
+        }
     }
 
     fn release_owner(&self, lease: &LogicalShardLease) -> Result<LogicalShardRecord, ControlError> {
@@ -2050,6 +2059,113 @@ mod tests {
             )
             .unwrap();
         store.release_owner(&rebound).unwrap();
+    }
+
+    #[test]
+    fn expired_recovery_session_cleanup_is_idempotent_and_rebinds_same_epoch() {
+        let store = InMemoryControlStore::new();
+        let first = acquire_placed_shard(&store, 1, 1);
+
+        // Simulate backend lease expiry without calling suspend_recovery().
+        // The durable Recovering record remains, but its liveness session is gone.
+        let expired = store
+            .state
+            .lock()
+            .expect("control store mutex poisoned")
+            .owner_sessions
+            .remove(&first.logical_shard_id);
+
+        assert_eq!(expired, Some(first.clone()));
+        assert!(matches!(
+            store.renew_owner(&first),
+            Err(ControlError::StaleLease(_))
+        ));
+
+        // Current main fails here with StaleLease even though the exact durable
+        // record still identifies this recovery attempt and no live session exists.
+        let retained = store.suspend_recovery(&first).unwrap();
+
+        assert_eq!(retained.state, LogicalShardState::Recovering);
+        assert_eq!(retained.owner_epoch, Some(first.owner_epoch));
+        assert_eq!(retained.owner.as_ref(), Some(&first.owner));
+        assert_eq!(retained.lease_id, first.lease_id);
+
+        // Cleanup should remain idempotent while the exact record is unchanged
+        // and the session remains absent.
+        assert_eq!(
+            store.suspend_recovery(&first).unwrap(),
+            retained,
+            "suspending an already-expired exact recovery session is idempotent"
+        );
+
+        // The durable recovery epoch must be rebound, not incremented.
+        let rebound = store
+            .reacquire_recovery(
+                &first.logical_shard_id,
+                first.owner_epoch,
+                node("node-b"),
+                "node-b:7000".to_owned(),
+            )
+            .unwrap();
+
+        assert_eq!(rebound.owner_epoch, first.owner_epoch);
+        assert_ne!(rebound.lease_id, first.lease_id);
+
+        store
+            .mark_serving(
+                &rebound,
+                RecoveryPublication {
+                    checkpoint: None,
+                    log: None,
+                    durable_lsn: 0,
+                },
+            )
+            .unwrap();
+
+        store.release_owner(&rebound).unwrap();
+    }
+
+    #[test]
+    fn expired_recovery_cleanup_cannot_suspend_rebound_live_session() {
+        let store = InMemoryControlStore::new();
+        let first = acquire_placed_shard(&store, 1, 1);
+
+        let expired = store
+            .state
+            .lock()
+            .expect("control store mutex poisoned")
+            .owner_sessions
+            .remove(&first.logical_shard_id);
+
+        assert_eq!(expired, Some(first.clone()));
+
+        // Rebind using the same owner and epoch, but a different lease ID. This
+        // isolates the lease-ID fence rather than relying on an owner mismatch.
+        let rebound = store
+            .reacquire_recovery(
+                &first.logical_shard_id,
+                first.owner_epoch,
+                first.owner.clone(),
+                "node-a:7001".to_owned(),
+            )
+            .unwrap();
+
+        assert_eq!(rebound.owner, first.owner);
+        assert_eq!(rebound.owner_epoch, first.owner_epoch);
+        assert_ne!(rebound.lease_id, first.lease_id);
+
+        // The old lease must never be allowed to suspend the rebound session.
+        assert!(matches!(
+            store.suspend_recovery(&first),
+            Err(ControlError::StaleLease(_))
+        ));
+
+        // Prove that the rebound session is still live and was not removed.
+        let renewed = store.renew_owner(&rebound).unwrap();
+        assert_eq!(renewed.lease_id, rebound.lease_id);
+        assert_eq!(renewed.owner_epoch, Some(rebound.owner_epoch));
+
+        store.suspend_recovery(&rebound).unwrap();
     }
 
     #[test]

--- a/crates/nokv-control/src/store.rs
+++ b/crates/nokv-control/src/store.rs
@@ -141,8 +141,9 @@ pub trait ControlStore: Send + Sync {
     /// retaining its durable recovery epoch for an exact retry.
     ///
     /// If the exact recorded recovery session has already expired, suspension
-    /// is an idempotent success. A different live or rebound session remains
-    /// fenced and must never be removed by this operation.
+    /// is an idempotent success only while the durable `Recovering` record still
+    /// identifies that exact lease. Backends must linearize record identity and
+    /// session absence. A different live or rebound lease remains fenced.
     fn suspend_recovery(
         &self,
         lease: &LogicalShardLease,
@@ -2166,6 +2167,85 @@ mod tests {
         assert_eq!(renewed.owner_epoch, Some(rebound.owner_epoch));
 
         store.suspend_recovery(&rebound).unwrap();
+    }
+
+    #[test]
+    fn double_expiry_cleanup_requires_exact_rebound_lease() {
+        let store = InMemoryControlStore::new();
+        let first = acquire_placed_shard(&store, 1, 1);
+
+        let expired_first = store
+            .state
+            .lock()
+            .expect("control store mutex poisoned")
+            .owner_sessions
+            .remove(&first.logical_shard_id);
+
+        assert_eq!(
+            expired_first,
+            Some(first.clone()),
+        );
+
+        let rebound = store
+            .reacquire_recovery(
+                &first.logical_shard_id,
+                first.owner_epoch,
+                first.owner.clone(),
+                "node-a:7001".to_owned(),
+            )
+            .unwrap();
+
+        assert_eq!(
+            &rebound.owner,
+            &first.owner,
+        );
+
+        assert_eq!(
+            rebound.owner_epoch,
+            first.owner_epoch,
+        );
+
+        assert_ne!(
+            rebound.lease_id,
+            first.lease_id,
+        );
+
+        let expired_rebound = store
+            .state
+            .lock()
+            .expect("control store mutex poisoned")
+            .owner_sessions
+            .remove(&rebound.logical_shard_id);
+
+        assert_eq!(
+            expired_rebound,
+            Some(rebound.clone()),
+        );
+
+        // Both sessions are absent. Only the durable record's exact lease ID
+        // can distinguish stale L1 cleanup from current L2 cleanup.
+        assert!(matches!(
+            store.suspend_recovery(&first),
+            Err(ControlError::StaleLease(_))
+        ));
+
+        let retained =
+            store.suspend_recovery(&rebound).unwrap();
+
+        assert_eq!(
+            retained.state,
+            LogicalShardState::Recovering,
+        );
+
+        assert_eq!(
+            retained.owner_epoch,
+            Some(rebound.owner_epoch),
+        );
+
+        assert_eq!(
+            retained.lease_id,
+            rebound.lease_id,
+        );
     }
 
     #[test]


### PR DESCRIPTION
<!--
Copyright 2024-2026 The NoKV Authors.
SPDX-License-Identifier: Apache-2.0
-->

## Related Issue

<!--
Every non-trivial PR should be tied to an existing issue so maintainers can
review the agreed problem, scope, and design history before reading the diff.

Use one of:
- Closes #issue_number
- Fixes #issue_number
- Relates to #issue_number

Small exceptions are allowed for typo-only docs edits, CI/dependency chores,
release chores, and maintainer-approved emergency fixes. If this PR has no
issue, explain the exception here.
-->


Fixes #492

## Summary

Make recovery suspension idempotent when the exact durable `Recovering`
record still matches the supplied lease but its backend owner session has
already expired.

This allows interrupted recovery cleanup to complete without returning a
second `StaleLease`, while preserving same-epoch recovery rebind and exact
owner fencing.

## Problem

A logical-shard recovery record intentionally remains durable after its
lease-attached owner session disappears. The record retains the recovery epoch
and last lease identity so that another contender can safely resume recovery at
the same epoch.

Before this change, `suspend_recovery()` required the exact live session to
exist before it would retain the recovery record. When that session had already
expired, cleanup returned `StaleLease` even though:

- the durable record still exactly matched the supplied owner, epoch, and lease
  ID;
- the record remained in `Recovering`;
- no live owner session existed;
- no replacement owner had been installed.

The etcd CAS-failure classifier already treated this state as successful when
the session disappeared during the suspension transaction. It did not handle
the same state when the session was already absent before suspension began.

## Fix

- Validate the exact durable recovery record before inspecting session
  liveness.
- Treat an already-absent session as idempotent suspension success only when
  the durable record still exactly matches the supplied recovery lease.
- Preserve the existing fenced session-delete transaction when the exact
  session is still live.
- Return `StaleLease` or `NotOwner` when the durable record or live session
  belongs to a different or rebound lease.
- Preserve the current owner epoch so `reacquire_recovery()` can rebind the same
  recovery epoch rather than allocate another one.
- Document the expired-session behavior on the `ControlStore` contract.

## Safety

This change does not let a stale contender remove a replacement session.

A stale lease is accepted only when:

1. the durable record still exactly matches its logical shard, owner, epoch,
   and lease ID;
2. the record is still in `Recovering`;
3. the owner session is absent.

If another contender has rebound the recovery epoch, the durable record and
session contain the replacement lease ID, so cleanup using the old lease
remains fenced.

## Regression Tests

Added deterministic in-memory coverage that:

1. acquires a recovery owner;
2. removes only its liveness session, simulating backend lease expiry;
3. confirms the expired lease cannot renew;
4. verifies `suspend_recovery()` succeeds for the exact retained recovery
   record;
5. verifies repeated suspension is idempotent;
6. rebinds the same recovery epoch to a new lease;
7. reaches `Serving` without allocating another owner epoch.

Added a fencing test that:

1. expires the original recovery session;
2. rebinds the same owner and epoch with a different lease ID;
3. verifies cleanup using the old lease returns `StaleLease`;
4. verifies the rebound session remains live.

Added an ignored real-etcd integration test that revokes an actual etcd lease
and exercises the same cleanup, same-epoch rebind, stale-lease fencing,
`Serving` transition, and release sequence.

Before the fix, the deterministic regression test failed with
`ControlError::StaleLease` after the exact session had already disappeared.

After the fix, the unchanged regression test passes.

## Scope

- [x] This PR changes one logical boundary only.
- [x] No unrelated refactor, benchmark, metadata model, Holt layout,
      object-store, agent interface, or docs change is mixed in.
- [x] The linked issue describes the user-visible problem, design decision, or
      maintenance task this PR resolves.
- [x] Any breaking change is intentional and documented.
      No breaking change is introduced.
- [x] No compatibility shim, deprecated alias, or forwarding wrapper was added without a removal condition.
      This directly defines recovery-suspension behavior for an exact recovery
      record whose backend session has already expired.

## Change Size And Review

- [x] I checked GitHub's additions plus deletions for this pull request.
      Total changed lines: `1003`.
- [x] If the total is more than 5,000 lines, one core maintainer other than the
      current-head pusher approved the exact current head commit. The author,
      bots, non-core reviewers, duplicate reviewers, dismissed reviews, and
      stale approvals do not count.
      This PR is below 5,000 changed lines, so the large-change rule is not triggered.
- [x] This change is still small enough for a focused review; approval count is
      not being used to justify mixed package or lifecycle boundaries.

## Code Contract (Code Changes Only)

- [ ] Not applicable; this is a docs/config-only change.
- [x] Package boundaries follow `docs/development/code_contract.md`.
      Recovery ownership, owner leases, epochs, and fencing remain entirely
      within `nokv-control`.
- [x] Shared helpers reuse the standard library or existing repository helpers.
      No generic helper module was added.
- [x] File names and file placement follow the code contract.
- [x] New types, interfaces, structs, fields, and functions use domain-specific names.
      No new type, interface, struct, or field was added.
- [x] New errors are in the owning package's `errors.rs` and carry stable error kinds when crossing package boundaries.
      No new error type or error kind was added.
- [x] New metrics/stats are owned by the package that reports or serves them.
      No metric or statistic was added.
- [x] Metadata changes document durability, atomicity, revision-reference
      lifetime, snapshot/commit/event retention, GC epochs, and fail-closed
      recovery boundaries.
      No workspace metadata schema, durability format, retention policy, or GC
      behavior changed.
- [x] Placement or routing changes preserve persisted `RootId -> LogicalShardId`
      affinity, one active writer per shard, owner-epoch fencing, and explicit
      shard-local atomicity; no split root or cross-shard transaction is implied.
      Exact record matching remains required, a different live session remains
      fenced, and the tests verify same-epoch recovery rebind without allocating
      another owner epoch.
- [x] Agent-interface changes keep the transport-free facade and schemas in
      `nokv-agent`, routing and workflows in `nokv-client`, and the concrete
      backend plus native full CLI and optional MCP-sidecar wiring in `nokv`.
      No Agent interface was changed.
- [x] User-facing integration guidance orders the native full CLI first, the
      direct Python SDK second, and MCP only as an optional sidecar.
      No integration guidance was changed.

## Claims and Evidence

- [x] User-facing documentation distinguishes current, experimental, and
      planned capabilities.
      No new user-facing capability claim was added.
- [x] Security claims do not treat a Workbench root or Agent scope as tenant
      authentication or authorization.
      This PR makes no authentication or authorization claim.
- [x] Performance claims state the topology, comparison boundary, cache state,
      run count, and raw-evidence location.
      This PR makes no performance claim.
- [x] Benchmark-only behavior does not alter product semantics.
      No benchmark-only behavior was added.

## Validation

### Before the fix

- `cargo test -p nokv-control expired_recovery_session_cleanup_is_idempotent_and_rebinds_same_epoch -- --nocapture`
  - **FAIL as expected**
  - Result: `ControlError::StaleLease` after the exact recovery session had
    already disappeared.

### After the fix

- `cargo test -p nokv-control expired_recovery_session_cleanup_is_idempotent_and_rebinds_same_epoch -- --nocapture`
  - **PASS**
- `cargo test -p nokv-control expired_recovery_cleanup_cannot_suspend_rebound_live_session -- --nocapture`
  - **PASS**
- `cargo test -p nokv-control unfinished_recovery_rebinds_the_same_epoch_after_session_loss -- --nocapture`
  - **PASS**
- `cargo test -p nokv-control serving_owner_cannot_be_suspended_as_recovery -- --nocapture`
  - **PASS**
- `cargo test -p nokv-control --lib`
  - **PASS**
- `cargo test -p nokv-control --all-features`
  - **PASS**
- `cargo test -p nokv-server --lib`
  - **PASS**
- `cargo clippy -p nokv-control --all-features --all-targets -- -D warnings`
  - **PASS**
- `cargo fmt --all -- --check`
  - **PASS**
- `cargo clippy --workspace --all-targets -- -D warnings`
  - **PASS**
- `cargo test --workspace`
  - **PASS**
- `python3 scripts/workbench/workbench_contract_test.py`
  - **PASS**
- `git diff --check`
  - **PASS**

### Real-etcd integration

- `cargo test -p nokv-control --all-features --no-run`
  - **PASS**; the ignored real-etcd integration test compiled.
- `NOKV_TEST_ETCD_ENDPOINT=http://127.0.0.1:2379 cargo test -p nokv-control --all-features etcd_expired_recovery_session_cleanup_rebinds_same_epoch -- --ignored --nocapture`
  - **NOT RUN locally:** requires a disposable etcd endpoint.

# PR #495 Scope and Summary Replacement

## Related Issue

Relates to #492.

PR #494 owns the bootstrap owner-lease keepalive and the broader slow-reopen liveness boundary. This PR is a narrower control-plane cleanup improvement and does not claim to resolve the complete reopen-thrash scenario described in #492.

## Summary

Make cleanup of an exact, already-expired recovery lease idempotent and linearizable.

The change removes a secondary `StaleLease` rollback error when the durable `Recovering` record still identifies the same lease and its backend session has already disappeared.

## Problem

Before this change, `suspend_recovery()` required the exact live session to exist. Cleanup therefore returned `StaleLease` when the session had already expired, even though the durable `Recovering` record still exactly identified that lease.

The first version of this PR added a missing-session fast path, but its etcd implementation read the durable record and owner-session key separately. A concurrent same-epoch rebind and `mark_serving()` could change the record between those reads, allowing cleanup to return a stale `Recovering` snapshot.

## Fix

* Continue requiring that the durable record exactly match the supplied logical shard, owner, epoch, and lease ID.
* Treat an already-absent session as idempotent success only when one etcd transaction simultaneously confirms:

  * the validated logical-shard record modification revision is unchanged;
  * the owner-session key remains absent.
* Reuse the same atomic predicate when classifying a failed session-delete transaction.
* Preserve the existing exact-session delete transaction when the original session is still live.
* Continue fencing a different, rebound, or serving lease.
* Preserve the existing recovery epoch; this change does not allocate a replacement epoch.

## Safety

Successful sessionless cleanup now has an explicit etcd linearization point.

If another contender rebinds the same recovery epoch or reaches `Serving` before that transaction, the record modification-revision comparison fails and cleanup reclassifies against the latest durable state rather than returning the stale record.

## Regression Tests

Added or retained coverage for:

1. Exact expired-session cleanup is idempotent while the durable record remains unchanged.
2. Cleanup using L1 cannot affect a live rebound L2.
3. Double expiry:

   * L1 expires;
   * the same owner and epoch rebind as L2;
   * L2 expires;
   * cleanup using L1 fails;
   * cleanup using L2 succeeds.
4. A deterministic real-etcd race:

   * cleanup observes the old L1 `Recovering` record and an absent session;
   * cleanup pauses before its atomic predicate;
   * L2 rebinds the same epoch and reaches `Serving`;
   * cleanup resumes;
   * cleanup cannot return `Ok(old Recovering)`;
   * the L2 `Serving` record and lease ID remain current.
5. The existing same-epoch recovery rebind behavior remains intact.

## Contributor Sign-off

- [x] Every commit in this PR includes a DCO `Signed-off-by` trailer.
