### PR TITLE
fix: pin Holt 0.8.6 for manifest writer exclusion

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -750,9 +750,9 @@ dependencies = [
 
 [[package]]
 name = "holt"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de964ee5f86d1ffba48f3213c97754bf80ea4289d5084419a4385a687c6818a4"
+checksum = "e2085e551b50cfea8208f572ad132de808157317fbfd5b98c689732a89db9eca"
 dependencies = [
  "crc32fast",
  "crossbeam-channel",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,7 @@ nokv-server = { path = "crates/nokv-server", version = "0.1.0" }
 nokv = { path = "crates/nokv", version = "0.11.0" }
 nokv-python = { path = "crates/nokv-python", version = "0.1.0" }
 nokv-bench = { path = "bench", version = "0.1.0" }
-holt = { version = "=0.8.5", default-features = false }
+holt = { version = "=0.8.6", default-features = false }
 etcd-client = { version = "0.19.0", default-features = false }
 opendal = { version = "0.57.0", default-features = false, features = ["blocking", "executors-tokio", "reqwest-rustls-tls", "services-s3"] }
 rmp-serde = "1.3"

--- a/bench/src/metadata/mod.rs
+++ b/bench/src/metadata/mod.rs
@@ -158,7 +158,7 @@ pub fn run(options: MetadataOptions) -> Result<MetadataBenchmarkReport, String> 
             architecture: env::consts::ARCH,
             metadata_device,
             metadata_store,
-            metadata_engine: "holt-0.8.5",
+            metadata_engine: "holt-0.8.6",
             object_provider: "not_applicable",
             object_endpoint_class: "not_applicable",
             durability_profile,
@@ -200,7 +200,7 @@ pub fn run(options: MetadataOptions) -> Result<MetadataBenchmarkReport, String> 
             cursor_scan_work: "measured_from_holt_range_iter_scan_stats",
             materialized_bytes: "measured_for_values_and_keys_emitted_by_holt",
             holt_storage_io: "measured_as_shared_db_counter_delta",
-            holt_internal_seek_count: "unavailable_in_holt_0.8.5",
+            holt_internal_seek_count: "unavailable_in_holt_0.8.6",
             metadata_decoded_bytes:
                 "unavailable_materialized_bytes_are_reported_without_claiming_decode_cost",
             host_cpu_memory_device_io: "not_measured",

--- a/crates/nokv/src/build_info.rs
+++ b/crates/nokv/src/build_info.rs
@@ -38,7 +38,7 @@ mod tests {
         assert_eq!(VERSION, "0.11.0");
         assert!(GIT_COMMIT == "unknown" || GIT_COMMIT.len() == 40);
         assert_eq!(CARGO_LOCK_SHA256.len(), 64);
-        assert_eq!(HOLT_VERSION, "0.8.5");
+        assert_eq!(HOLT_VERSION, "0.8.6");
         assert_eq!(
             HOLT_SOURCE,
             "registry+https://github.com/rust-lang/crates.io-index"

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -139,7 +139,7 @@ The report separates three different quantities:
 
 `visited` is a Holt cursor work unit, not a physical row or device read.
 Emitted value bytes are materialized bytes, not device bytes or a claim about
-decoder CPU cost. Holt 0.8.5 does not expose an exact internal seek count, so
+decoder CPU cost. Holt 0.8.6 does not expose an exact internal seek count, so
 the report leaves that metric unavailable rather than inferring it from scan
 calls. Logical counters exclude reads performed concurrently on other threads
 and by other stores. Their coverage is the fenced query paths used by these


### PR DESCRIPTION
## Related Issue

Relates to #493

## Summary

- Pin NoKV's Holt runtime from `=0.8.5` to the published `=0.8.6` maintenance release. This backport holds the authoritative `manifest.log` lock for the writable store lifetime, preventing a replaced `store.lock` from admitting two live manifest writers.
- Refresh the registry checksum and the CLI/benchmark version identities so shipped and reported evidence names the runtime actually in use.
- Keep `holt.0.8.5.checkpoint.v1` unchanged: Holt 0.8.6 has no checkpoint or on-disk format change.

## Scope

- [x] This PR changes one logical boundary only.
- [x] No unrelated refactor, metadata model, Holt layout, object-store, agent interface, or docs change is mixed in.
- [x] The linked issue describes the user-visible problem and design history.
- [x] No breaking change or compatibility shim is introduced.

## Change Size And Review

- [x] The diff is 14 changed lines, below the 5,000-line review threshold.
- [x] This remains a focused dependency-delivery change.

## Code Contract

- [x] Not applicable; this changes a dependency pin and its truthful build/benchmark identity only.

## Claims and Evidence

- [x] Benchmark labels report Holt 0.8.6 without making a new performance claim.
- [x] The durable checkpoint identity is deliberately preserved because the format did not change.

## Validation

- `cargo test -p nokv-meta-holt --all-features --locked` — 38 passed, 0 failed.
- `cargo test -p nokv --bin nokv --locked build_info::tests::compiled_identity_is_complete` — 1 passed, 0 failed.
- `cargo test -p nokv-bench --features metadata-read-stats --locked` — 9 passed, 0 failed.
- `cargo test --workspace --locked` — all suites passed, 0 failed.
- `cargo clippy --workspace --all-targets -- -D warnings` — passed.
- `cargo fmt --all -- --check` — passed.
- `python3 scripts/workbench/workbench_contract_test.py` — 8 passed, 0 failed.
- `git diff --check` — passed.

## Contributor Sign-off

- [x] Every commit includes a matching DCO `Signed-off-by` trailer.
