### PR TITLE
fix(control): make expired recovery suspension idempotent, with parallel-safe test hooks

### DIFF
--- a/crates/nokv-control/src/etcd.rs
+++ b/crates/nokv-control/src/etcd.rs
@@ -625,8 +625,20 @@ impl ControlStore for EtcdControlStore {
             let current = fetch_logical_shard(&mut client, &options, &lease.logical_shard_id)
                 .await?
                 .ok_or(ControlError::LogicalShardNotFound(lease.logical_shard_id))?;
-            let session = validate_owner_session(&mut client, &options, &lease).await?;
             let retained = prepare_recovery_suspension(&current.record, &lease)?;
+
+            let Some(session) =
+                fetch_owner_session(&mut client, &options, &lease.logical_shard_id).await?
+            else {
+                revoke_lease_best_effort(&mut client, lease.lease_id).await;
+                return Ok(retained);
+            };
+
+            if session.lease != lease || session.attached_lease_id != lease_id_i64(lease.lease_id)?
+            {
+                return Err(ControlError::StaleLease(lease.clone()));
+            }
+
             let record_key = options.logical_shard_record_key(&lease.logical_shard_id);
             let session_key = options.logical_shard_session_key(&lease.logical_shard_id);
             let txn = Txn::new()
@@ -1335,7 +1347,7 @@ mod tests {
     use etcd_client::DeleteOptions;
 
     use super::*;
-    use crate::{AgentId, PlacementGeneration, RootPlacementLifecycle};
+    use crate::{AgentId, LogicalShardState, PlacementGeneration, RootPlacementLifecycle};
 
     fn root(fill: u8) -> RootId {
         RootId::from_bytes([fill; 16])
@@ -1775,6 +1787,133 @@ mod tests {
                     .await
                     .map_err(etcd_backend)?;
                 Ok(())
+            })
+            .unwrap();
+    }
+
+    #[test]
+    #[ignore = "requires NOKV_TEST_ETCD_ENDPOINT"]
+    fn etcd_expired_recovery_session_cleanup_rebinds_same_epoch() {
+        let endpoint = std::env::var("NOKV_TEST_ETCD_ENDPOINT")
+            .expect("NOKV_TEST_ETCD_ENDPOINT must name an isolated test etcd endpoint");
+
+        let nonce = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+
+        let prefix = format!(
+            "/nokv/test/expired-recovery-session-{}-{nonce}",
+            std::process::id()
+        );
+
+        let options = EtcdControlStoreOptions::new([endpoint]).with_key_prefix(prefix.clone());
+        let store = EtcdControlStore::connect(options.clone()).unwrap();
+        let logical_shard_id = shard(9);
+
+        store.create_logical_shard(logical_shard_id).unwrap();
+
+        store
+            .create_root_placement(RootPlacement {
+                root_id: root(9),
+                logical_shard_id,
+                placement_generation: PlacementGeneration::new(1).unwrap(),
+                lifecycle: RootPlacementLifecycle::Provisioning,
+            })
+            .unwrap();
+
+        let first = store
+            .acquire_owner(
+                &logical_shard_id,
+                NodeId::new("node-a").unwrap(),
+                "node-a:7000".to_owned(),
+            )
+            .unwrap();
+
+        // Revoke the real etcd lease. etcd removes the attached session key,
+        // while the durable Recovering record intentionally remains.
+        let mut client = store.client.clone();
+
+        store
+            .block_on(async {
+                client
+                    .lease_revoke(lease_id_i64(first.lease_id)?)
+                    .await
+                    .map_err(etcd_backend)?;
+
+                Ok::<(), ControlError>(())
+            })
+            .unwrap();
+
+        assert!(
+            store
+                .block_on(fetch_owner_session(
+                    &mut client,
+                    &options,
+                    &logical_shard_id,
+                ))
+                .unwrap()
+                .is_none(),
+            "revoking the etcd lease must remove its attached owner session"
+        );
+
+        assert!(matches!(
+            store.renew_owner(&first),
+            Err(ControlError::StaleLease(_))
+        ));
+
+        // Before the fix this returns StaleLease.
+        let retained = store.suspend_recovery(&first).unwrap();
+
+        assert_eq!(retained.state, LogicalShardState::Recovering);
+        assert_eq!(retained.owner_epoch, Some(first.owner_epoch));
+        assert_eq!(retained.lease_id, first.lease_id);
+        assert_eq!(store.suspend_recovery(&first).unwrap(), retained);
+
+        let rebound = store
+            .reacquire_recovery(
+                &logical_shard_id,
+                first.owner_epoch,
+                NodeId::new("node-b").unwrap(),
+                "node-b:7000".to_owned(),
+            )
+            .unwrap();
+
+        assert_eq!(rebound.owner_epoch, first.owner_epoch);
+        assert_ne!(rebound.lease_id, first.lease_id);
+
+        // Cleanup using the expired lease must not affect the live replacement.
+        assert!(matches!(
+            store.suspend_recovery(&first),
+            Err(ControlError::NotOwner { .. }) | Err(ControlError::StaleLease(_))
+        ));
+
+        assert_eq!(
+            store.renew_owner(&rebound).unwrap().lease_id,
+            rebound.lease_id
+        );
+
+        store
+            .mark_serving(
+                &rebound,
+                RecoveryPublication {
+                    checkpoint: None,
+                    log: None,
+                    durable_lsn: 0,
+                },
+            )
+            .unwrap();
+
+        store.release_owner(&rebound).unwrap();
+
+        store
+            .block_on(async {
+                client
+                    .delete(prefix, Some(DeleteOptions::new().with_prefix()))
+                    .await
+                    .map_err(etcd_backend)?;
+
+                Ok::<(), ControlError>(())
             })
             .unwrap();
     }

--- a/crates/nokv-control/src/etcd.rs
+++ b/crates/nokv-control/src/etcd.rs
@@ -30,6 +30,8 @@ pub struct EtcdControlStore {
     options: EtcdControlStoreOptions,
     runtime: Runtime,
     client: Client,
+    #[cfg(test)]
+    suspend_recovery_test_hook: SuspendRecoveryTestHook,
 }
 
 struct StoredRootPlacement {
@@ -51,53 +53,56 @@ struct StoredOwnerSession {
 #[cfg(test)]
 type SuspendRecoveryMissingSessionHook = Box<dyn FnOnce() + Send + 'static>;
 
+/// Per-store test hook for the missing-session suspension path. Instance
+/// state, never a process global: concurrent tests each own their store, so
+/// one test's pause can neither collide with another test's install nor
+/// poison a mutex that unrelated tests consult.
 #[cfg(test)]
-static SUSPEND_RECOVERY_MISSING_SESSION_HOOK: std::sync::OnceLock<
-    std::sync::Mutex<Option<(LogicalShardId, SuspendRecoveryMissingSessionHook)>>,
-> = std::sync::OnceLock::new();
-
-#[cfg(test)]
-fn install_suspend_recovery_missing_session_hook(
-    logical_shard_id: LogicalShardId,
-    hook: impl FnOnce() + Send + 'static,
-) {
-    let slot = SUSPEND_RECOVERY_MISSING_SESSION_HOOK.get_or_init(|| std::sync::Mutex::new(None));
-
-    let mut guard = slot
-        .lock()
-        .expect("suspend-recovery test-hook mutex must remain available");
-
-    assert!(
-        guard.is_none(),
-        "suspend-recovery missing-session hook is already installed"
-    );
-
-    *guard = Some((logical_shard_id, Box::new(hook)));
+#[derive(Clone, Default)]
+struct SuspendRecoveryTestHook {
+    slot: std::sync::Arc<
+        std::sync::Mutex<Option<(LogicalShardId, SuspendRecoveryMissingSessionHook)>>,
+    >,
 }
 
 #[cfg(test)]
-fn run_suspend_recovery_missing_session_hook(logical_shard_id: &LogicalShardId) {
-    let slot = SUSPEND_RECOVERY_MISSING_SESSION_HOOK.get_or_init(|| std::sync::Mutex::new(None));
-
-    let hook = {
-        let mut guard = slot
+impl SuspendRecoveryTestHook {
+    fn install(&self, logical_shard_id: LogicalShardId, hook: impl FnOnce() + Send + 'static) {
+        let mut guard = self
+            .slot
             .lock()
             .expect("suspend-recovery test-hook mutex must remain available");
 
-        let should_run = guard
-            .as_ref()
-            .map(|(expected, _)| expected == logical_shard_id)
-            .unwrap_or(false);
+        assert!(
+            guard.is_none(),
+            "suspend-recovery missing-session hook is already installed for this store"
+        );
 
-        if should_run {
-            guard.take().map(|(_, hook)| hook)
-        } else {
-            None
+        *guard = Some((logical_shard_id, Box::new(hook)));
+    }
+
+    fn run(&self, logical_shard_id: &LogicalShardId) {
+        let hook = {
+            let mut guard = self
+                .slot
+                .lock()
+                .expect("suspend-recovery test-hook mutex must remain available");
+
+            let should_run = guard
+                .as_ref()
+                .map(|(expected, _)| expected == logical_shard_id)
+                .unwrap_or(false);
+
+            if should_run {
+                guard.take().map(|(_, hook)| hook)
+            } else {
+                None
+            }
+        };
+
+        if let Some(hook) = hook {
+            hook();
         }
-    };
-
-    if let Some(hook) = hook {
-        hook();
     }
 }
 
@@ -118,7 +123,19 @@ impl EtcdControlStore {
             options,
             runtime,
             client,
+            #[cfg(test)]
+            suspend_recovery_test_hook: SuspendRecoveryTestHook::default(),
         })
+    }
+
+    #[cfg(test)]
+    fn install_suspend_recovery_missing_session_hook(
+        &self,
+        logical_shard_id: LogicalShardId,
+        hook: impl FnOnce() + Send + 'static,
+    ) {
+        self.suspend_recovery_test_hook
+            .install(logical_shard_id, hook);
     }
 
     pub fn options(&self) -> &EtcdControlStoreOptions {
@@ -674,6 +691,8 @@ impl ControlStore for EtcdControlStore {
         let mut client = self.client.clone();
         let options = self.options.clone();
         let lease = lease.clone();
+        #[cfg(test)]
+        let test_hook = self.suspend_recovery_test_hook.clone();
 
         self.block_on(async move {
             let current = fetch_logical_shard(&mut client, &options, &lease.logical_shard_id)
@@ -688,7 +707,7 @@ impl ControlStore for EtcdControlStore {
             let result = match session {
                 None => {
                     #[cfg(test)]
-                    run_suspend_recovery_missing_session_hook(&lease.logical_shard_id);
+                    test_hook.run(&lease.logical_shard_id);
 
                     if exact_recovery_record_is_sessionless(&mut client, &options, &current).await?
                     {
@@ -1453,6 +1472,16 @@ fn etcd_backend(error: etcd_client::Error) -> ControlError {
     ControlError::Backend(format!("etcd: {error}"))
 }
 
+// The `#[ignore]` tests below run only against a real etcd:
+//
+//   NOKV_TEST_ETCD_ENDPOINT=http://127.0.0.1:2379 \
+//     cargo test -p nokv-control --features etcd -- --ignored
+//
+// `--features etcd` is load-bearing: without it this module is not compiled,
+// so `-- --ignored` silently runs zero tests and reads as green. The tests
+// are safe under the default parallel test runner: every test derives a
+// unique key prefix and shard id, and the suspend-recovery pause hook is
+// per-store state, not a process global.
 #[cfg(test)]
 mod tests {
     use std::sync::mpsc;
@@ -2104,7 +2133,7 @@ mod tests {
 
         let (resume_tx, resume_rx) = mpsc::channel();
 
-        install_suspend_recovery_missing_session_hook(logical_shard_id, move || {
+        cleanup_store.install_suspend_recovery_missing_session_hook(logical_shard_id, move || {
             reached_tx
                 .send(())
                 .expect("test must signal the missing-session boundary");
@@ -2384,7 +2413,7 @@ mod tests {
 
         let (resume_tx, resume_rx) = std::sync::mpsc::channel();
 
-        install_suspend_recovery_missing_session_hook(logical_shard_id, move || {
+        cleanup_store.install_suspend_recovery_missing_session_hook(logical_shard_id, move || {
             reached_tx
                 .send(())
                 .expect("test must signal that cleanup observed the absent L1 session");

--- a/crates/nokv-control/src/etcd.rs
+++ b/crates/nokv-control/src/etcd.rs
@@ -48,6 +48,81 @@ struct StoredOwnerSession {
     attached_lease_id: i64,
 }
 
+#[cfg(test)]
+type SuspendRecoveryMissingSessionHook =
+    Box<dyn FnOnce() + Send + 'static>;
+
+#[cfg(test)]
+static SUSPEND_RECOVERY_MISSING_SESSION_HOOK:
+    std::sync::OnceLock<
+        std::sync::Mutex<
+            Option<(
+                LogicalShardId,
+                SuspendRecoveryMissingSessionHook,
+            )>,
+        >,
+    > = std::sync::OnceLock::new();
+
+#[cfg(test)]
+fn install_suspend_recovery_missing_session_hook(
+    logical_shard_id: LogicalShardId,
+    hook: impl FnOnce() + Send + 'static,
+) {
+    let slot =
+        SUSPEND_RECOVERY_MISSING_SESSION_HOOK
+            .get_or_init(|| std::sync::Mutex::new(None));
+
+    let mut guard = slot
+        .lock()
+        .expect(
+            "suspend-recovery test-hook mutex must remain available",
+        );
+
+    assert!(
+        guard.is_none(),
+        "suspend-recovery missing-session hook is already installed"
+    );
+
+    *guard = Some((
+        logical_shard_id,
+        Box::new(hook),
+    ));
+}
+
+#[cfg(test)]
+fn run_suspend_recovery_missing_session_hook(
+    logical_shard_id: &LogicalShardId,
+) {
+    let slot =
+        SUSPEND_RECOVERY_MISSING_SESSION_HOOK
+            .get_or_init(|| std::sync::Mutex::new(None));
+
+    let hook = {
+        let mut guard = slot
+            .lock()
+            .expect(
+                "suspend-recovery test-hook mutex must remain available",
+            );
+
+        let should_run = guard
+            .as_ref()
+            .map(|(expected, _)| {
+                expected == logical_shard_id
+            })
+            .unwrap_or(false);
+
+        if should_run {
+            guard.take().map(|(_, hook)| hook)
+        } else {
+            None
+        }
+    };
+
+    if let Some(hook) = hook {
+        hook();
+    }
+}
+
 impl EtcdControlStore {
     pub fn connect(options: EtcdControlStoreOptions) -> Result<Self, ControlError> {
         options.validate()?;
@@ -621,47 +696,124 @@ impl ControlStore for EtcdControlStore {
         let mut client = self.client.clone();
         let options = self.options.clone();
         let lease = lease.clone();
+
         self.block_on(async move {
-            let current = fetch_logical_shard(&mut client, &options, &lease.logical_shard_id)
+            let current =
+                fetch_logical_shard(
+                    &mut client,
+                    &options,
+                    &lease.logical_shard_id,
+                )
                 .await?
-                .ok_or(ControlError::LogicalShardNotFound(lease.logical_shard_id))?;
-            let retained = prepare_recovery_suspension(&current.record, &lease)?;
+                .ok_or(ControlError::LogicalShardNotFound(
+                    lease.logical_shard_id,
+                ))?;
 
-            let Some(session) =
-                fetch_owner_session(&mut client, &options, &lease.logical_shard_id).await?
-            else {
-                revoke_lease_best_effort(&mut client, lease.lease_id).await;
-                return Ok(retained);
-            };
+            let retained =
+                prepare_recovery_suspension(&current.record, &lease)?;
 
-            if session.lease != lease || session.attached_lease_id != lease_id_i64(lease.lease_id)?
-            {
-                return Err(ControlError::StaleLease(lease.clone()));
-            }
+            let session =
+                fetch_owner_session(
+                    &mut client,
+                    &options,
+                    &lease.logical_shard_id,
+                )
+                .await?;
 
-            let record_key = options.logical_shard_record_key(&lease.logical_shard_id);
-            let session_key = options.logical_shard_session_key(&lease.logical_shard_id);
-            let txn = Txn::new()
-                .when(vec![
-                    Compare::mod_revision(record_key, CompareOp::Equal, current.mod_revision),
-                    Compare::value(session_key.clone(), CompareOp::Equal, session.encoded),
-                    Compare::lease(
-                        session_key.clone(),
-                        CompareOp::Equal,
-                        lease_id_i64(lease.lease_id)?,
-                    ),
-                ])
-                .and_then(vec![TxnOp::delete(session_key, None)]);
-            let result = match client.txn(txn).await {
-                Ok(response) if response.succeeded() => Ok(retained),
-                Ok(_) | Err(_) => {
-                    classify_suspend_recovery_failure(&mut client, &options, &lease, &retained)
+            let result = match session {
+                None => {
+                    #[cfg(test)]
+                    run_suspend_recovery_missing_session_hook(
+                        &lease.logical_shard_id,
+                    );
+
+                    if exact_recovery_record_is_sessionless(
+                        &mut client,
+                        &options,
+                        &current,
+                    )
+                    .await?
+                    {
+                        Ok(retained.clone())
+                    } else {
+                        classify_suspend_recovery_failure(
+                            &mut client,
+                            &options,
+                            &lease,
+                            &current,
+                            &retained,
+                        )
                         .await
+                    }
+                }
+                Some(session) => {
+                    if session.lease != lease
+                        || session.attached_lease_id
+                            != lease_id_i64(lease.lease_id)?
+                    {
+                        return Err(ControlError::StaleLease(
+                            lease.clone(),
+                        ));
+                    }
+
+                    let record_key = options
+                        .logical_shard_record_key(
+                            &lease.logical_shard_id,
+                        );
+
+                    let session_key = options
+                        .logical_shard_session_key(
+                            &lease.logical_shard_id,
+                        );
+
+                    let txn = Txn::new()
+                        .when(vec![
+                            Compare::mod_revision(
+                                record_key,
+                                CompareOp::Equal,
+                                current.mod_revision,
+                            ),
+                            Compare::value(
+                                session_key.clone(),
+                                CompareOp::Equal,
+                                session.encoded,
+                            ),
+                            Compare::lease(
+                                session_key.clone(),
+                                CompareOp::Equal,
+                                lease_id_i64(lease.lease_id)?,
+                            ),
+                        ])
+                        .and_then(vec![
+                            TxnOp::delete(session_key, None),
+                        ]);
+
+                    match client.txn(txn).await {
+                        Ok(response) if response.succeeded() => {
+                            Ok(retained.clone())
+                        }
+                        Ok(_) | Err(_) => {
+                            classify_suspend_recovery_failure(
+                                &mut client,
+                                &options,
+                                &lease,
+                                &current,
+                                &retained,
+                            )
+                            .await
+                        }
+                    }
                 }
             };
+
             if result.is_ok() {
-                revoke_lease_best_effort(&mut client, lease.lease_id).await;
+                revoke_lease_best_effort(
+                    &mut client,
+                    lease.lease_id,
+                )
+                .await;
             }
+
             result
         })
     }
@@ -1254,26 +1406,82 @@ async fn classify_owner_record_mutation_failure(
     ))
 }
 
+async fn exact_recovery_record_is_sessionless(
+    client: &mut Client,
+    options: &EtcdControlStoreOptions,
+    expected: &StoredLogicalShard,
+) -> Result<bool, ControlError> {
+    let logical_shard_id = expected.record.logical_shard_id;
+
+    let record_key =
+        options.logical_shard_record_key(&logical_shard_id);
+
+    let session_key =
+        options.logical_shard_session_key(&logical_shard_id);
+
+    // This transaction is the linearization point for sessionless recovery
+    // suspension. The validated record revision and session absence must both
+    // still be true at the same etcd revision.
+    let txn = Txn::new()
+        .when(vec![
+            Compare::mod_revision(
+                record_key.clone(),
+                CompareOp::Equal,
+                expected.mod_revision,
+            ),
+            Compare::version(
+                session_key,
+                CompareOp::Equal,
+                0,
+            ),
+        ])
+        .and_then(vec![
+            TxnOp::get(record_key, None),
+        ]);
+
+    Ok(
+        client
+            .txn(txn)
+            .await
+            .map_err(etcd_backend)?
+            .succeeded(),
+    )
+}
+
 async fn classify_suspend_recovery_failure(
     client: &mut Client,
     options: &EtcdControlStoreOptions,
     lease: &LogicalShardLease,
+    expected: &StoredLogicalShard,
     retained: &LogicalShardRecord,
 ) -> Result<LogicalShardRecord, ControlError> {
-    let latest = fetch_logical_shard(client, options, &lease.logical_shard_id)
-        .await?
-        .ok_or(ControlError::LogicalShardNotFound(lease.logical_shard_id))?;
-    if latest.record == *retained
-        && fetch_owner_session(client, options, &lease.logical_shard_id)
-            .await?
-            .is_none()
+    if exact_recovery_record_is_sessionless(
+        client,
+        options,
+        expected,
+    )
+    .await?
     {
         return Ok(retained.clone());
     }
+
+    let latest =
+        fetch_logical_shard(
+            client,
+            options,
+            &lease.logical_shard_id,
+        )
+        .await?
+        .ok_or(ControlError::LogicalShardNotFound(
+            lease.logical_shard_id,
+        ))?;
+
     validate_record_lease(&latest.record, lease)?;
     validate_owner_session(client, options, lease).await?;
+
     Err(ControlError::Backend(
-        "recovery suspension CAS failed while the exact owner session remained current".to_owned(),
+        "recovery suspension CAS failed while the exact owner session remained current"
+            .to_owned(),
     ))
 }
 
@@ -1342,7 +1550,9 @@ fn etcd_backend(error: etcd_client::Error) -> ControlError {
 
 #[cfg(test)]
 mod tests {
-    use std::time::{SystemTime, UNIX_EPOCH};
+    use std::sync::mpsc;
+    use std::thread;
+    use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
     use etcd_client::DeleteOptions;
 
@@ -1917,4 +2127,390 @@ mod tests {
             })
             .unwrap();
     }
+
+    #[test]
+    #[ignore = "requires NOKV_TEST_ETCD_ENDPOINT"]
+    fn etcd_missing_session_fast_path_is_linearizable_against_rebind_and_mark_serving() {
+        let endpoint =
+            std::env::var("NOKV_TEST_ETCD_ENDPOINT")
+                .expect(
+                    "NOKV_TEST_ETCD_ENDPOINT must name an isolated test etcd endpoint",
+                );
+
+        let nonce = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+
+        let prefix = format!(
+            "/nokv/test/suspend-linearizability-{}-{nonce}",
+            std::process::id(),
+        );
+
+        let options =
+            EtcdControlStoreOptions::new([endpoint])
+                .with_key_prefix(prefix.clone());
+
+        let setup_store =
+            EtcdControlStore::connect(options.clone()).unwrap();
+
+        let logical_shard_id = shard(10);
+
+        setup_store
+            .create_logical_shard(logical_shard_id)
+            .unwrap();
+
+        setup_store
+            .create_root_placement(RootPlacement {
+                root_id: root(10),
+                logical_shard_id,
+                placement_generation:
+                    PlacementGeneration::new(1).unwrap(),
+                lifecycle:
+                    RootPlacementLifecycle::Provisioning,
+            })
+            .unwrap();
+
+        let first = setup_store
+            .acquire_owner(
+                &logical_shard_id,
+                NodeId::new("node-a").unwrap(),
+                "node-a:7000".to_owned(),
+            )
+            .unwrap();
+
+        let mut setup_client =
+            setup_store.client.clone();
+
+        setup_store
+            .block_on(async {
+                setup_client
+                    .lease_revoke(
+                        lease_id_i64(first.lease_id)?,
+                    )
+                    .await
+                    .map_err(etcd_backend)?;
+
+                Ok::<(), ControlError>(())
+            })
+            .unwrap();
+
+        assert!(
+            setup_store
+                .block_on(fetch_owner_session(
+                    &mut setup_client,
+                    &options,
+                    &logical_shard_id,
+                ))
+                .unwrap()
+                .is_none(),
+        );
+
+        let cleanup_store =
+            EtcdControlStore::connect(options.clone()).unwrap();
+
+        let contender_store =
+            EtcdControlStore::connect(options.clone()).unwrap();
+
+        let (reached_tx, reached_rx) =
+            mpsc::channel();
+
+        let (resume_tx, resume_rx) =
+            mpsc::channel();
+
+        install_suspend_recovery_missing_session_hook(
+            logical_shard_id,
+            move || {
+                reached_tx
+                    .send(())
+                    .expect(
+                        "test must signal the missing-session boundary",
+                    );
+
+                resume_rx
+                    .recv()
+                    .expect(
+                        "test must resume missing-session cleanup",
+                    );
+            },
+        );
+
+        let first_for_cleanup = first.clone();
+
+        let cleanup_thread = thread::spawn(move || {
+            cleanup_store
+                .suspend_recovery(&first_for_cleanup)
+        });
+
+        reached_rx
+            .recv_timeout(Duration::from_secs(5))
+            .expect(
+                "cleanup did not reach the missing-session boundary",
+            );
+
+        let rebound = contender_store
+            .reacquire_recovery(
+                &logical_shard_id,
+                first.owner_epoch,
+                first.owner.clone(),
+                "node-a:7001".to_owned(),
+            )
+            .unwrap();
+
+        assert_eq!(
+            rebound.owner_epoch,
+            first.owner_epoch,
+        );
+
+        assert_ne!(
+            rebound.lease_id,
+            first.lease_id,
+        );
+
+        contender_store
+            .mark_serving(
+                &rebound,
+                RecoveryPublication {
+                    checkpoint: None,
+                    log: None,
+                    durable_lsn: 0,
+                },
+            )
+            .unwrap();
+
+        resume_tx
+            .send(())
+            .expect(
+                "test must release the cleanup thread",
+            );
+
+        let cleanup_result = cleanup_thread
+            .join()
+            .expect(
+                "cleanup thread must not panic",
+            );
+
+        assert!(matches!(
+            cleanup_result,
+            Err(ControlError::StaleLease(_))
+                | Err(ControlError::NotOwner { .. })
+                | Err(
+                    ControlError::RecoveryStateConflict { .. }
+                )
+        ));
+
+        let latest = contender_store
+            .get_logical_shard(&logical_shard_id)
+            .unwrap()
+            .unwrap();
+
+        assert_eq!(
+            latest.state,
+            LogicalShardState::Serving,
+        );
+
+        assert_eq!(
+            latest.owner_epoch,
+            Some(rebound.owner_epoch),
+        );
+
+        assert_eq!(
+            latest.lease_id,
+            rebound.lease_id,
+        );
+
+        contender_store
+            .release_owner(&rebound)
+            .unwrap();
+
+        let mut cleanup_client =
+            contender_store.client.clone();
+
+        contender_store
+            .block_on(async {
+                cleanup_client
+                    .delete(
+                        prefix,
+                        Some(
+                            DeleteOptions::new()
+                                .with_prefix(),
+                        ),
+                    )
+                    .await
+                    .map_err(etcd_backend)?;
+
+                Ok::<(), ControlError>(())
+            })
+            .unwrap();
+    }
+
+    #[test]
+    #[ignore = "requires NOKV_TEST_ETCD_ENDPOINT"]
+    fn etcd_double_expiry_cleanup_requires_exact_rebound_lease() {
+        let endpoint =
+            std::env::var("NOKV_TEST_ETCD_ENDPOINT")
+                .expect(
+                    "NOKV_TEST_ETCD_ENDPOINT must name an isolated test etcd endpoint",
+                );
+
+        let nonce = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+
+        let prefix = format!(
+            "/nokv/test/double-expiry-{}-{nonce}",
+            std::process::id(),
+        );
+
+        let options =
+            EtcdControlStoreOptions::new([endpoint])
+                .with_key_prefix(prefix.clone());
+
+        let store =
+            EtcdControlStore::connect(options.clone()).unwrap();
+
+        let logical_shard_id = shard(11);
+
+        store
+            .create_logical_shard(logical_shard_id)
+            .unwrap();
+
+        store
+            .create_root_placement(RootPlacement {
+                root_id: root(11),
+                logical_shard_id,
+                placement_generation:
+                    PlacementGeneration::new(1).unwrap(),
+                lifecycle:
+                    RootPlacementLifecycle::Provisioning,
+            })
+            .unwrap();
+
+        let first = store
+            .acquire_owner(
+                &logical_shard_id,
+                NodeId::new("node-a").unwrap(),
+                "node-a:7000".to_owned(),
+            )
+            .unwrap();
+
+        let mut client = store.client.clone();
+
+        store
+            .block_on(async {
+                client
+                    .lease_revoke(
+                        lease_id_i64(first.lease_id)?,
+                    )
+                    .await
+                    .map_err(etcd_backend)?;
+
+                Ok::<(), ControlError>(())
+            })
+            .unwrap();
+
+        assert!(
+            store
+                .block_on(fetch_owner_session(
+                    &mut client,
+                    &options,
+                    &logical_shard_id,
+                ))
+                .unwrap()
+                .is_none(),
+        );
+
+        let rebound = store
+            .reacquire_recovery(
+                &logical_shard_id,
+                first.owner_epoch,
+                first.owner.clone(),
+                "node-a:7001".to_owned(),
+            )
+            .unwrap();
+
+        assert_eq!(
+            &rebound.owner,
+            &first.owner,
+        );
+
+        assert_eq!(
+            rebound.owner_epoch,
+            first.owner_epoch,
+        );
+
+        assert_ne!(
+            rebound.lease_id,
+            first.lease_id,
+        );
+
+        store
+            .block_on(async {
+                client
+                    .lease_revoke(
+                        lease_id_i64(rebound.lease_id)?,
+                    )
+                    .await
+                    .map_err(etcd_backend)?;
+
+                Ok::<(), ControlError>(())
+            })
+            .unwrap();
+
+        assert!(
+            store
+                .block_on(fetch_owner_session(
+                    &mut client,
+                    &options,
+                    &logical_shard_id,
+                ))
+                .unwrap()
+                .is_none(),
+        );
+
+        // Both sessions are absent. Cleanup for L1 must still be rejected
+        // because the durable Recovering record now identifies L2.
+        assert!(matches!(
+            store.suspend_recovery(&first),
+            Err(ControlError::StaleLease(_))
+                | Err(ControlError::NotOwner { .. })
+        ));
+
+        let retained =
+            store.suspend_recovery(&rebound).unwrap();
+
+        assert_eq!(
+            retained.state,
+            LogicalShardState::Recovering,
+        );
+
+        assert_eq!(
+            retained.owner_epoch,
+            Some(rebound.owner_epoch),
+        );
+
+        assert_eq!(
+            retained.lease_id,
+            rebound.lease_id,
+        );
+
+        store
+            .block_on(async {
+                client
+                    .delete(
+                        prefix,
+                        Some(
+                            DeleteOptions::new()
+                                .with_prefix(),
+                        ),
+                    )
+                    .await
+                    .map_err(etcd_backend)?;
+
+                Ok::<(), ControlError>(())
+            })
+            .unwrap();
+    }
+
 }

--- a/crates/nokv-control/src/etcd.rs
+++ b/crates/nokv-control/src/etcd.rs
@@ -49,66 +49,44 @@ struct StoredOwnerSession {
 }
 
 #[cfg(test)]
-type SuspendRecoveryMissingSessionHook =
-    Box<dyn FnOnce() + Send + 'static>;
+type SuspendRecoveryMissingSessionHook = Box<dyn FnOnce() + Send + 'static>;
 
 #[cfg(test)]
-static SUSPEND_RECOVERY_MISSING_SESSION_HOOK:
-    std::sync::OnceLock<
-        std::sync::Mutex<
-            Option<(
-                LogicalShardId,
-                SuspendRecoveryMissingSessionHook,
-            )>,
-        >,
-    > = std::sync::OnceLock::new();
+static SUSPEND_RECOVERY_MISSING_SESSION_HOOK: std::sync::OnceLock<
+    std::sync::Mutex<Option<(LogicalShardId, SuspendRecoveryMissingSessionHook)>>,
+> = std::sync::OnceLock::new();
 
 #[cfg(test)]
 fn install_suspend_recovery_missing_session_hook(
     logical_shard_id: LogicalShardId,
     hook: impl FnOnce() + Send + 'static,
 ) {
-    let slot =
-        SUSPEND_RECOVERY_MISSING_SESSION_HOOK
-            .get_or_init(|| std::sync::Mutex::new(None));
+    let slot = SUSPEND_RECOVERY_MISSING_SESSION_HOOK.get_or_init(|| std::sync::Mutex::new(None));
 
     let mut guard = slot
         .lock()
-        .expect(
-            "suspend-recovery test-hook mutex must remain available",
-        );
+        .expect("suspend-recovery test-hook mutex must remain available");
 
     assert!(
         guard.is_none(),
         "suspend-recovery missing-session hook is already installed"
     );
 
-    *guard = Some((
-        logical_shard_id,
-        Box::new(hook),
-    ));
+    *guard = Some((logical_shard_id, Box::new(hook)));
 }
 
 #[cfg(test)]
-fn run_suspend_recovery_missing_session_hook(
-    logical_shard_id: &LogicalShardId,
-) {
-    let slot =
-        SUSPEND_RECOVERY_MISSING_SESSION_HOOK
-            .get_or_init(|| std::sync::Mutex::new(None));
+fn run_suspend_recovery_missing_session_hook(logical_shard_id: &LogicalShardId) {
+    let slot = SUSPEND_RECOVERY_MISSING_SESSION_HOOK.get_or_init(|| std::sync::Mutex::new(None));
 
     let hook = {
         let mut guard = slot
             .lock()
-            .expect(
-                "suspend-recovery test-hook mutex must remain available",
-            );
+            .expect("suspend-recovery test-hook mutex must remain available");
 
         let should_run = guard
             .as_ref()
-            .map(|(expected, _)| {
-                expected == logical_shard_id
-            })
+            .map(|(expected, _)| expected == logical_shard_id)
             .unwrap_or(false);
 
         if should_run {
@@ -698,41 +676,21 @@ impl ControlStore for EtcdControlStore {
         let lease = lease.clone();
 
         self.block_on(async move {
-            let current =
-                fetch_logical_shard(
-                    &mut client,
-                    &options,
-                    &lease.logical_shard_id,
-                )
+            let current = fetch_logical_shard(&mut client, &options, &lease.logical_shard_id)
                 .await?
-                .ok_or(ControlError::LogicalShardNotFound(
-                    lease.logical_shard_id,
-                ))?;
+                .ok_or(ControlError::LogicalShardNotFound(lease.logical_shard_id))?;
 
-            let retained =
-                prepare_recovery_suspension(&current.record, &lease)?;
+            let retained = prepare_recovery_suspension(&current.record, &lease)?;
 
             let session =
-                fetch_owner_session(
-                    &mut client,
-                    &options,
-                    &lease.logical_shard_id,
-                )
-                .await?;
+                fetch_owner_session(&mut client, &options, &lease.logical_shard_id).await?;
 
             let result = match session {
                 None => {
                     #[cfg(test)]
-                    run_suspend_recovery_missing_session_hook(
-                        &lease.logical_shard_id,
-                    );
+                    run_suspend_recovery_missing_session_hook(&lease.logical_shard_id);
 
-                    if exact_recovery_record_is_sessionless(
-                        &mut client,
-                        &options,
-                        &current,
-                    )
-                    .await?
+                    if exact_recovery_record_is_sessionless(&mut client, &options, &current).await?
                     {
                         Ok(retained.clone())
                     } else {
@@ -748,23 +706,14 @@ impl ControlStore for EtcdControlStore {
                 }
                 Some(session) => {
                     if session.lease != lease
-                        || session.attached_lease_id
-                            != lease_id_i64(lease.lease_id)?
+                        || session.attached_lease_id != lease_id_i64(lease.lease_id)?
                     {
-                        return Err(ControlError::StaleLease(
-                            lease.clone(),
-                        ));
+                        return Err(ControlError::StaleLease(lease.clone()));
                     }
 
-                    let record_key = options
-                        .logical_shard_record_key(
-                            &lease.logical_shard_id,
-                        );
+                    let record_key = options.logical_shard_record_key(&lease.logical_shard_id);
 
-                    let session_key = options
-                        .logical_shard_session_key(
-                            &lease.logical_shard_id,
-                        );
+                    let session_key = options.logical_shard_session_key(&lease.logical_shard_id);
 
                     let txn = Txn::new()
                         .when(vec![
@@ -773,25 +722,17 @@ impl ControlStore for EtcdControlStore {
                                 CompareOp::Equal,
                                 current.mod_revision,
                             ),
-                            Compare::value(
-                                session_key.clone(),
-                                CompareOp::Equal,
-                                session.encoded,
-                            ),
+                            Compare::value(session_key.clone(), CompareOp::Equal, session.encoded),
                             Compare::lease(
                                 session_key.clone(),
                                 CompareOp::Equal,
                                 lease_id_i64(lease.lease_id)?,
                             ),
                         ])
-                        .and_then(vec![
-                            TxnOp::delete(session_key, None),
-                        ]);
+                        .and_then(vec![TxnOp::delete(session_key, None)]);
 
                     match client.txn(txn).await {
-                        Ok(response) if response.succeeded() => {
-                            Ok(retained.clone())
-                        }
+                        Ok(response) if response.succeeded() => Ok(retained.clone()),
                         Ok(_) | Err(_) => {
                             classify_suspend_recovery_failure(
                                 &mut client,
@@ -807,11 +748,7 @@ impl ControlStore for EtcdControlStore {
             };
 
             if result.is_ok() {
-                revoke_lease_best_effort(
-                    &mut client,
-                    lease.lease_id,
-                )
-                .await;
+                revoke_lease_best_effort(&mut client, lease.lease_id).await;
             }
 
             result
@@ -1413,39 +1350,21 @@ async fn exact_recovery_record_is_sessionless(
 ) -> Result<bool, ControlError> {
     let logical_shard_id = expected.record.logical_shard_id;
 
-    let record_key =
-        options.logical_shard_record_key(&logical_shard_id);
+    let record_key = options.logical_shard_record_key(&logical_shard_id);
 
-    let session_key =
-        options.logical_shard_session_key(&logical_shard_id);
+    let session_key = options.logical_shard_session_key(&logical_shard_id);
 
     // This transaction is the linearization point for sessionless recovery
     // suspension. The validated record revision and session absence must both
     // still be true at the same etcd revision.
     let txn = Txn::new()
         .when(vec![
-            Compare::mod_revision(
-                record_key.clone(),
-                CompareOp::Equal,
-                expected.mod_revision,
-            ),
-            Compare::version(
-                session_key,
-                CompareOp::Equal,
-                0,
-            ),
+            Compare::mod_revision(record_key.clone(), CompareOp::Equal, expected.mod_revision),
+            Compare::version(session_key, CompareOp::Equal, 0),
         ])
-        .and_then(vec![
-            TxnOp::get(record_key, None),
-        ]);
+        .and_then(vec![TxnOp::get(record_key, None)]);
 
-    Ok(
-        client
-            .txn(txn)
-            .await
-            .map_err(etcd_backend)?
-            .succeeded(),
-    )
+    Ok(client.txn(txn).await.map_err(etcd_backend)?.succeeded())
 }
 
 async fn classify_suspend_recovery_failure(
@@ -1455,33 +1374,19 @@ async fn classify_suspend_recovery_failure(
     expected: &StoredLogicalShard,
     retained: &LogicalShardRecord,
 ) -> Result<LogicalShardRecord, ControlError> {
-    if exact_recovery_record_is_sessionless(
-        client,
-        options,
-        expected,
-    )
-    .await?
-    {
+    if exact_recovery_record_is_sessionless(client, options, expected).await? {
         return Ok(retained.clone());
     }
 
-    let latest =
-        fetch_logical_shard(
-            client,
-            options,
-            &lease.logical_shard_id,
-        )
+    let latest = fetch_logical_shard(client, options, &lease.logical_shard_id)
         .await?
-        .ok_or(ControlError::LogicalShardNotFound(
-            lease.logical_shard_id,
-        ))?;
+        .ok_or(ControlError::LogicalShardNotFound(lease.logical_shard_id))?;
 
     validate_record_lease(&latest.record, lease)?;
     validate_owner_session(client, options, lease).await?;
 
     Err(ControlError::Backend(
-        "recovery suspension CAS failed while the exact owner session remained current"
-            .to_owned(),
+        "recovery suspension CAS failed while the exact owner session remained current".to_owned(),
     ))
 }
 
@@ -2131,11 +2036,8 @@ mod tests {
     #[test]
     #[ignore = "requires NOKV_TEST_ETCD_ENDPOINT"]
     fn etcd_missing_session_fast_path_is_linearizable_against_rebind_and_mark_serving() {
-        let endpoint =
-            std::env::var("NOKV_TEST_ETCD_ENDPOINT")
-                .expect(
-                    "NOKV_TEST_ETCD_ENDPOINT must name an isolated test etcd endpoint",
-                );
+        let endpoint = std::env::var("NOKV_TEST_ETCD_ENDPOINT")
+            .expect("NOKV_TEST_ETCD_ENDPOINT must name an isolated test etcd endpoint");
 
         let nonce = SystemTime::now()
             .duration_since(UNIX_EPOCH)
@@ -2147,27 +2049,20 @@ mod tests {
             std::process::id(),
         );
 
-        let options =
-            EtcdControlStoreOptions::new([endpoint])
-                .with_key_prefix(prefix.clone());
+        let options = EtcdControlStoreOptions::new([endpoint]).with_key_prefix(prefix.clone());
 
-        let setup_store =
-            EtcdControlStore::connect(options.clone()).unwrap();
+        let setup_store = EtcdControlStore::connect(options.clone()).unwrap();
 
         let logical_shard_id = shard(10);
 
-        setup_store
-            .create_logical_shard(logical_shard_id)
-            .unwrap();
+        setup_store.create_logical_shard(logical_shard_id).unwrap();
 
         setup_store
             .create_root_placement(RootPlacement {
                 root_id: root(10),
                 logical_shard_id,
-                placement_generation:
-                    PlacementGeneration::new(1).unwrap(),
-                lifecycle:
-                    RootPlacementLifecycle::Provisioning,
+                placement_generation: PlacementGeneration::new(1).unwrap(),
+                lifecycle: RootPlacementLifecycle::Provisioning,
             })
             .unwrap();
 
@@ -2179,15 +2074,12 @@ mod tests {
             )
             .unwrap();
 
-        let mut setup_client =
-            setup_store.client.clone();
+        let mut setup_client = setup_store.client.clone();
 
         setup_store
             .block_on(async {
                 setup_client
-                    .lease_revoke(
-                        lease_id_i64(first.lease_id)?,
-                    )
+                    .lease_revoke(lease_id_i64(first.lease_id)?)
                     .await
                     .map_err(etcd_backend)?;
 
@@ -2195,58 +2087,41 @@ mod tests {
             })
             .unwrap();
 
-        assert!(
-            setup_store
-                .block_on(fetch_owner_session(
-                    &mut setup_client,
-                    &options,
-                    &logical_shard_id,
-                ))
-                .unwrap()
-                .is_none(),
-        );
+        assert!(setup_store
+            .block_on(fetch_owner_session(
+                &mut setup_client,
+                &options,
+                &logical_shard_id,
+            ))
+            .unwrap()
+            .is_none(),);
 
-        let cleanup_store =
-            EtcdControlStore::connect(options.clone()).unwrap();
+        let cleanup_store = EtcdControlStore::connect(options.clone()).unwrap();
 
-        let contender_store =
-            EtcdControlStore::connect(options.clone()).unwrap();
+        let contender_store = EtcdControlStore::connect(options.clone()).unwrap();
 
-        let (reached_tx, reached_rx) =
-            mpsc::channel();
+        let (reached_tx, reached_rx) = mpsc::channel();
 
-        let (resume_tx, resume_rx) =
-            mpsc::channel();
+        let (resume_tx, resume_rx) = mpsc::channel();
 
-        install_suspend_recovery_missing_session_hook(
-            logical_shard_id,
-            move || {
-                reached_tx
-                    .send(())
-                    .expect(
-                        "test must signal the missing-session boundary",
-                    );
+        install_suspend_recovery_missing_session_hook(logical_shard_id, move || {
+            reached_tx
+                .send(())
+                .expect("test must signal the missing-session boundary");
 
-                resume_rx
-                    .recv()
-                    .expect(
-                        "test must resume missing-session cleanup",
-                    );
-            },
-        );
+            resume_rx
+                .recv()
+                .expect("test must resume missing-session cleanup");
+        });
 
         let first_for_cleanup = first.clone();
 
-        let cleanup_thread = thread::spawn(move || {
-            cleanup_store
-                .suspend_recovery(&first_for_cleanup)
-        });
+        let cleanup_thread =
+            thread::spawn(move || cleanup_store.suspend_recovery(&first_for_cleanup));
 
         reached_rx
             .recv_timeout(Duration::from_secs(5))
-            .expect(
-                "cleanup did not reach the missing-session boundary",
-            );
+            .expect("cleanup did not reach the missing-session boundary");
 
         let rebound = contender_store
             .reacquire_recovery(
@@ -2257,15 +2132,9 @@ mod tests {
             )
             .unwrap();
 
-        assert_eq!(
-            rebound.owner_epoch,
-            first.owner_epoch,
-        );
+        assert_eq!(rebound.owner_epoch, first.owner_epoch,);
 
-        assert_ne!(
-            rebound.lease_id,
-            first.lease_id,
-        );
+        assert_ne!(rebound.lease_id, first.lease_id,);
 
         contender_store
             .mark_serving(
@@ -2280,23 +2149,17 @@ mod tests {
 
         resume_tx
             .send(())
-            .expect(
-                "test must release the cleanup thread",
-            );
+            .expect("test must release the cleanup thread");
 
         let cleanup_result = cleanup_thread
             .join()
-            .expect(
-                "cleanup thread must not panic",
-            );
+            .expect("cleanup thread must not panic");
 
         assert!(matches!(
             cleanup_result,
             Err(ControlError::StaleLease(_))
                 | Err(ControlError::NotOwner { .. })
-                | Err(
-                    ControlError::RecoveryStateConflict { .. }
-                )
+                | Err(ControlError::RecoveryStateConflict { .. })
         ));
 
         let latest = contender_store
@@ -2304,38 +2167,20 @@ mod tests {
             .unwrap()
             .unwrap();
 
-        assert_eq!(
-            latest.state,
-            LogicalShardState::Serving,
-        );
+        assert_eq!(latest.state, LogicalShardState::Serving,);
 
-        assert_eq!(
-            latest.owner_epoch,
-            Some(rebound.owner_epoch),
-        );
+        assert_eq!(latest.owner_epoch, Some(rebound.owner_epoch),);
 
-        assert_eq!(
-            latest.lease_id,
-            rebound.lease_id,
-        );
+        assert_eq!(latest.lease_id, rebound.lease_id,);
 
-        contender_store
-            .release_owner(&rebound)
-            .unwrap();
+        contender_store.release_owner(&rebound).unwrap();
 
-        let mut cleanup_client =
-            contender_store.client.clone();
+        let mut cleanup_client = contender_store.client.clone();
 
         contender_store
             .block_on(async {
                 cleanup_client
-                    .delete(
-                        prefix,
-                        Some(
-                            DeleteOptions::new()
-                                .with_prefix(),
-                        ),
-                    )
+                    .delete(prefix, Some(DeleteOptions::new().with_prefix()))
                     .await
                     .map_err(etcd_backend)?;
 
@@ -2347,43 +2192,30 @@ mod tests {
     #[test]
     #[ignore = "requires NOKV_TEST_ETCD_ENDPOINT"]
     fn etcd_double_expiry_cleanup_requires_exact_rebound_lease() {
-        let endpoint =
-            std::env::var("NOKV_TEST_ETCD_ENDPOINT")
-                .expect(
-                    "NOKV_TEST_ETCD_ENDPOINT must name an isolated test etcd endpoint",
-                );
+        let endpoint = std::env::var("NOKV_TEST_ETCD_ENDPOINT")
+            .expect("NOKV_TEST_ETCD_ENDPOINT must name an isolated test etcd endpoint");
 
         let nonce = SystemTime::now()
             .duration_since(UNIX_EPOCH)
             .unwrap()
             .as_nanos();
 
-        let prefix = format!(
-            "/nokv/test/double-expiry-{}-{nonce}",
-            std::process::id(),
-        );
+        let prefix = format!("/nokv/test/double-expiry-{}-{nonce}", std::process::id(),);
 
-        let options =
-            EtcdControlStoreOptions::new([endpoint])
-                .with_key_prefix(prefix.clone());
+        let options = EtcdControlStoreOptions::new([endpoint]).with_key_prefix(prefix.clone());
 
-        let store =
-            EtcdControlStore::connect(options.clone()).unwrap();
+        let store = EtcdControlStore::connect(options.clone()).unwrap();
 
         let logical_shard_id = shard(11);
 
-        store
-            .create_logical_shard(logical_shard_id)
-            .unwrap();
+        store.create_logical_shard(logical_shard_id).unwrap();
 
         store
             .create_root_placement(RootPlacement {
                 root_id: root(11),
                 logical_shard_id,
-                placement_generation:
-                    PlacementGeneration::new(1).unwrap(),
-                lifecycle:
-                    RootPlacementLifecycle::Provisioning,
+                placement_generation: PlacementGeneration::new(1).unwrap(),
+                lifecycle: RootPlacementLifecycle::Provisioning,
             })
             .unwrap();
 
@@ -2400,9 +2232,7 @@ mod tests {
         store
             .block_on(async {
                 client
-                    .lease_revoke(
-                        lease_id_i64(first.lease_id)?,
-                    )
+                    .lease_revoke(lease_id_i64(first.lease_id)?)
                     .await
                     .map_err(etcd_backend)?;
 
@@ -2410,16 +2240,14 @@ mod tests {
             })
             .unwrap();
 
-        assert!(
-            store
-                .block_on(fetch_owner_session(
-                    &mut client,
-                    &options,
-                    &logical_shard_id,
-                ))
-                .unwrap()
-                .is_none(),
-        );
+        assert!(store
+            .block_on(fetch_owner_session(
+                &mut client,
+                &options,
+                &logical_shard_id,
+            ))
+            .unwrap()
+            .is_none(),);
 
         let rebound = store
             .reacquire_recovery(
@@ -2430,27 +2258,16 @@ mod tests {
             )
             .unwrap();
 
-        assert_eq!(
-            &rebound.owner,
-            &first.owner,
-        );
+        assert_eq!(&rebound.owner, &first.owner,);
 
-        assert_eq!(
-            rebound.owner_epoch,
-            first.owner_epoch,
-        );
+        assert_eq!(rebound.owner_epoch, first.owner_epoch,);
 
-        assert_ne!(
-            rebound.lease_id,
-            first.lease_id,
-        );
+        assert_ne!(rebound.lease_id, first.lease_id,);
 
         store
             .block_on(async {
                 client
-                    .lease_revoke(
-                        lease_id_i64(rebound.lease_id)?,
-                    )
+                    .lease_revoke(lease_id_i64(rebound.lease_id)?)
                     .await
                     .map_err(etcd_backend)?;
 
@@ -2458,53 +2275,34 @@ mod tests {
             })
             .unwrap();
 
-        assert!(
-            store
-                .block_on(fetch_owner_session(
-                    &mut client,
-                    &options,
-                    &logical_shard_id,
-                ))
-                .unwrap()
-                .is_none(),
-        );
+        assert!(store
+            .block_on(fetch_owner_session(
+                &mut client,
+                &options,
+                &logical_shard_id,
+            ))
+            .unwrap()
+            .is_none(),);
 
         // Both sessions are absent. Cleanup for L1 must still be rejected
         // because the durable Recovering record now identifies L2.
         assert!(matches!(
             store.suspend_recovery(&first),
-            Err(ControlError::StaleLease(_))
-                | Err(ControlError::NotOwner { .. })
+            Err(ControlError::StaleLease(_)) | Err(ControlError::NotOwner { .. })
         ));
 
-        let retained =
-            store.suspend_recovery(&rebound).unwrap();
+        let retained = store.suspend_recovery(&rebound).unwrap();
 
-        assert_eq!(
-            retained.state,
-            LogicalShardState::Recovering,
-        );
+        assert_eq!(retained.state, LogicalShardState::Recovering,);
 
-        assert_eq!(
-            retained.owner_epoch,
-            Some(rebound.owner_epoch),
-        );
+        assert_eq!(retained.owner_epoch, Some(rebound.owner_epoch),);
 
-        assert_eq!(
-            retained.lease_id,
-            rebound.lease_id,
-        );
+        assert_eq!(retained.lease_id, rebound.lease_id,);
 
         store
             .block_on(async {
                 client
-                    .delete(
-                        prefix,
-                        Some(
-                            DeleteOptions::new()
-                                .with_prefix(),
-                        ),
-                    )
+                    .delete(prefix, Some(DeleteOptions::new().with_prefix()))
                     .await
                     .map_err(etcd_backend)?;
 
@@ -2513,4 +2311,193 @@ mod tests {
             .unwrap();
     }
 
+    #[test]
+    #[ignore = "requires NOKV_TEST_ETCD_ENDPOINT"]
+    fn etcd_record_revision_fences_stale_cleanup_after_double_expiry_interleaving() {
+        let endpoint = std::env::var("NOKV_TEST_ETCD_ENDPOINT")
+            .expect("NOKV_TEST_ETCD_ENDPOINT must name an isolated test etcd endpoint");
+
+        let nonce = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+
+        let process_id = std::process::id();
+
+        let prefix = format!("/nokv/test/record-revision-double-expiry-{process_id}-{nonce}");
+
+        let options = EtcdControlStoreOptions::new([endpoint]).with_key_prefix(prefix.clone());
+
+        let setup_store = EtcdControlStore::connect(options.clone()).unwrap();
+
+        let logical_shard_id = shard(12);
+
+        setup_store.create_logical_shard(logical_shard_id).unwrap();
+
+        setup_store
+            .create_root_placement(RootPlacement {
+                root_id: root(12),
+                logical_shard_id,
+                placement_generation: PlacementGeneration::new(1).unwrap(),
+                lifecycle: RootPlacementLifecycle::Provisioning,
+            })
+            .unwrap();
+
+        let first = setup_store
+            .acquire_owner(
+                &logical_shard_id,
+                NodeId::new("node-a").unwrap(),
+                "node-a:7000".to_owned(),
+            )
+            .unwrap();
+
+        let mut setup_client = setup_store.client.clone();
+
+        setup_store
+            .block_on(async {
+                setup_client
+                    .lease_revoke(lease_id_i64(first.lease_id)?)
+                    .await
+                    .map_err(etcd_backend)?;
+
+                Ok::<(), ControlError>(())
+            })
+            .unwrap();
+
+        assert!(
+            setup_store
+                .block_on(fetch_owner_session(
+                    &mut setup_client,
+                    &options,
+                    &logical_shard_id,
+                ))
+                .unwrap()
+                .is_none(),
+            "L1 session must be absent before cleanup reads it",
+        );
+
+        let cleanup_store = EtcdControlStore::connect(options.clone()).unwrap();
+
+        let contender_store = EtcdControlStore::connect(options.clone()).unwrap();
+
+        let (reached_tx, reached_rx) = std::sync::mpsc::channel();
+
+        let (resume_tx, resume_rx) = std::sync::mpsc::channel();
+
+        install_suspend_recovery_missing_session_hook(logical_shard_id, move || {
+            reached_tx
+                .send(())
+                .expect("test must signal that cleanup observed the absent L1 session");
+
+            resume_rx
+                .recv_timeout(std::time::Duration::from_secs(10))
+                .expect("test must resume stale L1 cleanup");
+        });
+
+        let first_for_cleanup = first.clone();
+
+        let cleanup_thread =
+            std::thread::spawn(move || cleanup_store.suspend_recovery(&first_for_cleanup));
+
+        reached_rx
+            .recv_timeout(std::time::Duration::from_secs(5))
+            .expect("cleanup did not reach the missing-session boundary");
+
+        // Rebind the exact same owner and recovery epoch as L2.
+        let rebound = contender_store
+            .reacquire_recovery(
+                &logical_shard_id,
+                first.owner_epoch,
+                first.owner.clone(),
+                "node-a:7001".to_owned(),
+            )
+            .unwrap();
+
+        assert_eq!(rebound.owner_epoch, first.owner_epoch,);
+
+        assert_ne!(rebound.lease_id, first.lease_id,);
+
+        // Expire L2 as well. Both session keys are now absent, while the
+        // durable Recovering record identifies L2 rather than L1.
+        let mut contender_client = contender_store.client.clone();
+
+        contender_store
+            .block_on(async {
+                contender_client
+                    .lease_revoke(lease_id_i64(rebound.lease_id)?)
+                    .await
+                    .map_err(etcd_backend)?;
+
+                Ok::<(), ControlError>(())
+            })
+            .unwrap();
+
+        let rebound_session = contender_store
+            .block_on(fetch_owner_session(
+                &mut contender_client,
+                &options,
+                &logical_shard_id,
+            ))
+            .unwrap();
+
+        let latest = contender_store
+            .get_logical_shard(&logical_shard_id)
+            .unwrap()
+            .unwrap();
+
+        assert_eq!(latest.state, LogicalShardState::Recovering,);
+
+        assert_eq!(latest.owner_epoch, Some(rebound.owner_epoch),);
+
+        assert_eq!(latest.lease_id, rebound.lease_id,);
+
+        assert_ne!(latest.lease_id, first.lease_id,);
+
+        // Always release the paused cleanup thread before assertions that can
+        // terminate this test.
+        resume_tx
+            .send(())
+            .expect("test must release stale L1 cleanup");
+
+        assert!(
+            rebound_session.is_none(),
+            "L2 session must be absent before stale L1 cleanup resumes",
+        );
+
+        let cleanup_result = cleanup_thread
+            .join()
+            .expect("stale L1 cleanup thread must not panic");
+
+        match cleanup_result {
+            Err(ControlError::StaleLease(stale)) => {
+                assert_eq!(
+                    stale, first,
+                    "StaleLease must identify the rejected L1 lease",
+                );
+            }
+            other => {
+                panic!("cleanup(L1) must be exactly StaleLease after L2 expires; got {other:?}")
+            }
+        }
+
+        // Cleanup of the exact currently recorded L2 lease must still succeed.
+        let retained = contender_store.suspend_recovery(&rebound).unwrap();
+
+        assert_eq!(retained.state, LogicalShardState::Recovering,);
+
+        assert_eq!(retained.owner_epoch, Some(rebound.owner_epoch),);
+
+        assert_eq!(retained.lease_id, rebound.lease_id,);
+
+        contender_store
+            .block_on(async {
+                contender_client
+                    .delete(prefix, Some(DeleteOptions::new().with_prefix()))
+                    .await
+                    .map_err(etcd_backend)?;
+
+                Ok::<(), ControlError>(())
+            })
+            .unwrap();
+    }
 }

--- a/crates/nokv-control/src/store.rs
+++ b/crates/nokv-control/src/store.rs
@@ -2181,10 +2181,7 @@ mod tests {
             .owner_sessions
             .remove(&first.logical_shard_id);
 
-        assert_eq!(
-            expired_first,
-            Some(first.clone()),
-        );
+        assert_eq!(expired_first, Some(first.clone()),);
 
         let rebound = store
             .reacquire_recovery(
@@ -2195,20 +2192,11 @@ mod tests {
             )
             .unwrap();
 
-        assert_eq!(
-            &rebound.owner,
-            &first.owner,
-        );
+        assert_eq!(&rebound.owner, &first.owner,);
 
-        assert_eq!(
-            rebound.owner_epoch,
-            first.owner_epoch,
-        );
+        assert_eq!(rebound.owner_epoch, first.owner_epoch,);
 
-        assert_ne!(
-            rebound.lease_id,
-            first.lease_id,
-        );
+        assert_ne!(rebound.lease_id, first.lease_id,);
 
         let expired_rebound = store
             .state
@@ -2217,10 +2205,7 @@ mod tests {
             .owner_sessions
             .remove(&rebound.logical_shard_id);
 
-        assert_eq!(
-            expired_rebound,
-            Some(rebound.clone()),
-        );
+        assert_eq!(expired_rebound, Some(rebound.clone()),);
 
         // Both sessions are absent. Only the durable record's exact lease ID
         // can distinguish stale L1 cleanup from current L2 cleanup.
@@ -2229,23 +2214,13 @@ mod tests {
             Err(ControlError::StaleLease(_))
         ));
 
-        let retained =
-            store.suspend_recovery(&rebound).unwrap();
+        let retained = store.suspend_recovery(&rebound).unwrap();
 
-        assert_eq!(
-            retained.state,
-            LogicalShardState::Recovering,
-        );
+        assert_eq!(retained.state, LogicalShardState::Recovering,);
 
-        assert_eq!(
-            retained.owner_epoch,
-            Some(rebound.owner_epoch),
-        );
+        assert_eq!(retained.owner_epoch, Some(rebound.owner_epoch),);
 
-        assert_eq!(
-            retained.lease_id,
-            rebound.lease_id,
-        );
+        assert_eq!(retained.lease_id, rebound.lease_id,);
     }
 
     #[test]

--- a/crates/nokv-control/src/store.rs
+++ b/crates/nokv-control/src/store.rs
@@ -139,6 +139,10 @@ pub trait ControlStore: Send + Sync {
 
     /// End the live session for a boot that has not reached `Serving`, while
     /// retaining its durable recovery epoch for an exact retry.
+    ///
+    /// If the exact recorded recovery session has already expired, suspension
+    /// is an idempotent success. A different live or rebound session remains
+    /// fenced and must never be removed by this operation.
     fn suspend_recovery(
         &self,
         lease: &LogicalShardLease,
@@ -540,11 +544,16 @@ impl ControlStore for InMemoryControlStore {
             .get(&lease.logical_shard_id)
             .cloned()
             .ok_or(ControlError::LogicalShardNotFound(lease.logical_shard_id))?;
-        validate_record_lease(&current, lease)?;
-        validate_in_memory_session(&state, lease)?;
         let retained = prepare_recovery_suspension(&current, lease)?;
-        state.owner_sessions.remove(&lease.logical_shard_id);
-        Ok(retained)
+
+        match state.owner_sessions.get(&lease.logical_shard_id).cloned() {
+            None => Ok(retained),
+            Some(session) if session == *lease => {
+                state.owner_sessions.remove(&lease.logical_shard_id);
+                Ok(retained)
+            }
+            Some(_) => Err(ControlError::StaleLease(lease.clone())),
+        }
     }
 
     fn release_owner(&self, lease: &LogicalShardLease) -> Result<LogicalShardRecord, ControlError> {
@@ -2050,6 +2059,113 @@ mod tests {
             )
             .unwrap();
         store.release_owner(&rebound).unwrap();
+    }
+
+    #[test]
+    fn expired_recovery_session_cleanup_is_idempotent_and_rebinds_same_epoch() {
+        let store = InMemoryControlStore::new();
+        let first = acquire_placed_shard(&store, 1, 1);
+
+        // Simulate backend lease expiry without calling suspend_recovery().
+        // The durable Recovering record remains, but its liveness session is gone.
+        let expired = store
+            .state
+            .lock()
+            .expect("control store mutex poisoned")
+            .owner_sessions
+            .remove(&first.logical_shard_id);
+
+        assert_eq!(expired, Some(first.clone()));
+        assert!(matches!(
+            store.renew_owner(&first),
+            Err(ControlError::StaleLease(_))
+        ));
+
+        // Current main fails here with StaleLease even though the exact durable
+        // record still identifies this recovery attempt and no live session exists.
+        let retained = store.suspend_recovery(&first).unwrap();
+
+        assert_eq!(retained.state, LogicalShardState::Recovering);
+        assert_eq!(retained.owner_epoch, Some(first.owner_epoch));
+        assert_eq!(retained.owner.as_ref(), Some(&first.owner));
+        assert_eq!(retained.lease_id, first.lease_id);
+
+        // Cleanup should remain idempotent while the exact record is unchanged
+        // and the session remains absent.
+        assert_eq!(
+            store.suspend_recovery(&first).unwrap(),
+            retained,
+            "suspending an already-expired exact recovery session is idempotent"
+        );
+
+        // The durable recovery epoch must be rebound, not incremented.
+        let rebound = store
+            .reacquire_recovery(
+                &first.logical_shard_id,
+                first.owner_epoch,
+                node("node-b"),
+                "node-b:7000".to_owned(),
+            )
+            .unwrap();
+
+        assert_eq!(rebound.owner_epoch, first.owner_epoch);
+        assert_ne!(rebound.lease_id, first.lease_id);
+
+        store
+            .mark_serving(
+                &rebound,
+                RecoveryPublication {
+                    checkpoint: None,
+                    log: None,
+                    durable_lsn: 0,
+                },
+            )
+            .unwrap();
+
+        store.release_owner(&rebound).unwrap();
+    }
+
+    #[test]
+    fn expired_recovery_cleanup_cannot_suspend_rebound_live_session() {
+        let store = InMemoryControlStore::new();
+        let first = acquire_placed_shard(&store, 1, 1);
+
+        let expired = store
+            .state
+            .lock()
+            .expect("control store mutex poisoned")
+            .owner_sessions
+            .remove(&first.logical_shard_id);
+
+        assert_eq!(expired, Some(first.clone()));
+
+        // Rebind using the same owner and epoch, but a different lease ID. This
+        // isolates the lease-ID fence rather than relying on an owner mismatch.
+        let rebound = store
+            .reacquire_recovery(
+                &first.logical_shard_id,
+                first.owner_epoch,
+                first.owner.clone(),
+                "node-a:7001".to_owned(),
+            )
+            .unwrap();
+
+        assert_eq!(rebound.owner, first.owner);
+        assert_eq!(rebound.owner_epoch, first.owner_epoch);
+        assert_ne!(rebound.lease_id, first.lease_id);
+
+        // The old lease must never be allowed to suspend the rebound session.
+        assert!(matches!(
+            store.suspend_recovery(&first),
+            Err(ControlError::StaleLease(_))
+        ));
+
+        // Prove that the rebound session is still live and was not removed.
+        let renewed = store.renew_owner(&rebound).unwrap();
+        assert_eq!(renewed.lease_id, rebound.lease_id);
+        assert_eq!(renewed.owner_epoch, Some(rebound.owner_epoch));
+
+        store.suspend_recovery(&rebound).unwrap();
     }
 
     #[test]

--- a/crates/nokv-control/src/store.rs
+++ b/crates/nokv-control/src/store.rs
@@ -141,8 +141,9 @@ pub trait ControlStore: Send + Sync {
     /// retaining its durable recovery epoch for an exact retry.
     ///
     /// If the exact recorded recovery session has already expired, suspension
-    /// is an idempotent success. A different live or rebound session remains
-    /// fenced and must never be removed by this operation.
+    /// is an idempotent success only while the durable `Recovering` record still
+    /// identifies that exact lease. Backends must linearize record identity and
+    /// session absence. A different live or rebound lease remains fenced.
     fn suspend_recovery(
         &self,
         lease: &LogicalShardLease,
@@ -2166,6 +2167,85 @@ mod tests {
         assert_eq!(renewed.owner_epoch, Some(rebound.owner_epoch));
 
         store.suspend_recovery(&rebound).unwrap();
+    }
+
+    #[test]
+    fn double_expiry_cleanup_requires_exact_rebound_lease() {
+        let store = InMemoryControlStore::new();
+        let first = acquire_placed_shard(&store, 1, 1);
+
+        let expired_first = store
+            .state
+            .lock()
+            .expect("control store mutex poisoned")
+            .owner_sessions
+            .remove(&first.logical_shard_id);
+
+        assert_eq!(
+            expired_first,
+            Some(first.clone()),
+        );
+
+        let rebound = store
+            .reacquire_recovery(
+                &first.logical_shard_id,
+                first.owner_epoch,
+                first.owner.clone(),
+                "node-a:7001".to_owned(),
+            )
+            .unwrap();
+
+        assert_eq!(
+            &rebound.owner,
+            &first.owner,
+        );
+
+        assert_eq!(
+            rebound.owner_epoch,
+            first.owner_epoch,
+        );
+
+        assert_ne!(
+            rebound.lease_id,
+            first.lease_id,
+        );
+
+        let expired_rebound = store
+            .state
+            .lock()
+            .expect("control store mutex poisoned")
+            .owner_sessions
+            .remove(&rebound.logical_shard_id);
+
+        assert_eq!(
+            expired_rebound,
+            Some(rebound.clone()),
+        );
+
+        // Both sessions are absent. Only the durable record's exact lease ID
+        // can distinguish stale L1 cleanup from current L2 cleanup.
+        assert!(matches!(
+            store.suspend_recovery(&first),
+            Err(ControlError::StaleLease(_))
+        ));
+
+        let retained =
+            store.suspend_recovery(&rebound).unwrap();
+
+        assert_eq!(
+            retained.state,
+            LogicalShardState::Recovering,
+        );
+
+        assert_eq!(
+            retained.owner_epoch,
+            Some(rebound.owner_epoch),
+        );
+
+        assert_eq!(
+            retained.lease_id,
+            rebound.lease_id,
+        );
     }
 
     #[test]


### PR DESCRIPTION
Carries PR #495 (`fix/expired-recovery-session-cleanup`, all commits preserved with attribution) plus the round-3 fix found during deep acceptance:

- **The suspend-recovery missing-session pause hook is now per-store instance state.** It was a process-global single slot (`OnceLock<Mutex<Option<..>>>`); under the default parallel test runner one test's held pause collided with another test's install assert, poisoned the shared mutex, and took down 4 of the 6 real-etcd tests, including the two that never touch the hook at all (only `--test-threads=1` passed). With the hook on the `EtcdControlStore` instance, the six ignored tests pass under the default parallel runner (verified three consecutive runs against etcd 3.7.1).
- **Documented the real-etcd invocation**: `--features etcd` is load-bearing; without it the module is not compiled and `-- --ignored` silently runs zero tests and reads as green.

The mutation guard from review round 2 still holds on this lineage: removing the `record.mod_revision` comparison from the sessionless linearization predicate turns exactly `etcd_record_revision_fences_stale_cleanup_after_double_expiry_interleaving` red.

Validation: nokv-control 46 passed + 6 real-etcd (parallel) on this branch; full workspace suite 1087 passed / 0 failed on the merge with #497; stable-1.98 `clippy --workspace --all-targets -- -D warnings` clean; rustfmt clean.

Relates to #492, which must stay open when this merges: this PR repairs the secondary `cleanup also failed` error and the cleanup contract's linearization, while the reopen-thrash liveness boundary in the #492 field report is owned by the bootstrap keepalive in #497.
