### PR TITLE
docs: add open-source collaboration statuses

### DIFF
--- a/README.md
+++ b/README.md
@@ -533,6 +533,13 @@ The [DBDB.io profile](https://dbdb.io/db/nokv) documents NoKV's earlier Go
 storage-engine line. Listings are discovery metadata, not foundation-hosted
 status, integration, deployment, or qualification evidence.
 
+**Open-source collaborations.** Active: [LoopX](https://github.com/huangruiteng/loopx),
+[OpenViking](https://github.com/volcengine/OpenViking), and
+[LingTai AI](https://github.com/Lingtai-AI/lingtai). Projects initiated:
+[Hermes Agent](https://github.com/NousResearch/hermes-agent) and
+[heima](https://github.com/litentry/heima). These labels describe collaboration
+stage, not production adoption or completed qualification.
+
 ## Contributing
 
 Read [CONTRIBUTING.md](CONTRIBUTING.md), the


### PR DESCRIPTION
## Related Issue

Relates to #505. This is an owner-requested follow-up to #506.

## Summary

- Add one compact open-source collaboration paragraph immediately after the
  third-party listings.
- Mark LoopX, OpenViking, and LingTai AI as active; mark Hermes Agent and heima
  as projects initiated.
- Keep collaboration stage distinct from production adoption or completed
  qualification.

## Scope

- [x] README-only, seven added lines.
- [x] No runtime, API, schema, benchmark, or qualification behavior changes.
- [x] Existing public project links are reused; no private context is included.

## Validation

- `cargo fmt --all -- --check` — passed.
- Local Markdown target scan — 63 references parsed; every local target exists.
- `pandoc README.md --from=gfm --to=html5 --standalone` — passed.
- Independent claims/link review — no P0/P1 blocker.
- Public/private boundary scan — clean.
- `git diff --check` — passed.
- Standard premerge canary — three direct checks and 13 selected checks passed;
  no warnings or manual holds.
- Change-quality receipt `cqr_c91fac4a87e3bbc92669` — passing exact committed
  scope.

Rust clippy and test suites were not rerun because this change adds only public
README prose and links.

## Contributor Sign-off

- [x] The single commit includes a DCO `Signed-off-by` trailer.
