### PR TITLE
Deprecate the Workbench MCP sidecar

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -37,7 +37,7 @@ If applicable, add screenshots or paste logs to help explain your problem.
  - OS: [e.g. Linux, macOS]
  - Rust Version: [e.g. 1.88]
  - NoKV Version: [e.g. commit SHA or release tag]
- - Surface: [e.g. native CLI, Python SDK, Rust SDK, optional MCP sidecar, Workbench contract, server, materialize/collect]
+ - Surface: [e.g. native CLI, Python SDK, Rust SDK, Workbench contract, server, materialize/collect]
  - Deployment topology: [e.g. local/direct or routed; include root id, logical shard, placement generation, owner, and epoch if relevant]
  - Object backend and version: [e.g. S3-compatible service and version]
  - Command and relevant configuration: [redact secrets]

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -63,9 +63,10 @@ Closes | Fixes | Relates to #
       shard-local atomicity; no split root or cross-shard transaction is implied.
 - [ ] Agent-interface changes keep the transport-free facade and schemas in
       `nokv-agent`, routing and workflows in `nokv-client`, and the concrete
-      backend plus native full CLI and optional MCP-sidecar wiring in `nokv`.
+      backend plus native full CLI wiring in `nokv`.
 - [ ] User-facing integration guidance orders the native full CLI first, the
-      direct Python SDK second, and MCP only as an optional sidecar.
+      direct Python SDK second, and the Rust SDK third, and does not present the
+      deprecated `nokv mcp` sidecar as a supported NoKV surface.
 
 ## Claims and Evidence
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,7 +42,7 @@ Before reviewing or editing a PR:
 Check for:
 
 - Scope drift across `nokv-types`, `nokv-meta`, `nokv-object`, `nokv-agent`,
-  `nokv-client`, `nokv-fuse`, docs, and example files.
+  `nokv-client`, `nokv-server`, `nokv-control`, docs, and example files.
 - Missing DCO `Signed-off-by` trailers.
 - Package-boundary violations.
 - New helpers that reimplement standard library or existing repository helpers.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,13 +24,23 @@ surface. Treat the direct Python SDK as the second-choice embedded surface.
 Downstream Agent systems should normally provide their own skills that invoke
 the CLI, or use the Python SDK when they need an in-process integration.
 
-The exact 18-tool Workbench MCP endpoint remains supported only as an optional
-sidecar for hosts that specifically need MCP discovery and JSON-RPC transport.
-It must delegate to the same client and transport-free Agent facade; it is not
-the canonical API, a required deployment component, or a separate state
-machine. Preserve the 18-tool names and semantics while keeping documentation,
-examples, release guidance, and reviews ordered as CLI first, Python SDK
-second, MCP sidecar third.
+The `nokv mcp` Workbench sidecar is deprecated. It is not a supported NoKV
+integration surface and must not be presented as one in documentation,
+examples, release guidance, or reviews. Do not accept new work that extends it,
+and do not restore MCP to any surface ordering: the order is CLI first, Python
+SDK second, Rust SDK third.
+
+The sidecar's code still ships because the live qualification harness drives
+the product through it. `scripts/workbench/live_workbench.py`,
+`scripts/workbench/object_namespace_recovery_gate.py`, and
+`scripts/workbench/restore_composition_gate.py` launch `nokv mcp` as a child
+process and retain `mcp-transcript.jsonl` as evidence;
+`scripts/workbench/lingtai_mcp_qualification.py` is a source-bound gap
+declaration that emits a synthetic transcript stub rather than running
+anything. Treat those references as harness plumbing, not as a product claim,
+and do not delete them while they are the only executed live path. The stable
+18-tool Workbench contract itself is independent of MCP and remains
+authoritative.
 
 Before reviewing or editing a PR:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,9 +15,8 @@ NoKV is a distributed workspace and artifact store built specifically for Agent
 infrastructure. Holt stores one canonical normalized full-path namespace per
 workspace, while immutable revision-owned blocks live in S3-compatible object
 storage. The primary product surface is the native full `nokv` CLI, followed
-by the direct Python SDK for embedded callers. The exact 18-tool Workbench
-endpoint is an optional MCP sidecar for hosts that need MCP transport; downstream
-Agent systems normally expose their own skills over the CLI or Python SDK.
+by the direct Python SDK for embedded callers. Downstream Agent systems
+normally expose their own skills over the CLI or Python SDK.
 NoKV does not implement a POSIX filesystem, FUSE frontend, or inode/dentry
 model.
 

--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@ commit, restore, retain, and collect it.
 ```text
 Downstream skills -> native full nokv CLI
 Embedded callers  -> direct Python SDK
-MCP hosts         -> optional 18-tool sidecar
+Native callers    -> lower-level Rust SDK
                              |
                              v
           NoKV workspace service
@@ -212,8 +212,8 @@ general NAS replacement are outside the product architecture.
 - **Safe restore.** A restore reuses immutable revisions in a fresh hidden
   same-root incarnation, then publishes visibility atomically.
 - **Deterministic Agent surface.** The same exact 18-tool Workbench semantics
-  are available through the primary native CLI, the direct Python SDK, and an
-  optional MCP sidecar.
+  are available through the primary native CLI, the direct Python SDK, and the
+  lower-level Rust SDK.
 
 These guarantees are shard-local. NoKV does not provide cross-shard
 transactions. Snapshot protection is leased, and root or Workbench scoping is
@@ -254,7 +254,7 @@ the evidence itself — files, manifests, lineage, and the bytes they attest
 
 | Status | Capabilities and limits |
 | --- | --- |
-| **Current product** | Persisted `RootId -> LogicalShardId` affinity; one epoch-fenced active owner per shard; canonical full-path metadata keys; immutable S3-compatible bodies; native full CLI; direct Python and Rust SDKs; optional MCP sidecar; exact 18-tool Workbench semantics; snapshots, commits, restore, queries, and reference-fenced GC |
+| **Current product** | Persisted `RootId -> LogicalShardId` affinity; one epoch-fenced active owner per shard; canonical full-path metadata keys; immutable S3-compatible bodies; native full CLI; direct Python and Rust SDKs; exact 18-tool Workbench semantics; snapshots, commits, restore, queries, and reference-fenced GC |
 | **Current durability profile** | Acknowledged metadata writes are synchronously durable in the owning shard's local Holt WAL. Each mutation also appends canonical hash-chained replay material in the same store. First-owner acquisition accepts a new or prepared epoch-zero store. Exact current-lease resume is also admitted. Unknown, mixed, or unverified successor stores fail closed. |
 | **Not qualified** | Remote checkpoint/log recovery, shared metadata durability, multi-machine failover, production metadata HA, tenant identity/RBAC, cross-shard transactions, and complete provider fault-injection qualification |
 
@@ -278,15 +278,13 @@ the exact contracts and qualification gates.
   materialize/collect adapters for local executables.
 - **Rust Agent SDK.** [`nokv-client`](crates/nokv-client) is the lower-level
   native integration and shared implementation boundary.
-- **Optional MCP sidecar.** `nokv mcp` exposes the exact 18 Workbench tools
-  over stdio only for hosts that require MCP discovery and JSON-RPC transport.
 - **Transport-free Agent contracts** in
   [`nokv-agent`](crates/nokv-agent), shared by every adapter.
 
 Downstream Agent systems should normally write skills that invoke the native
-CLI. Use the Python SDK when an in-process boundary is preferable. The MCP
-sidecar delegates to the same facade; it is not required to deploy NoKV and is
-not a separate metadata or lifecycle authority.
+CLI. Use the Python SDK when an in-process boundary is preferable. Every
+surface delegates to the same transport-free facade; none of them is a separate
+metadata or lifecycle authority.
 
 RootId is the only storage and routing identity. A Workbench presentation root
 shapes Agent-facing paths and manifests but never enters canonical metadata
@@ -294,8 +292,7 @@ keys.
 
 ## Stable Workbench
 
-The native CLI accepts exactly these 18 Workbench operation names; the
-optional MCP sidecar exposes the same names as tools:
+The native CLI accepts exactly these 18 Workbench operation names:
 
 ```text
 workbench_create
