### PR TITLE
doc: remove stable Workbench operations from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -290,41 +290,6 @@ RootId is the only storage and routing identity. A Workbench presentation root
 shapes Agent-facing paths and manifests but never enters canonical metadata
 keys.
 
-## Stable Workbench
-
-The native CLI accepts exactly these 18 Workbench operation names:
-
-```text
-workbench_create
-workbench_put_file
-workbench_append
-workbench_edit
-workbench_list
-workbench_stat
-workbench_read
-workbench_grep
-workbench_search
-workbench_aggregate
-workbench_catalog
-workbench_find
-workbench_commit
-workbench_snapshot
-workbench_snapshot_renew
-workbench_snapshot_retire
-workbench_snapshot_list
-workbench_restore
-```
-
-Tool names, normalized input schemas, create/replace semantics, generation and
-digest relationships, commit identity, snapshot lifecycle, and restore
-idempotency form the stable contract. Workbench result shaping remains an
-adapter concern and does not dictate durable metadata families.
-
-The 18 names define behavior, not a transport. The native CLI exposes them
-directly, and the Python SDK provides the underlying programmatic operations.
-
-See the [Workbench Contract](docs/workbench-contract.md).
-
 ## Integration Model
 
 The Workbench contract is runtime-neutral. A downstream Agent runtime exposes


### PR DESCRIPTION
Removed section detailing stable Workbench operation names and their descriptions.

<!--
Copyright 2024-2026 The NoKV Authors.
SPDX-License-Identifier: Apache-2.0
-->

## Related Issue

<!--
Every non-trivial PR should be tied to an existing issue so maintainers can
review the agreed problem, scope, and design history before reading the diff.

Use one of:
- Closes #issue_number
- Fixes #issue_number
- Relates to #issue_number

Small exceptions are allowed for typo-only docs edits, CI/dependency chores,
release chores, and maintainer-approved emergency fixes. If this PR has no
issue, explain the exception here.
-->

Closes | Fixes | Relates to #

## Summary

-

## Scope

- [ ] This PR changes one logical boundary only.
- [ ] No unrelated refactor, benchmark, metadata model, Holt layout,
      object-store, agent interface, or docs change is mixed in.
- [ ] The linked issue describes the user-visible problem, design decision, or
      maintenance task this PR resolves.
- [ ] Any breaking change is intentional and documented.
- [ ] No compatibility shim, deprecated alias, or forwarding wrapper was added without a removal condition.

## Change Size And Review

- [ ] I checked GitHub's additions plus deletions for this pull request.
- [ ] If the total is more than 5,000 lines, one core maintainer other than the
      current-head pusher approved the exact current head commit. The author,
      bots, non-core reviewers, duplicate reviewers, dismissed reviews, and
      stale approvals do not count.
- [ ] This change is still small enough for a focused review; approval count is
      not being used to justify mixed package or lifecycle boundaries.

## Code Contract (Code Changes Only)

- [ ] Not applicable; this is a docs/config-only change.
- [ ] Package boundaries follow `docs/development/code_contract.md`.
- [ ] Shared helpers reuse the standard library or existing repository helpers.
      New generic helper modules are domain-neutral and tested.
- [ ] File names and file placement follow the code contract.
- [ ] New types, interfaces, structs, fields, and functions use domain-specific names.
- [ ] New errors are in the owning package's `errors.rs` and carry stable error kinds when crossing package boundaries.
- [ ] New metrics/stats are owned by the package that reports or serves them.
- [ ] Metadata changes document durability, atomicity, revision-reference
      lifetime, snapshot/commit/event retention, GC epochs, and fail-closed
      recovery boundaries.
- [ ] Placement or routing changes preserve persisted `RootId -> LogicalShardId`
      affinity, one active writer per shard, owner-epoch fencing, and explicit
      shard-local atomicity; no split root or cross-shard transaction is implied.
- [ ] Agent-interface changes keep the transport-free facade and schemas in
      `nokv-agent`, routing and workflows in `nokv-client`, and the concrete
      backend plus native full CLI wiring in `nokv`.
- [ ] User-facing integration guidance orders the native full CLI first, the
      direct Python SDK second, and the Rust SDK third, and does not present the
      deprecated `nokv mcp` sidecar as a supported NoKV surface.

## Claims and Evidence

- [ ] User-facing documentation distinguishes current, experimental, and
      planned capabilities.
- [ ] Security claims do not treat a Workbench root or Agent scope as tenant
      authentication or authorization.
- [ ] Performance claims state the topology, comparison boundary, cache state,
      run count, and raw-evidence location.
- [ ] Benchmark-only behavior does not alter product semantics.

## Validation

<!-- List exact commands and key results. For each relevant check not run,
explain why. Docs-only changes may mark Rust checks not applicable. -->

- Command and result:
- Not run (with reason):

## Contributor Sign-off

- [ ] Every commit in this PR includes a DCO `Signed-off-by` trailer.