@@ -323,17 +320,15 @@ digest relationships, commit identity, snapshot lifecycle, and restore
 idempotency form the stable contract. Workbench result shaping remains an
 adapter concern and does not dictate durable metadata families.
 
-The 18 names define behavior, not a required transport. The native CLI exposes
-them directly, the Python SDK provides the underlying programmatic operations,
-and the MCP sidecar is an optional projection for compatible hosts.
+The 18 names define behavior, not a transport. The native CLI exposes them
+directly, and the Python SDK provides the underlying programmatic operations.
 
 See the [Workbench Contract](docs/workbench-contract.md).
 
 ## Integration Model
 
-The Workbench contract is runtime-neutral. A downstream Agent runtime should
-normally expose skills over the native CLI, or embed the Python SDK. A runtime
-that specifically requires MCP can opt into the sidecar and exercise the same
+The Workbench contract is runtime-neutral. A downstream Agent runtime exposes
+skills over the native CLI, or embeds the Python SDK, and exercises the same
 scientific reconstruction workflow:
 
 ```text
@@ -363,23 +358,13 @@ The default integration is a downstream skill that calls the native CLI. It
 can invoke the same 18 operations with `nokv workbench <tool> '<json
 arguments>'`; an embedded host can instead call the Python SDK directly.
 
-For a host that specifically requires MCP, one optional registry entry spawns
-the `nokv` binary as a stdio sidecar:
-
-```text
-nokv ... --agent-id {stable_agent_id_hex32} \
-  --workbench-root /agents/{agent_name}/wb mcp
-```
-
 In every integration shape, the runtime persists a stable `AgentId` and a
 distinct `RootId` for each
 isolation boundary. Provisioning immutably binds that root to the AgentId;
 `--workbench-root` remains only the human-facing path projection and cannot
 grant isolation by itself. The binding prevents accidental root reuse, but is
 not an authentication credential. The 18 `workbench_*` tools land next to the
-agent's local file tools instead of replacing them. The sidecar does not grant
-new authority; the runtime supplies the same persisted identities, route,
-presentation root, and object configuration used by the CLI or SDK.
+agent's local file tools instead of replacing them, and grant no new authority.
 
 A research run then follows the fixed section layout — `input`, `scripts`,
 `outputs`, `logs`, `metadata`:
@@ -419,6 +404,12 @@ cargo build --release -p nokv --bin nokv
 ./target/release/nokv --help
 ./target/release/nokv schema
 ```
+
+`nokv schema` reports the frozen contract marker
+`nokv.workbench.mcp_input_schemas.v1`, and `nokv --help` still lists an `mcp`
+subcommand. Both are retained wire identity for the qualification harness. The
+MCP sidecar is deprecated and is not a supported NoKV integration surface; use
+the native CLI or the Python SDK.
 
 Anyone can instead install the current stable source release from NoKV's public
 Homebrew tap. The fully qualified command adds the tap and trusts only the
@@ -467,10 +458,8 @@ python3 scripts/workbench/workbench_contract_test.py
 
 A live deployment additionally needs a root id, persisted logical-shard
 placement, one admitted shard owner, and S3-compatible object coordinates. The
-[Workbench MCP sidecar preflight](docs/workbench-preflight.md) gives the
-optional sidecar-specific registration and acceptance flow. Native CLI and
-Python SDK users use the same provision, serve, materialize, collect, and
-recovery contracts without running MCP.
+[live deployment preflight](docs/workbench-preflight.md) gives the provision,
+serve, admission, and acceptance flow.
 
 ## Documentation
 
@@ -486,7 +475,7 @@ recovery contracts without running MCP.
 - [Agent Contributor Handbook](docs/development/nokv-agent.md)
 - [Code Contract](docs/development/code_contract.md)
 - [PR Review Checklist](docs/development/pr_review_checklist.md)
-- [Workbench MCP Sidecar Preflight](docs/workbench-preflight.md)
+- [Live Deployment Preflight](docs/workbench-preflight.md)
 - [Source-only Homebrew Release](scripts/release/README.md)
 
 ## Contributing
@@ -524,7 +513,7 @@ git diff --check
 | [`nokv-agent`](crates/nokv-agent) | Transport-free 18-tool Workbench facade and stable result shaping |
 | [`nokv-python`](crates/nokv-python) | Direct Python SDK and explicit materialize/collect adapters |
 | [`nokv-server`](crates/nokv-server) | Logical-shard owner, metadata adapter composition, RPC server, and root-affine lifecycle workers |
-| [`nokv`](crates/nokv) | Thin native full CLI and optional MCP sidecar wiring |
+| [`nokv`](crates/nokv) | Thin native full CLI wiring |
 | [`nokv-bench`](bench) | Non-product contract, recovery, and performance workloads |
 
 ## License

--- a/bench/workbench-live/README.md
+++ b/bench/workbench-live/README.md
@@ -6,10 +6,12 @@ SPDX-License-Identifier: Apache-2.0
 # Live Workbench evidence
 
 The executable product-boundary workload lives at
-`scripts/workbench/live_workbench.py`. It exercises the flat `nokv`
-CLI-backed optional MCP sidecar against real root routing, Holt metadata
-ownership, and an S3-compatible object provider. It is sidecar qualification,
-not evidence that MCP is NoKV's primary integration surface. Its deterministic
+`scripts/workbench/live_workbench.py`. It exercises the flat `nokv` binary
+against real root routing, Holt metadata ownership, and an S3-compatible object
+provider. It currently reaches the 18 tools through a `nokv mcp` child process:
+that sidecar is deprecated and is not a supported NoKV integration surface, so
+this run qualifies that transport only and is not evidence for the CLI or
+Python SDK path. Its deterministic
 runtime evidence directory is under `target/workbench-live/evidence/` by
 default; evidence is not checked into this source directory.
 

--- a/crates/nokv-python/README.md
+++ b/crates/nokv-python/README.md
@@ -2,8 +2,7 @@
 
 The native full `nokv` CLI is NoKV's primary product and integration surface.
 This direct Python SDK is the secondary choice for callers that need an
-in-process API. Agent frameworks should normally expose skills over the CLI;
-they do not need the optional 18-tool MCP sidecar to use this package.
+in-process API. Agent frameworks should normally expose skills over the CLI.
 
 This package exposes API version `1` for path-native Workbenches and immutable
 artifacts. The version is available as `nokv.API_VERSION`; the stable package

--- a/crates/nokv/src/main.rs
+++ b/crates/nokv/src/main.rs
@@ -62,6 +62,14 @@ fn main() -> ExitCode {
 
 fn run() -> Result<(), String> {
     let invocation = cli::parse(std::env::args().skip(1)).map_err(|error| error.to_string())?;
+    if matches!(invocation.command, Command::Mcp { .. }) {
+        // stderr only: stdout carries the line-delimited JSON-RPC stream.
+        eprintln!(
+            "warning: `nokv mcp` is deprecated and is not a supported NoKV integration \
+             surface. Use `nokv workbench <tool>` or the direct Python SDK. The sidecar is \
+             retained only as the live qualification harness transport."
+        );
+    }
     match &invocation.command {
         Command::Help => {
             print_help();
@@ -578,7 +586,7 @@ NoKV Agent-workspace CLI
 
 USAGE:
   nokv [connection/object options] workbench <tool> '<json arguments>'
-  nokv [connection/object options] mcp [--profile workbench|agent]
+  nokv [connection/object options] mcp [--profile workbench|agent]   (DEPRECATED)
   nokv [connection/object options] materialize <workbench> <section> <path> <destination>
   nokv [connection/object options] collect <workbench> <section> <source> <path> [--replace] [--expected-generation N] [--content-type TYPE]
   nokv [route/agent options] workspace-path rename <workbench> <section> <source> <destination> --expected-generation N --request-id HEX32
@@ -605,6 +613,8 @@ AGENT PRESENTATION:
   --workbench-root /agents/AGENT_NAME/wb is required by workbench, collect, and mcp
   keep this presentation root stable: it shapes responses and canonical v1 manifest paths
   RootId remains the only storage/routing identity; the presentation root never enters Holt keys
+  mcp is DEPRECATED and is not a supported NoKV integration surface: use `nokv workbench <tool>`
+  or the direct Python SDK; it is retained only as the live qualification harness transport
   mcp defaults to the 18-tool Workbench profile; --profile agent selects the seven path tools
   workspace-path is a custom CLI surface; it does not add to the fixed 18 Workbench tools
   workspace-path requires an explicit lowercase HEX32 request id for exact cross-process replay
@@ -631,7 +641,7 @@ OBJECT DATA:
   --object-bucket NAME [--object-endpoint URL] [--object-root PREFIX]
   [--hot-cache-dir PATH --hot-cache-bytes BYTES]
 
-NoKV exposes SDK, CLI, and MCP operations. It does not expose FUSE or POSIX."
+NoKV exposes SDK and CLI operations. It does not expose FUSE or POSIX."
     );
 }
 

--- a/docs/ai-training.md
+++ b/docs/ai-training.md
@@ -12,7 +12,7 @@ NoKV serves training data, checkpoints, experiment outputs, and provenance
 through the native full CLI first, the direct Python SDK for embedded jobs,
 lower-level Rust SDK calls where needed, and explicit local adapters. Canonical
 identity remains a root, Workbench, and normalized path; a materialized local
-path is disposable. The optional MCP sidecar is not required for this profile.
+path is disposable.
 
 ## Workloads
 

--- a/docs/announcements/nokv-lingtai-design-partner.md
+++ b/docs/announcements/nokv-lingtai-design-partner.md
@@ -11,6 +11,12 @@
 > requires it, backed by NoKV's path-native workspace format. It does not use
 > NoKV as a FUSE/POSIX mount.
 > See [Product Design](../product-design.md).
+>
+> Update (2026-08): the optional Workbench MCP sidecar described on this page
+> is deprecated and is not a supported NoKV integration surface. The stable
+> boundary was and remains the 18-tool Workbench semantic contract, reached
+> through the native full CLI and the direct Python SDK. The text below is
+> preserved as published.
 
 This announcement marks the start of the design-partner collaboration between
 **NoKV** and **LingTai**

--- a/docs/announcements/nokv-lingtai-design-partner.zh-CN.md
+++ b/docs/announcements/nokv-lingtai-design-partner.zh-CN.md
@@ -9,6 +9,10 @@
 > 优先通过原生全量 CLI，其次通过 Python SDK；仅在 host 明确需要时
 > 使用可选的 MCP sidecar。三者使用同一套 NoKV workspace 格式，
 > 不把 NoKV 作为 FUSE/POSIX mount；参见[产品设计](../product-design.md)。
+>
+> 2026-08 更新：本文提到的可选 Workbench MCP sidecar 已废弃，不是受支持的
+> NoKV 接入面。稳定边界过去是、现在仍然是 18-tool Workbench 语义契约，
+> 经由原生全量 CLI 与 Python SDK 使用。以下正文按发布原文保留。
 
 本文记录 **NoKV** 与 **LingTai**（[Lingtai-AI/lingtai](https://github.com/Lingtai-AI/lingtai)）启动 **design-partner（设计共建伙伴）合作**的起点。
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -13,7 +13,6 @@ Status: normative workspace architecture.
 flowchart LR
     Skills["Downstream Agent skills"] --> CLI["Native full nokv CLI"]
     CLI --> Agent["Transport-free Workbench facade"]
-    Sidecar["Optional MCP sidecar"] --> Agent
     Agent --> SDK["Rust Agent SDK"]
     CLI --> SDK
     Python["Python SDK"] --> SDK
@@ -45,7 +44,6 @@ FUSE, POSIX, CSI, and fsspec are not architecture layers.
 ```mermaid
 flowchart TD
     CLI["native full nokv CLI"] --> Agent["nokv-agent"]
-    Sidecar["optional MCP sidecar"] --> Agent
     CLI --> Client["nokv-client"]
     Python["nokv-python"] --> Client
     Agent --> Client
@@ -80,8 +78,7 @@ Key constraints:
 - client uses protocol/routing and never imports meta/server;
 - Agent adapters shape tools over SDK traits and remain transport-free;
 - the native full CLI is the primary integration surface;
-- the Python SDK is the secondary embedded surface;
-- the optional MCP sidecar is thin wiring over the same Agent facade.
+- the Python SDK is the secondary embedded surface.
 
 ## Identity And Namespace
 
@@ -420,7 +417,7 @@ experiments. The required evidence covers:
    amplification across the declared workload matrix;
 2. revision-owned publication, visibility, lifecycle, references, GC, and
    recovery;
-3. protocol, server, native CLI, Python and Rust SDKs, optional MCP sidecar,
+3. protocol, server, native CLI, Python and Rust SDKs,
    control routing, and lifecycle workers on
    the same schema and identity model;
 4. owner failover, checkpoint/log recovery, ambiguous provider outcomes, and

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -23,7 +23,7 @@ The normative qualification gates are in
 | Holt engine | Named trees, point/range reads, atomic batches | Engine throughput, conflicts, WAL cost, checkpoint behavior |
 | Metadata domain | Workspace marker, paths, commands, operations | Namespace amplification, visibility, replay, lifecycle cost |
 | Service | Protocol through shard owner and object provider | Routing, serialization, fencing, provider latency, recovery |
-| Product | Primary native CLI, secondary Python SDK, Rust SDK, optional MCP sidecar, or transport-free Workbench facade | User-visible latency, results, errors, retries, and end-to-end throughput |
+| Product | Primary native CLI, secondary Python SDK, Rust SDK, or transport-free Workbench facade | User-visible latency, results, errors, retries, and end-to-end throughput |
 
 A report names its level. Results from different levels are not interchangeable.
 

--- a/docs/development/code_contract.md
+++ b/docs/development/code_contract.md
@@ -8,8 +8,8 @@ SPDX-License-Identifier: Apache-2.0
 NoKV is an Agent-native distributed workspace and artifact store. Its primary
 product surface is the native full `nokv` CLI; the direct Python SDK is the
 secondary embedded surface. The stable
-[Workbench contract](../workbench-contract.md) defines shared semantics, while
-MCP is an optional sidecar transport for hosts that require it. NoKV persists
+[Workbench contract](../workbench-contract.md) defines shared semantics. NoKV
+persists
 workspace metadata through the storage-neutral transaction-store contract.
 Holt is the current serving local adapter. S3-compatible storage owns durable artifact
 bytes.
@@ -41,7 +41,7 @@ These are the package boundaries:
 | `crates/nokv-agent/` | Transport-free Workbench/Agent tool schemas, the 18-tool Workbench facade, the seven-tool generic Agent profile, stable result shaping, and adapters over SDK traits. | Import Holt/layout, object providers, server implementations, FUSE, or duplicate SDK state machines. |
 | `crates/nokv-python/` | Direct Python SDK, explicit materialize/collect adapters, and Workbench-scoped immutable compatibility adapters for fsspec, checkpoint, and torch DCP callers. | Own metadata layout, bypass `nokv-client`, reimplement range/retry planning, promise POSIX directory/inode semantics or an arbitrary root filesystem, or import FUSE. |
 | `crates/nokv-server/` | Shard-owner process, versioned RPC, startup/schema gates, health, backup/log sync, and background lifecycle workers. | Own domain semantics outside `nokv-meta`, leak provider internals into RPC, or silently migrate/fallback between schemas. |
-| `crates/nokv/` | Thin native full `nokv` CLI and optional MCP sidecar wiring over client and Agent interfaces. | Own metadata semantics, durable layout, object-provider behavior, or embed a second implementation of the SDK. |
+| `crates/nokv/` | Thin native full `nokv` CLI wiring over client and Agent interfaces. | Own metadata semantics, durable layout, object-provider behavior, or embed a second implementation of the SDK. |
 | `bench/` | Contract, recovery, and performance workloads with explicit environment and workload profiles. | Own product APIs, add benchmark-only product behavior, or compare results from materially different profiles as equivalent. |
 
 FUSE, POSIX emulation, CSI, and arbitrary-root generic filesystem integration
@@ -68,8 +68,8 @@ become canonical metadata or introduce fields outside that contract.
 
 Delivery priority and semantic ownership are separate. The CLI is the default
 integration surface, the Python SDK is second for in-process callers, and the
-MCP endpoint is an optional sidecar. Agent frameworks should build skills over
-the CLI or Python SDK by default. None of those transports may fork the stable
+Rust SDK is third for native integrations. The `nokv mcp` sidecar is deprecated
+and is not a supported surface. None of these transports may fork the stable
 Workbench semantics or duplicate the client state machines.
 
 The Agent adapter owns canonical Workbench projections. It must recompute any

--- a/docs/development/metadata-store-interface.md
+++ b/docs/development/metadata-store-interface.md
@@ -36,8 +36,7 @@ This decision changes internal metadata storage and shard bootstrap. It
 preserves these Agent and Workbench boundaries:
 
 - the 18-tool Workbench semantic contract
-- primary native CLI Workbench commands, secondary Python SDK behavior, and
-  optional MCP-sidecar tool behavior
+- primary native CLI Workbench commands and secondary Python SDK behavior
 - the path-native `PathCurrent` namespace
 - immutable artifact storage
 - root placement in `nokv-control`

--- a/docs/development/nokv-agent.md
+++ b/docs/development/nokv-agent.md
@@ -14,16 +14,17 @@ The normative behavior is [Workbench Contract](../workbench-contract.md).
 ## Package Position
 
 ```text
-native full CLI (primary) / optional MCP sidecar
+native full CLI (primary)
   -> nokv-agent
   -> nokv-client traits
   -> versioned protocol and direct object data path
 ```
 
 The direct Python SDK is the secondary embedded product surface and calls the
-client boundary without requiring MCP. Downstream Agent frameworks should
-normally implement skills over the CLI. The MCP adapter is transport wiring
-only and must never become a second facade or state machine.
+client boundary directly. Downstream Agent frameworks should normally implement
+skills over the CLI. The `nokv mcp` sidecar is deprecated transport wiring
+retained for the live qualification harness; it is not a supported surface and
+must never become a second facade or state machine.
 
 Allowed dependencies are storage-neutral types and SDK interfaces. The crate
 must not import:
@@ -65,7 +66,7 @@ workbench_restore
 The normalized input schemas are frozen in
 `crates/nokv-agent/workbench_contract_schema.json`. Tool registration
 fails closed when a name or normalized schema differs. The native CLI exposes
-the same operations directly; the optional sidecar registers them as MCP tools.
+the same operations directly.
 
 ## Adapter Responsibilities
 

--- a/docs/development/path-native-metadata-comparison.md
+++ b/docs/development/path-native-metadata-comparison.md
@@ -14,8 +14,7 @@ Workbench behavior and does not treat a code-shape reduction as measured
 latency or throughput.
 
 The stable 18-tool Workbench facade is unchanged. Its primary delivery is the
-native full CLI, followed by the direct Python SDK; MCP is an optional sidecar
-transport and is outside this metadata comparison. The comparison stops at the
+native full CLI, followed by the direct Python SDK. The comparison stops at the
 metadata boundary and excludes object-body I/O, transport, WAL device cost,
 and recovery-log chunking unless stated otherwise.
 

--- a/docs/development/pr_review_checklist.md
+++ b/docs/development/pr_review_checklist.md
@@ -152,9 +152,8 @@ boundaries, or Workbench behavior.
 ## Workbench Contract
 
 - Do public docs and examples present the native full CLI first, the Python SDK
-  second, and the exact 18-tool MCP endpoint only as an optional sidecar?
-- Does the MCP sidecar remain thin over the transport-free facade instead of
-  becoming a required deployment component or a second state machine?
+  second, and the Rust SDK third, without presenting the deprecated `nokv mcp`
+  sidecar as a supported integration surface?
 - Do all 18 tool names and normalized input schemas remain stable?
 - Does golden-transcript validation cover observable result and error behavior,
   rather than treating input-schema validation as equivalent?

--- a/docs/development/pre423-contract-ledger.md
+++ b/docs/development/pre423-contract-ledger.md
@@ -15,8 +15,10 @@ It is not an inventory or qualification claim for every pre-#423 feature, and
 
 This ledger preserves historical MCP and LingTai evidence classes; it does not
 set current delivery priority. Current integrations use the native full CLI
-first, the direct Python SDK second, and the 18-tool endpoint only as an
-optional MCP sidecar. A sidecar-specific receipt qualifies only that boundary.
+first and the direct Python SDK second. The `nokv mcp` sidecar is deprecated
+and is not a supported integration surface; the MCP and LingTai rows below are
+retained evidence history, and a transport-specific receipt qualifies only that
+transport.
 
 Each stable item records:
 

--- a/docs/development/workspace-acceptance.md
+++ b/docs/development/workspace-acceptance.md
@@ -8,10 +8,14 @@ SPDX-License-Identifier: Apache-2.0
 Status: normative qualification gates for the supported NoKV workspace.
 
 NoKV is qualified as one Agent-facing system: Workbench semantics, the primary
-native full CLI, the secondary direct Python SDK, the optional MCP sidecar,
-metadata semantics, object publication, root routing, recovery, and garbage
-collection must run against the same workspace format. An MCP-only result does
-not qualify the CLI or Python SDK paths.
+native full CLI, the secondary direct Python SDK, metadata semantics, object
+publication, root routing, recovery, and garbage collection must run against
+the same workspace format.
+
+The `nokv mcp` sidecar is a deprecated transport, not a qualified surface. It
+is named in this document only because several live runners still drive the
+product through it. Evidence produced over that transport qualifies neither the
+CLI nor the Python SDK path.
 Passing a codec or Holt microbenchmark alone does not qualify the product.
 
 Every applicable gate reports exactly one status:
@@ -48,9 +52,10 @@ Workbench semantics through the primary native CLI boundary. The direct Python
 SDK must independently exercise its supported programmatic path. The existing
 black-box runner,
 [`scripts/workbench/live_workbench.py`](../../scripts/workbench/live_workbench.py),
-qualifies the optional MCP sidecar only. Its dry-run proves only command
-construction and tool coverage; a live run retains exact sidecar and process
-evidence. It cannot substitute for native CLI or Python SDK evidence. Absent
+reaches the 18 tools through a `nokv mcp` child process and therefore qualifies
+that deprecated transport only. Its dry-run proves only command construction
+and tool coverage; a live run retains exact transport and process evidence. It
+cannot substitute for native CLI or Python SDK evidence. Absent
 etcd, S3-compatible storage, or the requested binary is `NOT QUALIFIED`, never
 `PASS`.
 
@@ -73,6 +78,14 @@ Required evidence:
 The bounded live Workbench runner uses a minimum one-day snapshot lease. Even
 when its 18-tool workflow passes, Gate 0 remains `NOT QUALIFIED` until separate
 retained evidence observes expiry and the terminal `reaped` state.
+
+A second, independent reason Gate 0 cannot report `PASS` today: the frozen
+pre-#423 ledger's `native-workbench-e2e` expectation profile admits only the
+`live-workbench` producer, whose required evidence roles include
+`mcp-transcript`. That producer's transport is the deprecated sidecar, so the
+gate is unsatisfiable as specified. Admitting a CLI-driven producer is a
+ledger-policy change, not a documentation change, and the ledger is digest
+pinned.
 
 Workbench responses must not expose storage keys, owner addresses, internal
 incarnations, or host-filesystem identities.
@@ -225,7 +238,8 @@ same Holt authority; the production CLI contains no fault-only admission path.
 The independent object-provider runner is
 [`scripts/workbench/object_namespace_recovery_gate.py`](../../scripts/workbench/object_namespace_recovery_gate.py).
 It owns real etcd and digest-pinned RustFS instances and retains its raw process
-and MCP evidence separately from the epoch-boundary runner.
+and transport evidence separately from the epoch-boundary runner. It also drives
+the product through the deprecated `nokv mcp` child process.
 
 Required evidence:
 
@@ -277,7 +291,7 @@ Required evidence:
   CLI builds contain no fault hook, flag, environment branch, or arbitrary
   executor injection surface.
 
-## Gate 7: CLI, Python SDK, MCP Sidecar, And Package Boundaries
+## Gate 7: CLI, Python SDK, And Package Boundaries
 
 Required evidence:
 
@@ -290,8 +304,9 @@ Required evidence:
   explicit materialize/collect adapters;
 - `nokv-agent` remains transport-free and shapes the stable 18 tools over SDK
   traits;
-- the optional MCP sidecar is a thin consumer of the same Agent facade and is
-  neither a required deployment component nor a second state machine;
+- the deprecated `nokv mcp` sidecar remains a thin consumer of the same Agent
+  facade, is presented in no document as a supported integration surface, and
+  gains no new behavior;
 - protocol DTOs are versioned and storage-neutral;
 - provider-specific behavior stays inside the object package;
 - no second implementation of namespace, publication, restore, references, or

--- a/docs/index.md
+++ b/docs/index.md
@@ -4,7 +4,7 @@ layout: home
 hero:
   name: NoKV
   text: Agent-native distributed workspace and artifact storage.
-  tagline: A native full CLI and direct Python SDK over path-primary ordered metadata, with an optional Workbench MCP sidecar.
+  tagline: A native full CLI and direct Python SDK over path-primary ordered metadata.
   image:
     src: /img/logo.png
     alt: NoKV
@@ -23,7 +23,7 @@ hero:
       link: /development/workspace-acceptance
 features:
   - title: Stable Agent surface
-    details: Use the native full CLI first, the direct Python SDK for embedded callers, and the exact 18-tool MCP endpoint only as an optional sidecar.
+    details: Use the native full CLI first, the direct Python SDK for embedded callers, and the lower-level Rust SDK for native integrations. One 18-tool Workbench contract fixes behavior across all three.
   - title: Path-primary metadata
     details: One normalized full path is namespace truth. Exact artifacts use point reads; child listing uses component-safe delimiter scans.
   - title: Immutable revisions
@@ -48,9 +48,10 @@ SPDX-License-Identifier: Apache-2.0
   <div class="nokv-grid-3">
     <div class="nokv-card">
       <div class="nokv-card-kicker">Application surface</div>
-      <h3>CLI · Python SDK · MCP sidecar</h3>
+      <h3>CLI · Python SDK · Rust SDK</h3>
       <p>Downstream skills use the native CLI by default; embedded callers use
-      the Python SDK, and MCP hosts can opt into the same 18-tool semantics.</p>
+      the Python SDK, and native integrations use the Rust SDK. All three share
+      the same 18-tool semantics.</p>
     </div>
     <div class="nokv-card">
       <div class="nokv-card-kicker">Metadata layer</div>
@@ -94,7 +95,7 @@ SPDX-License-Identifier: Apache-2.0
   [RustFS Provider Profile](./rustfs.md).
 - Workloads and evidence: [AI Training Workload](./ai-training.md),
   [Benchmarks](./benchmarks.md),
-  [Workbench MCP Sidecar Preflight](./workbench-preflight.md), and
+  [Live Deployment Preflight](./workbench-preflight.md), and
   [Workspace Acceptance](./development/workspace-acceptance.md).
 - Development: [Code Contract](./development/code_contract.md),
   [`nokv-agent` Handbook](./development/nokv-agent.md),

--- a/docs/product-design.md
+++ b/docs/product-design.md
@@ -17,13 +17,12 @@ The supported front doors, in delivery order, are:
 
 1. the native full `nokv` CLI, including all 18 Workbench operations;
 2. the direct Python SDK for embedded programmatic callers;
-3. the Rust SDK for lower-level native integrations; and
-4. the optional MCP sidecar for hosts that require MCP discovery and transport.
+3. the Rust SDK for lower-level native integrations.
 
 The complete 18-tool [Workbench contract](./workbench-contract.md) fixes shared
 behavior across these surfaces. Downstream Agent systems normally provide
 skills that invoke the CLI, or call the Python SDK when an in-process boundary
-is preferable. MCP is not required to deploy or operate NoKV.
+is preferable.
 
 NoKV also provides explicit materialize/collect adapters for executables that
 require local files.
@@ -77,7 +76,8 @@ Workbench-specific result shaping stays above the storage core:
 - grep matching;
 - section projection;
 - the delta digest returned by append;
-- friendly errors and optional MCP-sidecar envelopes;
+- friendly errors, and the JSON-RPC result envelope the qualification harness
+  consumes;
 - stable `run_manifest.json` and `restore_manifest.json` projections.
 
 Workbench responses do not contain storage-specific node identities. Stable

--- a/docs/rustfs.md
+++ b/docs/rustfs.md
@@ -15,7 +15,7 @@ collection policy.
 ## Boundary
 
 ```text
-native full CLI / Python SDK / lower-level Rust SDK / optional Workbench MCP sidecar
+native full CLI / Python SDK / lower-level Rust SDK
   -> NoKV metadata and publication service
   -> S3-compatible object interface
   -> RustFS

--- a/docs/workbench-contract.md
+++ b/docs/workbench-contract.md
@@ -9,8 +9,8 @@ Status: normative Agent-facing contract.
 
 The Workbench profile is NoKV's stable Agent-facing semantic contract. The
 native full `nokv` CLI is the primary delivery surface, and the direct Python
-SDK is the secondary embedded surface. The exact 18-tool MCP endpoint is an
-optional sidecar for hosts that require MCP discovery and JSON-RPC transport.
+SDK is the secondary embedded surface, and the Rust SDK is the lower-level
+native integration.
 Downstream Agent systems should normally expose skills over the CLI, or use the
 Python SDK in process. The workspace architecture implements the same profile
 while keeping physical namespace records, object keys, operation journals, and
@@ -25,12 +25,11 @@ The contract sources are:
 - `scripts/workbench/workbench_contract.py` for checking tool names and
   normalized input schemas.
 
-CLI, SDK, and MCP-sidecar wiring are consumers of this contract, not schema
-authorities. The sidecar delegates to the transport-free facade and is neither
-a required deployment component nor a separate state machine.
+CLI and SDK wiring are consumers of this contract, not schema authorities.
+Every surface delegates to the transport-free facade and is neither a required
+deployment component nor a separate state machine.
 
-The native CLI accepts exactly these 18 names under `nokv workbench`. When the
-optional MCP sidecar is enabled, it registers the same 18 tools and fails
+The native CLI accepts exactly these 18 names under `nokv workbench`. It fails
 closed unless every possible destination owner supports the durable restore
 contract and the complete schema.
 
@@ -66,7 +65,7 @@ The deployment root is `/agents/{agent_id}/wb` and must not be `/`.
 
 This root is durable presentation configuration. It shapes returned paths and
 the presentation-path fields in canonical run/restore manifest v1 envelopes,
-so a deployment must retain the same value across CLI or MCP-sidecar restarts
+so a deployment must retain the same value across restarts
 and exact operation replay. It is not a namespace, routing, Holt-key,
 object-key, or sharding identity; `RootId` remains the storage and routing
 authority.

--- a/docs/workbench-preflight.md
+++ b/docs/workbench-preflight.md
@@ -3,13 +3,12 @@ Copyright 2024-2026 The NoKV Authors.
 SPDX-License-Identifier: Apache-2.0
 -->
 
-# Workbench MCP Sidecar Preflight
+# Live Deployment Preflight
 
-This guide qualifies the optional `nokv mcp` stdio sidecar for an
-MCP-compatible Agent runtime. It is not the default NoKV integration guide:
-downstream systems should normally provide skills over the native full CLI,
-and embedded callers should use the Python SDK. The sidecar uses the same
-workspace format and grants no additional authority or compatibility route.
+This guide covers bringing up a live NoKV deployment and qualifying it before
+a production handoff. Downstream systems provide skills over the native full
+CLI; embedded callers use the Python SDK. Every surface uses the same workspace
+format and grants no additional authority or compatibility route.
 
 ## Required Inputs
 
@@ -65,18 +64,12 @@ recovery path itself. It is switched on implicitly by
 The corresponding invariant for operators: back up the Holt directory. In the
 default shape it is the only copy of the metadata.
 
-## Live Sidecar Contract Check
-
-If the host requires MCP, start the optional `nokv mcp` sidecar with the same
-root, route, owner, and object configuration that its CLI or SDK path would
-use. Send `initialize`, then `tools/list`, and validate the response with
-`workbench_contract.validate_tool_contract`.
+## Live Contract Check
 
 For the complete live Workbench path, run
 `scripts/workbench/live_workbench.py`. It calls `nokv provision`,
-starts `nokv serve` with explicit metadata create/reopen intent, starts
-`nokv ... --agent-id {stable-id} --workbench-root /agents/{name}/wb mcp`,
-exercises all 18 tools, and
+starts `nokv serve` with explicit metadata create/reopen intent, exercises all
+18 tools, and
 retains exact requests/responses plus materialize/collect evidence. Run
 `--dry-run` first to inspect the redacted command and normalized-input plan.
 In the local-WAL profile, `reopen` qualifies only a restart of the same
@@ -90,6 +83,10 @@ The release-level epoch proof is the real-etcd fence-before/fence-after
 `SIGKILL` runner in
 [`scripts/workbench/local_wal_recovery_gate.py`](../scripts/workbench/local_wal_recovery_gate.py);
 a normal reopen alone does not cover interrupted `Recovering` retries.
+`live_workbench.py` currently drives the 18 tools through a `nokv mcp` child
+process. That sidecar is deprecated and is not a supported NoKV integration
+surface; it remains only as this harness's transport, and evidence produced
+over it qualifies neither the CLI nor the Python SDK path.
 The selected `--workbench-root` is durable presentation configuration because
 canonical v1 manifests contain its projected paths. Keep it identical across
 restart/replay; it never replaces `RootId` as the storage or routing identity.
@@ -99,11 +96,11 @@ tool advertisement. This is a fail-closed deployment identity check, not
 authentication. A legacy root without a binding requires a one-time,
 operator-verified provision with `--adopt-legacy-agent-binding`; NoKV never
 infers identity from the presentation path.
-Before reading MCP stdin or advertising tools, the flat CLI performs the typed
-workspace RPC preflight for every capability required by this 18-tool profile;
-a missing capability or route mismatch stops startup.
+Before serving any Agent-facing command, the CLI performs the typed workspace
+RPC preflight for every capability required by the 18-tool profile; a missing
+capability or route mismatch stops startup.
 
-Registration must stop if:
+Bring-up must stop if:
 
 - the tool set is not exactly 18 tools;
 - any normalized input schema differs;

--- a/scripts/release/README.md
+++ b/scripts/release/README.md
@@ -55,9 +55,7 @@ Agent systems should normally expose skills over that command. The direct
 Python SDK is the secondary embedded distribution. Neither installation creates
 a NoKV deployment: callers must still supply the selected control-plane
 endpoint, object-store configuration, root identity, and stable Agent
-presentation root. A LingTai or other MCP-compatible host may run the optional
-MCP sidecar through the Homebrew-installed `nokv` executable with final
-argument `mcp`; that transport is not required for CLI or Python SDK use.
+presentation root.
 
 ## Release invariants
 

--- a/scripts/workbench/README.md
+++ b/scripts/workbench/README.md
@@ -155,13 +155,16 @@ is not a NoKV namespace. Keep the configured Workbench root stable across
 restarts because canonical v1 manifest presentation paths are replay-bound;
 `RootId`, not this display root, remains the storage/routing identity.
 
-`nokv serve` publishes shared recovery segments by default
-(`--recovery-publication shared`), which is what the recovery gates qualify.
-Until shared checkpoint compaction exists that chain is bounded by the Control
-record size, so a long-lived deployment such as a partner pre-pilot should run
-`--recovery-publication local-only`: the exclusive Holt WAL is then the only
-recovery authority, nothing is published, and `--metadata-recover-log` is not
-available for that shard.
+`nokv serve` defaults to `--recovery-publication local-only`: the exclusive
+local Holt WAL is the only recovery authority, nothing is published to Control,
+and `--metadata-recover-log` is not available for that shard. Every gate in
+this directory runs on that default, so the recovery gates qualify local-WAL
+recovery only.
+
+Shared publication (`--recovery-publication shared`) is an unqualified opt-in
+and no gate exercises it. Until shared checkpoint compaction exists the segment
+chain is bounded by the Control record size, and a shard that reaches that
+bound loses its owner fence and stops accepting writes.
 
 The deterministic evidence directory contains `plan.json`, exact paired
 requests/responses in `mcp-transcript.jsonl`, `processes.jsonl` and process

--- a/scripts/workbench/README.md
+++ b/scripts/workbench/README.md
@@ -7,10 +7,15 @@ SPDX-License-Identifier: Apache-2.0
 
 These assets validate the same 18-tool Workbench semantics exported by
 `crates/nokv-agent`. The native full CLI is the primary integration surface,
-and the direct Python SDK is second for embedded callers. The MCP-focused
-assets here qualify the optional `nokv mcp` sidecar; they do not make MCP a
-required deployment component or define a runtime-specific metadata layout,
-capability alias, migration helper, or filesystem frontend.
+and the direct Python SDK is second for embedded callers.
+
+Several runners here still reach the 18 tools through a `nokv mcp` child
+process. That sidecar is deprecated and is not a supported NoKV integration
+surface: it survives only as this harness's transport, evidence produced over
+it qualifies that transport alone, and nothing here makes MCP a deployment
+component or defines a runtime-specific metadata layout, capability alias,
+migration helper, or filesystem frontend. Re-pointing these runners at
+`nokv workbench <tool>` is tracked work, not a documentation change.
 
 The checked-in integration assets are deliberately small:
 
@@ -95,12 +100,8 @@ PYTHONPATH=scripts/workbench python3 -m unittest \
 python3 scripts/workbench/fork_restore_recovery_gate_test.py
 ```
 
-To qualify the optional sidecar, register the built binary in an MCP-compatible
-Agent runtime as a stdio MCP command:
-
-```text
-/absolute/path/to/nokv <root, route, object, and workbench options> mcp
-```
+The runners below invoke the built binary directly; do not register it in an
+Agent runtime as an MCP command.
 
 The deployment must provide one persisted `RootId` placement, its
 `LogicalShardId`, current placement generation and owner epoch, a reachable


### PR DESCRIPTION
## Summary

Deprecates the `nokv mcp` Workbench sidecar as a product surface, and fixes two
stale references that let a reader quote this repository against itself.

Three independent commits:

1. **`docs: correct stale recovery-publication and package-scope references`**
   `scripts/workbench/README.md` claimed `nokv serve` publishes shared recovery
   segments by default and that the recovery gates qualify that mode. Both
   halves are false: `RecoveryPublicationConfig` defaults to `LocalOnly`, no
   gate passes `--recovery-publication shared`, and `fork_restore_recovery_gate.py`
   forces `local-only`. `AGENTS.md` listed `nokv-fuse` in the scope-drift
   checklist; that crate does not exist and is a forbidden token in the
   workspace-graph assertion, so the line was the only quotable
   counter-evidence against the product's FUSE exclusion.

2. **`docs: deprecate the Workbench MCP sidecar`** — 26 files, docs only.
   The delivery order becomes CLI, Python SDK, Rust SDK. `AGENTS.md` previously
   mandated the opposite, so the repository contract is inverted here.

3. **`feat(cli): warn that `nokv mcp` is deprecated`** — `crates/nokv/src/main.rs`.

## Why the sidecar's code is untouched

Four of the five live qualification producers
(`lingtai-mcp`, `live-workbench`, `object-namespace-recovery`,
`restore-composition`) reach the product through a `nokv mcp` child process and
retain `mcp-transcript.jsonl` as evidence. There is no CLI-driven 18-tool live
runner. Removing the sidecar today would delete the only executed live evidence
path, so this change separates "MCP as a supported integration surface"
(deleted) from "MCP as the harness's transport" (named as deprecated, kept).

Re-pointing those runners at `nokv workbench <tool>` is follow-up work.

## Three places handled deliberately, not by deletion

- **`docs/development/workspace-acceptance.md`** keeps its MCP language.
  Stripping it would silently promote MCP-derived evidence into CLI and Python
  SDK evidence, which is the opposite of the intent. MCP is restated as a
  deprecated transport whose evidence qualifies neither path.

  Gate 0 also now records a second, independent reason it cannot report `PASS`:
  the digest-pinned pre-#423 ledger's `native-workbench-e2e` expectation
  profile admits only the `live-workbench` producer, whose required evidence
  roles include `mcp-transcript`. The gate named *native* is satisfiable only
  by MCP-transport evidence. Admitting a CLI-driven producer is a ledger-policy
  change, not a documentation change.

- **`docs/workbench-preflight.md`** is retitled to "Live Deployment Preflight"
  **in place**, not deleted. It holds the only user-facing copy of the
  shared-publication write-stop warning and the "back up the Holt directory"
  operator invariant, and three documents link to its path. There is no link
  checker in CI, so a rename would break those silently.

- **The LingTai announcements** keep their published bodies byte-verbatim and
  carry a dated 2026-08 update block instead. Those pages are dated records;
  rewriting one is not a correction.

## The residual risk this closes

Docs-only deprecation would leave an undocumented shipping surface: `nokv --help`
still lists the subcommand and `nokv schema` still prints the frozen
`nokv.workbench.mcp_input_schemas.v1` marker, and the README Quick Start tells
every new user to run both. Commit 3 marks the subcommand `(DEPRECATED)` in the
usage block and emits one warning per invocation; the README explains the
tokens where a reader first meets them.

The warning is written to **stderr and never to stdout**, because stdout carries
the line-delimited JSON-RPC stream. The three runners that spawn the sidecar
route its stderr to a dedicated log file rather than merging it into stdout, so
their transcripts are unaffected. It is emitted immediately after argument
parsing rather than inside the dispatch arm, so a parseable `nokv mcp` reports
the deprecation even when routing or admission fails afterwards.

## Verification

```
cargo fmt --all -- --check
cargo clippy --workspace --all-targets -- -D warnings
cargo test -p nokv
python3 scripts/workbench/*_test.py          # 20/20
python3 scripts/release/test_homebrew_source_release.py
git diff --check
```

All pass. The CI-asserted documentation literals were checked before editing
and are untouched: the FUSE/POSIX paragraph in `docs/development/code_contract.md`,
the `metadata/checkpoints.jsonl` sentence in `docs/workbench-contract.md`, and
the `L03`–`L06` paragraph in `docs/development/pre423-contract-ledger.md`.
`scripts/workbench/pre423_contract_ledger.json` is digest pinned and was not
modified.

Manual check of the warning:

```
$ nokv --root-id ... --agent-id ... --workbench-root /agents/x/wb mcp
warning: `nokv mcp` is deprecated and is not a supported NoKV integration surface. ...
```

stdout stays empty; `nokv schema`, `nokv version --json`, and `nokv workbench`
emit no warning.

## Follow-up, not in this PR

`README.md:259`'s `Not qualified` table row still merges "built, awaiting
validation" (remote recovery, shared durability) with "not built / non-goal"
(cross-shard transactions, tenant identity/RBAC, multi-machine HA), and
contradicts the same file's line 218. That row should be split into two.
